### PR TITLE
fix: reduce QML runtime warning regressions

### DIFF
--- a/src/ui/A11yButton.qml
+++ b/src/ui/A11yButton.qml
@@ -22,25 +22,24 @@ Button {
     ToolTip.visible: hovered && toolTipText.length > 0
     ToolTip.text: toolTipText
 
+    onClicked: activated()
+
     Keys.onReturnPressed: function(event) {
         if (event.isAutoRepeat)
             return
         activated()
-        clicked()
         event.accepted = true
     }
     Keys.onEnterPressed: function(event) {
         if (event.isAutoRepeat)
             return
         activated()
-        clicked()
         event.accepted = true
     }
     Keys.onSpacePressed: function(event) {
         if (event.isAutoRepeat)
             return
         activated()
-        clicked()
         event.accepted = true
     }
 }

--- a/src/ui/A11yButton.qml
+++ b/src/ui/A11yButton.qml
@@ -10,9 +10,37 @@ Button {
     // Accessibility properties
     property string a11yName: ""
     property string a11yDescription: ""
+    property string toolTipText: ""
+
+    signal activated()
     
     Accessible.role: Accessible.Button
     Accessible.name: a11yName || text
     Accessible.description: a11yDescription
     Accessible.focusable: true
+
+    ToolTip.visible: hovered && toolTipText.length > 0
+    ToolTip.text: toolTipText
+
+    Keys.onReturnPressed: function(event) {
+        if (event.isAutoRepeat)
+            return
+        activated()
+        clicked()
+        event.accepted = true
+    }
+    Keys.onEnterPressed: function(event) {
+        if (event.isAutoRepeat)
+            return
+        activated()
+        clicked()
+        event.accepted = true
+    }
+    Keys.onSpacePressed: function(event) {
+        if (event.isAutoRepeat)
+            return
+        activated()
+        clicked()
+        event.accepted = true
+    }
 }

--- a/src/ui/ActiveSessionsScreen.qml
+++ b/src/ui/ActiveSessionsScreen.qml
@@ -27,13 +27,13 @@ FocusScope {
 
     // Handle self-session revocation
     Connections {
-        target: sessionService
+        target: root.sessionService
         function onSelfSessionRevoked() {
             // Current session was revoked - show message and navigate to login
             toast.show("Your session was revoked on another device. Logging out...");
             Qt.callLater(function() {
-                if (authService) {
-                    authService.logout();
+                if (root.authService) {
+                    root.authService.logout();
                 }
             });
         }
@@ -60,8 +60,8 @@ FocusScope {
                 text: "\ue92f"  // Back arrow icon
                 font.family: Icons.materialFamily
                 font.pixelSize: Theme.iconSizeMedium
-                width: Theme.iconSizeLarge
-                height: Theme.iconSizeLarge
+                Layout.preferredWidth: Theme.iconSizeLarge
+                Layout.preferredHeight: Theme.iconSizeLarge
 
                 onClicked: root.backRequested()
                 onActivated: root.backRequested()
@@ -83,8 +83,8 @@ FocusScope {
                 text: "\ue5d5"  // Refresh icon
                 font.family: Icons.materialFamily
                 font.pixelSize: Theme.iconSizeSmall
-                width: Theme.iconSizeMedium
-                height: Theme.iconSizeMedium
+                Layout.preferredWidth: Theme.iconSizeMedium
+                Layout.preferredHeight: Theme.iconSizeMedium
                 toolTipText: "Refresh"
 
                 onClicked: refresh()
@@ -99,17 +99,17 @@ FocusScope {
                 text: "Revoke All Others"
                 font.pixelSize: Theme.fontSizeBody
                 height: Theme.iconSizeMedium
-                enabled: sessionService && sessionService.sessions.length > 1
+                enabled: root.sessionService && root.sessionService.sessions.length > 1
                 opacity: enabled ? 1.0 : 0.5
 
                 onClicked: {
-                    if (sessionService) {
-                        sessionService.revokeAllOtherSessions();
+                    if (root.sessionService) {
+                        root.sessionService.revokeAllOtherSessions();
                     }
                 }
                 onActivated: {
-                    if (sessionService) {
-                        sessionService.revokeAllOtherSessions();
+                    if (root.sessionService) {
+                        root.sessionService.revokeAllOtherSessions();
                     }
                 }
 
@@ -121,17 +121,17 @@ FocusScope {
         // Loading indicator
         BusyIndicator {
             Layout.alignment: Qt.AlignHCenter
-            running: sessionService && sessionService.isLoading
+            running: root.sessionService && root.sessionService.isLoading
             visible: running
-            width: Theme.iconSizeLarge
-            height: Theme.iconSizeLarge
+            Layout.preferredWidth: Theme.iconSizeLarge
+            Layout.preferredHeight: Theme.iconSizeLarge
         }
 
         // Error display
         Label {
             Layout.fillWidth: true
-            text: sessionService ? sessionService.errorString : ""
-            visible: sessionService && sessionService.errorString.length > 0
+            text: root.sessionService ? root.sessionService.errorString : ""
+            visible: root.sessionService && root.sessionService.errorString.length > 0
             color: Theme.errorColor
             font.pixelSize: Theme.fontSizeBody
             wrapMode: Text.Wrap
@@ -145,7 +145,7 @@ FocusScope {
             Layout.fillHeight: true
             clip: true
             spacing: Theme.spacingSmall
-            model: sessionService ? sessionService.sessions : []
+            model: root.sessionService ? root.sessionService.sessions : []
 
             KeyNavigation.up: backButton
 
@@ -153,7 +153,7 @@ FocusScope {
                 id: sessionDelegate
                 width: sessionsList.width
                 height: 80
-                property bool isCurrent: model.id === (sessionService ? sessionService.currentSessionId : "")
+                property bool isCurrent: model.id === (root.sessionService ? root.sessionService.currentSessionId : "")
 
                 // Background
                 Rectangle {
@@ -198,8 +198,8 @@ FocusScope {
                             // Current session badge
                             Rectangle {
                                 visible: sessionDelegate.isCurrent
-                                width: currentSessionLabel.width + Theme.spacingSmall * 2
-                                height: currentSessionLabel.height + Theme.spacingXSmall * 2
+                                implicitWidth: currentSessionLabel.implicitWidth + Theme.spacingSmall * 2
+                                implicitHeight: currentSessionLabel.implicitHeight + Theme.spacingXSmall * 2
                                 color: Theme.accentColor
                                 radius: Theme.radiusSmall
 
@@ -235,18 +235,18 @@ FocusScope {
                         text: "\ue14c"  // Close/cancel icon
                         font.family: Icons.materialFamily
                         font.pixelSize: Theme.iconSizeSmall
-                        width: Theme.iconSizeMedium
-                        height: Theme.iconSizeMedium
+                        Layout.preferredWidth: Theme.iconSizeMedium
+                        Layout.preferredHeight: Theme.iconSizeMedium
                         toolTipText: "Revoke session"
 
                         onClicked: {
-                            if (sessionService) {
-                                sessionService.revokeSession(model.id);
+                            if (root.sessionService) {
+                                root.sessionService.revokeSession(model.id);
                             }
                         }
                         onActivated: {
-                            if (sessionService) {
-                                sessionService.revokeSession(model.id);
+                            if (root.sessionService) {
+                                root.sessionService.revokeSession(model.id);
                             }
                         }
 
@@ -268,7 +268,7 @@ FocusScope {
 
             // Empty state
             Label {
-                visible: parent.count === 0 && (!sessionService || !sessionService.isLoading)
+                visible: parent.count === 0 && (!root.sessionService || !root.sessionService.isLoading)
                 anchors.centerIn: parent
                 text: "No active sessions found"
                 font.pixelSize: Theme.fontSizeBody

--- a/src/ui/ActiveSessionsScreen.qml
+++ b/src/ui/ActiveSessionsScreen.qml
@@ -63,7 +63,6 @@ FocusScope {
                 Layout.preferredWidth: Theme.iconSizeLarge
                 Layout.preferredHeight: Theme.iconSizeLarge
 
-                onClicked: root.backRequested()
                 onActivated: root.backRequested()
 
                 KeyNavigation.right: refreshButton
@@ -87,7 +86,6 @@ FocusScope {
                 Layout.preferredHeight: Theme.iconSizeMedium
                 toolTipText: "Refresh"
 
-                onClicked: refresh()
                 onActivated: refresh()
 
                 KeyNavigation.left: backButton
@@ -102,11 +100,6 @@ FocusScope {
                 enabled: root.sessionService && root.sessionService.sessions.length > 1
                 opacity: enabled ? 1.0 : 0.5
 
-                onClicked: {
-                    if (root.sessionService) {
-                        root.sessionService.revokeAllOtherSessions();
-                    }
-                }
                 onActivated: {
                     if (root.sessionService) {
                         root.sessionService.revokeAllOtherSessions();
@@ -239,11 +232,6 @@ FocusScope {
                         Layout.preferredHeight: Theme.iconSizeMedium
                         toolTipText: "Revoke session"
 
-                        onClicked: {
-                            if (root.sessionService) {
-                                root.sessionService.revokeSession(model.id);
-                            }
-                        }
                         onActivated: {
                             if (root.sessionService) {
                                 root.sessionService.revokeSession(model.id);

--- a/src/ui/HomeScreen.qml
+++ b/src/ui/HomeScreen.qml
@@ -172,9 +172,11 @@ FocusScope {
             // Check if a recentlyAddedList has focus and save its state
             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
                 var item = recentlyAddedRepeater.itemAt(i)
-                if (item && item.recentlyAddedListRef && item.recentlyAddedListRef.activeFocus) {
-                    savedRecentlyAddedLibraryId = item.libraryId
-                    savedRecentlyAddedIndex = item.recentlyAddedListRef.currentIndex
+                var recentlyAddedListRef = item ? item["recentlyAddedListRef"] : null
+                var libraryId = item ? item["libraryId"] : ""
+                if (item && recentlyAddedListRef && recentlyAddedListRef.activeFocus) {
+                    savedRecentlyAddedLibraryId = libraryId
+                    savedRecentlyAddedIndex = recentlyAddedListRef.currentIndex
                     break
                 }
             }
@@ -195,8 +197,10 @@ FocusScope {
             // Find the matching recentlyAddedList for the saved library
             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
                 var item = recentlyAddedRepeater.itemAt(i)
-                if (item && item.libraryId === savedRecentlyAddedLibraryId && item.recentlyAddedListRef) {
-                    var list = item.recentlyAddedListRef
+                var itemLibraryId = item ? item["libraryId"] : ""
+                var itemListRef = item ? item["recentlyAddedListRef"] : null
+                if (item && itemLibraryId === savedRecentlyAddedLibraryId && itemListRef) {
+                    var list = itemListRef
                     if (savedRecentlyAddedIndex < list.count) {
                         list.currentIndex = savedRecentlyAddedIndex
                         list.positionViewAtIndex(savedRecentlyAddedIndex, ListView.Contain)
@@ -228,9 +232,11 @@ FocusScope {
             // Check recentlyAdded lists
             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
                 var list = recentlyAddedRepeater.itemAt(i)
-                if (list && list.recentlyAddedListRef && list.recentlyAddedListRef.activeFocus) {
-                    section = "recentlyAdded:" + list.libraryId
-                    index = list.recentlyAddedListRef.currentIndex
+                var recentlyAddedListRef = list ? list["recentlyAddedListRef"] : null
+                var libraryId = list ? list["libraryId"] : ""
+                if (list && recentlyAddedListRef && recentlyAddedListRef.activeFocus) {
+                    section = "recentlyAdded:" + libraryId
+                    index = recentlyAddedListRef.currentIndex
                     break
                 }
             }
@@ -262,8 +268,10 @@ FocusScope {
             var libraryId = lastFocusedSection.substring("recentlyAdded:".length)
             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
                 var list = recentlyAddedRepeater.itemAt(i)
-                if (list && list.libraryId === libraryId && list.recentlyAddedListRef) {
-                    targetList = list.recentlyAddedListRef
+                var listLibraryId = list ? list["libraryId"] : ""
+                var listRef = list ? list["recentlyAddedListRef"] : null
+                if (list && listLibraryId === libraryId && listRef) {
+                    targetList = listRef
                     targetSection = list
                     break
                 }
@@ -516,7 +524,7 @@ FocusScope {
             spacing: Theme.spacingXLarge
             
             // Top spacing
-            Item { height: Theme.paddingLarge }
+            Item { Layout.preferredHeight: Theme.paddingLarge }
             
             // My Media Section
             ColumnLayout {
@@ -703,8 +711,9 @@ FocusScope {
                             // Find first visible recently added list
                             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
                                 var item = recentlyAddedRepeater.itemAt(i)
-                                if (item && item.visible) {
-                                    item.recentlyAddedListRef.forceActiveFocus()
+                                var recentlyAddedListRef = item ? item["recentlyAddedListRef"] : null
+                                if (item && item.visible && recentlyAddedListRef) {
+                                    recentlyAddedListRef.forceActiveFocus()
                                     break
                                 }
                             }
@@ -970,8 +979,9 @@ FocusScope {
                         if (recentlyAddedRepeater.count > 0) {
                             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
                                 var item = recentlyAddedRepeater.itemAt(i)
-                                if (item && item.visible) {
-                                    item.recentlyAddedListRef.forceActiveFocus()
+                                var recentlyAddedListRef = item ? item["recentlyAddedListRef"] : null
+                                if (item && item.visible && recentlyAddedListRef) {
+                                    recentlyAddedListRef.forceActiveFocus()
                                     break
                                 }
                             }
@@ -1300,7 +1310,7 @@ FocusScope {
             }
             
             // Bottom spacing
-            Item { height: Theme.paddingLarge }
+            Item { Layout.preferredHeight: Theme.paddingLarge }
         } // end mainColumn
     } // end Flickable
 

--- a/src/ui/HomeScreen.qml
+++ b/src/ui/HomeScreen.qml
@@ -164,6 +164,15 @@ FocusScope {
     property int savedRecentlyAddedIndex: -1
     property string savedRecentlyAddedLibraryId: ""
 
+    function getRecentlyAddedDelegateMeta(index) {
+        var item = recentlyAddedRepeater.itemAt(index)
+        return {
+            item: item || null,
+            recentlyAddedListRef: item ? (item["recentlyAddedListRef"] || null) : null,
+            libraryId: item ? (item["libraryId"] || "") : ""
+        }
+    }
+
     Connections {
         target: ResponsiveLayoutManager
         function onBreakpointChanged() {
@@ -171,12 +180,10 @@ FocusScope {
             if (nextUpList.activeFocus) savedNextUpIndex = nextUpList.currentIndex
             // Check if a recentlyAddedList has focus and save its state
             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
-                var item = recentlyAddedRepeater.itemAt(i)
-                var recentlyAddedListRef = item ? item["recentlyAddedListRef"] : null
-                var libraryId = item ? item["libraryId"] : ""
-                if (item && recentlyAddedListRef && recentlyAddedListRef.activeFocus) {
-                    savedRecentlyAddedLibraryId = libraryId
-                    savedRecentlyAddedIndex = recentlyAddedListRef.currentIndex
+                var meta = getRecentlyAddedDelegateMeta(i)
+                if (meta.item && meta.recentlyAddedListRef && meta.recentlyAddedListRef.activeFocus) {
+                    savedRecentlyAddedLibraryId = meta.libraryId
+                    savedRecentlyAddedIndex = meta.recentlyAddedListRef.currentIndex
                     break
                 }
             }
@@ -196,11 +203,9 @@ FocusScope {
         } else if (savedRecentlyAddedLibraryId !== "" && savedRecentlyAddedIndex >= 0) {
             // Find the matching recentlyAddedList for the saved library
             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
-                var item = recentlyAddedRepeater.itemAt(i)
-                var itemLibraryId = item ? item["libraryId"] : ""
-                var itemListRef = item ? item["recentlyAddedListRef"] : null
-                if (item && itemLibraryId === savedRecentlyAddedLibraryId && itemListRef) {
-                    var list = itemListRef
+                var savedMeta = getRecentlyAddedDelegateMeta(i)
+                if (savedMeta.item && savedMeta.libraryId === savedRecentlyAddedLibraryId && savedMeta.recentlyAddedListRef) {
+                    var list = savedMeta.recentlyAddedListRef
                     if (savedRecentlyAddedIndex < list.count) {
                         list.currentIndex = savedRecentlyAddedIndex
                         list.positionViewAtIndex(savedRecentlyAddedIndex, ListView.Contain)
@@ -231,12 +236,10 @@ FocusScope {
         } else {
             // Check recentlyAdded lists
             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
-                var list = recentlyAddedRepeater.itemAt(i)
-                var recentlyAddedListRef = list ? list["recentlyAddedListRef"] : null
-                var libraryId = list ? list["libraryId"] : ""
-                if (list && recentlyAddedListRef && recentlyAddedListRef.activeFocus) {
-                    section = "recentlyAdded:" + libraryId
-                    index = recentlyAddedListRef.currentIndex
+                var focusMeta = getRecentlyAddedDelegateMeta(i)
+                if (focusMeta.item && focusMeta.recentlyAddedListRef && focusMeta.recentlyAddedListRef.activeFocus) {
+                    section = "recentlyAdded:" + focusMeta.libraryId
+                    index = focusMeta.recentlyAddedListRef.currentIndex
                     break
                 }
             }
@@ -267,12 +270,10 @@ FocusScope {
         } else if (lastFocusedSection.indexOf("recentlyAdded:") === 0) {
             var libraryId = lastFocusedSection.substring("recentlyAdded:".length)
             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
-                var list = recentlyAddedRepeater.itemAt(i)
-                var listLibraryId = list ? list["libraryId"] : ""
-                var listRef = list ? list["recentlyAddedListRef"] : null
-                if (list && listLibraryId === libraryId && listRef) {
-                    targetList = listRef
-                    targetSection = list
+                var restoreMeta = getRecentlyAddedDelegateMeta(i)
+                if (restoreMeta.item && restoreMeta.libraryId === libraryId && restoreMeta.recentlyAddedListRef) {
+                    targetList = restoreMeta.recentlyAddedListRef
+                    targetSection = restoreMeta.item
                     break
                 }
             }
@@ -710,10 +711,9 @@ FocusScope {
                         } else if (recentlyAddedRepeater.count > 0) {
                             // Find first visible recently added list
                             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
-                                var item = recentlyAddedRepeater.itemAt(i)
-                                var recentlyAddedListRef = item ? item["recentlyAddedListRef"] : null
-                                if (item && item.visible && recentlyAddedListRef) {
-                                    recentlyAddedListRef.forceActiveFocus()
+                                var firstVisibleMeta = getRecentlyAddedDelegateMeta(i)
+                                if (firstVisibleMeta.item && firstVisibleMeta.item.visible && firstVisibleMeta.recentlyAddedListRef) {
+                                    firstVisibleMeta.recentlyAddedListRef.forceActiveFocus()
                                     break
                                 }
                             }
@@ -978,10 +978,9 @@ FocusScope {
                     Keys.onDownPressed: {
                         if (recentlyAddedRepeater.count > 0) {
                             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
-                                var item = recentlyAddedRepeater.itemAt(i)
-                                var recentlyAddedListRef = item ? item["recentlyAddedListRef"] : null
-                                if (item && item.visible && recentlyAddedListRef) {
-                                    recentlyAddedListRef.forceActiveFocus()
+                                var nextVisibleMeta = getRecentlyAddedDelegateMeta(i)
+                                if (nextVisibleMeta.item && nextVisibleMeta.item.visible && nextVisibleMeta.recentlyAddedListRef) {
+                                    nextVisibleMeta.recentlyAddedListRef.forceActiveFocus()
                                     break
                                 }
                             }
@@ -1284,9 +1283,9 @@ FocusScope {
                                     else myMediaList.forceActiveFocus()
                                 } else {
                                     for (var i = libraryIndex - 1; i >= 0; i--) {
-                                        var item = recentlyAddedRepeater.itemAt(i)
-                                        if (item && item.visible) {
-                                            item.recentlyAddedListRef.forceActiveFocus()
+                                        var previousMeta = getRecentlyAddedDelegateMeta(i)
+                                        if (previousMeta.item && previousMeta.item.visible && previousMeta.recentlyAddedListRef) {
+                                            previousMeta.recentlyAddedListRef.forceActiveFocus()
                                             break
                                         }
                                     }
@@ -1294,9 +1293,9 @@ FocusScope {
                             }
                             Keys.onDownPressed: {
                                 for (var i = libraryIndex + 1; i < recentlyAddedRepeater.count; i++) {
-                                    var item = recentlyAddedRepeater.itemAt(i)
-                                    if (item && item.visible) {
-                                        item.recentlyAddedListRef.forceActiveFocus()
+                                    var followingMeta = getRecentlyAddedDelegateMeta(i)
+                                    if (followingMeta.item && followingMeta.item.visible && followingMeta.recentlyAddedListRef) {
+                                        followingMeta.recentlyAddedListRef.forceActiveFocus()
                                         break
                                     }
                                 }

--- a/src/ui/Icons.qml
+++ b/src/ui/Icons.qml
@@ -1,5 +1,6 @@
 pragma Singleton
 import QtQuick
+import BloomUI
 
 /**
  * Icons - Material Symbols icon codepoints
@@ -18,6 +19,8 @@ import QtQuick
  * Find codepoints at: https://github.com/AlejandroAkbal/Google-Material-Symbols-Icons-Codepoints-JSON
  */
 QtObject {
+    readonly property string materialFamily: Theme.fontIcon
+
     // Navigation - Using Unicode codepoints from Material Symbols
     readonly property string home: "\ue88a"
     readonly property string menu: "\ue5d2"

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -370,7 +370,8 @@ Window {
             modal: true
             focus: true
             anchors.centerIn: parent
-            width: Math.round(720 * Theme.layoutScale)
+            width: Math.min(Math.round(720 * Theme.layoutScale),
+                            Math.max(0, window.width - (Theme.spacingLarge * 2)))
             padding: Theme.spacingLarge
 
             onRejected: UpdateService.dismissStartupPopup()
@@ -488,6 +489,13 @@ Window {
     // Sidebar Navigation Shell
     // ========================================
     
+    function saveHomeFocusState() {
+        var homeScreen = stackView.find(function(item) { return item && item["navigationId"] === "home" })
+        if (homeScreen && typeof homeScreen["saveFocusState"] === "function") {
+            homeScreen["saveFocusState"]()
+        }
+    }
+
     QtObject {
         id: sidebarStub
         property bool expanded: false
@@ -518,32 +526,24 @@ Window {
                 // Handle navigation requests
                 switch (navigationId) {
                     case "home":
-                        // Save focus state before navigating
-                        var homeScreen = stackView.find(function(item) { return item && item["navigationId"] === "home" })
-                        if (homeScreen && typeof homeScreen["saveFocusState"] === "function") homeScreen["saveFocusState"]()
+                        saveHomeFocusState()
                         // Pop back to home screen
                         while (stackView.depth > 1) {
                             stackView.pop()
                         }
                         break
                     case "search":
-                        // Save focus state before navigating
-                        var homeForSearch = stackView.find(function(item) { return item && item["navigationId"] === "home" })
-                        if (homeForSearch && typeof homeForSearch["saveFocusState"] === "function") homeForSearch["saveFocusState"]()
+                        saveHomeFocusState()
                         // Navigate to search screen
                         pushSearchScreen()
                         break
                     case "settings":
-                        // Save focus state before navigating
-                        var homeForSettings = stackView.find(function(item) { return item && item["navigationId"] === "home" })
-                        if (homeForSettings && typeof homeForSettings["saveFocusState"] === "function") homeForSettings["saveFocusState"]()
+                        saveHomeFocusState()
                         // Navigate to settings screen
                         pushSettingsScreen()
                         break
                     case "updates":
-                        // Save focus state before navigating
-                        var homeForUpdates = stackView.find(function(item) { return item && item["navigationId"] === "home" })
-                        if (homeForUpdates && typeof homeForUpdates["saveFocusState"] === "function") homeForUpdates["saveFocusState"]()
+                        saveHomeFocusState()
                         pushSettingsScreen({ focusUpdatesOnActivate: true })
                         break
                 }
@@ -553,9 +553,7 @@ Window {
                 playPointerSelectSound()
                 if (!libraryId)
                     return
-                // Save focus state before navigating
-                var homeScreenForLibrary = stackView.find(function(item) { return item && item["navigationId"] === "home" })
-                if (homeScreenForLibrary && typeof homeScreenForLibrary["saveFocusState"] === "function") homeScreenForLibrary["saveFocusState"]()
+                saveHomeFocusState()
                 stackView.push("LibraryScreen.qml", {
                     currentParentId: libraryId,
                     currentLibraryId: libraryId,
@@ -676,7 +674,7 @@ Window {
         target: UpdateService
         ignoreUnknownSignals: true
         function onStartupPopupRequested() {
-            if (!window.isLoggedIn && !AuthenticationService.authenticated) {
+            if (!window.isLoggedIn || !AuthenticationService.authenticated) {
                 pendingStartupUpdatePopup = true
                 return
             }
@@ -822,12 +820,12 @@ Window {
         function onLoggedOut() {
             console.log("Main.qml: Logged out, returning to login screen")
             
-            // Mark as logged out to hide sidebar
-            window.isLoggedIn = false
-            
             // Close sidebar if open
             sidebarProxy.close()
-            
+
+            // Mark as logged out to hide sidebar
+            window.isLoggedIn = false
+
             // Clear all screens and go back to login
             stackView.clear()
             stackView.push("LoginScreen.qml")

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -165,17 +165,19 @@ Window {
         }
 
         function saveFocusForSidebar() {
-            if (stackView.currentItem && typeof stackView.currentItem.saveFocusForSidebar === "function") {
-                stackView.currentItem.saveFocusForSidebar()
+            var currentItem = stackView.currentItem
+            if (currentItem && typeof currentItem["saveFocusForSidebar"] === "function") {
+                currentItem["saveFocusForSidebar"]()
             }
         }
 
         function restoreFocusFromSidebar() {
             restoringFocusFromSidebar = true
-            if (stackView.currentItem && typeof stackView.currentItem.restoreFocusFromSidebar === "function") {
-                stackView.currentItem.restoreFocusFromSidebar()
-            } else if (stackView.currentItem) {
-                stackView.currentItem.forceActiveFocus()
+            var currentItem = stackView.currentItem
+            if (currentItem && typeof currentItem["restoreFocusFromSidebar"] === "function") {
+                currentItem["restoreFocusFromSidebar"]()
+            } else if (currentItem) {
+                currentItem.forceActiveFocus()
             } else {
                 forceActiveFocus()
             }
@@ -209,13 +211,14 @@ Window {
             if (restoringFocusFromSidebar) {
                 return
             }
-            if (stackView.currentItem
-                    && stackView.currentItem.restoringFocusFromSeriesDetailsReturn) {
+            var currentItem = stackView.currentItem
+            if (currentItem
+                    && currentItem["restoringFocusFromSeriesDetailsReturn"]) {
                 return
             }
-            if (activeFocus && stackView.currentItem && !stackView.currentItem.activeFocus) {
+            if (activeFocus && currentItem && !currentItem.activeFocus) {
                 console.log("[FocusDebug] mainContentArea got focus, forwarding to currentItem")
-                const item = stackView.currentItem
+                const item = currentItem
                 Qt.callLater(function() {
                     if (!mainContentArea.activeFocus || !item || item !== stackView.currentItem || item.activeFocus) {
                         return
@@ -235,7 +238,7 @@ Window {
                 // Let screens with restoreFocusState handle their own focus restoration
                 // This allows HomeScreen to restore focus to the previously selected item
                 if (currentItem && !sidebar.expanded) {
-                    if (currentItem.restoreFocusState) {
+                    if (typeof currentItem["restoreFocusState"] === "function") {
                         console.log("[FocusDebug] Screen has restoreFocusState, letting it handle focus")
                         // Don't force focus here - let StackView.onStatusChanged in the screen handle it
                     } else {
@@ -285,8 +288,8 @@ Window {
             BusyIndicator {
                 Layout.alignment: Qt.AlignHCenter
                 running: upNextBlockingOverlay.visible
-                width: Math.round(52 * Theme.layoutScale)
-                height: Math.round(52 * Theme.layoutScale)
+                Layout.preferredWidth: Math.round(52 * Theme.layoutScale)
+                Layout.preferredHeight: Math.round(52 * Theme.layoutScale)
                 palette.dark: Theme.textPrimary
                 palette.light: Theme.accentSecondary
             }
@@ -447,8 +450,8 @@ Window {
             switch (navigationId) {
                 case "home":
                     // Save focus state before navigating
-                    var homeScreen = stackView.find(function(item) { return item && item.navigationId === "home" })
-                    if (homeScreen) homeScreen.saveFocusState()
+                    var homeScreen = stackView.find(function(item) { return item && item["navigationId"] === "home" })
+                    if (homeScreen && typeof homeScreen["saveFocusState"] === "function") homeScreen["saveFocusState"]()
                     // Pop back to home screen
                     while (stackView.depth > 1) {
                         stackView.pop()
@@ -456,22 +459,22 @@ Window {
                     break
                 case "search":
                     // Save focus state before navigating
-                    var homeForSearch = stackView.find(function(item) { return item && item.navigationId === "home" })
-                    if (homeForSearch) homeForSearch.saveFocusState()
+                    var homeForSearch = stackView.find(function(item) { return item && item["navigationId"] === "home" })
+                    if (homeForSearch && typeof homeForSearch["saveFocusState"] === "function") homeForSearch["saveFocusState"]()
                     // Navigate to search screen
                     pushSearchScreen()
                     break
                 case "settings":
                     // Save focus state before navigating
-                    var homeForSettings = stackView.find(function(item) { return item && item.navigationId === "home" })
-                    if (homeForSettings) homeForSettings.saveFocusState()
+                    var homeForSettings = stackView.find(function(item) { return item && item["navigationId"] === "home" })
+                    if (homeForSettings && typeof homeForSettings["saveFocusState"] === "function") homeForSettings["saveFocusState"]()
                     // Navigate to settings screen
                     pushSettingsScreen()
                     break
                 case "updates":
                     // Save focus state before navigating
-                    var homeForUpdates = stackView.find(function(item) { return item && item.navigationId === "home" })
-                    if (homeForUpdates) homeForUpdates.saveFocusState()
+                    var homeForUpdates = stackView.find(function(item) { return item && item["navigationId"] === "home" })
+                    if (homeForUpdates && typeof homeForUpdates["saveFocusState"] === "function") homeForUpdates["saveFocusState"]()
                     pushSettingsScreen({ focusUpdatesOnActivate: true })
                     break
             }
@@ -482,8 +485,8 @@ Window {
             if (!libraryId)
                 return
             // Save focus state before navigating
-            var homeScreenForLibrary = stackView.find(function(item) { return item && item.navigationId === "home" })
-            if (homeScreenForLibrary) homeScreenForLibrary.saveFocusState()
+            var homeScreenForLibrary = stackView.find(function(item) { return item && item["navigationId"] === "home" })
+            if (homeScreenForLibrary && typeof homeScreenForLibrary["saveFocusState"] === "function") homeScreenForLibrary["saveFocusState"]()
             stackView.push("LibraryScreen.qml", {
                 currentParentId: libraryId,
                 currentLibraryId: libraryId,
@@ -505,7 +508,7 @@ Window {
     // Function to push settings screen and wire up signals
     function updateSidebarNavigation() {
         var item = stackView.currentItem
-        var navigationId = (item && item.navigationId) ? item.navigationId : "home"
+        var navigationId = (item && item["navigationId"]) ? item["navigationId"] : "home"
         sidebar.currentNavigation = navigationId
         if (navigationId && navigationId.indexOf("library:") === 0) {
             sidebar.currentLibraryId = navigationId.substring("library:".length)
@@ -528,13 +531,13 @@ Window {
         })
         Qt.callLater(function() {
             var settingsScreen = stackView.currentItem
-            if (settingsScreen && settingsScreen.signOutRequested) {
-                settingsScreen.signOutRequested.connect(function() {
+            if (settingsScreen && settingsScreen["signOutRequested"]) {
+                settingsScreen["signOutRequested"].connect(function() {
                     AuthenticationService.logout()
                 })
             }
-            if (settingsScreen && options.focusUpdatesOnActivate && settingsScreen.requestUpdateSectionFocus) {
-                settingsScreen.requestUpdateSectionFocus()
+            if (settingsScreen && options.focusUpdatesOnActivate && typeof settingsScreen["requestUpdateSectionFocus"] === "function") {
+                settingsScreen["requestUpdateSectionFocus"]()
             }
         })
         updateSidebarNavigation()
@@ -668,8 +671,8 @@ Window {
                     // Defer calling showMovieDetailsView until screen is ready
                     Qt.callLater(function() {
                         var screen = stackView.currentItem
-                        if (screen && screen.showMovieDetailsView) {
-                            screen.showMovieDetailsView(movieData)
+                        if (screen && typeof screen["showMovieDetailsView"] === "function") {
+                            screen["showMovieDetailsView"](movieData)
                         }
                     })
                 })
@@ -690,8 +693,8 @@ Window {
                     // Defer calling showEpisodeDetails until screen is ready
                     Qt.callLater(function() {
                         var screen = stackView.currentItem
-                        if (screen && screen.showEpisodeDetails) {
-                            screen.showEpisodeDetails(episodeData)
+                        if (screen && typeof screen["showEpisodeDetails"] === "function") {
+                            screen["showEpisodeDetails"](episodeData)
                         }
                     })
                 })
@@ -872,7 +875,7 @@ Window {
         enabled: !PlayerController.isPlaybackActive
                  && stackView.depth > 1
                  && !sidebar.expanded
-                 && !(stackView.currentItem && stackView.currentItem.handlesOwnBackNavigation === true)
+                 && !(stackView.currentItem && stackView.currentItem["handlesOwnBackNavigation"] === true)
         onActivated: {
             console.log("[FocusDebug] Back shortcut activated, stackView.depth:", stackView.depth, "sidebar.expanded:", sidebar.expanded)
             if (stackView.depth > 1) {

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -47,6 +47,7 @@ Window {
     
     /// Whether the user is logged in (controls sidebar visibility)
     property bool isLoggedIn: false
+    property var sidebarProxy: sidebarLoader.item || sidebarStub
     
     /// Sidebar overlay mode threshold (narrow screens use overlay)
     readonly property int overlayThreshold: 960
@@ -54,8 +55,8 @@ Window {
     /// Current content offset based on sidebar state
     readonly property int contentOffset: {
         if (!isLoggedIn) return 0
-        if (sidebar.overlayMode) return 0
-        return sidebar.sidebarWidth
+        if (sidebarProxy.overlayMode) return 0
+        return sidebarProxy.sidebarWidth
     }
     readonly property bool embeddedPlaybackActive: PlayerController.supportsEmbeddedVideo && PlayerController.isPlaybackActive
     readonly property bool useDetachedPlaybackOverlayWindow: Qt.platform.os === "windows"
@@ -65,6 +66,37 @@ Window {
                                               && activeEmbeddedPlaybackOverlay.selectorOpen
     readonly property bool awaitingUpNextTransition: PlayerController.awaitingNextEpisodeResolution
                                                   && !PlayerController.isPlaybackActive
+    property bool pendingStartupUpdatePopup: false
+
+    function ensureMediaSourceSelectionDialog() {
+        if (!mediaSourceSelectionDialogLoader.active) {
+            mediaSourceSelectionDialogLoader.active = true
+        }
+        return mediaSourceSelectionDialogLoader.item
+    }
+
+    function openStartupUpdateDialog() {
+        if (!updateDialogLoader.active) {
+            updateDialogLoader.active = true
+        }
+
+        const dialog = updateDialogLoader.item
+        if (!dialog) {
+            Qt.callLater(openStartupUpdateDialog)
+            return
+        }
+
+        if (dialog.visible) {
+            return
+        }
+
+        dialog.open()
+        Qt.callLater(function() {
+            if (dialog.primaryButton) {
+                dialog.primaryButton.forceActiveFocus()
+            }
+        })
+    }
 
     function ensurePlaybackOverlayFocus() {
         if (!embeddedPlaybackActive) {
@@ -190,13 +222,13 @@ Window {
         Keys.onLeftPressed: function(event) {
             if (isLoggedIn) {
                 saveFocusForSidebar()
-                if (sidebar.expanded) {
+                if (sidebarProxy.expanded) {
                     // When sidebar is expanded, focus first nav item
-                    sidebar.focusNavigation()
+                    sidebarProxy.focusNavigation()
                     event.accepted = true
-                } else if (!sidebar.overlayMode) {
+                } else if (!sidebarProxy.overlayMode) {
                     // When sidebar is collapsed (rail mode), focus hamburger
-                    sidebar.focusHamburger()
+                    sidebarProxy.focusHamburger()
                     event.accepted = true
                 } else {
                     event.accepted = false
@@ -234,10 +266,10 @@ Window {
             initialItem: "LoginScreen.qml"
             
             onCurrentItemChanged: {
-                console.log("[FocusDebug] StackView.currentItemChanged:", currentItem ? currentItem.toString() : "null", "sidebar.expanded:", sidebar.expanded)
+                console.log("[FocusDebug] StackView.currentItemChanged:", currentItem ? currentItem.toString() : "null", "sidebar.expanded:", sidebarProxy.expanded)
                 // Let screens with restoreFocusState handle their own focus restoration
                 // This allows HomeScreen to restore focus to the previously selected item
-                if (currentItem && !sidebar.expanded) {
+                if (currentItem && !sidebarProxy.expanded) {
                     if (typeof currentItem["restoreFocusState"] === "function") {
                         console.log("[FocusDebug] Screen has restoreFocusState, letting it handle focus")
                         // Don't force focus here - let StackView.onStatusChanged in the screen handle it
@@ -245,7 +277,7 @@ Window {
                         console.log("[FocusDebug] Setting focus to currentItem (no restoreFocusState)")
                         currentItem.forceActiveFocus()
                     }
-                } else if (currentItem && sidebar.expanded) {
+                } else if (currentItem && sidebarProxy.expanded) {
                     console.log("[FocusDebug] Skipping focus - sidebar is expanded, will restore later")
                 }
                 updateSidebarNavigation()
@@ -299,12 +331,25 @@ Window {
     Connections {
         target: PlayerController
         function onPlaybackVersionSelectionRequested(requestId, dialogModel, restoreFocusHint) {
-            mediaSourceSelectionDialog.openForRequest(requestId, dialogModel, restoreFocusHint)
+            const dialog = ensureMediaSourceSelectionDialog()
+            if (dialog) {
+                dialog.openForRequest(requestId, dialogModel, restoreFocusHint)
+            } else {
+                Qt.callLater(function() {
+                    const deferredDialog = ensureMediaSourceSelectionDialog()
+                    if (deferredDialog) {
+                        deferredDialog.openForRequest(requestId, dialogModel, restoreFocusHint)
+                    }
+                })
+            }
         }
     }
 
-    MediaSourceSelectionDialog {
-        id: mediaSourceSelectionDialog
+    Loader {
+        id: mediaSourceSelectionDialogLoader
+        active: false
+        sourceComponent: MediaSourceSelectionDialog {
+        }
     }
 
     Timer {
@@ -314,118 +359,125 @@ Window {
         onTriggered: UpdateService.performStartupCheck()
     }
 
-    Dialog {
-        id: updateDialog
-        modal: true
-        focus: true
-        anchors.centerIn: parent
-        width: Math.round(720 * Theme.layoutScale)
-        padding: Theme.spacingLarge
+    Loader {
+        id: updateDialogLoader
+        active: false
 
-        onRejected: UpdateService.dismissStartupPopup()
+        sourceComponent: Dialog {
+            id: updateDialog
+            property alias primaryButton: updatePrimaryButton
+            parent: Overlay.overlay
+            modal: true
+            focus: true
+            anchors.centerIn: parent
+            width: Math.round(720 * Theme.layoutScale)
+            padding: Theme.spacingLarge
 
-        background: Rectangle {
-            color: Theme.cardBackground
-            radius: Theme.radiusMedium
-            border.color: Theme.cardBorder
-            border.width: 1
-        }
+            onRejected: UpdateService.dismissStartupPopup()
 
-        header: Rectangle {
-            color: "transparent"
-            height: Math.round(84 * Theme.layoutScale)
-
-            Column {
-                anchors.fill: parent
-                anchors.margins: Theme.spacingLarge
-                spacing: Theme.spacingSmall
-
-                Text {
-                    text: qsTr("Update Available")
-                    font.pixelSize: Theme.fontSizeTitle
-                    font.family: Theme.fontPrimary
-                    font.weight: Font.DemiBold
-                    color: Theme.textPrimary
-                }
-
-                Text {
-                    text: UpdateService.availableVersion.length > 0
-                          ? qsTr("Bloom %1 is available on the %2 channel.")
-                                .arg(UpdateService.availableVersion)
-                                .arg(UpdateService.availableChannel)
-                          : qsTr("A Bloom update is available.")
-                    font.pixelSize: Theme.fontSizeBody
-                    font.family: Theme.fontPrimary
-                    color: Theme.textSecondary
-                    wrapMode: Text.WordWrap
-                }
+            background: Rectangle {
+                color: Theme.cardBackground
+                radius: Theme.radiusMedium
+                border.color: Theme.cardBorder
+                border.width: 1
             }
-        }
 
-        contentItem: ColumnLayout {
-            spacing: Theme.spacingMedium
+            header: Rectangle {
+                color: "transparent"
+                height: Math.round(84 * Theme.layoutScale)
 
-            ScrollView {
-                Layout.fillWidth: true
-                Layout.preferredHeight: Math.min(updateDialogNotesText.implicitHeight + Theme.spacingMedium,
-                                                 Math.round(window.height * 0.32))
-                Layout.maximumHeight: Math.round(window.height * 0.32)
-                clip: true
+                Column {
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingLarge
+                    spacing: Theme.spacingSmall
 
-                Text {
-                    id: updateDialogNotesText
-                    width: parent.width
-                    text: UpdateService.releaseNotes.length > 0
-                          ? UpdateService.releaseNotes
-                          : qsTr("Open Settings > Updates for full details and download options.")
-                    font.pixelSize: Theme.fontSizeBody
-                    font.family: Theme.fontPrimary
-                    color: Theme.textPrimary
-                    wrapMode: Text.WordWrap
+                    Text {
+                        text: qsTr("Update Available")
+                        font.pixelSize: Theme.fontSizeTitle
+                        font.family: Theme.fontPrimary
+                        font.weight: Font.DemiBold
+                        color: Theme.textPrimary
+                    }
+
+                    Text {
+                        text: UpdateService.availableVersion.length > 0
+                              ? qsTr("Bloom %1 is available on the %2 channel.")
+                                    .arg(UpdateService.availableVersion)
+                                    .arg(UpdateService.availableChannel)
+                              : qsTr("A Bloom update is available.")
+                        font.pixelSize: Theme.fontSizeBody
+                        font.family: Theme.fontPrimary
+                        color: Theme.textSecondary
+                        wrapMode: Text.WordWrap
+                    }
                 }
             }
 
-            Text {
-                text: UpdateService.applySupported
-                      ? qsTr("Bloom can download and launch the installer for you.")
-                      : qsTr("This build cannot auto-install updates, but download links are available.")
-                font.pixelSize: Theme.fontSizeSmall
-                font.family: Theme.fontPrimary
-                color: Theme.textSecondary
-                wrapMode: Text.WordWrap
-                Layout.fillWidth: true
-            }
-        }
-
-        footer: Item {
-            implicitHeight: footerLayout.implicitHeight + (Theme.spacingLarge * 2)
-
-            RowLayout {
-                id: footerLayout
-                anchors.fill: parent
-                anchors.margins: Theme.spacingLarge
+            contentItem: ColumnLayout {
                 spacing: Theme.spacingMedium
 
-                Button {
-                    id: updatePrimaryButton
-                    text: UpdateService.applySupported ? qsTr("Download and Install") : qsTr("Open Download Page")
-                    enabled: !UpdateService.downloadInProgress && !UpdateService.installerLaunched
-                    onClicked: {
-                        if (UpdateService.applySupported) {
-                            updateDialog.close()
-                            UpdateService.downloadAndInstallUpdate()
-                        } else {
-                            UpdateService.openUpdateDownloadPage()
-                            updateDialog.close()
-                        }
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: Math.min(updateDialogNotesText.implicitHeight + Theme.spacingMedium,
+                                                     Math.round(window.height * 0.32))
+                    Layout.maximumHeight: Math.round(window.height * 0.32)
+                    clip: true
+
+                    Text {
+                        id: updateDialogNotesText
+                        width: parent.width
+                        text: UpdateService.releaseNotes.length > 0
+                              ? UpdateService.releaseNotes
+                              : qsTr("Open Settings > Updates for full details and download options.")
+                        font.pixelSize: Theme.fontSizeBody
+                        font.family: Theme.fontPrimary
+                        color: Theme.textPrimary
+                        wrapMode: Text.WordWrap
                     }
                 }
 
-                Button {
-                    text: qsTr("Later")
-                    onClicked: {
-                        UpdateService.dismissStartupPopup()
-                        updateDialog.close()
+                Text {
+                    text: UpdateService.applySupported
+                          ? qsTr("Bloom can download and launch the installer for you.")
+                          : qsTr("This build cannot auto-install updates, but download links are available.")
+                    font.pixelSize: Theme.fontSizeSmall
+                    font.family: Theme.fontPrimary
+                    color: Theme.textSecondary
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
+                }
+            }
+
+            footer: Item {
+                implicitHeight: footerLayout.implicitHeight + (Theme.spacingLarge * 2)
+
+                RowLayout {
+                    id: footerLayout
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingLarge
+                    spacing: Theme.spacingMedium
+
+                    Button {
+                        id: updatePrimaryButton
+                        text: UpdateService.applySupported ? qsTr("Download and Install") : qsTr("Open Download Page")
+                        enabled: !UpdateService.downloadInProgress && !UpdateService.installerLaunched
+                        onClicked: {
+                            if (UpdateService.applySupported) {
+                                updateDialog.close()
+                                UpdateService.downloadAndInstallUpdate()
+                            } else {
+                                UpdateService.openUpdateDownloadPage()
+                                updateDialog.close()
+                            }
+                        }
+                    }
+
+                    Button {
+                        text: qsTr("Later")
+                        onClicked: {
+                            UpdateService.dismissStartupPopup()
+                            updateDialog.close()
+                        }
                     }
                 }
             }
@@ -436,72 +488,90 @@ Window {
     // Sidebar Navigation Shell
     // ========================================
     
-    Sidebar {
-        id: sidebar
+    QtObject {
+        id: sidebarStub
+        property bool expanded: false
+        property bool overlayMode: false
+        property int sidebarWidth: 0
+        property string currentNavigation: "home"
+        property string currentLibraryId: ""
+        function focusNavigation() {}
+        function focusHamburger() {}
+        function close() {}
+        function toggle() {}
+    }
+
+    Loader {
+        id: sidebarLoader
         anchors.fill: parent
-        visible: isLoggedIn && !embeddedPlaybackActive
-        overlayMode: window.width < overlayThreshold
-        currentNavigation: "home"
-        mainContent: mainContentArea  // Connect to main content for focus navigation
+        active: isLoggedIn
+        visible: active
 
-        onNavigationRequested: function(navigationId) {
-            playPointerSelectSound()
-            // Handle navigation requests
-            switch (navigationId) {
-                case "home":
-                    // Save focus state before navigating
-                    var homeScreen = stackView.find(function(item) { return item && item["navigationId"] === "home" })
-                    if (homeScreen && typeof homeScreen["saveFocusState"] === "function") homeScreen["saveFocusState"]()
-                    // Pop back to home screen
-                    while (stackView.depth > 1) {
-                        stackView.pop()
-                    }
-                    break
-                case "search":
-                    // Save focus state before navigating
-                    var homeForSearch = stackView.find(function(item) { return item && item["navigationId"] === "home" })
-                    if (homeForSearch && typeof homeForSearch["saveFocusState"] === "function") homeForSearch["saveFocusState"]()
-                    // Navigate to search screen
-                    pushSearchScreen()
-                    break
-                case "settings":
-                    // Save focus state before navigating
-                    var homeForSettings = stackView.find(function(item) { return item && item["navigationId"] === "home" })
-                    if (homeForSettings && typeof homeForSettings["saveFocusState"] === "function") homeForSettings["saveFocusState"]()
-                    // Navigate to settings screen
-                    pushSettingsScreen()
-                    break
-                case "updates":
-                    // Save focus state before navigating
-                    var homeForUpdates = stackView.find(function(item) { return item && item["navigationId"] === "home" })
-                    if (homeForUpdates && typeof homeForUpdates["saveFocusState"] === "function") homeForUpdates["saveFocusState"]()
-                    pushSettingsScreen({ focusUpdatesOnActivate: true })
-                    break
+        sourceComponent: Sidebar {
+            visible: !embeddedPlaybackActive
+            overlayMode: window.width < overlayThreshold
+            currentNavigation: "home"
+            mainContent: mainContentArea  // Connect to main content for focus navigation
+
+            onNavigationRequested: function(navigationId) {
+                playPointerSelectSound()
+                // Handle navigation requests
+                switch (navigationId) {
+                    case "home":
+                        // Save focus state before navigating
+                        var homeScreen = stackView.find(function(item) { return item && item["navigationId"] === "home" })
+                        if (homeScreen && typeof homeScreen["saveFocusState"] === "function") homeScreen["saveFocusState"]()
+                        // Pop back to home screen
+                        while (stackView.depth > 1) {
+                            stackView.pop()
+                        }
+                        break
+                    case "search":
+                        // Save focus state before navigating
+                        var homeForSearch = stackView.find(function(item) { return item && item["navigationId"] === "home" })
+                        if (homeForSearch && typeof homeForSearch["saveFocusState"] === "function") homeForSearch["saveFocusState"]()
+                        // Navigate to search screen
+                        pushSearchScreen()
+                        break
+                    case "settings":
+                        // Save focus state before navigating
+                        var homeForSettings = stackView.find(function(item) { return item && item["navigationId"] === "home" })
+                        if (homeForSettings && typeof homeForSettings["saveFocusState"] === "function") homeForSettings["saveFocusState"]()
+                        // Navigate to settings screen
+                        pushSettingsScreen()
+                        break
+                    case "updates":
+                        // Save focus state before navigating
+                        var homeForUpdates = stackView.find(function(item) { return item && item["navigationId"] === "home" })
+                        if (homeForUpdates && typeof homeForUpdates["saveFocusState"] === "function") homeForUpdates["saveFocusState"]()
+                        pushSettingsScreen({ focusUpdatesOnActivate: true })
+                        break
+                }
             }
-        }
 
-        onLibraryRequested: function(libraryId, libraryName) {
-            playPointerSelectSound()
-            if (!libraryId)
-                return
-            // Save focus state before navigating
-            var homeScreenForLibrary = stackView.find(function(item) { return item && item["navigationId"] === "home" })
-            if (homeScreenForLibrary && typeof homeScreenForLibrary["saveFocusState"] === "function") homeScreenForLibrary["saveFocusState"]()
-            stackView.push("LibraryScreen.qml", {
-                currentParentId: libraryId,
-                currentLibraryId: libraryId,
-                currentLibraryName: libraryName
-            })
-        }
-        
-        onSignOutRequested: {
-            // Trigger logout process
-            AuthenticationService.logout()
-        }
-        
-        onExitRequested: {
-            // Exit the application (saves config and quits)
-            ConfigManager.exitApplication()
+            onLibraryRequested: function(libraryId, libraryName) {
+                playPointerSelectSound()
+                if (!libraryId)
+                    return
+                // Save focus state before navigating
+                var homeScreenForLibrary = stackView.find(function(item) { return item && item["navigationId"] === "home" })
+                if (homeScreenForLibrary && typeof homeScreenForLibrary["saveFocusState"] === "function") homeScreenForLibrary["saveFocusState"]()
+                stackView.push("LibraryScreen.qml", {
+                    currentParentId: libraryId,
+                    currentLibraryId: libraryId,
+                    currentLibraryName: libraryName
+                })
+            }
+
+            onSignOutRequested: {
+                // Trigger logout process
+                AuthenticationService.logout()
+            }
+
+            onExitRequested: {
+                // Exit the application (saves config and quits)
+                ConfigManager.exitApplication()
+            }
         }
     }
     
@@ -509,11 +579,11 @@ Window {
     function updateSidebarNavigation() {
         var item = stackView.currentItem
         var navigationId = (item && item["navigationId"]) ? item["navigationId"] : "home"
-        sidebar.currentNavigation = navigationId
+        sidebarProxy.currentNavigation = navigationId
         if (navigationId && navigationId.indexOf("library:") === 0) {
-            sidebar.currentLibraryId = navigationId.substring("library:".length)
+            sidebarProxy.currentLibraryId = navigationId.substring("library:".length)
         } else {
-            sidebar.currentLibraryId = ""
+            sidebarProxy.currentLibraryId = ""
         }
     }
 
@@ -606,12 +676,12 @@ Window {
         target: UpdateService
         ignoreUnknownSignals: true
         function onStartupPopupRequested() {
-            if (!updateDialog.visible) {
-                updateDialog.open()
-                Qt.callLater(function() {
-                    updatePrimaryButton.forceActiveFocus()
-                })
+            if (!window.isLoggedIn && !AuthenticationService.authenticated) {
+                pendingStartupUpdatePopup = true
+                return
             }
+            pendingStartupUpdatePopup = false
+            openStartupUpdateDialog()
         }
     }
     
@@ -738,6 +808,15 @@ Window {
                 })
             }
             updateSidebarNavigation()
+
+            if (pendingStartupUpdatePopup) {
+                Qt.callLater(function() {
+                    if (window.isLoggedIn) {
+                        pendingStartupUpdatePopup = false
+                        openStartupUpdateDialog()
+                    }
+                })
+            }
         }
         
         function onLoggedOut() {
@@ -747,7 +826,7 @@ Window {
             window.isLoggedIn = false
             
             // Close sidebar if open
-            sidebar.close()
+            sidebarProxy.close()
             
             // Clear all screens and go back to login
             stackView.clear()
@@ -874,10 +953,10 @@ Window {
         sequences: ["Esc"]
         enabled: !PlayerController.isPlaybackActive
                  && stackView.depth > 1
-                 && !sidebar.expanded
+                 && !sidebarProxy.expanded
                  && !(stackView.currentItem && stackView.currentItem["handlesOwnBackNavigation"] === true)
         onActivated: {
-            console.log("[FocusDebug] Back shortcut activated, stackView.depth:", stackView.depth, "sidebar.expanded:", sidebar.expanded)
+            console.log("[FocusDebug] Back shortcut activated, stackView.depth:", stackView.depth, "sidebar.expanded:", sidebarProxy.expanded)
             if (stackView.depth > 1) {
                 if (InputModeManager.pointerActive) UiSoundController.playBack()
                 stackView.pop()
@@ -890,7 +969,7 @@ Window {
     Shortcut {
         sequence: "M"
         enabled: isLoggedIn
-        onActivated: sidebar.toggle()
+        onActivated: sidebarProxy.toggle()
     }
 
     Shortcut {

--- a/src/ui/MediaSourceSelectionDialog.qml
+++ b/src/ui/MediaSourceSelectionDialog.qml
@@ -98,14 +98,14 @@ FocusScope {
             var pointInContent = item.mapToItem(optionColumn, 0, 0)
             var itemTop = pointInContent.y
             var itemBottom = itemTop + item.height
-            var viewTop = flick.contentY
+            var viewTop = flick["contentY"]
             var viewBottom = viewTop + flick.height
 
             if (itemTop < viewTop) {
-                flick.contentY = Math.max(0, itemTop - Theme.spacingSmall)
+                flick["contentY"] = Math.max(0, itemTop - Theme.spacingSmall)
             } else if (itemBottom > viewBottom) {
-                var maxY = Math.max(0, flick.contentHeight - flick.height)
-                flick.contentY = Math.min(maxY, itemBottom - flick.height + Theme.spacingSmall)
+                var maxY = Math.max(0, flick["contentHeight"] - flick.height)
+                flick["contentY"] = Math.min(maxY, itemBottom - flick.height + Theme.spacingSmall)
             }
         }
 
@@ -130,13 +130,6 @@ FocusScope {
             if (initialItem) {
                 initialItem.forceActiveFocus()
                 ensureOptionVisible(initialItem)
-            }
-        }
-
-        Keys.onPressed: function(event) {
-            if (event.key === Qt.Key_Escape || event.key === Qt.Key_Back) {
-                closeWithoutSelection()
-                event.accepted = true
             }
         }
 
@@ -200,9 +193,16 @@ FocusScope {
             }
         }
 
-        contentItem: Item {
+        contentItem: FocusScope {
             implicitWidth: Math.round(680 * Theme.layoutScale)
             implicitHeight: Math.round(560 * Theme.layoutScale)
+
+            Keys.onPressed: function(event) {
+                if (event.key === Qt.Key_Escape || event.key === Qt.Key_Back) {
+                    dialog.closeWithoutSelection()
+                    event.accepted = true
+                }
+            }
 
             ScrollView {
                 id: contentScroll
@@ -217,12 +217,12 @@ FocusScope {
 
                     Repeater {
                         id: optionRepeater
-                        model: optionsModel
+                        model: dialog.optionsModel
 
                         delegate: Button {
                             id: optionButton
                             required property int index
-                            readonly property var optionData: optionsModel[index]
+                            readonly property var optionData: dialog.optionsModel[index]
                             readonly property bool selectedOption: !!(optionData && optionData.selected)
 
                             width: optionColumn.width

--- a/src/ui/MediaSourceSelectionDialog.qml
+++ b/src/ui/MediaSourceSelectionDialog.qml
@@ -155,6 +155,12 @@ FocusScope {
             }
         }
 
+        Shortcut {
+            sequences: ["Escape", "Back"]
+            enabled: dialog.visible
+            onActivated: dialog.closeWithoutSelection()
+        }
+
         background: Rectangle {
             color: Theme.cardBackground
             radius: Theme.radiusMedium
@@ -313,8 +319,15 @@ FocusScope {
             }
         }
 
-        footer: Item {
+        footer: FocusScope {
             implicitHeight: Math.round(64 * Theme.layoutScale)
+
+            Keys.onPressed: function(event) {
+                if (event.key === Qt.Key_Escape || event.key === Qt.Key_Back) {
+                    dialog.closeWithoutSelection()
+                    event.accepted = true
+                }
+            }
 
             RowLayout {
                 anchors.right: parent.right

--- a/src/ui/RetryButton.qml
+++ b/src/ui/RetryButton.qml
@@ -8,12 +8,12 @@ Column {
     property bool autoHide: true      // Hide unless hasError when true
     property string fallbackMessage: qsTr("Something went wrong")
     spacing: 8
-    visible: !autoHide || (target && target.hasError)
+    visible: !root.autoHide || (root.target && root.target.hasError)
 
     Label {
         id: messageLabel
-        visible: target && target.hasError
-        text: target && target.errorMessage ? target.errorMessage : fallbackMessage
+        visible: root.target && root.target.hasError
+        text: root.target && root.target.errorMessage ? root.target.errorMessage : root.fallbackMessage
         color: Theme.textMuted
         wrapMode: Text.WordWrap
         horizontalAlignment: Text.AlignHCenter
@@ -22,21 +22,20 @@ Column {
     Button {
         id: retryButton
         text: qsTr("Retry")
-        enabled: target && !target.isLoading
+        enabled: root.target && !root.target.isLoading
         onClicked: {
-            if (target && target.reload) {
-                target.reload()
+            if (root.target && root.target.reload) {
+                root.target.reload()
             }
         }
     }
 
     BusyIndicator {
         anchors.horizontalCenter: retryButton.horizontalCenter
-        running: target && target.isLoading
+        running: root.target && root.target.isLoading
         visible: running
     }
 }
-
 
 
 

--- a/src/ui/ScrollingCardLabel.qml
+++ b/src/ui/ScrollingCardLabel.qml
@@ -28,10 +28,6 @@ Item {
                 anchors.horizontalCenter: scrollingLabel.overflowWidth > 0 ? undefined : scrollingLabel.horizontalCenter
             }
 
-            PropertyChanges {
-                target: label
-                x: 0
-            }
         },
         State {
             name: "scrolling"
@@ -43,10 +39,6 @@ Item {
                 anchors.horizontalCenter: undefined
             }
 
-            PropertyChanges {
-                target: label
-                x: 0
-            }
         }
     ]
 
@@ -58,6 +50,7 @@ Item {
         font.weight: scrollingLabel.fontWeight
         color: scrollingLabel.textColor
         wrapMode: Text.NoWrap
+        x: 0
     }
 
     SequentialAnimation {

--- a/src/ui/SeasonView.qml
+++ b/src/ui/SeasonView.qml
@@ -333,13 +333,13 @@ FocusScope {
                     background: Rectangle {
                         radius: Theme.radiusLarge
                         color: {
-                            if (!parent.enabled) return Theme.buttonSecondaryBackground
-                            if (parent.down) return Theme.buttonPrimaryBackgroundPressed
-                            if (parent.hovered) return Theme.buttonPrimaryBackgroundHover
+                            if (!playButton.enabled) return Theme.buttonSecondaryBackground
+                            if (playButton.down) return Theme.buttonPrimaryBackgroundPressed
+                            if (playButton.hovered) return Theme.buttonPrimaryBackgroundHover
                             return Theme.buttonPrimaryBackground
                         }
-                        border.width: parent.activeFocus ? Theme.buttonFocusBorderWidth : Theme.buttonBorderWidth
-                        border.color: parent.activeFocus ? Theme.buttonPrimaryBorderFocused : Theme.buttonPrimaryBorder
+                        border.width: playButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.buttonBorderWidth
+                        border.color: playButton.activeFocus ? Theme.buttonPrimaryBorderFocused : Theme.buttonPrimaryBorder
                         
                         Behavior on color { ColorAnimation { duration: Theme.durationShort } }
                         Behavior on border.color { ColorAnimation { duration: Theme.durationShort } }
@@ -360,14 +360,14 @@ FocusScope {
                     background: Rectangle {
                         radius: Theme.radiusLarge
                         color: {
-                            if (parent.down) return Theme.buttonIconBackgroundPressed
-                            if (parent.hovered) return Theme.buttonIconBackgroundHover
+                            if (bookmarkButton.down) return Theme.buttonIconBackgroundPressed
+                            if (bookmarkButton.hovered) return Theme.buttonIconBackgroundHover
                             return Theme.buttonIconBackground
                         }
-                        border.width: parent.activeFocus ? Theme.buttonFocusBorderWidth : Theme.buttonBorderWidth
+                        border.width: bookmarkButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.buttonBorderWidth
                         border.color: {
-                            if (parent.activeFocus) return Theme.buttonIconBorderFocused
-                            if (parent.hovered) return Theme.buttonIconBorderHover
+                            if (bookmarkButton.activeFocus) return Theme.buttonIconBorderFocused
+                            if (bookmarkButton.hovered) return Theme.buttonIconBorderHover
                             return Theme.buttonIconBorder
                         }
                         
@@ -399,14 +399,14 @@ FocusScope {
                     background: Rectangle {
                         radius: Theme.radiusLarge
                         color: {
-                            if (parent.down) return Theme.buttonIconBackgroundPressed
-                            if (parent.hovered) return Theme.buttonIconBackgroundHover
+                            if (markWatchedButton.down) return Theme.buttonIconBackgroundPressed
+                            if (markWatchedButton.hovered) return Theme.buttonIconBackgroundHover
                             return Theme.buttonIconBackground
                         }
-                        border.width: parent.activeFocus ? Theme.buttonFocusBorderWidth : Theme.buttonBorderWidth
+                        border.width: markWatchedButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.buttonBorderWidth
                         border.color: {
-                            if (parent.activeFocus) return Theme.buttonIconBorderFocused
-                            if (parent.hovered) return Theme.buttonIconBorderHover
+                            if (markWatchedButton.activeFocus) return Theme.buttonIconBorderFocused
+                            if (markWatchedButton.hovered) return Theme.buttonIconBorderHover
                             return Theme.buttonIconBorder
                         }
                         
@@ -451,14 +451,14 @@ FocusScope {
                     background: Rectangle {
                         radius: Theme.radiusLarge
                         color: {
-                            if (parent.down) return Theme.buttonIconBackgroundPressed
-                            if (parent.hovered) return Theme.buttonIconBackgroundHover
+                            if (favoriteButton.down) return Theme.buttonIconBackgroundPressed
+                            if (favoriteButton.hovered) return Theme.buttonIconBackgroundHover
                             return Theme.buttonIconBackground
                         }
-                        border.width: parent.activeFocus ? Theme.buttonFocusBorderWidth : Theme.buttonBorderWidth
+                        border.width: favoriteButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.buttonBorderWidth
                         border.color: {
-                            if (parent.activeFocus) return Theme.buttonIconBorderFocused
-                            if (parent.hovered) return Theme.buttonIconBorderHover
+                            if (favoriteButton.activeFocus) return Theme.buttonIconBorderFocused
+                            if (favoriteButton.hovered) return Theme.buttonIconBorderHover
                             return Theme.buttonIconBorder
                         }
                         
@@ -491,14 +491,14 @@ FocusScope {
                     background: Rectangle {
                         radius: Theme.radiusLarge
                         color: {
-                            if (parent.down) return Theme.buttonIconBackgroundPressed
-                            if (parent.hovered) return Theme.buttonIconBackgroundHover
+                            if (moreButton.down) return Theme.buttonIconBackgroundPressed
+                            if (moreButton.hovered) return Theme.buttonIconBackgroundHover
                             return Theme.buttonIconBackground
                         }
-                        border.width: parent.activeFocus ? Theme.buttonFocusBorderWidth : Theme.buttonBorderWidth
+                        border.width: moreButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.buttonBorderWidth
                         border.color: {
-                            if (parent.activeFocus) return Theme.buttonIconBorderFocused
-                            if (parent.hovered) return Theme.buttonIconBorderHover
+                            if (moreButton.activeFocus) return Theme.buttonIconBorderFocused
+                            if (moreButton.hovered) return Theme.buttonIconBorderHover
                             return Theme.buttonIconBorder
                         }
                         
@@ -507,7 +507,7 @@ FocusScope {
                     }
                     
                     contentItem: Text {
-                        text: parent.text
+                        text: moreButton.text
                         font.pixelSize: 24
                         color: Theme.textPrimary
                         horizontalAlignment: Text.AlignHCenter

--- a/src/ui/SecondaryActionButton.qml
+++ b/src/ui/SecondaryActionButton.qml
@@ -44,11 +44,9 @@ Button {
         id: buttonContent
         implicitWidth: buttonInnerRow.implicitWidth
         implicitHeight: buttonInnerRow.implicitHeight
-        anchors.centerIn: parent
 
         RowLayout {
             id: buttonInnerRow
-            anchors.centerIn: parent
             spacing: Theme.spacingSmall
 
             Text {

--- a/src/ui/SeerrRequestDialog.qml
+++ b/src/ui/SeerrRequestDialog.qml
@@ -205,7 +205,7 @@ Dialog {
         for (var i = 0; i < seasonRepeater.count; ++i) {
             var item = seasonRepeater.itemAt(i)
             if (item) {
-                item.checked = selectedSeasons.indexOf(item.seasonNumber) >= 0
+                item.checked = selectedSeasons.indexOf(item["seasonNumber"]) >= 0
             }
         }
         syncingSeasonChecks = false
@@ -286,14 +286,14 @@ Dialog {
         var pointInContent = item.mapToItem(requestLayout, 0, 0)
         var itemTop = pointInContent.y
         var itemBottom = itemTop + item.height
-        var viewTop = flick.contentY
+        var viewTop = flick["contentY"]
         var viewBottom = viewTop + flick.height
 
         if (itemTop < viewTop) {
-            flick.contentY = Math.max(0, itemTop - Theme.spacingSmall)
+            flick["contentY"] = Math.max(0, itemTop - Theme.spacingSmall)
         } else if (itemBottom > viewBottom) {
-            var maxY = Math.max(0, flick.contentHeight - flick.height)
-            flick.contentY = Math.min(maxY, itemBottom - flick.height + Theme.spacingSmall)
+            var maxY = Math.max(0, flick["contentHeight"] - flick.height)
+            flick["contentY"] = Math.min(maxY, itemBottom - flick.height + Theme.spacingSmall)
         }
     }
 

--- a/src/ui/SettingsScreen.qml
+++ b/src/ui/SettingsScreen.qml
@@ -443,7 +443,7 @@ FocusScope {
                     onClicked: newProfileDialog.reject()
 
                     contentItem: Text {
-                        text: parent.text
+                        text: newProfileCancelBtn.text
                         font.pixelSize: Theme.fontSizeBody
                         font.family: Theme.fontPrimary
                         color: Theme.textSecondary
@@ -487,7 +487,7 @@ FocusScope {
                     onClicked: newProfileDialog.accept()
 
                     contentItem: Text {
-                        text: parent.text
+                        text: newProfileCreateBtn.text
                         font.pixelSize: Theme.fontSizeBody
                         font.family: Theme.fontPrimary
                         color: parent.enabled ? Theme.textPrimary : Theme.textDisabled
@@ -639,7 +639,7 @@ FocusScope {
                     onClicked: deleteProfileDialog.reject()
 
                     contentItem: Text {
-                        text: parent.text
+                        text: deleteDialogCancelBtn.text
                         font.pixelSize: Theme.fontSizeBody
                         font.family: Theme.fontPrimary
                         color: Theme.textSecondary
@@ -672,7 +672,7 @@ FocusScope {
                     onClicked: deleteProfileDialog.accept()
 
                     contentItem: Text {
-                        text: parent.text
+                        text: deleteDialogConfirmBtn.text
                         font.pixelSize: Theme.fontSizeBody
                         font.family: Theme.fontPrimary
                         color: "#ff6b6b"
@@ -844,7 +844,7 @@ FocusScope {
                                 KeyNavigation.down: accountSection.toggleButton
 
                                 contentItem: Text {
-                                    text: parent.text
+                                    text: expandAllButton.text
                                     font.pixelSize: Theme.fontSizeSmall
                                     font.family: Theme.fontPrimary
                                     color: Theme.textPrimary
@@ -874,7 +874,7 @@ FocusScope {
                                 KeyNavigation.down: accountSection.toggleButton
 
                                 contentItem: Text {
-                                    text: parent.text
+                                    text: collapseAllButton.text
                                     font.pixelSize: Theme.fontSizeSmall
                                     font.family: Theme.fontPrimary
                                     color: Theme.textPrimary
@@ -1196,8 +1196,6 @@ FocusScope {
 
                                         ScrollIndicator.vertical: ScrollIndicator { }
 
-                                        onCurrentIndexChanged: autoplayCountdownCombo.highlightedIndex = currentIndex
-
                                         onActiveFocusChanged: {
                                             if (activeFocus) {
                                                 InputModeManager.setNavigationMode("keyboard")
@@ -1452,8 +1450,6 @@ FocusScope {
 
                                         ScrollIndicator.vertical: ScrollIndicator { }
 
-                                        onCurrentIndexChanged: uiSoundsVolumeCombo.highlightedIndex = currentIndex
-
                                         Keys.onReturnPressed: {
                                             uiSoundsVolumeCombo.currentIndex = currentIndex
                                             uiSoundsVolumeCombo.popup.close()
@@ -1593,8 +1589,6 @@ FocusScope {
 
                                         ScrollIndicator.vertical: ScrollIndicator { }
 
-                                        onCurrentIndexChanged: themeSongVolumeCombo.highlightedIndex = currentIndex
-                                        
                                         Keys.onReturnPressed: { 
                                             themeSongVolumeCombo.currentIndex = currentIndex
                                             themeSongVolumeCombo.popup.close() 
@@ -1773,8 +1767,6 @@ FocusScope {
 
                                         ScrollIndicator.vertical: ScrollIndicator { }
 
-                                        onCurrentIndexChanged: themeCombo.highlightedIndex = currentIndex
-                                        
                                         Keys.onReturnPressed: { 
                                             themeCombo.currentIndex = currentIndex
                                             themeCombo.popup.close() 
@@ -2212,8 +2204,6 @@ FocusScope {
 
                                         ScrollIndicator.vertical: ScrollIndicator { }
 
-                                        onCurrentIndexChanged: defaultProfileCombo.highlightedIndex = currentIndex
-                                        
                                         Keys.onReturnPressed: { 
                                             defaultProfileCombo.currentIndex = currentIndex
                                             defaultProfileCombo.popup.close() 
@@ -2426,8 +2416,6 @@ FocusScope {
                                                 : editProfileCombo.currentIndex
 
                                             ScrollIndicator.vertical: ScrollIndicator { }
-                                            onCurrentIndexChanged: editProfileCombo.highlightedIndex = currentIndex
-
                                             Keys.onReturnPressed: {
                                                 editProfileCombo.currentIndex = currentIndex
                                                 editProfileCombo.popup.close()
@@ -2465,7 +2453,7 @@ FocusScope {
                                     Keys.onRightPressed: duplicateProfileBtn.forceActiveFocus()
                                     
                                     contentItem: Text {
-                                        text: parent.text
+                                        text: newProfileBtn.text
                                         font.pixelSize: Theme.fontSizeSmall
                                         font.family: Theme.fontPrimary
                                         color: Theme.accentPrimary
@@ -2538,7 +2526,7 @@ FocusScope {
                                     }
 
                                     contentItem: Text {
-                                        text: parent.text
+                                        text: duplicateProfileBtn.text
                                         font.pixelSize: Theme.fontSizeSmall
                                         font.family: Theme.fontPrimary
                                         color: duplicateProfileBtn.enabled ? Theme.accentPrimary : Theme.textDisabled
@@ -2593,7 +2581,7 @@ FocusScope {
                                     }
 
                                     contentItem: Text {
-                                        text: parent.text
+                                        text: deleteProfileBtn.text
                                         font.pixelSize: Theme.fontSizeSmall
                                         font.family: Theme.fontPrimary
                                         color: deleteProfileBtn.enabled ? "#ff8c8c" : Theme.textDisabled
@@ -3937,11 +3925,15 @@ FocusScope {
         property int stepSize: 1
         property string unit: ""
         
-        Accessible.role: Accessible.SpinButton
+        Accessible.role: Accessible.SpinBox
         Accessible.name: label
         Accessible.description: description
         
         signal spinBoxValueChanged(int newValue)
+
+        function formatSpinBoxValue(value) {
+            return value + (spinBoxRow.unit ? " " + spinBoxRow.unit : "")
+        }
         
         implicitHeight: spinBoxContent.implicitHeight
         
@@ -4006,10 +3998,6 @@ FocusScope {
                         spinBoxRow.spinBoxValueChanged(value)
                     }
                     
-                    textFromValue: function(value, locale) {
-                        return value + (spinBoxRow.unit ? " " + spinBoxRow.unit : "")
-                    }
-
                     valueFromText: function(text, locale) {
                         var cleanText = text
                         if (spinBoxRow.unit) {
@@ -4020,7 +4008,7 @@ FocusScope {
                     
                     contentItem: TextInput {
                         z: 2
-                        text: spinBox.textFromValue(spinBox.value, spinBox.locale)
+                        text: spinBoxRow.formatSpinBoxValue(spinBox.value)
                         font.pixelSize: Theme.fontSizeBody
                         font.family: Theme.fontPrimary
                         color: Theme.textPrimary

--- a/src/ui/Theme.qml
+++ b/src/ui/Theme.qml
@@ -120,14 +120,17 @@ QtObject {
     property color accentSecondary: activeTheme.accentSecondary
     property color accentGradientStart: activeTheme.accentGradientStart
     property color accentGradientEnd: activeTheme.accentGradientEnd
+    property color accentColor: accentPrimary
 
     // Text colors
     property color textPrimary: activeTheme.textPrimary
     property color textSecondary: activeTheme.textSecondary
     property color textDisabled: activeTheme.textDisabled
+    property color textMuted: textSecondary
     property color chipBackground: activeTheme.chipBackground
     property color chipBorder: activeTheme.chipBorder
     property color textOnAccent: "#191724"  // Dark text for use on accent-colored backgrounds
+    property color errorColor: "#ff6b6b"
     
     // Overlays & Gradients
     property color overlayDark: "#60000000"
@@ -205,6 +208,9 @@ QtObject {
     property int fontSizeSmall: Math.round(fontSizeSmallBase * layoutScale)
     property int fontSizeCaption: Math.round(fontSizeCaptionBase * layoutScale)
     property int fontSizeMedium: Math.round(fontSizeMediumBase * layoutScale)
+    property int iconSizeSmall: fontSizeSmall
+    property int iconSizeMedium: fontSizeIcon
+    property int iconSizeLarge: fontSizeMedium
     
     // ============================
     // Responsive Spacing
@@ -221,6 +227,8 @@ QtObject {
     property int spacingMedium: Math.round(spacingMediumBase * layoutScale)
     property int spacingLarge: Math.round(spacingLargeBase * layoutScale)
     property int spacingXLarge: Math.round(spacingXLargeBase * layoutScale)
+    property int spacingXSmall: Math.max(4, Math.round(spacingSmall * 0.5))
+    property int spacingLg: spacingLarge
     property int paddingLarge: Math.round(paddingLargeBase * layoutScale)
     
     // ============================
@@ -328,6 +336,7 @@ QtObject {
     // Animation durations are fixed (not scaled) for consistent feel
     property int durationShort: uiAnimationsEnabled ? 150 : 0
     property int durationNormal: uiAnimationsEnabled ? 200 : 0
+    property int durationMedium: durationNormal
     property int durationLong: uiAnimationsEnabled ? 300 : 0
     property int durationFade: uiAnimationsEnabled ? 500 : 0
     

--- a/src/ui/TrackSelector.qml
+++ b/src/ui/TrackSelector.qml
@@ -186,14 +186,14 @@ FocusScope {
             background: Rectangle {
                 radius: Theme.radiusSmall
                 color: {
-                    if (parent.down) return Theme.buttonSecondaryBackgroundPressed
-                    if (parent.hovered || popup.visible) return Theme.buttonSecondaryBackgroundHover
+                    if (selectorButton.down) return Theme.buttonSecondaryBackgroundPressed
+                    if (selectorButton.hovered || popup.visible) return Theme.buttonSecondaryBackgroundHover
                     return Theme.buttonSecondaryBackground
                 }
-                border.width: parent.activeFocus ? Theme.buttonFocusBorderWidth : Theme.buttonBorderWidth
+                border.width: selectorButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.buttonBorderWidth
                 border.color: {
-                    if (parent.activeFocus) return Theme.buttonSecondaryBorderFocused
-                    if (parent.hovered) return Theme.buttonSecondaryBorderHover
+                    if (selectorButton.activeFocus) return Theme.buttonSecondaryBorderFocused
+                    if (selectorButton.hovered) return Theme.buttonSecondaryBorderHover
                     return Theme.buttonSecondaryBorder
                 }
                 

--- a/src/ui/VideoSurface.qml
+++ b/src/ui/VideoSurface.qml
@@ -21,42 +21,50 @@ Item {
         }
     }
 
-    MpvVideoItem {
-        id: videoTarget
-        anchors {
-            right: parent.right
-            bottom: parent.bottom
-            rightMargin: root.shrinkEnabled ? Theme.spacingLarge : 0
-            bottomMargin: root.shrinkEnabled ? Theme.spacingLarge : 0
-        }
-        width: root.shrinkEnabled ? parent.width * 0.72 : parent.width
-        height: root.shrinkEnabled ? (parent.height * 0.72) : parent.height
+    Loader {
+        id: videoTargetLoader
+        anchors.fill: parent
+        active: root.visible
 
-        onViewportChanged: function(x, y, width, height) {
-            PlayerController.setEmbeddedVideoViewport(x, y, width, height)
-        }
+        sourceComponent: Component {
+            MpvVideoItem {
+                id: videoTarget
+                anchors {
+                    right: parent.right
+                    bottom: parent.bottom
+                    rightMargin: root.shrinkEnabled ? Theme.spacingLarge : 0
+                    bottomMargin: root.shrinkEnabled ? Theme.spacingLarge : 0
+                }
+                width: root.shrinkEnabled ? parent.width * 0.72 : parent.width
+                height: root.shrinkEnabled ? (parent.height * 0.72) : parent.height
 
-        function syncEmbeddedViewport() {
-            if (width > 0 && height > 0) {
-                var topLeft = videoTarget.mapToItem(null, 0, 0)
-                PlayerController.setEmbeddedVideoViewport(topLeft.x, topLeft.y, width, height)
+                onViewportChanged: function(x, y, width, height) {
+                    PlayerController.setEmbeddedVideoViewport(x, y, width, height)
+                }
+
+                function syncEmbeddedViewport() {
+                    if (width > 0 && height > 0) {
+                        var topLeft = videoTarget.mapToItem(null, 0, 0)
+                        PlayerController.setEmbeddedVideoViewport(topLeft.x, topLeft.y, width, height)
+                    }
+                }
+
+                onWidthChanged: syncEmbeddedViewport()
+                onHeightChanged: syncEmbeddedViewport()
+
+                Component.onCompleted: {
+                    PlayerController.attachEmbeddedVideoTarget(videoTarget)
+                    if (width > 0 && height > 0) {
+                        syncEmbeddedViewport()
+                    } else {
+                        Qt.callLater(syncEmbeddedViewport)
+                    }
+                }
+
+                Component.onDestruction: {
+                    PlayerController.detachEmbeddedVideoTarget(videoTarget)
+                }
             }
-        }
-
-        onWidthChanged: syncEmbeddedViewport()
-        onHeightChanged: syncEmbeddedViewport()
-
-        Component.onCompleted: {
-            PlayerController.attachEmbeddedVideoTarget(videoTarget)
-            if (width > 0 && height > 0) {
-                syncEmbeddedViewport()
-            } else {
-                Qt.callLater(syncEmbeddedViewport)
-            }
-        }
-
-        Component.onDestruction: {
-            PlayerController.detachEmbeddedVideoTarget(videoTarget)
         }
     }
 }

--- a/src/ui/VideoSurface.qml
+++ b/src/ui/VideoSurface.qml
@@ -26,11 +26,11 @@ Item {
         anchors {
             right: parent.right
             bottom: parent.bottom
-            rightMargin: shrinkEnabled ? Theme.spacingLg : 0
-            bottomMargin: shrinkEnabled ? Theme.spacingLg : 0
+            rightMargin: root.shrinkEnabled ? Theme.spacingLarge : 0
+            bottomMargin: root.shrinkEnabled ? Theme.spacingLarge : 0
         }
-        width: shrinkEnabled ? parent.width * 0.72 : parent.width
-        height: shrinkEnabled ? (parent.height * 0.72) : parent.height
+        width: root.shrinkEnabled ? parent.width * 0.72 : parent.width
+        height: root.shrinkEnabled ? (parent.height * 0.72) : parent.height
 
         onViewportChanged: function(x, y, width, height) {
             PlayerController.setEmbeddedVideoViewport(x, y, width, height)


### PR DESCRIPTION
## Summary
- keep the `qmllint` build surfacing and reduce a broad set of concrete QML runtime/property warnings
- merge the startup hotfix so heavyweight QML objects are lazy-loaded instead of being instantiated during app bootstrap
- fix `MediaSourceSelectionDialog` runtime errors and defer the embedded video target until it is visible

## Root Cause
The warning cleanup exposed and fixed several real QML compatibility issues, but the Linux startup regression turned out to be broader than the updater dialog footer alone. Startup was still eagerly constructing sidebar/dialog/video paths before the unauthenticated login screen had finished mapping.

On Linux, that prevented the window from appearing reliably. On Windows, the same pattern could present as a black startup surface with a white dialog rectangle.

## Verification
- `./scripts/build-docker.sh`
- short Linux launch probe with `./build-docker/src/Bloom`
- compositor check confirmed a mapped Bloom window under Niri during startup

## Notes
- This PR now includes the startup fix that had temporarily lived on `fix/defer-startup-update-popup`.
- There is still a broader `qmllint` backlog, mostly `unqualified` warnings plus some generic-object access patterns in larger screens such as `LibraryScreen.qml`, `Main.qml`, `Sidebar.qml`, and `MpvProfileEditor.qml`. Those look like follow-up cleanup/refactor work rather than one-line compatibility fixes.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix QML runtime warnings by hardening property access and lazy-loading components
> - Converts `MediaSourceSelectionDialog` and the update dialog in [Main.qml](https://github.com/crowquillx/Bloom/pull/29/files#diff-f4773d055809f8f8ae1877220a16747bc781215089a7b6b7eb33e5b444a27be5) to lazy-loaded `Loader`-based components, with the update dialog deferred until after login.
> - Wraps the `Sidebar` in a `Loader` and routes all sidebar interactions through a proxy/stub to prevent null-access warnings when the user is not logged in.
> - Replaces `parent.*` property references with explicit element IDs in [SeasonView.qml](https://github.com/crowquillx/Bloom/pull/29/files#diff-51df280062136365242f1e4a2255a06b068de9209d1f8a836101ecb65eddbb70) and [TrackSelector.qml](https://github.com/crowquillx/Bloom/pull/29/files#diff-df56f3be05bae142c0e78c1dc2c9e72cc627916407ad07d76af5ee10b03f07d5), and uses bracketed property lookups across several components to avoid scope resolution warnings.
> - Adds an `activated` signal to [A11yButton.qml](https://github.com/crowquillx/Bloom/pull/29/files#diff-ff919d05296e11cc618c06bae114900515a7d8e813259c29281f1540081736c8) triggered by mouse click and non-auto-repeated Return/Enter/Space keypresses, enabling keyboard activation paths.
> - Wraps `MpvVideoItem` in a visibility-gated `Loader` in [VideoSurface.qml](https://github.com/crowquillx/Bloom/pull/29/files#diff-1d1ee913b84f78f62c3ba659488fbd26734b657e5a83370c497dcaa24c4cea10), destroying the video item when hidden.
> - Behavioral Change: the update dialog no longer opens before login; requests are queued and shown after authentication.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 851c046.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tooltip support and keyboard activation for accessible buttons
  * Extended theme with new colors, spacing and icon size aliases

* **Bug Fixes**
  * Improved lazy-loading for dialogs and media components to reduce startup cost
  * Fixed focus/restore and list-navigation issues in home and recently-added sections
  * Ensured dialogs close via Escape/Back consistently

* **Style & Layout**
  * Refined button visuals, sizing and responsive spacing across screens

* **Accessibility**
  * Adjusted roles and focus behavior for better keyboard/assistive support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->