### PR TITLE
fix: update placeholder text for server URL in LoginScreen.qml

### DIFF
--- a/src/ui/LoginScreen.qml
+++ b/src/ui/LoginScreen.qml
@@ -93,6 +93,7 @@ FocusScope {
         Button {
             id: connectButton
             text: "Connect"
+            enabled: serverField.text.length > 0
             font.pixelSize: 24
             font.family: Theme.fontPrimary
             Layout.fillWidth: true


### PR DESCRIPTION
Previously the login screen contained actual placeholder text for the URL which is annoying to have to remove

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed pre-filled server URL so the server field is empty by default; a placeholder shows the example address.
* **UX Improvements**
  * The Connect button is now enabled only when a server address has been entered, preventing accidental submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->