### PR TITLE
fix: harden Windows embedded playback stop teardown

### DIFF
--- a/docs/playback.md
+++ b/docs/playback.md
@@ -38,6 +38,9 @@ Windows embedded overlay layering model
 - Playback controls are rendered in a separate transparent QML overlay window that tracks the main window geometry and sits above video.
 - UX contract: showing/hiding controls must not resize, shift, or clip the video viewport.
 - Credits/next-up shrink mode remains a separate feature path and must continue to work independently of normal full-frame overlay behavior.
+- Terminal playback transitions are backend-first: Bloom now waits for backend stop confirmation before changing `PlayerController` into `Idle`/`Error`, so embedded host-window teardown cannot race ahead of libmpv shutdown.
+- Windows display restoration after playback stop is deferred and non-blocking. HDR-off settle and refresh-rate restore are scheduled after the UI returns to `Idle`, allowing the main scene and detached playback overlay window to repaint/hide promptly.
+- Natural playback end, explicit stop, and error-triggered shutdown now share one coordinated terminal-transition path so reporting/autoplay work runs once per playback attempt.
 
 Reference implementation notes (Plezy)
 - External reference: https://github.com/edde746/plezy

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -311,6 +311,8 @@ PlayerController::~PlayerController()
     m_volumePersistTimer->stop();
     m_startDelayTimer->stop();
     m_autoplayPlaybackInfoTimeoutTimer->stop();
+    cancelPendingDisplayRestore();
+    resetTerminalTransitionState(true);
 }
 
 void PlayerController::connectBackendSignals(IPlayerBackend *backend)
@@ -560,50 +562,29 @@ void PlayerController::onExitErrorState()
 
 void PlayerController::onEnterIdleState()
 {
+    const bool needsHdrRestore = m_displayManager != nullptr && m_displayManager->needsHdrRestore();
+    const bool needsRefreshRestore = m_displayManager != nullptr && m_displayManager->needsRefreshRestore();
+
     qCInfo(lcPlayback) << "Entering Idle state (playback ended)";
     qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                             << "] enter-idle"
                             << "itemId=" << m_currentItemId
                             << "contentIsHDR=" << m_contentIsHDR
                             << "contentFramerate=" << m_contentFramerate;
-    
-    // Stop all timers
+
+    enterIdleStateImmediate();
+    startDeferredDisplayRestore(needsHdrRestore, needsRefreshRestore);
+}
+
+void PlayerController::enterIdleStateImmediate()
+{
     m_loadingTimeoutTimer->stop();
     m_bufferingTimeoutTimer->stop();
     m_progressReportTimer->stop();
     m_startDelayTimer->stop();
-    
-    // Emit playbackStopped so UI can refresh watch progress, next up, etc.
-    emit playbackStopped();
-    
-    // Restore display settings
-    if (m_displayManager) {
-        // If we enabled HDR for this content, disable it first.
-        // Some setups cannot apply higher refresh rates while HDR is active.
-        bool hdrDisabledForRestore = false;
-        if (m_config->getEnableHDR() && m_contentIsHDR) {
-            qDebug() << "PlayerController: Restoring HDR to off after HDR content playback";
-            qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
-                                    << "] restore-display: setHDR(false) begin";
-            hdrDisabledForRestore = m_displayManager->setHDR(false);
-            qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
-                                    << "] restore-display: setHDR(false) result=" << hdrDisabledForRestore;
-        }
 
-        if (hdrDisabledForRestore) {
-            static constexpr unsigned long kHdrOffSettleDelayMs = 300;
-            qDebug() << "PlayerController: Waiting" << kHdrOffSettleDelayMs
-                     << "ms after HDR-off before refresh restore";
-            QThread::msleep(kHdrOffSettleDelayMs);
-        }
-        qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
-                                << "] restore-display: restoreRefreshRate begin";
-        m_displayManager->restoreRefreshRate();
-        qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
-                                << "] restore-display: restoreRefreshRate done";
-    }
-    
-    // Clear playback state
+    emit playbackStopped();
+
     if (!m_currentItemId.isEmpty()) {
         m_currentItemId.clear();
         emit currentItemIdChanged();
@@ -666,8 +647,7 @@ void PlayerController::onEnterIdleState()
     emit timelineChanged();
     emit skipSegmentsChanged();
     emit trickplayStateChanged();
-    
-    // Clear trickplay processor data
+
     m_trickplayProcessor->clear();
 }
 
@@ -827,11 +807,7 @@ void PlayerController::onEnterErrorState()
     m_loadingTimeoutTimer->stop();
     m_bufferingTimeoutTimer->stop();
     m_progressReportTimer->stop();
-    
-    // Stop mpv if running
-    if (m_playerBackend->isRunning()) {
-        m_playerBackend->stopMpv();
-    }
+
     clearPendingAutoplayContext();
     clearNextEpisodePrefetchState();
 }
@@ -842,14 +818,14 @@ void PlayerController::onLoadingTimeout()
 {
     qDebug() << "PlayerController: Loading timeout";
     setErrorMessage(tr("Loading timed out. Please check your connection and try again."));
-    processEvent(Event::ErrorOccurred);
+    requestTerminalTransition(TerminalReason::Error);
 }
 
 void PlayerController::onBufferingTimeout()
 {
     qDebug() << "PlayerController: Buffering timeout";
     setErrorMessage(tr("Buffering timed out. Network may be too slow."));
-    processEvent(Event::ErrorOccurred);
+    requestTerminalTransition(TerminalReason::Error);
 }
 
 /**
@@ -875,10 +851,27 @@ void PlayerController::onProcessStateChanged(bool running)
         m_pendingPlaylistAppendUrls.clear();
     }
 
-    if (!running && m_playbackState != Idle && m_playbackState != Error) {
-        // Process stopped unexpectedly (e.g., mpv quit via 'q' or crash)
-        // Treat this like an explicit stop so we report progress and consider autoplay.
-        handlePlaybackStopAndAutoplay(Event::Stop);
+    if (!running) {
+        qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                << "] backend-stopped-confirmed"
+                                << "terminalActive=" << m_terminalTransitionActive
+                                << "backendStopRequested=" << m_backendStopRequested;
+
+        if (m_suppressBackendStopHandling) {
+            qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                    << "] backend-stop ignored during replacement playback";
+            return;
+        }
+
+        if (m_terminalTransitionActive) {
+            m_backendStopRequested = true;
+            queueTerminalFinalization();
+            return;
+        }
+
+        if (m_playbackState != Idle && m_playbackState != Error) {
+            requestTerminalTransition(TerminalReason::Stop);
+        }
     }
 }
 
@@ -895,7 +888,7 @@ void PlayerController::onProcessError(const QString &error)
     }
 
     setErrorMessage(error);
-    processEvent(Event::ErrorOccurred);
+    requestTerminalTransition(TerminalReason::Error);
 }
 
 /**
@@ -1032,8 +1025,8 @@ void PlayerController::onPlaybackEnded()
                             << "] playback-ended"
                             << "position=" << m_currentPosition
                             << "duration=" << m_duration;
-    
-    handlePlaybackStopAndAutoplay(Event::PlaybackEnd);
+
+    requestTerminalTransition(TerminalReason::PlaybackEnd);
 }
 
 void PlayerController::onPlaylistPositionChanged(int index)
@@ -1065,36 +1058,303 @@ void PlayerController::onPlaylistPositionChanged(int index)
  *
  * @param stopEvent Event value representing how playback ended (e.g., Stop, PlaybackEnd) to be processed.
  */
-void PlayerController::handlePlaybackStopAndAutoplay(Event stopEvent)
+void PlayerController::prepareTerminalTransition(TerminalReason reason)
 {
+    if (m_terminalTransitionActive) {
+        updatePendingTerminalReason(reason);
+        return;
+    }
+
+    m_terminalTransitionActive = true;
+    m_backendStopRequested = false;
+    m_terminalFinalizationQueued = false;
+    m_terminalPrefetchedReady = false;
+    ++m_terminalTransitionGeneration;
+    m_pendingTerminalReason = reason;
+
     reportPlaybackStop();
 
-    bool thresholdMet = checkCompletionThresholdAndAutoplay();
-    bool prefetchedReady = false;
-
-    // If threshold met for an episode, request next episode directly.
-    if (thresholdMet && !m_currentSeriesId.isEmpty()) {
-        m_shouldAutoplay = true;
-        m_waitingForNextEpisodeAtPlaybackEnd = true;
-        stashPendingAutoplayContext();
-        prefetchedReady = hasUsablePrefetchedNextEpisode();
-        if (!prefetchedReady) {
-            m_libraryService->getNextUnplayedEpisode(m_pendingAutoplaySeriesId,
-                                                     m_pendingAutoplayItemId,
-                                                     expectedAutoplayResolutionRequestContext());
+    if (reason != TerminalReason::Error) {
+        const bool thresholdMet = checkCompletionThresholdAndAutoplay();
+        if (thresholdMet && !m_currentSeriesId.isEmpty()) {
+            m_shouldAutoplay = true;
+            m_waitingForNextEpisodeAtPlaybackEnd = true;
+            stashPendingAutoplayContext();
+            m_terminalPrefetchedReady = hasUsablePrefetchedNextEpisode();
+            if (!m_terminalPrefetchedReady) {
+                m_libraryService->getNextUnplayedEpisode(m_pendingAutoplaySeriesId,
+                                                         m_pendingAutoplayItemId,
+                                                         expectedAutoplayResolutionRequestContext());
+            }
+            qDebug() << "PlayerController: Threshold met, requesting next episode for autoplay";
+        } else {
+            clearPendingAutoplayContext();
+            clearNextEpisodePrefetchState();
+            m_shouldAutoplay = false;
         }
-        qDebug() << "PlayerController: Threshold met, requesting next episode for autoplay";
     } else {
         clearPendingAutoplayContext();
         clearNextEpisodePrefetchState();
         m_shouldAutoplay = false;
     }
 
-    processEvent(stopEvent);
+    qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                            << "] terminal-transition prepared"
+                            << "reason=" << static_cast<int>(m_pendingTerminalReason)
+                            << "prefetchedReady=" << m_terminalPrefetchedReady
+                            << "backendRunning=" << (m_playerBackend && m_playerBackend->isRunning());
+}
 
-    if (prefetchedReady) {
+void PlayerController::requestTerminalTransition(TerminalReason reason)
+{
+    if (reason == TerminalReason::Error && m_playbackState == Error && !m_terminalTransitionActive) {
+        return;
+    }
+
+    prepareTerminalTransition(reason);
+
+    if (m_backendStopRequested) {
+        if (!m_playerBackend || !m_playerBackend->isRunning()) {
+            queueTerminalFinalization();
+        }
+        return;
+    }
+
+    m_backendStopRequested = true;
+    qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                            << "] backend-stop requested"
+                            << "reason=" << static_cast<int>(m_pendingTerminalReason);
+
+    if (m_playerBackend && m_playerBackend->isRunning()) {
+        m_playerBackend->stopMpv();
+        if (!m_playerBackend->isRunning()) {
+            queueTerminalFinalization();
+        }
+        return;
+    }
+
+    queueTerminalFinalization();
+}
+
+void PlayerController::queueTerminalFinalization()
+{
+    if (!m_terminalTransitionActive || m_terminalFinalizationQueued) {
+        return;
+    }
+
+    m_terminalFinalizationQueued = true;
+    const quint64 generation = m_terminalTransitionGeneration;
+    QMetaObject::invokeMethod(this,
+                              [this, generation]() {
+                                  if (!m_terminalTransitionActive
+                                      || generation != m_terminalTransitionGeneration) {
+                                      return;
+                                  }
+                                  finalizeTerminalTransition();
+                              },
+                              Qt::QueuedConnection);
+}
+
+void PlayerController::finalizeTerminalTransition()
+{
+    if (!m_terminalTransitionActive) {
+        return;
+    }
+
+    const TerminalReason reason = m_pendingTerminalReason;
+    const bool prefetchedReady = m_terminalPrefetchedReady;
+
+    qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                            << "] terminal-transition finalized"
+                            << "reason=" << static_cast<int>(reason)
+                            << "prefetchedReady=" << prefetchedReady
+                            << "state=" << stateToString(m_playbackState);
+
+    resetTerminalTransitionState();
+    processEvent(eventForTerminalReason(reason));
+
+    if (prefetchedReady && reason != TerminalReason::Error) {
         consumePrefetchedNextEpisodeAndNavigate();
     }
+}
+
+void PlayerController::resetTerminalTransitionState(bool invalidateQueuedWork)
+{
+    if (invalidateQueuedWork) {
+        ++m_terminalTransitionGeneration;
+    }
+    m_terminalTransitionActive = false;
+    m_backendStopRequested = false;
+    m_terminalFinalizationQueued = false;
+    m_terminalPrefetchedReady = false;
+}
+
+void PlayerController::updatePendingTerminalReason(TerminalReason reason)
+{
+    if (!m_terminalTransitionActive
+        || terminalReasonPriority(reason) <= terminalReasonPriority(m_pendingTerminalReason)) {
+        return;
+    }
+
+    qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                            << "] terminal-transition reason upgraded"
+                            << "from=" << static_cast<int>(m_pendingTerminalReason)
+                            << "to=" << static_cast<int>(reason);
+    m_pendingTerminalReason = reason;
+}
+
+PlayerController::Event PlayerController::eventForTerminalReason(TerminalReason reason) const
+{
+    switch (reason) {
+    case TerminalReason::PlaybackEnd:
+        return Event::PlaybackEnd;
+    case TerminalReason::Error:
+        return Event::ErrorOccurred;
+    case TerminalReason::Stop:
+    default:
+        return Event::Stop;
+    }
+}
+
+int PlayerController::terminalReasonPriority(TerminalReason reason)
+{
+    switch (reason) {
+    case TerminalReason::Error:
+        return 3;
+    case TerminalReason::PlaybackEnd:
+        return 2;
+    case TerminalReason::Stop:
+    default:
+        return 1;
+    }
+}
+
+void PlayerController::handlePlaybackStopAndAutoplay(Event stopEvent)
+{
+    TerminalReason reason = TerminalReason::Stop;
+    if (stopEvent == Event::PlaybackEnd) {
+        reason = TerminalReason::PlaybackEnd;
+    } else if (stopEvent == Event::ErrorOccurred) {
+        reason = TerminalReason::Error;
+    }
+
+    prepareTerminalTransition(reason);
+    finalizeTerminalTransition();
+}
+
+void PlayerController::startDeferredDisplayRestore(bool needsHdrRestore, bool needsRefreshRestore)
+{
+    cancelPendingDisplayRestore();
+
+    if (!needsHdrRestore && !needsRefreshRestore) {
+        return;
+    }
+
+    const quint64 generation = m_displayRestoreGeneration;
+    qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                            << "] deferred-display-restore queued"
+                            << "generation=" << generation
+                            << "needsHdrRestore=" << needsHdrRestore
+                            << "needsRefreshRestore=" << needsRefreshRestore;
+
+    QMetaObject::invokeMethod(this,
+                              [this, generation, needsHdrRestore, needsRefreshRestore]() {
+                                  if (generation != m_displayRestoreGeneration) {
+                                      qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                                              << "] deferred-display-restore canceled before start"
+                                                              << "generation=" << generation;
+                                      return;
+                                  }
+
+                                  qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                                          << "] deferred-display-restore begin"
+                                                          << "generation=" << generation
+                                                          << "needsHdrRestore=" << needsHdrRestore
+                                                          << "needsRefreshRestore=" << needsRefreshRestore;
+
+                                  if (needsHdrRestore && m_displayManager != nullptr) {
+                                      m_hdrRestoreFinishedConnection = connect(m_displayManager,
+                                                                               &DisplayManager::hdrChangeFinished,
+                                                                               this,
+                                                                               [this, generation, needsRefreshRestore](bool enabled, bool success) {
+                                                                                   if (enabled || generation != m_displayRestoreGeneration) {
+                                                                                       return;
+                                                                                   }
+                                                                                   if (m_hdrRestoreFinishedConnection) {
+                                                                                       disconnect(m_hdrRestoreFinishedConnection);
+                                                                                       m_hdrRestoreFinishedConnection = QMetaObject::Connection();
+                                                                                   }
+
+                                                                                   qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                                                                                           << "] deferred-display-restore hdr-finished"
+                                                                                                           << "generation=" << generation
+                                                                                                           << "success=" << success;
+
+                                                                                   if (needsRefreshRestore) {
+                                                                                       scheduleDeferredRefreshRestore(generation, success ? 300 : 0);
+                                                                                   }
+                                                                               });
+                                      m_displayManager->setHDRAsync(false);
+                                      return;
+                                  }
+
+                                  if (needsRefreshRestore) {
+                                      scheduleDeferredRefreshRestore(generation, 0);
+                                  }
+                              },
+                              Qt::QueuedConnection);
+}
+
+void PlayerController::scheduleDeferredRefreshRestore(quint64 generation, int delayMs)
+{
+    if (m_displayManager == nullptr) {
+        return;
+    }
+
+    QTimer::singleShot(delayMs,
+                       this,
+                       [this, generation]() {
+                           if (generation != m_displayRestoreGeneration || m_displayManager == nullptr) {
+                               qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                                       << "] deferred-display-restore refresh canceled"
+                                                       << "generation=" << generation;
+                               return;
+                           }
+
+                           qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                                   << "] deferred-display-restore refresh begin"
+                                                   << "generation=" << generation;
+                           m_displayManager->restoreRefreshRate();
+                           qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                                   << "] deferred-display-restore refresh done"
+                                                   << "generation=" << generation;
+                       });
+}
+
+void PlayerController::cancelPendingDisplayRestore()
+{
+    qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                            << "] deferred-display-restore cancel"
+                            << "generation=" << (m_displayRestoreGeneration + 1);
+    ++m_displayRestoreGeneration;
+    if (m_hdrRestoreFinishedConnection) {
+        disconnect(m_hdrRestoreFinishedConnection);
+        m_hdrRestoreFinishedConnection = QMetaObject::Connection();
+    }
+    if (m_displayManager != nullptr) {
+        m_displayManager->cancelPendingHdrAsync();
+    }
+}
+
+void PlayerController::cancelPendingTerminalTransition()
+{
+    if (!m_terminalTransitionActive && !m_terminalFinalizationQueued) {
+        return;
+    }
+
+    qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                            << "] terminal-transition canceled";
+    resetTerminalTransitionState(true);
 }
 
 /**
@@ -2219,6 +2479,8 @@ void PlayerController::setEmbeddedVideoShrinkEnabled(bool enabled)
  */
 void PlayerController::playTestVideo()
 {
+    cancelPendingTerminalTransition();
+    cancelPendingDisplayRestore();
     clearPendingAutoplayContext();
     clearNextEpisodePrefetchState();
     clearPlaybackSegments();
@@ -2232,7 +2494,9 @@ void PlayerController::playTestVideo()
     
     if (m_playerBackend->isRunning()) {
         reportPlaybackStop();
+        m_suppressBackendStopHandling = true;
         m_playerBackend->stopMpv();
+        m_suppressBackendStopHandling = false;
     }
     
     processEvent(Event::Play);
@@ -2258,6 +2522,8 @@ void PlayerController::playTestVideo()
  */
 void PlayerController::playUrl(const QString &url, const QString &itemId, qint64 startPositionTicks, const QString &seriesId, const QString &seasonId, const QString &libraryId, double framerate, bool isHDR)
 {
+    cancelPendingTerminalTransition();
+    cancelPendingDisplayRestore();
     m_playbackAttemptId = ++gPlaybackAttemptCounter;
     m_reportProgressOnNextPositionUpdate = false;
     qDebug() << "PlayerController: playUrl called with itemId:" << itemId 
@@ -2280,7 +2546,9 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
     if (m_playerBackend->isRunning()) {
         reportPlaybackStop();
         // Don't check completion threshold here - we're starting new content intentionally
+        m_suppressBackendStopHandling = true;
         m_playerBackend->stopMpv();
+        m_suppressBackendStopHandling = false;
     }
 
     clearPendingAutoplayContext();
@@ -2355,13 +2623,16 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
 void PlayerController::stop()
 {
     qDebug() << "PlayerController: stop requested";
+    qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                            << "] stop requested"
+                            << "state=" << stateToString(m_playbackState)
+                            << "terminalActive=" << m_terminalTransitionActive;
 
-    if (m_playbackState == Idle || m_playbackState == Error) {
+    if (m_playbackState == Idle || m_playbackState == Error || m_terminalTransitionActive) {
         return;
     }
 
-    handlePlaybackStopAndAutoplay(Event::Stop);
-    m_playerBackend->stopMpv();
+    requestTerminalTransition(TerminalReason::Stop);
 }
 
 void PlayerController::pause()

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -833,7 +833,7 @@ void PlayerController::onBufferingTimeout()
  *
  * When the backend reports it is no longer running and the controller's
  * playback state is neither Idle nor Error, this method treats the event
- * as an unexpected stop and triggers the playback stop / autoplay handling.
+ * as an unexpected stop and requests a backend-first terminal transition.
  *
  * @param running True if the backend process is running, false otherwise.
  */
@@ -858,6 +858,7 @@ void PlayerController::onProcessStateChanged(bool running)
                                 << "backendStopRequested=" << m_backendStopRequested;
 
         if (m_suppressBackendStopHandling) {
+            m_suppressBackendStopHandling = false;
             qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                                     << "] backend-stop ignored during replacement playback";
             return;
@@ -1049,14 +1050,13 @@ void PlayerController::onPlaylistPositionChanged(int index)
 }
 
 /**
- * @brief Handle end-of-playback duties and trigger autoplay or prefetched navigation when appropriate.
+ * @brief Prepare a terminal playback transition for a specific termination reason.
  *
- * Checks completion progress and, if the configured completion threshold is met for the current series,
- * marks the session for autoplay, stashes the pending autoplay context, and awaits next-episode resolution.
- * Always reports playback stop and processes the provided stop event through the state machine.
- * If a usable prefetched next episode is available, consumes that prefetched data and navigates to it.
+ * Starts terminal-transition bookkeeping unless one is already active, reports playback stop once,
+ * evaluates completion/autoplay state for non-error transitions, and kicks off next-episode resolution
+ * when needed. The matching state-machine event is finalized separately after backend stop is confirmed.
  *
- * @param stopEvent Event value representing how playback ended (e.g., Stop, PlaybackEnd) to be processed.
+ * @param reason Terminal reason that should eventually drive the state-machine transition.
  */
 void PlayerController::prepareTerminalTransition(TerminalReason reason)
 {
@@ -1229,19 +1229,6 @@ int PlayerController::terminalReasonPriority(TerminalReason reason)
     }
 }
 
-void PlayerController::handlePlaybackStopAndAutoplay(Event stopEvent)
-{
-    TerminalReason reason = TerminalReason::Stop;
-    if (stopEvent == Event::PlaybackEnd) {
-        reason = TerminalReason::PlaybackEnd;
-    } else if (stopEvent == Event::ErrorOccurred) {
-        reason = TerminalReason::Error;
-    }
-
-    prepareTerminalTransition(reason);
-    finalizeTerminalTransition();
-}
-
 void PlayerController::startDeferredDisplayRestore(bool needsHdrRestore, bool needsRefreshRestore)
 {
     cancelPendingDisplayRestore();
@@ -1278,6 +1265,10 @@ void PlayerController::startDeferredDisplayRestore(bool needsHdrRestore, bool ne
                                                                                this,
                                                                                [this, generation, needsRefreshRestore](bool enabled, bool success) {
                                                                                    if (enabled || generation != m_displayRestoreGeneration) {
+                                                                                       if (m_hdrRestoreFinishedConnection) {
+                                                                                           disconnect(m_hdrRestoreFinishedConnection);
+                                                                                           m_hdrRestoreFinishedConnection = QMetaObject::Connection();
+                                                                                       }
                                                                                        return;
                                                                                    }
                                                                                    if (m_hdrRestoreFinishedConnection) {
@@ -2473,9 +2464,8 @@ void PlayerController::setEmbeddedVideoShrinkEnabled(bool enabled)
  * @brief Start playback of the configured test video.
  *
  * Clears any pending autoplay context and next-episode prefetch state, disables autoplay,
- * clears the current item identifier, sets the pending URL to the configured test video,
- * stops any currently running backend playback, and triggers the player state machine to
- * begin loading and playing the test video.
+ * reports/stops any currently running backend playback, replaces the current item context
+ * with the configured test video, and triggers the player state machine to begin loading it.
  */
 void PlayerController::playTestVideo()
 {
@@ -2483,21 +2473,23 @@ void PlayerController::playTestVideo()
     cancelPendingDisplayRestore();
     clearPendingAutoplayContext();
     clearNextEpisodePrefetchState();
-    clearPlaybackSegments();
     m_shouldAutoplay = false;
-
-    if (!m_currentItemId.isEmpty()) {
-        m_currentItemId.clear();
-        emit currentItemIdChanged();
-    }
-    m_pendingUrl = m_testVideoUrl;
     
     if (m_playerBackend->isRunning()) {
         reportPlaybackStop();
         m_suppressBackendStopHandling = true;
         m_playerBackend->stopMpv();
-        m_suppressBackendStopHandling = false;
+        if (!m_playerBackend->isRunning()) {
+            m_suppressBackendStopHandling = false;
+        }
     }
+
+    clearPlaybackSegments();
+    if (!m_currentItemId.isEmpty()) {
+        m_currentItemId.clear();
+        emit currentItemIdChanged();
+    }
+    m_pendingUrl = m_testVideoUrl;
     
     processEvent(Event::Play);
 }
@@ -2548,7 +2540,9 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
         // Don't check completion threshold here - we're starting new content intentionally
         m_suppressBackendStopHandling = true;
         m_playerBackend->stopMpv();
-        m_suppressBackendStopHandling = false;
+        if (!m_playerBackend->isRunning()) {
+            m_suppressBackendStopHandling = false;
+        }
     }
 
     clearPendingAutoplayContext();
@@ -2611,14 +2605,10 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
 /**
  * @brief Stops current playback.
  *
- * If the current playback position has reached the configured completion
- * threshold for a series episode, routes through handlePlaybackStopAndAutoplay()
- * so the Up Next flow is shown (same behavior as natural playback end).
- * Otherwise clears autoplay/prefetch state and transitions to Idle without
- * requesting next-episode navigation.
- *
- * Note: some backends may emit a synchronous state change when stopped; that
- * may already transition the controller to Idle via onProcessStateChanged.
+ * Requests a backend-first terminal transition using TerminalReason::Stop.
+ * Completion-threshold and autoplay evaluation happen inside prepareTerminalTransition(),
+ * and the state-machine transition to Idle is finalized only after backend stop is confirmed.
+ * If a terminal transition is already in flight, this method returns without duplicating it.
  */
 void PlayerController::stop()
 {

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -858,9 +858,9 @@ void PlayerController::onProcessStateChanged(bool running)
                                 << "backendStopRequested=" << m_backendStopRequested;
 
         if (m_suppressBackendStopHandling) {
-            m_suppressBackendStopHandling = false;
             qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                                     << "] backend-stop ignored during replacement playback";
+            finalizeReplacementPlaybackStop();
             return;
         }
 
@@ -1081,12 +1081,7 @@ void PlayerController::prepareTerminalTransition(TerminalReason reason)
             m_waitingForNextEpisodeAtPlaybackEnd = true;
             stashPendingAutoplayContext();
             m_terminalPrefetchedReady = hasUsablePrefetchedNextEpisode();
-            if (!m_terminalPrefetchedReady) {
-                m_libraryService->getNextUnplayedEpisode(m_pendingAutoplaySeriesId,
-                                                         m_pendingAutoplayItemId,
-                                                         expectedAutoplayResolutionRequestContext());
-            }
-            qDebug() << "PlayerController: Threshold met, requesting next episode for autoplay";
+            qDebug() << "PlayerController: Threshold met, next episode will resolve after terminal finalization";
         } else {
             clearPendingAutoplayContext();
             clearNextEpisodePrefetchState();
@@ -1175,6 +1170,18 @@ void PlayerController::finalizeTerminalTransition()
 
     if (prefetchedReady && reason != TerminalReason::Error) {
         consumePrefetchedNextEpisodeAndNavigate();
+    } else if (reason != TerminalReason::Error
+               && m_shouldAutoplay
+               && m_waitingForNextEpisodeAtPlaybackEnd
+               && !m_pendingAutoplaySeriesId.isEmpty()
+               && !m_pendingAutoplayItemId.isEmpty()) {
+        qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                << "] resolving-next-episode after terminal finalization"
+                                << "seriesId=" << m_pendingAutoplaySeriesId
+                                << "itemId=" << m_pendingAutoplayItemId;
+        m_libraryService->getNextUnplayedEpisode(m_pendingAutoplaySeriesId,
+                                                 m_pendingAutoplayItemId,
+                                                 expectedAutoplayResolutionRequestContext());
     }
 }
 
@@ -1322,7 +1329,7 @@ void PlayerController::scheduleDeferredRefreshRestore(quint64 generation, int de
                        });
 }
 
-void PlayerController::cancelPendingDisplayRestore()
+void PlayerController::cancelPendingDisplayRestore(bool applyCurrentPlaybackDisplayState)
 {
     qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                             << "] deferred-display-restore cancel"
@@ -1334,6 +1341,21 @@ void PlayerController::cancelPendingDisplayRestore()
     }
     if (m_displayManager != nullptr) {
         m_displayManager->cancelPendingHdrAsync();
+        if (applyCurrentPlaybackDisplayState) {
+            const bool shouldEnableHdr = m_config->getEnableHDR() && m_contentIsHDR;
+            const bool shouldMatchRefresh = m_config->getEnableFramerateMatching() && m_contentFramerate > 0.0;
+
+            if (!shouldEnableHdr && m_displayManager->needsHdrRestore()) {
+                qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                        << "] applying-immediate-display-sync disable-hdr";
+                m_displayManager->setHDR(false);
+            }
+            if (!shouldMatchRefresh && m_displayManager->needsRefreshRestore()) {
+                qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                        << "] applying-immediate-display-sync restore-refresh";
+                m_displayManager->restoreRefreshRate();
+            }
+        }
     }
 }
 
@@ -1346,6 +1368,50 @@ void PlayerController::cancelPendingTerminalTransition()
     qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                             << "] terminal-transition canceled";
     resetTerminalTransitionState(true);
+}
+
+void PlayerController::scheduleReplacementPlayback(const std::function<void()> &action)
+{
+    m_pendingReplacementPlaybackAction = action;
+
+    if (m_playerBackend && m_playerBackend->isRunning()) {
+        reportPlaybackStop();
+        m_suppressBackendStopHandling = true;
+        m_playerBackend->stopMpv();
+        if (m_playerBackend->isRunning()) {
+            return;
+        }
+    }
+
+    finalizeReplacementPlaybackStop();
+}
+
+void PlayerController::finalizeReplacementPlaybackStop()
+{
+    m_suppressBackendStopHandling = false;
+
+    if (m_playbackState != Idle) {
+        const PlaybackState oldState = m_playbackState;
+        qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                << "] replacement-stop finalized"
+                                << "state=" << stateToString(oldState);
+        exitState(oldState);
+        m_loadingTimeoutTimer->stop();
+        m_bufferingTimeoutTimer->stop();
+        m_progressReportTimer->stop();
+        m_startDelayTimer->stop();
+        setPlaybackState(Idle);
+        setBufferingProgress(0);
+        emit playbackStopped();
+    }
+
+    if (!m_pendingReplacementPlaybackAction) {
+        return;
+    }
+
+    const std::function<void()> action = m_pendingReplacementPlaybackAction;
+    m_pendingReplacementPlaybackAction = std::function<void()>();
+    action();
 }
 
 /**
@@ -2470,28 +2536,69 @@ void PlayerController::setEmbeddedVideoShrinkEnabled(bool enabled)
 void PlayerController::playTestVideo()
 {
     cancelPendingTerminalTransition();
-    cancelPendingDisplayRestore();
     clearPendingAutoplayContext();
     clearNextEpisodePrefetchState();
     m_shouldAutoplay = false;
-    
-    if (m_playerBackend->isRunning()) {
-        reportPlaybackStop();
-        m_suppressBackendStopHandling = true;
-        m_playerBackend->stopMpv();
-        if (!m_playerBackend->isRunning()) {
-            m_suppressBackendStopHandling = false;
-        }
-    }
 
-    clearPlaybackSegments();
-    if (!m_currentItemId.isEmpty()) {
-        m_currentItemId.clear();
-        emit currentItemIdChanged();
-    }
-    m_pendingUrl = m_testVideoUrl;
-    
-    processEvent(Event::Play);
+    scheduleReplacementPlayback([this]() {
+        m_currentSeriesId.clear();
+        m_currentSeasonId.clear();
+        m_currentLibraryId.clear();
+        m_contentFramerate = 0.0;
+        m_contentIsHDR = false;
+        m_currentPosition = 0.0;
+        m_duration = 0.0;
+        m_hasReportedStart = false;
+        m_seekTargetWhileBuffering = -1;
+        m_reportProgressOnNextPositionUpdate = false;
+        m_startPositionTicks = 0;
+        m_playMethod = inferPlayMethod(m_testVideoUrl);
+        m_hasReportedStopForAttempt = false;
+        m_hasEvaluatedCompletionForAttempt = false;
+        cancelPendingDisplayRestore(true);
+        clearPlaybackSegments();
+        if (!m_currentItemId.isEmpty()) {
+            m_currentItemId.clear();
+            emit currentItemIdChanged();
+        }
+        clearOverlayMetadata();
+        m_selectedAudioTrack = -1;
+        m_selectedSubtitleTrack = -1;
+        m_mpvAudioTrack = -1;
+        m_mpvSubtitleTrack = -1;
+        m_audioTrackMap.clear();
+        m_subtitleTrackMap.clear();
+        m_audioTrackReverseMap.clear();
+        m_subtitleTrackReverseMap.clear();
+        m_mediaSourceId.clear();
+        m_playSessionId.clear();
+        m_availableAudioTracks.clear();
+        m_availableSubtitleTracks.clear();
+        m_activeMediaSource.clear();
+        emit selectedAudioTrackChanged();
+        emit selectedSubtitleTrackChanged();
+        emit mediaSourceIdChanged();
+        emit playSessionIdChanged();
+        emit availableTracksChanged();
+        m_currentSegments.clear();
+        m_isInIntroSegment = false;
+        m_isInOutroSegment = false;
+        m_hasAutoSkippedIntroForCurrentItem = false;
+        m_hasAutoSkippedOutroForCurrentItem = false;
+        m_hasTrickplayInfo = false;
+        m_currentTrickplayInfo = TrickplayTileInfo{};
+        m_trickplayBinaryPath.clear();
+        m_currentTrickplayFrameIndex = -1;
+        m_hasTrickplayPreviewPositionOverride = false;
+        m_trickplayPreviewPositionOverrideSeconds = 0.0;
+        clearTrickplayPreview();
+        emit timelineChanged();
+        emit skipSegmentsChanged();
+        emit trickplayStateChanged();
+        m_pendingUrl = m_testVideoUrl;
+
+        processEvent(Event::Play);
+    });
 }
 
 /**
@@ -2515,7 +2622,6 @@ void PlayerController::playTestVideo()
 void PlayerController::playUrl(const QString &url, const QString &itemId, qint64 startPositionTicks, const QString &seriesId, const QString &seasonId, const QString &libraryId, double framerate, bool isHDR)
 {
     cancelPendingTerminalTransition();
-    cancelPendingDisplayRestore();
     m_playbackAttemptId = ++gPlaybackAttemptCounter;
     m_reportProgressOnNextPositionUpdate = false;
     qDebug() << "PlayerController: playUrl called with itemId:" << itemId 
@@ -2533,73 +2639,65 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
                             << "isHDR=" << isHDR
                             << "enableHDRSetting=" << m_config->getEnableHDR()
                             << "enableFramerateMatchSetting=" << m_config->getEnableFramerateMatching();
-    
-    // If already playing, stop first
-    if (m_playerBackend->isRunning()) {
-        reportPlaybackStop();
-        // Don't check completion threshold here - we're starting new content intentionally
-        m_suppressBackendStopHandling = true;
-        m_playerBackend->stopMpv();
-        if (!m_playerBackend->isRunning()) {
-            m_suppressBackendStopHandling = false;
-        }
-    }
 
     clearPendingAutoplayContext();
     clearNextEpisodePrefetchState();
-    clearPlaybackSegments();
-    
-    // Store pending playback info before transition
-    if (m_currentItemId != itemId) {
-        m_currentItemId = itemId;
-        emit currentItemIdChanged();
-    }
-    m_currentSeriesId = seriesId;
-    m_currentSeasonId = seasonId;
-    m_currentLibraryId = libraryId;
-    m_pendingUrl = url;
-    m_currentPosition = 0;
-    m_duration = 0;
-    m_hasReportedStart = false;
-    m_startPositionTicks = startPositionTicks;
-    m_shouldAutoplay = false;
-    m_contentFramerate = framerate;
-    m_contentIsHDR = isHDR;
-    m_playMethod = inferPlayMethod(url);
-    m_hasReportedStopForAttempt = false;
-    m_hasEvaluatedCompletionForAttempt = false;
-    
-    // Clear previous OSC/trickplay state and request new data
-    m_currentSegments.clear();
-    m_isInIntroSegment = false;
-    m_isInOutroSegment = false;
-    m_hasAutoSkippedIntroForCurrentItem = false;
-    m_hasAutoSkippedOutroForCurrentItem = false;
-    m_hasTrickplayInfo = false;
-    m_currentTrickplayInfo = TrickplayTileInfo{};
-    m_trickplayBinaryPath.clear();
-    m_currentTrickplayFrameIndex = -1;
-    m_hasTrickplayPreviewPositionOverride = false;
-    m_trickplayPreviewPositionOverrideSeconds = 0.0;
-    clearTrickplayPreview();
-    emit timelineChanged();
-    emit skipSegmentsChanged();
-    emit trickplayStateChanged();
-    if (!itemId.isEmpty()) {
-        m_playbackService->getMediaSegments(itemId);
-        m_playbackService->getTrickplayInfo(itemId);
-    }
-    
-    // If we have a start position, queue it as a seek target
-    // Jellyfin ticks are 100ns units, so divide by 10,000,000 to get seconds
-    if (startPositionTicks > 0) {
-        m_seekTargetWhileBuffering = static_cast<double>(startPositionTicks) / 10000000.0;
-        qDebug() << "PlayerController: Will seek to" << m_seekTargetWhileBuffering << "seconds after buffering";
-    } else {
-        m_seekTargetWhileBuffering = -1;
-    }
-    
-    processEvent(Event::Play);
+
+    scheduleReplacementPlayback([this, url, itemId, startPositionTicks, seriesId, seasonId, libraryId, framerate, isHDR]() {
+        // Store pending playback info after the previous item has fully stopped.
+        if (m_currentItemId != itemId) {
+            m_currentItemId = itemId;
+            emit currentItemIdChanged();
+        }
+        m_currentSeriesId = seriesId;
+        m_currentSeasonId = seasonId;
+        m_currentLibraryId = libraryId;
+        m_pendingUrl = url;
+        m_currentPosition = 0;
+        m_duration = 0;
+        m_hasReportedStart = false;
+        m_startPositionTicks = startPositionTicks;
+        m_shouldAutoplay = false;
+        m_contentFramerate = framerate;
+        m_contentIsHDR = isHDR;
+        m_playMethod = inferPlayMethod(url);
+        m_hasReportedStopForAttempt = false;
+        m_hasEvaluatedCompletionForAttempt = false;
+        cancelPendingDisplayRestore(true);
+        clearPlaybackSegments();
+
+        // Clear previous OSC/trickplay state and request new data
+        m_currentSegments.clear();
+        m_isInIntroSegment = false;
+        m_isInOutroSegment = false;
+        m_hasAutoSkippedIntroForCurrentItem = false;
+        m_hasAutoSkippedOutroForCurrentItem = false;
+        m_hasTrickplayInfo = false;
+        m_currentTrickplayInfo = TrickplayTileInfo{};
+        m_trickplayBinaryPath.clear();
+        m_currentTrickplayFrameIndex = -1;
+        m_hasTrickplayPreviewPositionOverride = false;
+        m_trickplayPreviewPositionOverrideSeconds = 0.0;
+        clearTrickplayPreview();
+        emit timelineChanged();
+        emit skipSegmentsChanged();
+        emit trickplayStateChanged();
+        if (!itemId.isEmpty()) {
+            m_playbackService->getMediaSegments(itemId);
+            m_playbackService->getTrickplayInfo(itemId);
+        }
+
+        // If we have a start position, queue it as a seek target
+        // Jellyfin ticks are 100ns units, so divide by 10,000,000 to get seconds
+        if (startPositionTicks > 0) {
+            m_seekTargetWhileBuffering = static_cast<double>(startPositionTicks) / 10000000.0;
+            qDebug() << "PlayerController: Will seek to" << m_seekTargetWhileBuffering << "seconds after buffering";
+        } else {
+            m_seekTargetWhileBuffering = -1;
+        }
+
+        processEvent(Event::Play);
+    });
 }
 
 /**

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -509,8 +509,10 @@ private:
     void enterIdleStateImmediate();
     void startDeferredDisplayRestore(bool needsHdrRestore, bool needsRefreshRestore);
     void scheduleDeferredRefreshRestore(quint64 generation, int delayMs);
-    void cancelPendingDisplayRestore();
+    void cancelPendingDisplayRestore(bool applyCurrentPlaybackDisplayState = false);
     void cancelPendingTerminalTransition();
+    void scheduleReplacementPlayback(const std::function<void()> &action);
+    void finalizeReplacementPlaybackStop();
     /**
      * Attempt to fall back from the internal player backend to an external backend for the current attempt.
      * @param reason Human-readable reason for attempting the fallback.
@@ -743,6 +745,7 @@ private:
     bool m_terminalPrefetchedReady = false;
     quint64 m_terminalTransitionGeneration = 0;
     bool m_suppressBackendStopHandling = false;
+    std::function<void()> m_pendingReplacementPlaybackAction;
     quint64 m_displayRestoreGeneration = 0;
     QMetaObject::Connection m_hdrRestoreFinishedConnection;
     

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -420,7 +420,6 @@ private:
     void updatePendingTerminalReason(TerminalReason reason);
     [[nodiscard]] Event eventForTerminalReason(TerminalReason reason) const;
     [[nodiscard]] static int terminalReasonPriority(TerminalReason reason);
-    void handlePlaybackStopAndAutoplay(Event stopEvent);
     void maybeTriggerNextEpisodePrefetch();
     /**
      * Returns whether a prefetched "next episode" payload is available and usable for navigation.

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -5,6 +5,7 @@
 #include <QElapsedTimer>
 #include <QHash>
 #include <QMap>
+#include <QMetaObject>
 #include <QSet>
 #include <QStringList>
 #include <QVariantMap>
@@ -371,6 +372,12 @@ private:
 #ifdef BLOOM_TESTING
     friend class PlayerControllerAutoplayContextTest;
 #endif
+    enum class TerminalReason {
+        Stop,
+        PlaybackEnd,
+        Error
+    };
+
     struct PendingPlaybackRequest;
     // State machine
     void setupStateMachine();
@@ -405,6 +412,14 @@ private:
     bool wouldMeetCompletionThreshold() const;
     void checkCompletionThreshold();
     bool checkCompletionThresholdAndAutoplay();  // Returns true if threshold was met (for autoplay)
+    void prepareTerminalTransition(TerminalReason reason);
+    void requestTerminalTransition(TerminalReason reason);
+    void queueTerminalFinalization();
+    void finalizeTerminalTransition();
+    void resetTerminalTransitionState(bool invalidateQueuedWork = false);
+    void updatePendingTerminalReason(TerminalReason reason);
+    [[nodiscard]] Event eventForTerminalReason(TerminalReason reason) const;
+    [[nodiscard]] static int terminalReasonPriority(TerminalReason reason);
     void handlePlaybackStopAndAutoplay(Event stopEvent);
     void maybeTriggerNextEpisodePrefetch();
     /**
@@ -492,6 +507,11 @@ private:
      * @param backend Backend instance whose signals should be connected.
      */
     void connectBackendSignals(IPlayerBackend *backend);
+    void enterIdleStateImmediate();
+    void startDeferredDisplayRestore(bool needsHdrRestore, bool needsRefreshRestore);
+    void scheduleDeferredRefreshRestore(quint64 generation, int delayMs);
+    void cancelPendingDisplayRestore();
+    void cancelPendingTerminalTransition();
     /**
      * Attempt to fall back from the internal player backend to an external backend for the current attempt.
      * @param reason Human-readable reason for attempting the fallback.
@@ -717,6 +737,15 @@ private:
     quint64 m_playbackAttemptId = 0;
     bool m_hasReportedStopForAttempt = false;
     bool m_hasEvaluatedCompletionForAttempt = false;
+    bool m_terminalTransitionActive = false;
+    TerminalReason m_pendingTerminalReason = TerminalReason::Stop;
+    bool m_backendStopRequested = false;
+    bool m_terminalFinalizationQueued = false;
+    bool m_terminalPrefetchedReady = false;
+    quint64 m_terminalTransitionGeneration = 0;
+    bool m_suppressBackendStopHandling = false;
+    quint64 m_displayRestoreGeneration = 0;
+    QMetaObject::Connection m_hdrRestoreFinishedConnection;
     
     // Buffering detection
     QElapsedTimer m_lastPositionUpdateTime;

--- a/src/player/backend/WindowsMpvBackend.cpp
+++ b/src/player/backend/WindowsMpvBackend.cpp
@@ -192,6 +192,9 @@ void WindowsMpvBackend::appendUrlsToPlaylist(const QStringList &mediaUrls)
 
 void WindowsMpvBackend::stopMpv()
 {
+    qCInfo(lcWindowsLibmpvBackend) << "stopMpv requested"
+                                   << "directControlActive=" << m_directControlActive
+                                   << "running=" << m_running;
     if (m_directControlActive) {
 #if defined(Q_OS_WIN) && defined(BLOOM_HAS_LIBMPV)
         if (m_mpvHandle != nullptr) {
@@ -476,6 +479,9 @@ bool WindowsMpvBackend::isHdrRelatedArg(const QString &arg)
 
 void WindowsMpvBackend::clearVideoTarget()
 {
+    qCInfo(lcWindowsLibmpvBackend) << "Clearing embedded video target"
+                                   << "hadTarget=" << (m_videoTarget != nullptr)
+                                   << "hostWinId=" << static_cast<qulonglong>(m_videoHostWinId);
     if (m_videoTarget != nullptr) {
         m_videoTarget->removeEventFilter(this);
     }
@@ -1157,6 +1163,8 @@ void WindowsMpvBackend::destroyVideoHostWindow()
 
     HWND hostWindow = reinterpret_cast<HWND>(m_videoHostWinId);
     if (hostWindow != nullptr) {
+        qCInfo(lcWindowsLibmpvBackend) << "Destroying embedded mpv host window"
+                                       << static_cast<qulonglong>(m_videoHostWinId);
         DestroyWindow(hostWindow);
     }
 #endif

--- a/src/utils/DisplayManager.cpp
+++ b/src/utils/DisplayManager.cpp
@@ -5,9 +5,11 @@
 #include <QScreen>
 #include <QtMath>
 #include <QElapsedTimer>
+#include <QFutureWatcher>
 #include <QLoggingCategory>
 #include <QMetaObject>
 #include <QThread>
+#include <QtConcurrent/QtConcurrent>
 #include <vector>
 
 #ifdef Q_OS_WIN
@@ -20,6 +22,24 @@
 
 namespace {
 Q_LOGGING_CATEGORY(lcDisplayTrace, "bloom.playback.displaytrace")
+
+struct HdrAsyncFallbackResult
+{
+    bool success = false;
+    bool preState = false;
+};
+
+bool runCommandAndWait(const QString &cmd, int *exitCode = nullptr)
+{
+    QProcess process;
+    process.startCommand(cmd);
+    process.waitForFinished();
+    const int code = process.exitCode();
+    if (exitCode != nullptr) {
+        *exitCode = code;
+    }
+    return code == 0;
+}
 
 bool isCadenceCompatible(double currentHz, double targetHz)
 {
@@ -113,6 +133,137 @@ bool isAnyAdvancedColorEnabled()
 
     return false;
 }
+
+bool setHDRWindowsImpl(bool enabled)
+{
+    // Use undocumented API to toggle HDR.
+    UINT32 numPathArrayElements = 0;
+    UINT32 numModeInfoArrayElements = 0;
+
+    const LONG sizeRet = GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &numPathArrayElements, &numModeInfoArrayElements);
+    qCInfo(lcDisplayTrace) << "setHDRWindows buffer-sizes"
+                           << "requested=" << enabled
+                           << "ret=" << sizeRet
+                           << "paths=" << numPathArrayElements
+                           << "modes=" << numModeInfoArrayElements;
+    if (sizeRet != ERROR_SUCCESS) {
+        qWarning() << "DisplayManager: GetDisplayConfigBufferSizes failed";
+        return false;
+    }
+
+    std::vector<DISPLAYCONFIG_PATH_INFO> pathArray(numPathArrayElements);
+    std::vector<DISPLAYCONFIG_MODE_INFO> modeInfoArray(numModeInfoArrayElements);
+
+    const LONG queryRet = QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS,
+                                             &numPathArrayElements,
+                                             pathArray.data(),
+                                             &numModeInfoArrayElements,
+                                             modeInfoArray.data(),
+                                             nullptr);
+    qCInfo(lcDisplayTrace) << "setHDRWindows query-display-config"
+                           << "requested=" << enabled
+                           << "ret=" << queryRet
+                           << "paths=" << numPathArrayElements
+                           << "modes=" << numModeInfoArrayElements;
+    if (queryRet != ERROR_SUCCESS) {
+        qWarning() << "DisplayManager: QueryDisplayConfig failed";
+        return false;
+    }
+
+    bool success = false;
+
+    for (UINT32 i = 0; i < numPathArrayElements; ++i) {
+        const AdvancedColorStateQueryResult preState = queryAdvancedColorState(pathArray[i]);
+        qCInfo(lcDisplayTrace) << "setHDRWindows pre-state"
+                               << "path=" << i
+                               << "adapter=" << formatAdapterId(pathArray[i].targetInfo.adapterId)
+                               << "targetId=" << pathArray[i].targetInfo.id
+                               << "queryRet=" << preState.ret
+                               << "enabled=" << preState.enabled;
+        if (preState.ok && preState.enabled == enabled) {
+            qCInfo(lcDisplayTrace) << "setHDRWindows no-op (already requested state)"
+                                   << "path=" << i
+                                   << "requested=" << enabled;
+            success = true;
+            continue;
+        }
+
+        DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE setAdvancedColorState = {};
+        setAdvancedColorState.header.type = DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE;
+        setAdvancedColorState.header.size = sizeof(DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE);
+        setAdvancedColorState.header.adapterId = pathArray[i].targetInfo.adapterId;
+        setAdvancedColorState.header.id = pathArray[i].targetInfo.id;
+        setAdvancedColorState.value = enabled ? 1 : 0;
+
+        const LONG ret = DisplayConfigSetDeviceInfo(&setAdvancedColorState.header);
+        qCInfo(lcDisplayTrace) << "setHDRWindows path"
+                               << i
+                               << "adapter=" << formatAdapterId(pathArray[i].targetInfo.adapterId)
+                               << "targetId=" << pathArray[i].targetInfo.id
+                               << "requested=" << enabled
+                               << "ret=" << ret;
+        if (ret == ERROR_SUCCESS) {
+            qDebug() << "DisplayManager: Successfully set HDR to" << enabled << "for path" << i;
+            static constexpr int kHdrSettleTimeoutMs = 5000;
+            static constexpr int kHdrSettlePollMs = 50;
+            const bool settled = waitForAdvancedColorState(pathArray[i], enabled, kHdrSettleTimeoutMs, kHdrSettlePollMs);
+            const AdvancedColorStateQueryResult postState = queryAdvancedColorState(pathArray[i]);
+            qCInfo(lcDisplayTrace) << "setHDRWindows post-state"
+                                   << "path=" << i
+                                   << "settled=" << settled
+                                   << "queryRet=" << postState.ret
+                                   << "enabled=" << postState.enabled;
+            if (!settled) {
+                qCWarning(lcDisplayTrace) << "setHDRWindows settle-timeout"
+                                          << "path=" << i
+                                          << "requested=" << enabled
+                                          << "timeoutMs=" << kHdrSettleTimeoutMs;
+                continue;
+            }
+            success = true;
+        } else {
+            qWarning() << "DisplayManager: Failed to set HDR for path" << i << "error:" << ret;
+        }
+    }
+
+    return success;
+}
+
+HdrAsyncFallbackResult runBlockingWindowsHdrToggle(bool enabled, const QString &customCmdTemplate)
+{
+    HdrAsyncFallbackResult result;
+    result.preState = isAnyAdvancedColorEnabled();
+
+    if (!customCmdTemplate.isEmpty()) {
+        QString cmd = customCmdTemplate;
+        cmd.replace("{STATE}", enabled ? "on" : "off");
+        qDebug() << "DisplayManager: Executing custom Windows HDR command:" << cmd;
+
+        int exitCode = -1;
+        result.success = runCommandAndWait(cmd, &exitCode);
+        qCInfo(lcDisplayTrace) << "setHDR custom-command result"
+                               << "requested=" << enabled
+                               << "exitCode=" << exitCode;
+        return result;
+    }
+
+    result.success = setHDRWindowsImpl(enabled);
+    return result;
+}
+#else
+bool setHDRLinuxImpl(const QString &cmdTemplate, bool enabled)
+{
+    if (cmdTemplate.isEmpty()) {
+        qWarning() << "DisplayManager: No Linux HDR command configured";
+        return false;
+    }
+
+    QString cmd = cmdTemplate;
+    cmd.replace("{STATE}", enabled ? "on" : "off");
+
+    qDebug() << "DisplayManager: Executing Linux HDR command:" << cmd;
+    return runCommandAndWait(cmd);
+}
 #endif
 }
 
@@ -175,10 +326,15 @@ void DisplayManager::updateHdrRestoreTracking(bool requestedState, bool preState
     }
 
     m_hdrChanged = (requestedState != m_originalHDRState);
+    if (!m_hdrChanged) {
+        m_hasCapturedOriginalHDRState = false;
+        m_originalHDRState = requestedState;
+    }
     qCInfo(lcDisplayTrace) << "updateHdrRestoreTracking"
                            << "requestedState=" << requestedState
                            << "originalState=" << m_originalHDRState
-                           << "restoreNeeded=" << m_hdrChanged;
+                           << "restoreNeeded=" << m_hdrChanged
+                           << "capturedOriginalState=" << m_hasCapturedOriginalHDRState;
 }
 
 bool DisplayManager::setRefreshRate(double hz)
@@ -271,41 +427,18 @@ bool DisplayManager::setHDR(bool enabled)
                            << "requested=" << enabled
                            << "hdrChanged=" << m_hdrChanged;
 
-#ifdef Q_OS_WIN
-    const bool preState = isAnyAdvancedColorEnabled();
-#else
+#ifndef Q_OS_WIN
     const bool preState = m_hasCapturedOriginalHDRState ? m_originalHDRState : false;
 #endif
 
 #ifdef Q_OS_WIN
-    // Check if we have a custom command override
-    QString customCmd = m_config->getWindowsCustomHDRCommand();
-    if (!customCmd.isEmpty()) {
-        QString cmd = customCmd;
-        cmd.replace("{STATE}", enabled ? "on" : "off");
-        qDebug() << "DisplayManager: Executing custom Windows HDR command:" << cmd;
-        
-        // Simple command execution
-        QProcess process;
-        process.startCommand(cmd);
-        process.waitForFinished();
-        const bool success = process.exitCode() == 0;
-        qCInfo(lcDisplayTrace) << "setHDR custom-command result"
-                               << "requested=" << enabled
-                               << "exitCode=" << process.exitCode()
-                               << "elapsedMs=" << hdrTimer.elapsed();
-        if (success) {
-            updateHdrRestoreTracking(enabled, preState);
-        }
-        return success;
-    }
-    
-    if (setHDRWindows(enabled)) {
-        updateHdrRestoreTracking(enabled, preState);
+    const HdrAsyncFallbackResult result = runBlockingWindowsHdrToggle(enabled, m_config->getWindowsCustomHDRCommand());
+    if (result.success) {
+        updateHdrRestoreTracking(enabled, result.preState);
         return true;
     }
 #else
-    if (setHDRLinux(enabled)) {
+    if (setHDRLinuxImpl(m_config->getLinuxHDRCommand(), enabled)) {
         updateHdrRestoreTracking(enabled, preState);
         return true;
     }
@@ -329,22 +462,43 @@ void DisplayManager::setHDRAsync(bool enabled)
 #endif
 
     const quint64 generation = m_hdrAsyncGeneration;
-    QMetaObject::invokeMethod(this,
-                              [this, enabled, generation]() {
-                                  if (generation != m_hdrAsyncGeneration) {
-                                      return;
-                                  }
-                                  const bool success = setHDR(enabled);
-                                  if (generation != m_hdrAsyncGeneration) {
-                                      return;
-                                  }
-                                  emit hdrChangeFinished(enabled, success);
-                              },
-                              Qt::QueuedConnection);
+    auto *watcher = new QFutureWatcher<HdrAsyncFallbackResult>(this);
+    connect(watcher, &QFutureWatcher<HdrAsyncFallbackResult>::finished, this, [this, watcher, enabled, generation]() {
+        const HdrAsyncFallbackResult result = watcher->result();
+        watcher->deleteLater();
+
+        if (generation != m_hdrAsyncGeneration) {
+            return;
+        }
+
+        if (result.success) {
+            updateHdrRestoreTracking(enabled, result.preState);
+        }
+        emit hdrChangeFinished(enabled, result.success);
+    });
+
+#ifdef Q_OS_WIN
+    const QString customCmd = m_config->getWindowsCustomHDRCommand();
+    watcher->setFuture(QtConcurrent::run([enabled, customCmd]() {
+        return runBlockingWindowsHdrToggle(enabled, customCmd);
+    }));
+#else
+    const bool preState = m_hasCapturedOriginalHDRState ? m_originalHDRState : false;
+    const QString cmdTemplate = m_config->getLinuxHDRCommand();
+    watcher->setFuture(QtConcurrent::run([enabled, cmdTemplate, preState]() {
+        HdrAsyncFallbackResult result;
+        result.preState = preState;
+        result.success = setHDRLinuxImpl(cmdTemplate, enabled);
+        return result;
+    }));
+#endif
 }
 
 void DisplayManager::cancelPendingHdrAsync()
 {
+    if (m_hdrAsyncPending) {
+        updateHdrRestoreTracking(m_hdrAsyncRequestedState, m_hdrAsyncPreState);
+    }
     ++m_hdrAsyncGeneration;
     m_hdrAsyncPending = false;
     if (m_hdrAsyncPollTimer.isActive()) {
@@ -486,102 +640,13 @@ bool DisplayManager::restoreRefreshRateWindows()
 
 bool DisplayManager::setHDRWindows(bool enabled)
 {
-    // Use undocumented API to toggle HDR
-    // Note: This targets the primary display path.
-    // A robust implementation would enumerate paths and find the active one.
-    
-    UINT32 numPathArrayElements = 0;
-    UINT32 numModeInfoArrayElements = 0;
-    
-    const LONG sizeRet = GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &numPathArrayElements, &numModeInfoArrayElements);
-    qCInfo(lcDisplayTrace) << "setHDRWindows buffer-sizes"
-                           << "requested=" << enabled
-                           << "ret=" << sizeRet
-                           << "paths=" << numPathArrayElements
-                           << "modes=" << numModeInfoArrayElements;
-    if (sizeRet != ERROR_SUCCESS) {
-        qWarning() << "DisplayManager: GetDisplayConfigBufferSizes failed";
-        return false;
-    }
-    
-    std::vector<DISPLAYCONFIG_PATH_INFO> pathArray(numPathArrayElements);
-    std::vector<DISPLAYCONFIG_MODE_INFO> modeInfoArray(numModeInfoArrayElements);
-    
-    const LONG queryRet = QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &numPathArrayElements, pathArray.data(), &numModeInfoArrayElements, modeInfoArray.data(), nullptr);
-    qCInfo(lcDisplayTrace) << "setHDRWindows query-display-config"
-                           << "requested=" << enabled
-                           << "ret=" << queryRet
-                           << "paths=" << numPathArrayElements
-                           << "modes=" << numModeInfoArrayElements;
-    if (queryRet != ERROR_SUCCESS) {
-        qWarning() << "DisplayManager: QueryDisplayConfig failed";
-        return false;
-    }
-    
-    bool success = false;
-    
-    // Try to set for all active paths (usually just one for primary)
-    for (UINT32 i = 0; i < numPathArrayElements; ++i) {
-        const AdvancedColorStateQueryResult preState = queryAdvancedColorState(pathArray[i]);
-        qCInfo(lcDisplayTrace) << "setHDRWindows pre-state"
-                               << "path=" << i
-                               << "adapter=" << formatAdapterId(pathArray[i].targetInfo.adapterId)
-                               << "targetId=" << pathArray[i].targetInfo.id
-                               << "queryRet=" << preState.ret
-                               << "enabled=" << preState.enabled;
-        if (preState.ok && preState.enabled == enabled) {
-            qCInfo(lcDisplayTrace) << "setHDRWindows no-op (already requested state)"
-                                   << "path=" << i
-                                   << "requested=" << enabled;
-            success = true;
-            continue;
-        }
-
-        DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE setAdvancedColorState = {};
-        setAdvancedColorState.header.type = DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE;
-        setAdvancedColorState.header.size = sizeof(DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE);
-        setAdvancedColorState.header.adapterId = pathArray[i].targetInfo.adapterId;
-        setAdvancedColorState.header.id = pathArray[i].targetInfo.id;
-        
-        setAdvancedColorState.value = enabled ? 1 : 0;
-        
-        LONG ret = DisplayConfigSetDeviceInfo(&setAdvancedColorState.header);
-        qCInfo(lcDisplayTrace) << "setHDRWindows path"
-                               << i
-                               << "adapter=" << formatAdapterId(pathArray[i].targetInfo.adapterId)
-                               << "targetId=" << pathArray[i].targetInfo.id
-                               << "requested=" << enabled
-                               << "ret=" << ret;
-        if (ret == ERROR_SUCCESS) {
-            qDebug() << "DisplayManager: Successfully set HDR to" << enabled << "for path" << i;
-            static constexpr int kHdrSettleTimeoutMs = 5000;
-            static constexpr int kHdrSettlePollMs = 50;
-            const bool settled = waitForAdvancedColorState(pathArray[i], enabled, kHdrSettleTimeoutMs, kHdrSettlePollMs);
-            const AdvancedColorStateQueryResult postState = queryAdvancedColorState(pathArray[i]);
-            qCInfo(lcDisplayTrace) << "setHDRWindows post-state"
-                                   << "path=" << i
-                                   << "settled=" << settled
-                                   << "queryRet=" << postState.ret
-                                   << "enabled=" << postState.enabled;
-            if (!settled) {
-                qCWarning(lcDisplayTrace) << "setHDRWindows settle-timeout"
-                                          << "path=" << i
-                                          << "requested=" << enabled
-                                          << "timeoutMs=" << kHdrSettleTimeoutMs;
-                continue;
-            }
-            success = true;
-        } else {
-            qWarning() << "DisplayManager: Failed to set HDR for path" << i << "error:" << ret;
-        }
-    }
-    
-    return success;
+    return setHDRWindowsImpl(enabled);
 }
 
 bool DisplayManager::startHDRAsyncWindows(bool enabled)
 {
     const bool preState = isAnyAdvancedColorEnabled();
+    const quint64 generation = m_hdrAsyncGeneration;
     m_hdrAsyncRequestedState = enabled;
     m_hdrAsyncPreState = preState;
 
@@ -611,7 +676,8 @@ bool DisplayManager::startHDRAsyncWindows(bool enabled)
         return false;
     }
 
-    bool success = false;
+    bool success = true;
+    bool handledAnyPath = false;
     bool issuedRequest = false;
     m_hdrAsyncPaths.clear();
     m_hdrAsyncPaths.reserve(static_cast<int>(numPathArrayElements));
@@ -619,8 +685,11 @@ bool DisplayManager::startHDRAsyncWindows(bool enabled)
     for (UINT32 i = 0; i < numPathArrayElements; ++i) {
         const DISPLAYCONFIG_PATH_INFO &pathInfo = pathArray[i];
         const AdvancedColorStateQueryResult prePathState = queryAdvancedColorState(pathInfo);
+        if (!prePathState.ok) {
+            success = false;
+        }
         if (prePathState.ok && prePathState.enabled == enabled) {
-            success = true;
+            handledAnyPath = true;
             continue;
         }
 
@@ -639,23 +708,29 @@ bool DisplayManager::startHDRAsyncWindows(bool enabled)
                                << "requested=" << enabled
                                << "ret=" << ret;
         if (ret == ERROR_SUCCESS) {
-            success = true;
+            handledAnyPath = true;
             issuedRequest = true;
             m_hdrAsyncPaths.push_back(pathInfo);
         } else {
+            success = false;
             qWarning() << "DisplayManager: Failed async HDR toggle for path" << i << "error:" << ret;
         }
     }
 
-    if (!success) {
+    if (!handledAnyPath) {
         return false;
     }
 
     if (!issuedRequest || m_hdrAsyncPaths.isEmpty()) {
-        updateHdrRestoreTracking(enabled, preState);
+        if (success) {
+            updateHdrRestoreTracking(enabled, preState);
+        }
         QMetaObject::invokeMethod(this,
-                                  [this, enabled]() {
-                                      emit hdrChangeFinished(enabled, true);
+                                  [this, enabled, success, generation]() {
+                                      if (generation != m_hdrAsyncGeneration) {
+                                          return;
+                                      }
+                                      emit hdrChangeFinished(enabled, success);
                                   },
                                   Qt::QueuedConnection);
         return true;
@@ -723,22 +798,7 @@ bool DisplayManager::restoreRefreshRateLinux()
 
 bool DisplayManager::setHDRLinux(bool enabled)
 {
-    QString cmdTemplate = m_config->getLinuxHDRCommand();
-    if (cmdTemplate.isEmpty()) {
-        qWarning() << "DisplayManager: No Linux HDR command configured";
-        return false;
-    }
-    
-    QString cmd = cmdTemplate;
-    cmd.replace("{STATE}", enabled ? "on" : "off"); // Example replacement
-    
-    qDebug() << "DisplayManager: Executing Linux HDR command:" << cmd;
-    
-    QProcess process;
-    process.startCommand(cmd);
-    process.waitForFinished();
-    
-    return process.exitCode() == 0;
+    return setHDRLinuxImpl(m_config->getLinuxHDRCommand(), enabled);
 }
 #endif
 

--- a/src/utils/DisplayManager.cpp
+++ b/src/utils/DisplayManager.cpp
@@ -33,12 +33,19 @@ bool runCommandAndWait(const QString &cmd, int *exitCode = nullptr)
 {
     QProcess process;
     process.startCommand(cmd);
-    process.waitForFinished();
-    const int code = process.exitCode();
+    const bool finished = process.waitForFinished();
+    if (!finished) {
+        qWarning() << "DisplayManager: Command timed out:" << cmd;
+        process.kill();
+        process.waitForFinished(1000);
+    }
+
+    const bool exitedNormally = finished && process.exitStatus() == QProcess::NormalExit;
+    const int code = exitedNormally ? process.exitCode() : -1;
     if (exitCode != nullptr) {
         *exitCode = code;
     }
-    return code == 0;
+    return exitedNormally && code == 0;
 }
 
 bool isCadenceCompatible(double currentHz, double targetHz)

--- a/src/utils/DisplayManager.cpp
+++ b/src/utils/DisplayManager.cpp
@@ -6,6 +6,7 @@
 #include <QtMath>
 #include <QElapsedTimer>
 #include <QLoggingCategory>
+#include <QMetaObject>
 #include <QThread>
 #include <vector>
 
@@ -121,10 +122,14 @@ DisplayManager::DisplayManager(ConfigManager *config, QObject *parent)
 {
     // Baseline target used for restore if runtime capture happens while HDR is already on.
     m_baselineRefreshRate = getCurrentRefreshRate();
+    m_hdrAsyncPollTimer.setInterval(50);
+    m_hdrAsyncPollTimer.setSingleShot(false);
+    connect(&m_hdrAsyncPollTimer, &QTimer::timeout, this, &DisplayManager::pollPendingHdrAsync);
 }
 
 DisplayManager::~DisplayManager()
 {
+    cancelPendingHdrAsync();
     if (m_refreshRateChanged) {
         restoreRefreshRate();
     }
@@ -160,6 +165,20 @@ void DisplayManager::captureOriginalRefreshRate()
     qCInfo(lcDisplayTrace) << "captureOriginalRefreshRate"
                            << "capturedHz=" << m_originalRefreshRate
                            << "refreshOverrideActive=" << m_refreshRateChanged;
+}
+
+void DisplayManager::updateHdrRestoreTracking(bool requestedState, bool preState)
+{
+    if (!m_hasCapturedOriginalHDRState) {
+        m_originalHDRState = preState;
+        m_hasCapturedOriginalHDRState = true;
+    }
+
+    m_hdrChanged = (requestedState != m_originalHDRState);
+    qCInfo(lcDisplayTrace) << "updateHdrRestoreTracking"
+                           << "requestedState=" << requestedState
+                           << "originalState=" << m_originalHDRState
+                           << "restoreNeeded=" << m_hdrChanged;
 }
 
 bool DisplayManager::setRefreshRate(double hz)
@@ -253,6 +272,12 @@ bool DisplayManager::setHDR(bool enabled)
                            << "hdrChanged=" << m_hdrChanged;
 
 #ifdef Q_OS_WIN
+    const bool preState = isAnyAdvancedColorEnabled();
+#else
+    const bool preState = m_hasCapturedOriginalHDRState ? m_originalHDRState : false;
+#endif
+
+#ifdef Q_OS_WIN
     // Check if we have a custom command override
     QString customCmd = m_config->getWindowsCustomHDRCommand();
     if (!customCmd.isEmpty()) {
@@ -270,21 +295,18 @@ bool DisplayManager::setHDR(bool enabled)
                                << "exitCode=" << process.exitCode()
                                << "elapsedMs=" << hdrTimer.elapsed();
         if (success) {
-            m_hdrChanged = true;
+            updateHdrRestoreTracking(enabled, preState);
         }
         return success;
     }
     
     if (setHDRWindows(enabled)) {
-        m_hdrChanged = true;
-        // We don't track original state perfectly here as querying it is hard,
-        // but we assume if we toggled it ON, we should toggle it OFF later.
-        // Ideally we'd query first.
+        updateHdrRestoreTracking(enabled, preState);
         return true;
     }
 #else
     if (setHDRLinux(enabled)) {
-        m_hdrChanged = true;
+        updateHdrRestoreTracking(enabled, preState);
         return true;
     }
 #endif
@@ -292,6 +314,45 @@ bool DisplayManager::setHDR(bool enabled)
                               << "requested=" << enabled
                               << "elapsedMs=" << hdrTimer.elapsed();
     return false;
+}
+
+void DisplayManager::setHDRAsync(bool enabled)
+{
+    cancelPendingHdrAsync();
+    qCInfo(lcDisplayTrace) << "setHDRAsync begin"
+                           << "requested=" << enabled;
+
+#ifdef Q_OS_WIN
+    if (startHDRAsyncWindows(enabled)) {
+        return;
+    }
+#endif
+
+    const quint64 generation = m_hdrAsyncGeneration;
+    QMetaObject::invokeMethod(this,
+                              [this, enabled, generation]() {
+                                  if (generation != m_hdrAsyncGeneration) {
+                                      return;
+                                  }
+                                  const bool success = setHDR(enabled);
+                                  if (generation != m_hdrAsyncGeneration) {
+                                      return;
+                                  }
+                                  emit hdrChangeFinished(enabled, success);
+                              },
+                              Qt::QueuedConnection);
+}
+
+void DisplayManager::cancelPendingHdrAsync()
+{
+    ++m_hdrAsyncGeneration;
+    m_hdrAsyncPending = false;
+    if (m_hdrAsyncPollTimer.isActive()) {
+        m_hdrAsyncPollTimer.stop();
+    }
+#ifdef Q_OS_WIN
+    m_hdrAsyncPaths.clear();
+#endif
 }
 
 double DisplayManager::getCurrentRefreshRate()
@@ -518,6 +579,94 @@ bool DisplayManager::setHDRWindows(bool enabled)
     return success;
 }
 
+bool DisplayManager::startHDRAsyncWindows(bool enabled)
+{
+    const bool preState = isAnyAdvancedColorEnabled();
+    m_hdrAsyncRequestedState = enabled;
+    m_hdrAsyncPreState = preState;
+
+    QString customCmd = m_config->getWindowsCustomHDRCommand();
+    if (!customCmd.isEmpty()) {
+        return false;
+    }
+
+    UINT32 numPathArrayElements = 0;
+    UINT32 numModeInfoArrayElements = 0;
+    const LONG sizeRet = GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &numPathArrayElements, &numModeInfoArrayElements);
+    if (sizeRet != ERROR_SUCCESS) {
+        qWarning() << "DisplayManager: GetDisplayConfigBufferSizes failed for async HDR toggle";
+        return false;
+    }
+
+    std::vector<DISPLAYCONFIG_PATH_INFO> pathArray(numPathArrayElements);
+    std::vector<DISPLAYCONFIG_MODE_INFO> modeInfoArray(numModeInfoArrayElements);
+    const LONG queryRet = QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS,
+                                             &numPathArrayElements,
+                                             pathArray.data(),
+                                             &numModeInfoArrayElements,
+                                             modeInfoArray.data(),
+                                             nullptr);
+    if (queryRet != ERROR_SUCCESS) {
+        qWarning() << "DisplayManager: QueryDisplayConfig failed for async HDR toggle";
+        return false;
+    }
+
+    bool success = false;
+    bool issuedRequest = false;
+    m_hdrAsyncPaths.clear();
+    m_hdrAsyncPaths.reserve(static_cast<int>(numPathArrayElements));
+
+    for (UINT32 i = 0; i < numPathArrayElements; ++i) {
+        const DISPLAYCONFIG_PATH_INFO &pathInfo = pathArray[i];
+        const AdvancedColorStateQueryResult prePathState = queryAdvancedColorState(pathInfo);
+        if (prePathState.ok && prePathState.enabled == enabled) {
+            success = true;
+            continue;
+        }
+
+        DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE setAdvancedColorState = {};
+        setAdvancedColorState.header.type = DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE;
+        setAdvancedColorState.header.size = sizeof(DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE);
+        setAdvancedColorState.header.adapterId = pathInfo.targetInfo.adapterId;
+        setAdvancedColorState.header.id = pathInfo.targetInfo.id;
+        setAdvancedColorState.value = enabled ? 1 : 0;
+
+        const LONG ret = DisplayConfigSetDeviceInfo(&setAdvancedColorState.header);
+        qCInfo(lcDisplayTrace) << "setHDRAsyncWindows path"
+                               << i
+                               << "adapter=" << formatAdapterId(pathInfo.targetInfo.adapterId)
+                               << "targetId=" << pathInfo.targetInfo.id
+                               << "requested=" << enabled
+                               << "ret=" << ret;
+        if (ret == ERROR_SUCCESS) {
+            success = true;
+            issuedRequest = true;
+            m_hdrAsyncPaths.push_back(pathInfo);
+        } else {
+            qWarning() << "DisplayManager: Failed async HDR toggle for path" << i << "error:" << ret;
+        }
+    }
+
+    if (!success) {
+        return false;
+    }
+
+    if (!issuedRequest || m_hdrAsyncPaths.isEmpty()) {
+        updateHdrRestoreTracking(enabled, preState);
+        QMetaObject::invokeMethod(this,
+                                  [this, enabled]() {
+                                      emit hdrChangeFinished(enabled, true);
+                                  },
+                                  Qt::QueuedConnection);
+        return true;
+    }
+
+    m_hdrAsyncPending = true;
+    m_hdrAsyncElapsed.restart();
+    m_hdrAsyncPollTimer.start();
+    return true;
+}
+
 #else
 bool DisplayManager::setRefreshRateLinux(double hz)
 {
@@ -592,3 +741,48 @@ bool DisplayManager::setHDRLinux(bool enabled)
     return process.exitCode() == 0;
 }
 #endif
+
+void DisplayManager::pollPendingHdrAsync()
+{
+    if (!m_hdrAsyncPending) {
+        return;
+    }
+
+#ifdef Q_OS_WIN
+    bool allSettled = true;
+    bool success = !m_hdrAsyncPaths.isEmpty();
+    for (const DISPLAYCONFIG_PATH_INFO &pathInfo : m_hdrAsyncPaths) {
+        const AdvancedColorStateQueryResult state = queryAdvancedColorState(pathInfo);
+        if (!state.ok || state.enabled != m_hdrAsyncRequestedState) {
+            allSettled = false;
+            if (!state.ok) {
+                success = false;
+            }
+        }
+    }
+
+    if (!allSettled && m_hdrAsyncElapsed.elapsed() < 5000) {
+        return;
+    }
+
+    if (!allSettled) {
+        success = false;
+        qCWarning(lcDisplayTrace) << "setHDRAsync settle-timeout"
+                                  << "requested=" << m_hdrAsyncRequestedState
+                                  << "elapsedMs=" << m_hdrAsyncElapsed.elapsed();
+    }
+#else
+    const bool success = false;
+#endif
+
+    m_hdrAsyncPending = false;
+    if (m_hdrAsyncPollTimer.isActive()) {
+        m_hdrAsyncPollTimer.stop();
+    }
+
+    if (success) {
+        updateHdrRestoreTracking(m_hdrAsyncRequestedState, m_hdrAsyncPreState);
+    }
+
+    emit hdrChangeFinished(m_hdrAsyncRequestedState, success);
+}

--- a/src/utils/DisplayManager.h
+++ b/src/utils/DisplayManager.h
@@ -1,8 +1,15 @@
 #pragma once
 
 #include <QObject>
+#include <QElapsedTimer>
 #include <QString>
+#include <QTimer>
+#include <QVector>
 #include "ConfigManager.h"
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
 
 class DisplayManager : public QObject
 {
@@ -11,6 +18,9 @@ class DisplayManager : public QObject
 public:
     explicit DisplayManager(ConfigManager *config, QObject *parent = nullptr);
     ~DisplayManager();
+
+signals:
+    void hdrChangeFinished(bool enabled, bool success);
 
 public slots:
     /**
@@ -45,6 +55,17 @@ public slots:
     bool setHDR(bool enabled);
 
     /**
+     * @brief Toggles HDR on or off without blocking the GUI thread.
+     * @param enabled true to enable HDR, false to disable.
+     */
+    void setHDRAsync(bool enabled);
+
+    /**
+     * @brief Cancels any pending asynchronous HDR settle polling.
+     */
+    void cancelPendingHdrAsync();
+
+    /**
      * @brief Gets the current refresh rate of the primary display.
      * @return The refresh rate in Hz (fractional), or 0 if failed.
      */
@@ -54,6 +75,8 @@ public slots:
      * @brief Whether playback is currently using a temporary refresh-rate override.
      */
     bool hasActiveRefreshRateOverride() const { return m_refreshRateChanged; }
+    bool needsRefreshRestore() const { return m_refreshRateChanged || (m_hasCapturedOriginalRefreshRate && m_originalRefreshRate > 0.0); }
+    bool needsHdrRestore() const { return m_hdrChanged; }
 
 private:
     ConfigManager *m_config;
@@ -65,15 +88,28 @@ private:
     bool m_hasCapturedOriginalRefreshRate = false;
     bool m_hdrChanged = false;
     bool m_originalHDRState = false;
+    bool m_hasCapturedOriginalHDRState = false;
+    QTimer m_hdrAsyncPollTimer;
+    QElapsedTimer m_hdrAsyncElapsed;
+    bool m_hdrAsyncPending = false;
+    bool m_hdrAsyncRequestedState = false;
+    bool m_hdrAsyncPreState = false;
+    quint64 m_hdrAsyncGeneration = 0;
+#ifdef Q_OS_WIN
+    QVector<DISPLAYCONFIG_PATH_INFO> m_hdrAsyncPaths;
+#endif
 
     // Platform-specific helpers
 #ifdef Q_OS_WIN
     bool setRefreshRateWindows(double hz);
     bool restoreRefreshRateWindows();
     bool setHDRWindows(bool enabled);
+    bool startHDRAsyncWindows(bool enabled);
 #else
     bool setRefreshRateLinux(double hz);
     bool restoreRefreshRateLinux();
     bool setHDRLinux(bool enabled);
 #endif
+    void pollPendingHdrAsync();
+    void updateHdrRestoreTracking(bool requestedState, bool preState);
 };

--- a/tests/PlayerControllerAutoplayContextTest.cpp
+++ b/tests/PlayerControllerAutoplayContextTest.cpp
@@ -42,6 +42,7 @@ public:
 
     void stopMpv() override
     {
+        ++stopCallCount;
         if (!m_running) {
             return;
         }
@@ -92,6 +93,7 @@ private:
 
 public:
     bool emitStopStateChangeSynchronously = true;
+    int stopCallCount = 0;
     QList<QVariantList> variantCommands;
     QList<QStringList> commands;
     QStringList appendedUrls;
@@ -116,6 +118,17 @@ public:
     void emitPlaylistPosition(int index)
     {
         emit playlistPositionChanged(index);
+    }
+
+    void emitRunningState(bool running)
+    {
+        m_running = running;
+        emit stateChanged(running);
+    }
+
+    void emitPlaybackEndedSignal()
+    {
+        emit playbackEnded();
     }
 };
 
@@ -237,7 +250,8 @@ class PlayerControllerAutoplayContextTest : public QObject
 private slots:
     void thresholdMetRequestsNextEpisodeDirectly();
     void userStopPastThresholdRequestsNextEpisode();
-    void userStopBelowThresholdTransitionsIdleBeforeBackendExit();
+    void userStopBelowThresholdWaitsForBackendExit();
+    void playbackEndedUpgradesQueuedStopFinalization();
     void nextEpisodeNavigationUsesPendingTrackContext();
     void nextEpisodeIgnoresMismatchedSeries();
     void playbackPrefetchIgnoresGenericNextEpisodeResponses();
@@ -283,7 +297,7 @@ void PlayerControllerAutoplayContextTest::thresholdMetRequestsNextEpisodeDirectl
     controller.m_currentPosition = 95.0;
     controller.m_playbackState = PlayerController::Playing;
 
-    controller.handlePlaybackStopAndAutoplay(PlayerController::Event::PlaybackEnd);
+    controller.prepareTerminalTransition(PlayerController::TerminalReason::PlaybackEnd);
 
     QCOMPARE(libraryService.requestedSeriesIds.size(), 1);
     QCOMPARE(libraryService.requestedSeriesIds.first(), QStringLiteral("series-1"));
@@ -296,7 +310,7 @@ void PlayerControllerAutoplayContextTest::thresholdMetRequestsNextEpisodeDirectl
     QCOMPARE(controller.m_pendingAutoplaySeriesId, QStringLiteral("series-1"));
 
     controller.m_hasEvaluatedCompletionForAttempt = true;
-    controller.handlePlaybackStopAndAutoplay(PlayerController::Event::PlaybackEnd);
+    controller.prepareTerminalTransition(PlayerController::TerminalReason::PlaybackEnd);
     QCOMPARE(libraryService.requestedSeriesIds.size(), 1);
     QCOMPARE(libraryService.requestedExcludeIds.first(), QStringLiteral("item-1"));
 }
@@ -340,7 +354,7 @@ void PlayerControllerAutoplayContextTest::userStopPastThresholdRequestsNextEpiso
     QCOMPARE(controller.m_pendingAutoplaySeriesId, QStringLiteral("series-1"));
 }
 
-void PlayerControllerAutoplayContextTest::userStopBelowThresholdTransitionsIdleBeforeBackendExit()
+void PlayerControllerAutoplayContextTest::userStopBelowThresholdWaitsForBackendExit()
 {
     ConfigManager config;
     config.setAutoplayNextEpisode(false);
@@ -374,12 +388,61 @@ void PlayerControllerAutoplayContextTest::userStopBelowThresholdTransitionsIdleB
 
     controller.stop();
 
-    QCOMPARE(controller.playbackState(), PlayerController::Idle);
+    QCOMPARE(backend.stopCallCount, 1);
+    QCOMPARE(controller.playbackState(), PlayerController::Playing);
+    QVERIFY(controller.m_terminalTransitionActive);
+    QVERIFY(!controller.m_terminalFinalizationQueued);
     QVERIFY(!controller.awaitingNextEpisodeResolution());
     QVERIFY(!controller.m_shouldAutoplay);
     QVERIFY(controller.m_pendingAutoplayItemId.isEmpty());
     QVERIFY(controller.m_pendingAutoplaySeriesId.isEmpty());
     QVERIFY(libraryService.requestedSeriesIds.isEmpty());
+
+    backend.emitRunningState(false);
+    QCoreApplication::processEvents();
+
+    QCOMPARE(controller.playbackState(), PlayerController::Idle);
+    QVERIFY(!controller.m_terminalTransitionActive);
+}
+
+void PlayerControllerAutoplayContextTest::playbackEndedUpgradesQueuedStopFinalization()
+{
+    ConfigManager config;
+    config.setPlaybackCompletionThreshold(90);
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+
+    controller.m_currentItemId = QStringLiteral("item-1");
+    controller.m_currentSeriesId = QStringLiteral("series-1");
+    controller.m_duration = 100.0;
+    controller.m_currentPosition = 95.0;
+    controller.m_playbackState = PlayerController::Playing;
+
+    controller.requestTerminalTransition(PlayerController::TerminalReason::Stop);
+    QVERIFY(controller.m_terminalTransitionActive);
+    controller.queueTerminalFinalization();
+    QVERIFY(controller.m_terminalFinalizationQueued);
+
+    controller.onPlaybackEnded();
+    QCoreApplication::processEvents();
+
+    QCOMPARE(controller.playbackState(), PlayerController::Idle);
+    QVERIFY(!controller.m_terminalTransitionActive);
+    QCOMPARE(libraryService.requestedSeriesIds.size(), 1);
+    QCOMPARE(libraryService.requestedContexts.first(),
+             QStringLiteral("player:resolve:series-1:item-1"));
 }
 
 void PlayerControllerAutoplayContextTest::nextEpisodeNavigationUsesPendingTrackContext()


### PR DESCRIPTION
## Summary
- make terminal playback transitions backend-first so `PlayerController` does not transition to `Idle` before embedded libmpv has stopped
- defer Windows HDR-off and refresh-rate restoration off the synchronous `Idle` entry path so the UI and detached overlay window can repaint/hide promptly
- add terminal-transition regression coverage and document the new playback lifecycle behavior

## Testing
- `nix build .#Bloom`

## Notes
- this keeps the Windows geometry sync timers unchanged; they were not the root cause
- stop/end/error now share a one-shot terminal transition path to avoid duplicate reporting/autoplay handling

## Manual Windows validation still recommended
- stop immediately after playback start
- stop after several seconds of playback
- pause, then `Esc`
- seek left/right, then `Esc`
- pause + seek, then `Esc`
- resize, minimize/restore, maximize, and fullscreen transitions while stopping
- HDR content with refresh-rate matching enabled
- SDR content with no display restore needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous HDR control with completion reporting and public queries for whether HDR/refresh restore is needed.

* **Bug Fixes**
  * Coordinated Windows playback stop to wait for backend termination before tearing down embedded window.
  * Made HDR and refresh-rate restoration non-blocking so UI and playback overlay can repaint promptly.
  * Unified stop/end/error paths to ensure autoplay/reporting runs exactly once per playback attempt.

* **Tests**
  * Updated controller tests to validate backend-coordinated stop behavior and queued terminal finalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden Windows embedded playback stop teardown with backend-first terminal transitions and deferred display restore
> - Introduces a unified terminal transition subsystem in `PlayerController` that waits for backend stop confirmation before transitioning the state machine to Idle/Error, preventing races on stop, error, and playback-end paths.
> - Replaces immediate HDR/refresh-rate restoration with a deferred, non-blocking flow using new `setHDRAsync` and polling in `DisplayManager`; completion is signaled via `hdrChangeFinished`.
> - `playUrl` and `playTestVideo` now use a replacement playback flow that cancels in-flight transitions, waits for backend stop, then starts the new item — eliminating double-stop reporting.
> - Adds generation counters throughout to invalidate stale queued callbacks after cancellation or destruction.
> - Risk: Idle state entry is no longer synchronous with display restoration; HDR and refresh-rate changes complete asynchronously after the state machine has already settled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39d4cf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->