### PR TITLE
feat(playback): show series and movie logos in embedded overlay

### DIFF
--- a/docs/playback.md
+++ b/docs/playback.md
@@ -195,7 +195,8 @@ UI Components for Track Selection
     - Optional automatic skip is controlled by `ConfigManager.autoSkipIntro` and `ConfigManager.autoSkipOutro`; each auto-skip applies at most once per playback item even if the user seeks back.
 
 Playback overlay metadata
-- `PlayerController` now exposes `overlayTitle` and `overlaySubtitle` for native overlay header text.
+- `PlayerController` exposes `overlayTitle`, `overlaySubtitle`, `overlayBackdropUrl`, and `overlayLogoUrl` for the native overlay (header, buffering card, and backdrop).
+- Optional `overlayLogoUrl` is a Jellyfin logo image URL (typically the `image://cached/...` form from `LibraryService::getCachedImageUrlWithWidth`). `EmbeddedPlaybackOverlay.qml` shows the logo when the URL is non-empty and the image reaches `Image.Ready`; on load failure (`Image.Error`) or when the URL is empty, the overlay falls back to `overlayTitle` text.
 - Detail views set metadata before playback starts:
   - Movies: title + production year.
   - Episodes: series title + `Sxx Exx - Episode Name`.

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -1693,6 +1693,7 @@ void PlayerController::requestPlayback(const QVariantMap &request)
     pending.overlayTitle = request.value(QStringLiteral("overlayTitle")).toString();
     pending.overlaySubtitle = request.value(QStringLiteral("overlaySubtitle")).toString();
     pending.overlayBackdropUrl = request.value(QStringLiteral("overlayBackdropUrl")).toString();
+    pending.overlayLogoUrl = request.value(QStringLiteral("overlayLogoUrl")).toString();
     pending.startPositionTicks = request.value(QStringLiteral("startPositionTicks")).toLongLong();
     pending.preferredAudioIndex = request.value(QStringLiteral("preferredAudioIndex"), -2).toInt();
     pending.preferredSubtitleIndex = request.value(QStringLiteral("preferredSubtitleIndex"), -2).toInt();
@@ -1861,7 +1862,10 @@ void PlayerController::launchResolvedPlaybackRequest(const QString &requestId)
             ? 0.0
             : m_pendingAutoplayFramerate;
         const bool isHdr = false;
-        setOverlayMetadata(request.overlayTitle, request.overlaySubtitle, request.overlayBackdropUrl);
+        setOverlayMetadata(request.overlayTitle,
+                           request.overlaySubtitle,
+                           request.overlayBackdropUrl,
+                           request.overlayLogoUrl);
         playUrl(m_libraryService->getStreamUrl(request.itemId),
                 request.itemId,
                 request.startPositionTicks,
@@ -1893,7 +1897,10 @@ void PlayerController::launchResolvedPlaybackRequest(const QString &requestId)
         return;
     }
 
-    setOverlayMetadata(request.overlayTitle, request.overlaySubtitle, request.overlayBackdropUrl);
+    setOverlayMetadata(request.overlayTitle,
+                       request.overlaySubtitle,
+                       request.overlayBackdropUrl,
+                       request.overlayLogoUrl);
 
     const QVariantMap firstSegment = segments.first().toMap();
     playUrlWithTracks(firstSegment.value(QStringLiteral("url")).toString(),
@@ -2361,8 +2368,14 @@ void PlayerController::playNextEpisode(const QJsonObject &episodeData, const QSt
     if (!episodeName.isEmpty()) {
         subtitle += QStringLiteral(" - ") + episodeName;
     }
-    setOverlayMetadata(seriesName.isEmpty() ? QStringLiteral("Now Playing") : seriesName, subtitle);
-    
+    const QString overlayLogoUrl = (m_libraryService && !seriesId.isEmpty())
+        ? m_libraryService->getCachedImageUrlWithWidth(seriesId, QStringLiteral("Logo"), 600)
+        : QString();
+    setOverlayMetadata(seriesName.isEmpty() ? QStringLiteral("Now Playing") : seriesName,
+                       subtitle,
+                       QString(),
+                       overlayLogoUrl);
+
     emit autoplayingNextEpisode(episodeName, seriesName);
 
     QString targetSeasonId = episodeData.value(QStringLiteral("SeasonId")).toString();
@@ -2388,6 +2401,9 @@ void PlayerController::playNextEpisode(const QJsonObject &episodeData, const QSt
     request[QStringLiteral("startPositionTicks")] = startPositionTicks;
     request[QStringLiteral("overlayTitle")] = seriesName.isEmpty() ? QStringLiteral("Now Playing") : seriesName;
     request[QStringLiteral("overlaySubtitle")] = subtitle;
+    if (!overlayLogoUrl.isEmpty()) {
+        request[QStringLiteral("overlayLogoUrl")] = overlayLogoUrl;
+    }
     request[QStringLiteral("isMovie")] = false;
     request[QStringLiteral("allowVersionPrompt")] = false;
     request[QStringLiteral("useAffinityFallback")] = true;
@@ -4475,32 +4491,40 @@ void PlayerController::onScriptMessage(const QString &messageName, const QString
     // Script-driven trickplay handlers were retired with the native overlay migration.
 }
 
-void PlayerController::setOverlayMetadata(const QString &title, const QString &subtitle, const QString &backdropUrl)
+void PlayerController::setOverlayMetadata(const QString &title,
+                                          const QString &subtitle,
+                                          const QString &backdropUrl,
+                                          const QString &logoUrl)
 {
     const QString normalizedTitle = title.trimmed();
     const QString normalizedSubtitle = subtitle.trimmed();
     const QString normalizedBackdropUrl = backdropUrl.trimmed();
+    const QString normalizedLogoUrl = logoUrl.trimmed();
     if (m_overlayTitle == normalizedTitle
         && m_overlaySubtitle == normalizedSubtitle
-        && m_overlayBackdropUrl == normalizedBackdropUrl) {
+        && m_overlayBackdropUrl == normalizedBackdropUrl
+        && m_overlayLogoUrl == normalizedLogoUrl) {
         return;
     }
 
     m_overlayTitle = normalizedTitle;
     m_overlaySubtitle = normalizedSubtitle;
     m_overlayBackdropUrl = normalizedBackdropUrl;
+    m_overlayLogoUrl = normalizedLogoUrl;
     emit overlayMetadataChanged();
 }
 
 void PlayerController::clearOverlayMetadata()
 {
-    if (m_overlayTitle.isEmpty() && m_overlaySubtitle.isEmpty() && m_overlayBackdropUrl.isEmpty()) {
+    if (m_overlayTitle.isEmpty() && m_overlaySubtitle.isEmpty() && m_overlayBackdropUrl.isEmpty()
+        && m_overlayLogoUrl.isEmpty()) {
         return;
     }
 
     m_overlayTitle.clear();
     m_overlaySubtitle.clear();
     m_overlayBackdropUrl.clear();
+    m_overlayLogoUrl.clear();
     emit overlayMetadataChanged();
 }
 

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -82,6 +82,7 @@ class PlayerController : public QObject
     Q_PROPERTY(QString overlayTitle READ overlayTitle NOTIFY overlayMetadataChanged)
     Q_PROPERTY(QString overlaySubtitle READ overlaySubtitle NOTIFY overlayMetadataChanged)
     Q_PROPERTY(QString overlayBackdropUrl READ overlayBackdropUrl NOTIFY overlayMetadataChanged)
+    Q_PROPERTY(QString overlayLogoUrl READ overlayLogoUrl NOTIFY overlayMetadataChanged)
     
     // Track selection properties
     Q_PROPERTY(int selectedAudioTrack READ selectedAudioTrack WRITE setSelectedAudioTrack NOTIFY selectedAudioTrackChanged)
@@ -187,6 +188,7 @@ public:
     QString overlayTitle() const { return m_overlayTitle; }
     QString overlaySubtitle() const { return m_overlaySubtitle; }
     QString overlayBackdropUrl() const { return m_overlayBackdropUrl; }
+    QString overlayLogoUrl() const { return m_overlayLogoUrl; }
     Q_INVOKABLE void setAudioDelay(int ms);
     Q_INVOKABLE bool attachEmbeddedVideoTarget(QObject *target);
     Q_INVOKABLE void detachEmbeddedVideoTarget(QObject *target = nullptr);
@@ -262,7 +264,10 @@ public:
     Q_INVOKABLE void toggleMpvStats();
     Q_INVOKABLE void showMpvStatsPage(int page);
     Q_INVOKABLE void sendMpvKeypress(const QString &key);
-    Q_INVOKABLE void setOverlayMetadata(const QString &title, const QString &subtitle = QString(), const QString &backdropUrl = QString());
+    Q_INVOKABLE void setOverlayMetadata(const QString &title,
+                                        const QString &subtitle = QString(),
+                                        const QString &backdropUrl = QString(),
+                                        const QString &logoUrl = QString());
     Q_INVOKABLE void clearOverlayMetadata();
     Q_INVOKABLE void setTrickplayPreviewPositionSeconds(double seconds);
     Q_INVOKABLE void clearTrickplayPreviewPositionOverride();
@@ -612,6 +617,7 @@ private:
         QString overlayTitle;
         QString overlaySubtitle;
         QString overlayBackdropUrl;
+        QString overlayLogoUrl;
         qint64 startPositionTicks = 0;
         int preferredAudioIndex = -2;
         int preferredSubtitleIndex = -2;
@@ -766,6 +772,7 @@ private:
     QString m_overlayTitle;
     QString m_overlaySubtitle;
     QString m_overlayBackdropUrl;
+    QString m_overlayLogoUrl;
     
     // OSC and trickplay data
     QList<MediaSegmentInfo> m_currentSegments;

--- a/src/ui/EmbeddedPlaybackOverlay.qml
+++ b/src/ui/EmbeddedPlaybackOverlay.qml
@@ -25,6 +25,9 @@ FocusScope {
     readonly property string mediaSubtitle: (PlayerController.overlaySubtitle && PlayerController.overlaySubtitle.length > 0)
                                            ? PlayerController.overlaySubtitle
                                            : (paused ? qsTr("Paused") : qsTr("Playing"))
+    readonly property string overlayLogoSource: (PlayerController.overlayLogoUrl && PlayerController.overlayLogoUrl.length > 0)
+                                                ? PlayerController.overlayLogoUrl
+                                                : ""
     property bool controlsVisible: false
     property bool seekPreviewActive: false
     property bool seekOnlyMode: false
@@ -963,15 +966,36 @@ FocusScope {
                 font.pixelSize: Math.round(20 * Theme.layoutScale)
             }
 
-            Text {
-                text: root.mediaTitle
-                anchors.horizontalCenter: parent.horizontalCenter
+            Item {
                 width: parent.width
-                horizontalAlignment: Text.AlignHCenter
-                color: Qt.rgba(Theme.textPrimary.r, Theme.textPrimary.g, Theme.textPrimary.b, 0.82)
-                font.family: Theme.fontPrimary
-                font.pixelSize: Math.round(18 * Theme.layoutScale)
-                elide: Text.ElideRight
+                height: Math.max(bufferingTitleLogo.height, bufferingTitleText.implicitHeight)
+
+                Image {
+                    id: bufferingTitleLogo
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                    height: Math.round(56 * Theme.layoutScale)
+                    width: Math.min(Math.round(300 * Theme.layoutScale), parent.width)
+                    source: root.overlayLogoSource
+                    fillMode: Image.PreserveAspectFit
+                    asynchronous: true
+                    cache: true
+                    visible: root.overlayLogoSource.length > 0 && status !== Image.Error
+                    opacity: status === Image.Ready ? 1.0 : 0.0
+                }
+                Text {
+                    id: bufferingTitleText
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: parent.width
+                    horizontalAlignment: Text.AlignHCenter
+                    text: root.mediaTitle
+                    visible: root.overlayLogoSource.length === 0 || bufferingTitleLogo.status === Image.Error
+                    color: Qt.rgba(Theme.textPrimary.r, Theme.textPrimary.g, Theme.textPrimary.b, 0.82)
+                    font.family: Theme.fontPrimary
+                    font.pixelSize: Math.round(18 * Theme.layoutScale)
+                    elide: Text.ElideRight
+                }
             }
         }
     }
@@ -1009,14 +1033,36 @@ FocusScope {
                 anchors.verticalCenter: backButton.verticalCenter
                 width: parent.width - backButton.width - parent.spacing
 
-                Text {
-                    text: root.mediaTitle
-                    color: Theme.textPrimary
-                    font.family: Theme.fontPrimary
-                    font.pixelSize: Math.round(36 * Theme.layoutScale)
-                    font.weight: Font.DemiBold
-                    elide: Text.ElideRight
+                Item {
                     width: parent.width
+                    height: Math.max(chromeTitleLogo.height, chromeTitleText.implicitHeight)
+
+                    Image {
+                        id: chromeTitleLogo
+                        anchors.left: parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+                        height: Math.round(72 * Theme.layoutScale)
+                        width: Math.min(Math.round(360 * Theme.layoutScale), parent.width)
+                        source: root.overlayLogoSource
+                        fillMode: Image.PreserveAspectFit
+                        asynchronous: true
+                        cache: true
+                        visible: root.overlayLogoSource.length > 0 && status !== Image.Error
+                        opacity: status === Image.Ready ? 1.0 : 0.0
+                    }
+                    Text {
+                        id: chromeTitleText
+                        anchors.left: parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: parent.width
+                        text: root.mediaTitle
+                        visible: root.overlayLogoSource.length === 0 || chromeTitleLogo.status === Image.Error
+                        color: Theme.textPrimary
+                        font.family: Theme.fontPrimary
+                        font.pixelSize: Math.round(36 * Theme.layoutScale)
+                        font.weight: Font.DemiBold
+                        elide: Text.ElideRight
+                    }
                 }
 
                 Text {

--- a/src/ui/EmbeddedPlaybackOverlay.qml
+++ b/src/ui/EmbeddedPlaybackOverlay.qml
@@ -982,6 +982,7 @@ FocusScope {
                     cache: true
                     visible: root.overlayLogoSource.length > 0 && status !== Image.Error
                     opacity: status === Image.Ready ? 1.0 : 0.0
+                    Behavior on opacity { NumberAnimation { duration: Theme.durationFade } }
                 }
                 Text {
                     id: bufferingTitleText
@@ -990,7 +991,10 @@ FocusScope {
                     width: parent.width
                     horizontalAlignment: Text.AlignHCenter
                     text: root.mediaTitle
-                    visible: root.overlayLogoSource.length === 0 || bufferingTitleLogo.status === Image.Error
+                    visible: root.overlayLogoSource.length === 0
+                             || bufferingTitleLogo.status === Image.Error
+                             || bufferingTitleLogo.status === Image.Loading
+                             || bufferingTitleLogo.status === Image.Null
                     color: Qt.rgba(Theme.textPrimary.r, Theme.textPrimary.g, Theme.textPrimary.b, 0.82)
                     font.family: Theme.fontPrimary
                     font.pixelSize: Math.round(18 * Theme.layoutScale)
@@ -1049,6 +1053,7 @@ FocusScope {
                         cache: true
                         visible: root.overlayLogoSource.length > 0 && status !== Image.Error
                         opacity: status === Image.Ready ? 1.0 : 0.0
+                        Behavior on opacity { NumberAnimation { duration: Theme.durationFade } }
                     }
                     Text {
                         id: chromeTitleText
@@ -1056,7 +1061,10 @@ FocusScope {
                         anchors.verticalCenter: parent.verticalCenter
                         width: parent.width
                         text: root.mediaTitle
-                        visible: root.overlayLogoSource.length === 0 || chromeTitleLogo.status === Image.Error
+                        visible: root.overlayLogoSource.length === 0
+                                 || chromeTitleLogo.status === Image.Error
+                                 || chromeTitleLogo.status === Image.Loading
+                                 || chromeTitleLogo.status === Image.Null
                         color: Theme.textPrimary
                         font.family: Theme.fontPrimary
                         font.pixelSize: Math.round(36 * Theme.layoutScale)

--- a/src/ui/LibraryScreen.qml
+++ b/src/ui/LibraryScreen.qml
@@ -402,6 +402,14 @@ FocusScope {
             }
             
             onPlayNextEpisode: function(episodeId, startPositionTicks) {
+                var overlayLogoUrl = ""
+                if (SeriesDetailsViewModel.seriesId === root.currentSeriesId
+                        && SeriesDetailsViewModel.logoUrl !== "") {
+                    overlayLogoUrl = SeriesDetailsViewModel.logoUrl
+                } else if (root.currentSeriesId && root.currentSeriesData && root.currentSeriesData.ImageTags
+                           && root.currentSeriesData.ImageTags.Logo) {
+                    overlayLogoUrl = LibraryService.getCachedImageUrlWithWidth(root.currentSeriesId, "Logo", 600)
+                }
                 root.requestPlaybackWithResolvedLibrary({
                     itemId: episodeId,
                     startPositionTicks: startPositionTicks || 0,
@@ -412,6 +420,7 @@ FocusScope {
                                   : qsTr("Now Playing"),
                     overlaySubtitle: qsTr("Episode"),
                     overlayBackdropUrl: root.currentBackdropUrl,
+                    overlayLogoUrl: overlayLogoUrl,
                     preferredAudioIndex: -2,
                     preferredSubtitleIndex: -2,
                     isMovie: false,

--- a/src/ui/MovieDetailsView.qml
+++ b/src/ui/MovieDetailsView.qml
@@ -325,6 +325,7 @@ FocusScope {
             overlayTitle: movieName || qsTr("Now Playing"),
             overlaySubtitle: overlaySubtitle,
             overlayBackdropUrl: backdropUrl,
+            overlayLogoUrl: logoUrl,
             preferredAudioIndex: preferredAudioIndex,
             preferredSubtitleIndex: preferredSubtitleIndex,
             isMovie: true,

--- a/src/ui/SeriesSeasonEpisodeView.qml
+++ b/src/ui/SeriesSeasonEpisodeView.qml
@@ -853,6 +853,7 @@ FocusScope {
             overlayTitle: overlayTitle,
             overlaySubtitle: overlaySubtitle,
             overlayBackdropUrl: SeriesDetailsViewModel.backdropUrl || SeriesDetailsViewModel.posterUrl,
+            overlayLogoUrl: displayLogoUrl,
             preferredAudioIndex: selectedAudioIndex,
             preferredSubtitleIndex: selectedSubtitleIndex,
             isMovie: false,


### PR DESCRIPTION
## Summary
- Add `PlayerController.overlayLogoUrl` and wire it through `requestPlayback`, `setOverlayMetadata`, and Up Next `playNextEpisode` (series logo via `LibraryService::getCachedImageUrlWithWidth`).
- Pass logo URLs from `SeriesSeasonEpisodeView`, `MovieDetailsView`, and `LibraryScreen` when starting playback.
- `EmbeddedPlaybackOverlay`: render a larger logo in the top chrome and buffering card with `Image.Ready` / `Image.Error` fallback to title text.
- Document overlay metadata in `docs/playback.md`.

## Testing
- [x] Manual: embedded playback overlay shows logo when available and title when not.
- [x] Manual: buffering state shows matching behavior.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show series and movie logos in the embedded playback overlay
> - Adds an `overlayLogoUrl` property to `PlayerController` that carries a Jellyfin logo image URL through the playback request pipeline to the overlay UI.
> - [`EmbeddedPlaybackOverlay.qml`](https://github.com/crowquillx/Bloom/pull/39/files#diff-751291eab37e3edc8b0215dfcbffd3d478827844a1f97a824910affa2af6a216) displays the logo image when loaded successfully, falling back to the title text if the URL is empty or the image fails to load.
> - Movie and episode playback requests from [`MovieDetailsView.qml`](https://github.com/crowquillx/Bloom/pull/39/files#diff-5dce7290a6d672e72eca44878fbbb123483f3c2de846347d16891f4467d213a8), [`SeriesSeasonEpisodeView.qml`](https://github.com/crowquillx/Bloom/pull/39/files#diff-c539954ce8eec484b58ff0ae0f64bbd2af20f6099e0ca3829b876f2a2e4d5a94), and [`LibraryScreen.qml`](https://github.com/crowquillx/Bloom/pull/39/files#diff-892f3c8b0cdc7073101ac08700746894b475ae1446f2bd63b86d40cf79440a7e) now include a logo URL when available.
> - Up Next autoplay in `PlayerController` fetches the series logo via `LibraryService::getCachedImageUrlWithWidth` and passes it to the overlay.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 460a887.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->