### PR TITLE
fix(playback): harden windows embedded stop teardown

### DIFF
--- a/src/player/backend/WindowsMpvBackend.cpp
+++ b/src/player/backend/WindowsMpvBackend.cpp
@@ -146,6 +146,7 @@ void WindowsMpvBackend::startMpv(const QString &mpvBin, const QStringList &args,
     const QStringList finalArgs = sanitizeStartupArgs(args);
     m_playlistPosition = -1;
     m_playlistCount = 0;
+    m_stopRequested = false;
 
 #if defined(Q_OS_WIN)
     if (m_videoTarget != nullptr) {
@@ -196,14 +197,23 @@ void WindowsMpvBackend::stopMpv()
                                    << "directControlActive=" << m_directControlActive
                                    << "running=" << m_running;
     if (m_directControlActive) {
+        m_stopRequested = true;
 #if defined(Q_OS_WIN) && defined(BLOOM_HAS_LIBMPV)
         if (m_mpvHandle != nullptr) {
             mpv_handle *handle = static_cast<mpv_handle *>(m_mpvHandle);
             const char *command[] = {"stop", nullptr};
-            mpv_command_async(handle, 0, command);
+            const int status = mpv_command_async(handle, 0, command);
+            if (status < 0) {
+                qCWarning(lcWindowsLibmpvBackend) << "Direct libmpv stop command failed; falling back to immediate teardown";
+                teardownMpv();
+                syncContainerGeometry();
+                return;
+            }
         }
 #endif
-        teardownMpv();
+        // Do not synchronously destroy libmpv here. A blocking terminate can hold the UI
+        // in playback mode long enough to leave a black window behind the hidden shell.
+        setDirectRunning(false);
         syncContainerGeometry();
         return;
     }
@@ -315,16 +325,29 @@ bool WindowsMpvBackend::eventFilter(QObject *watched, QEvent *event)
 void WindowsMpvBackend::syncContainerGeometry()
 {
 #if defined(Q_OS_WIN)
+    const auto hideHostWindow = [this]() {
+        if (m_videoHostWinId == 0) {
+            return;
+        }
+
+        if (HWND hostWindow = reinterpret_cast<HWND>(m_videoHostWinId)) {
+            ShowWindow(hostWindow, SW_HIDE);
+        }
+    };
+
     if (m_videoTarget == nullptr) {
+        hideHostWindow();
         return;
     }
 
     if (!resolveContainerHandle(m_videoTarget)) {
         qCDebug(lcWindowsLibmpvBackend) << "Container handle unavailable; postponing geometry sync";
+        hideHostWindow();
         return;
     }
 
     if (!m_lastViewport.isValid() || m_lastViewport.isEmpty()) {
+        hideHostWindow();
         return;
     }
 
@@ -544,6 +567,7 @@ bool WindowsMpvBackend::tryStartDirectMpv(const QStringList &args, const QString
     return false;
 #else
     teardownMpv();
+    m_stopRequested = false;
 
     if (!initializeMpv(args)) {
         qCWarning(lcWindowsLibmpvBackend) << "Direct libmpv initialize failed";
@@ -613,6 +637,7 @@ void WindowsMpvBackend::teardownMpv()
     m_eventDispatchQueued.store(false, std::memory_order_release);
     m_playlistPosition = -1;
     m_playlistCount = 0;
+    m_stopRequested = false;
     setDirectRunning(false);
     m_directControlActive = false;
 }
@@ -653,6 +678,7 @@ void WindowsMpvBackend::processMpvEvents()
 
         switch (event->event_id) {
         case MPV_EVENT_SHUTDOWN:
+            m_stopRequested = false;
             teardownMpv();
             return;
         case MPV_EVENT_END_FILE: {
@@ -679,7 +705,12 @@ void WindowsMpvBackend::processMpvEvents()
                 && (m_playlistPosition + 1) < m_playlistCount;
             const bool reachedTerminalPlaybackState = !hasRemainingPlaylistItems && !isRedirectTransition;
 
+            if (m_stopRequested && reachedTerminalPlaybackState) {
+                shouldEmitPlaybackEnded = false;
+            }
+
             if (reachedTerminalPlaybackState) {
+                m_stopRequested = false;
                 setDirectRunning(false);
             }
 
@@ -698,18 +729,23 @@ void WindowsMpvBackend::processMpvEvents()
             }
             break;
         case MPV_EVENT_IDLE:
+            m_stopRequested = false;
             setDirectRunning(false);
             break;
         case MPV_EVENT_START_FILE:
+            m_stopRequested = false;
             setDirectRunning(true);
             break;
         case MPV_EVENT_PLAYBACK_RESTART:
+            m_stopRequested = false;
             setDirectRunning(true);
             break;
         case MPV_EVENT_FILE_LOADED:
+            m_stopRequested = false;
             setDirectRunning(true);
             break;
         case MPV_EVENT_SEEK:
+            m_stopRequested = false;
             setDirectRunning(true);
             break;
         case MPV_EVENT_CLIENT_MESSAGE: {

--- a/src/player/backend/WindowsMpvBackend.cpp
+++ b/src/player/backend/WindowsMpvBackend.cpp
@@ -740,6 +740,7 @@ void WindowsMpvBackend::processMpvEvents()
                         << QString::fromUtf8(mpv_error_string(event->error));
                     teardownMpv();
                     syncContainerGeometry();
+                    return;
                 }
                 break;
             }

--- a/src/player/backend/WindowsMpvBackend.cpp
+++ b/src/player/backend/WindowsMpvBackend.cpp
@@ -21,6 +21,10 @@ extern "C" {
 }
 #endif
 
+namespace {
+std::atomic<quint64> gWindowsMpvReplyUserdataCounter{0};
+}
+
 Q_LOGGING_CATEGORY(lcWindowsLibmpvBackend, "bloom.playback.backend.windows.libmpv")
 
 class WindowsMpvBackend::WindowsNativeGeometryFilter : public QAbstractNativeEventFilter
@@ -147,6 +151,7 @@ void WindowsMpvBackend::startMpv(const QString &mpvBin, const QStringList &args,
     m_playlistPosition = -1;
     m_playlistCount = 0;
     m_stopRequested = false;
+    m_pendingStopReplyUserdata = 0;
 
 #if defined(Q_OS_WIN)
     if (m_videoTarget != nullptr) {
@@ -202,13 +207,17 @@ void WindowsMpvBackend::stopMpv()
         if (m_mpvHandle != nullptr) {
             mpv_handle *handle = static_cast<mpv_handle *>(m_mpvHandle);
             const char *command[] = {"stop", nullptr};
-            const int status = mpv_command_async(handle, 0, command);
+            const quint64 replyUserdata = ++gWindowsMpvReplyUserdataCounter;
+            const int status = mpv_command_async(handle,
+                                                 static_cast<uint64_t>(replyUserdata),
+                                                 command);
             if (status < 0) {
                 qCWarning(lcWindowsLibmpvBackend) << "Direct libmpv stop command failed; falling back to immediate teardown";
                 teardownMpv();
                 syncContainerGeometry();
                 return;
             }
+            m_pendingStopReplyUserdata = replyUserdata;
         }
 #endif
         // Do not synchronously destroy libmpv here. A blocking terminate can hold the UI
@@ -638,6 +647,7 @@ void WindowsMpvBackend::teardownMpv()
     m_playlistPosition = -1;
     m_playlistCount = 0;
     m_stopRequested = false;
+    m_pendingStopReplyUserdata = 0;
     setDirectRunning(false);
     m_directControlActive = false;
 }
@@ -720,6 +730,19 @@ void WindowsMpvBackend::processMpvEvents()
             break;
         }
         case MPV_EVENT_COMMAND_REPLY:
+            if (m_pendingStopReplyUserdata != 0
+                && static_cast<quint64>(event->reply_userdata) == m_pendingStopReplyUserdata) {
+                const bool stopFailed = event->error < 0;
+                m_pendingStopReplyUserdata = 0;
+                if (stopFailed) {
+                    qCWarning(lcWindowsLibmpvBackend)
+                        << "Direct libmpv stop command reply failed; falling back to immediate teardown:"
+                        << QString::fromUtf8(mpv_error_string(event->error));
+                    teardownMpv();
+                    syncContainerGeometry();
+                }
+                break;
+            }
             if (event->error < 0) {
                 const QString errorMessage = QStringLiteral("libmpv command failed (id=%1): %2")
                                                  .arg(static_cast<qulonglong>(event->reply_userdata))
@@ -729,19 +752,21 @@ void WindowsMpvBackend::processMpvEvents()
             }
             break;
         case MPV_EVENT_IDLE:
-            m_stopRequested = false;
             setDirectRunning(false);
             break;
         case MPV_EVENT_START_FILE:
             m_stopRequested = false;
+            m_pendingStopReplyUserdata = 0;
             setDirectRunning(true);
             break;
         case MPV_EVENT_PLAYBACK_RESTART:
             m_stopRequested = false;
+            m_pendingStopReplyUserdata = 0;
             setDirectRunning(true);
             break;
         case MPV_EVENT_FILE_LOADED:
             m_stopRequested = false;
+            m_pendingStopReplyUserdata = 0;
             setDirectRunning(true);
             break;
         case MPV_EVENT_SEEK:

--- a/src/player/backend/WindowsMpvBackend.h
+++ b/src/player/backend/WindowsMpvBackend.h
@@ -78,6 +78,7 @@ private:
     bool m_running = false;
     bool m_directControlActive = false;
     bool m_stopRequested = false;
+    quint64 m_pendingStopReplyUserdata = 0;
     void *m_mpvHandle = nullptr;
     std::atomic_bool m_eventDispatchQueued{false};
     QList<QByteArray> m_commandScratch;

--- a/src/player/backend/WindowsMpvBackend.h
+++ b/src/player/backend/WindowsMpvBackend.h
@@ -77,6 +77,7 @@ private:
     bool m_transitionMitigationActive = false;
     bool m_running = false;
     bool m_directControlActive = false;
+    bool m_stopRequested = false;
     void *m_mpvHandle = nullptr;
     std::atomic_bool m_eventDispatchQueued{false};
     QList<QByteArray> m_commandScratch;


### PR DESCRIPTION
## Summary
- avoid synchronous immediate libmpv teardown on manual Windows stop so the shell can exit playback mode without waiting on a blocking destroy path
- suppress terminal `playbackEnded` emission for user-requested stop teardown on the Windows embedded backend
- always hide the native embedded host window when geometry/viewport state becomes invalid during teardown

## Testing
- not run in this environment

## Notes
- intended to address intermittent Windows post-playback black-screen states where the overlay sometimes remained active and other times only a black window remained visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed and improved stop command handling to prevent player state inconsistencies on Windows
  * Enhanced window visibility management when stopping media playback
  * Improved event processing during playback transitions for better state consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden async stop teardown in `WindowsMpvBackend` for embedded Windows playback
> - `stopMpv` now issues an async `stop` command to libmpv instead of synchronously terminating the mpv instance; teardown completes when the async reply is received via `processMpvEvents`.
> - A file-scoped atomic counter generates unique `reply_userdata` values to track the pending stop command; a failed async submission falls back to immediate teardown.
> - `processMpvEvents` suppresses `playbackEnded` when a user-initiated stop is in progress and clears stop state on `MPV_EVENT_SHUTDOWN` and terminal `END_FILE` events.
> - `syncContainerGeometry` now explicitly hides the host window when no valid video target, container handle, or viewport is available.
> - Stop-related state (`m_stopRequested`, `m_pendingStopReplyUserdata`) is reset at session start and fully cleared in `teardownMpv` to prevent stale state from affecting future sessions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ebb2f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->