### PR TITLE
fix(playback): prevent windows stop race from reviving black host window

### DIFF
--- a/docs/playback.md
+++ b/docs/playback.md
@@ -41,6 +41,7 @@ Windows embedded overlay layering model
 - Terminal playback transitions are backend-first: Bloom now waits for backend stop confirmation before changing `PlayerController` into `Idle`/`Error`, so embedded host-window teardown cannot race ahead of libmpv shutdown.
 - Windows display restoration after playback stop is deferred and non-blocking. HDR-off settle and refresh-rate restore are scheduled after the UI returns to `Idle`, allowing the main scene and detached playback overlay window to repaint/hide promptly.
 - Natural playback end, explicit stop, and error-triggered shutdown now share one coordinated terminal-transition path so reporting/autoplay work runs once per playback attempt.
+- Windows direct-libmpv event handling now suppresses playback reactivation events (`START_FILE`/`FILE_LOADED`/`PLAYBACK_RESTART`/`SEEK`) while a stop command is pending, preventing stale wakeup events from re-showing the embedded host window as a black frame during teardown.
 
 Reference implementation notes (Plezy)
 - External reference: https://github.com/edde746/plezy

--- a/src/player/backend/WindowsMpvBackend.cpp
+++ b/src/player/backend/WindowsMpvBackend.cpp
@@ -715,17 +715,11 @@ void WindowsMpvBackend::processMpvEvents()
                 && (m_playlistPosition + 1) < m_playlistCount;
             const bool reachedTerminalPlaybackState = !hasRemainingPlaylistItems && !isRedirectTransition;
 
-            if (m_stopRequested) {
-                // Keep the host window hidden while a stop transition is in flight, even when
-                // playlist bookkeeping has not yet converged on a terminal state.
-                setDirectRunning(false);
-            }
-
             if (m_stopRequested && reachedTerminalPlaybackState) {
                 shouldEmitPlaybackEnded = false;
             }
 
-            if (reachedTerminalPlaybackState) {
+            if (reachedTerminalPlaybackState && m_pendingStopReplyUserdata == 0) {
                 m_stopRequested = false;
                 setDirectRunning(false);
             }
@@ -748,6 +742,8 @@ void WindowsMpvBackend::processMpvEvents()
                     syncContainerGeometry();
                     return;
                 }
+                m_stopRequested = false;
+                setDirectRunning(false);
                 break;
             }
             if (event->error < 0) {
@@ -767,8 +763,6 @@ void WindowsMpvBackend::processMpvEvents()
                     << "Ignoring START_FILE while stop is pending";
                 break;
             }
-            m_stopRequested = false;
-            m_pendingStopReplyUserdata = 0;
             setDirectRunning(true);
             break;
         case MPV_EVENT_PLAYBACK_RESTART:
@@ -777,8 +771,6 @@ void WindowsMpvBackend::processMpvEvents()
                     << "Ignoring PLAYBACK_RESTART while stop is pending";
                 break;
             }
-            m_stopRequested = false;
-            m_pendingStopReplyUserdata = 0;
             setDirectRunning(true);
             break;
         case MPV_EVENT_FILE_LOADED:
@@ -787,8 +779,6 @@ void WindowsMpvBackend::processMpvEvents()
                     << "Ignoring FILE_LOADED while stop is pending";
                 break;
             }
-            m_stopRequested = false;
-            m_pendingStopReplyUserdata = 0;
             setDirectRunning(true);
             break;
         case MPV_EVENT_SEEK:

--- a/src/player/backend/WindowsMpvBackend.cpp
+++ b/src/player/backend/WindowsMpvBackend.cpp
@@ -715,6 +715,12 @@ void WindowsMpvBackend::processMpvEvents()
                 && (m_playlistPosition + 1) < m_playlistCount;
             const bool reachedTerminalPlaybackState = !hasRemainingPlaylistItems && !isRedirectTransition;
 
+            if (m_stopRequested) {
+                // Keep the host window hidden while a stop transition is in flight, even when
+                // playlist bookkeeping has not yet converged on a terminal state.
+                setDirectRunning(false);
+            }
+
             if (m_stopRequested && reachedTerminalPlaybackState) {
                 shouldEmitPlaybackEnded = false;
             }
@@ -756,21 +762,41 @@ void WindowsMpvBackend::processMpvEvents()
             setDirectRunning(false);
             break;
         case MPV_EVENT_START_FILE:
+            if (m_stopRequested || m_pendingStopReplyUserdata != 0) {
+                qCDebug(lcWindowsLibmpvBackend)
+                    << "Ignoring START_FILE while stop is pending";
+                break;
+            }
             m_stopRequested = false;
             m_pendingStopReplyUserdata = 0;
             setDirectRunning(true);
             break;
         case MPV_EVENT_PLAYBACK_RESTART:
+            if (m_stopRequested || m_pendingStopReplyUserdata != 0) {
+                qCDebug(lcWindowsLibmpvBackend)
+                    << "Ignoring PLAYBACK_RESTART while stop is pending";
+                break;
+            }
             m_stopRequested = false;
             m_pendingStopReplyUserdata = 0;
             setDirectRunning(true);
             break;
         case MPV_EVENT_FILE_LOADED:
+            if (m_stopRequested || m_pendingStopReplyUserdata != 0) {
+                qCDebug(lcWindowsLibmpvBackend)
+                    << "Ignoring FILE_LOADED while stop is pending";
+                break;
+            }
             m_stopRequested = false;
             m_pendingStopReplyUserdata = 0;
             setDirectRunning(true);
             break;
         case MPV_EVENT_SEEK:
+            if (m_stopRequested || m_pendingStopReplyUserdata != 0) {
+                qCDebug(lcWindowsLibmpvBackend)
+                    << "Ignoring SEEK while stop is pending";
+                break;
+            }
             m_stopRequested = false;
             setDirectRunning(true);
             break;


### PR DESCRIPTION
### Motivation
- Prevent a race on Windows where stale libmpv wakeup events re-show the embedded host window as a black frame during stop/teardown transitions. 
- Ensure the embedded host window remains hidden while a stop is pending so UI overlay layering and geometry aren't briefly broken during backend shutdown.

### Description
- In `WindowsMpvBackend::processMpvEvents()` keep playback marked non-running (`setDirectRunning(false)`) when `END_FILE` arrives while a stop was requested to keep the host window hidden during stop transitions. 
- Added guards to ignore reactivation events (`START_FILE`, `PLAYBACK_RESTART`, `FILE_LOADED`, `SEEK`) when `m_stopRequested` or `m_pendingStopReplyUserdata` is set so stale wakeups cannot revive the embedded host window. 
- Updated `docs/playback.md` to document the new direct-libmpv teardown behavior and the suppression of reactivation events. 
- Note: this change touches Windows embedded playback layering/geometry and requires manual runtime validation on Windows (controls visible above video and no video move/clip during show/hide, resize, minimize/restore, maximize, and fullscreen transitions).

### Testing
- Ran `./scripts/build-docker.sh`, which failed in this environment because neither `docker` nor `podman` is installed. 
- Ran `git diff --check`, which passed with no whitespace or diff-check problems. 
- No automated unit/integration tests were executed in this environment; manual Windows runtime validation is still required per project guardrails.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4d9f7ab0832d975e65f31301c4b5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix black host window flash during playback stop in `WindowsMpvBackend`
> - Guards `START_FILE`, `FILE_LOADED`, `PLAYBACK_RESTART`, and `SEEK` events in `processMpvEvents` so they are ignored when a stop is pending (`m_stopRequested` or `m_pendingStopReplyUserdata != 0`), preventing stale wakeups from calling `setDirectRunning(true)` during teardown.
> - Moves the `setDirectRunning(false)` call to the `MPV_EVENT_COMMAND_REPLY` handler for the explicit stop command, and restricts the `MPV_EVENT_END_FILE` path to only clear state when no stop reply is pending.
> - Behavioral Change: direct running is no longer set to false unconditionally on terminal end-file; it now waits for the stop command reply when one is in flight.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99b11c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on Windows where stale playback events could cause the application window to briefly reappear during shutdown or when stopping playback, preventing black frame artifacts during the shutdown sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->