### PR TITLE
feat(ui): dismiss playback overlay before stop on Esc

### DIFF
--- a/docs/playback.md
+++ b/docs/playback.md
@@ -188,6 +188,7 @@ UI Components for Track Selection
   - Center group: skip back 10s, previous chapter, play/pause, next chapter, skip forward 10s.
   - Right group: volume icon button opens a native volume panel (slider + muted state) with left/right keyboard/gamepad adjustment and Enter/Space mute toggle.
   - Progress row: clickable seek track, current/total time labels, and keyboard seek via left/right.
+  - Escape (and the header back affordance) first dismisses visible playback chrome (full controls, seek preview, skip-intro popup, or open track/volume panels); a second Escape stops playback when the overlay is already hidden.
   - Trickplay preview bubble: renders processed Jellyfin trickplay thumbnails from `PlayerController` and is hidden entirely when trickplay images are unavailable.
   - Intro/outro skip UX: transient "Skip Intro"/"Skip Credits" pop-up button auto-focuses when a segment window starts, then a compact persistent skip button remains available until that segment ends.
     - Popup timing is controlled by `ConfigManager.skipButtonAutoHideSeconds` (`settings.playback.skip_button_auto_hide_seconds`, range 0-15; 0 disables popup only).

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -188,7 +188,7 @@ UI Components for Track Selection
   - Center group: skip back 10s, previous chapter, play/pause, next chapter, skip forward 10s.
   - Right group: volume icon button opens a native volume panel (slider + muted state) with left/right keyboard/gamepad adjustment and Enter/Space mute toggle.
   - Progress row: clickable seek track, current/total time labels, and keyboard seek via left/right.
-  - Escape (and the header back affordance) first dismisses visible playback chrome (full controls, seek preview, skip-intro popup, or open track/volume panels); a second Escape stops playback when the overlay is already hidden.
+  - Escape first dismisses visible playback chrome (full controls, seek preview, skip-intro popup, or open track/volume panels); a second Escape stops playback when the overlay is already hidden. The header back control exits playback immediately while controls are visible.
   - Trickplay preview bubble: renders processed Jellyfin trickplay thumbnails from `PlayerController` and is hidden entirely when trickplay images are unavailable.
   - Intro/outro skip UX: transient "Skip Intro"/"Skip Credits" pop-up button auto-focuses when a segment window starts, then a compact persistent skip button remains available until that segment ends.
     - Popup timing is controlled by `ConfigManager.skipButtonAutoHideSeconds` (`settings.playback.skip_button_auto_hide_seconds`, range 0-15; 0 disables popup only).

--- a/src/ui/EmbeddedPlaybackOverlay.qml
+++ b/src/ui/EmbeddedPlaybackOverlay.qml
@@ -45,6 +45,8 @@ FocusScope {
                                                  && !buffering
                                                  && activeSkipSegmentType.length > 0
     property bool skipPopupVisible: false
+    /// When true, `showSkipPopupIfEligible` is a no-op (e.g. after Esc dismisses full chrome).
+    property bool suppressSkipPopupReshow: false
     property string skipPopupSegmentType: ""
     property double skipPopupWindowEndEpochMs: 0
     property int controlsAutoHideMs: 2500
@@ -84,7 +86,8 @@ FocusScope {
     }
 
     function showSkipPopupIfEligible() {
-        if (!overlayActive || controlsVisible || activeSkipSegmentType.length === 0 || skipPopupDurationMs <= 0) {
+        if (!overlayActive || controlsVisible || suppressSkipPopupReshow
+                || activeSkipSegmentType.length === 0 || skipPopupDurationMs <= 0) {
             skipPopupVisible = false
             skipPopupTimer.stop()
             return
@@ -273,17 +276,26 @@ FocusScope {
     }
 
     function closeSelectors() {
+        var focusTarget = null
+        if (audioSelectorOpen) {
+            focusTarget = audioButton
+        } else if (subtitleSelectorOpen) {
+            focusTarget = subtitleButton
+        } else if (volumeSelectorOpen) {
+            focusTarget = volumeButton
+        }
         var wasOpen = selectorOpen
         audioSelectorOpen = false
         subtitleSelectorOpen = false
         volumeSelectorOpen = false
         if (wasOpen) {
-            Qt.callLater(function() { playPauseButton.forceActiveFocus() })
+            var target = focusTarget || playPauseButton
+            Qt.callLater(function() { target.forceActiveFocus() })
         }
         return wasOpen
     }
 
-    /// Returns true if playback should continue (chrome/popup/selector was dismissed).
+    /// Returns true if a dismissal occurred (caller should not stop playback).
     function tryDismissPlaybackOverlayBeforeStop() {
         if (!overlayActive) {
             return false
@@ -297,11 +309,13 @@ FocusScope {
             return true
         }
         if (seekPreviewActive || controlsVisible) {
+            suppressSkipPopupReshow = true
             seekPreviewTimer.stop()
             hideTimer.stop()
             seekPreviewActive = false
             controlsVisible = false
             seekOnlyMode = false
+            Qt.callLater(function() { root.suppressSkipPopupReshow = false })
             return true
         }
         return false
@@ -473,6 +487,7 @@ FocusScope {
             skipPopupVisible = false
             skipPopupSegmentType = ""
             skipPopupWindowEndEpochMs = 0
+            suppressSkipPopupReshow = false
         }
     }
 
@@ -984,11 +999,7 @@ FocusScope {
                 diameter: Math.round(56 * Theme.layoutScale)
                 iconSize: Math.round(28 * Theme.layoutScale)
                 text: Icons.arrowBack
-                onClicked: {
-                    if (!root.tryDismissPlaybackOverlayBeforeStop()) {
-                        PlayerController.stop()
-                    }
-                }
+                onClicked: PlayerController.stop()
                 KeyNavigation.down: progressFocus
                 KeyNavigation.right: progressFocus
             }

--- a/src/ui/EmbeddedPlaybackOverlay.qml
+++ b/src/ui/EmbeddedPlaybackOverlay.qml
@@ -283,6 +283,30 @@ FocusScope {
         return wasOpen
     }
 
+    /// Returns true if playback should continue (chrome/popup/selector was dismissed).
+    function tryDismissPlaybackOverlayBeforeStop() {
+        if (!overlayActive) {
+            return false
+        }
+        if (closeSelectors()) {
+            return true
+        }
+        if (skipPopupVisible) {
+            skipPopupVisible = false
+            skipPopupTimer.stop()
+            return true
+        }
+        if (seekPreviewActive || controlsVisible) {
+            seekPreviewTimer.stop()
+            hideTimer.stop()
+            seekPreviewActive = false
+            controlsVisible = false
+            seekOnlyMode = false
+            return true
+        }
+        return false
+    }
+
     function openVolumeSelector() {
         if (volumeSelectorOpen) {
             volumeSelectorOpen = false
@@ -960,7 +984,11 @@ FocusScope {
                 diameter: Math.round(56 * Theme.layoutScale)
                 iconSize: Math.round(28 * Theme.layoutScale)
                 text: Icons.arrowBack
-                onClicked: PlayerController.stop()
+                onClicked: {
+                    if (!root.tryDismissPlaybackOverlayBeforeStop()) {
+                        PlayerController.stop()
+                    }
+                }
                 KeyNavigation.down: progressFocus
                 KeyNavigation.right: progressFocus
             }

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -1013,7 +1013,7 @@ Window {
         sequence: "Esc"
         enabled: PlayerController.isPlaybackActive
         onActivated: {
-            if (activeEmbeddedPlaybackOverlay.closeSelectors()) {
+            if (activeEmbeddedPlaybackOverlay.tryDismissPlaybackOverlayBeforeStop()) {
                 return
             }
             PlayerController.stop()


### PR DESCRIPTION
## Summary
While playback is active, **Escape** and the overlay **back** control now dismiss visible playback chrome (track/volume panels, skip popup, seek preview, full controls) instead of stopping immediately. A second **Escape** stops playback when the overlay is already hidden.

## Changes
- `EmbeddedPlaybackOverlay.qml`: add `tryDismissPlaybackOverlayBeforeStop()`; wire header back button through it
- `Main.qml`: Esc shortcut uses the same helper before `PlayerController.stop()`
- `docs/playback.md`: document two-step Escape behavior

## Documentation
- [x] `docs/playback.md` updated

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dismiss playback overlay UI before stopping playback on Esc
> - Pressing Esc during playback now first dismisses visible overlay UI (open selector panels, skip popup, seek preview, or controls) and only stops playback if nothing was dismissed.
> - Adds `tryDismissPlaybackOverlayBeforeStop()` in [EmbeddedPlaybackOverlay.qml](https://github.com/crowquillx/Bloom/pull/38/files#diff-751291eab37e3edc8b0215dfcbffd3d478827844a1f97a824910affa2af6a216) as a unified dismissal path, called from the Esc handler in [Main.qml](https://github.com/crowquillx/Bloom/pull/38/files#diff-f4773d055809f8f8ae1877220a16747bc781215089a7b6b7eb33e5b444a27be5) instead of the previous `closeSelectors()` call.
> - Adds a `suppressSkipPopupReshow` flag that prevents the skip intro popup from immediately reappearing after Esc dismisses the controls.
> - After closing a selector panel (audio, subtitle, or volume), focus now returns to the button that opened it rather than always to the play/pause button.
> - Behavioral Change: a single Esc no longer stops playback if any overlay UI is visible; a second Esc is required to stop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25077b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Escape-key and back-button behavior: first press dismisses playback chrome (controls, seek preview, skip popup, open panels); subsequent press stops playback only when overlay is hidden.

* **Documentation**
  * Updated playback documentation describing the revised keyboard handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->