### PR TITLE
fix(playback): resolve home library profiles in controller

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -41,6 +41,7 @@ MPV profile management
 - `settings.mpv_profiles` contains the base set of profiles (`Default`, `High Quality`, plus any user-created profiles) and their structured options (hwdec, interpolation, extra args).
 - `settings.default_profile` names the profile to use when no library/series override is present.
 - `settings.library_profiles` and `settings.series_profiles` hold dictionaries keyed by Jellyfin library/series IDs when an override is required at a higher level.
+- Playback requests may omit `libraryId` in direct-navigation contexts such as Home > Continue Watching / Next Up. QML should pass any known context but must not block playback waiting for a library id; `PlayerController` recovers episodic library context from the series `ParentId` before starting mpv and falls back to the default profile if no mapping is available.
 - The settings-screen rework did not change the on-disk MPV profile schema; existing `settings.mpv_profiles` and `settings.default_profile` entries continue to load as-is.
 
 When adding settings

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -1704,10 +1704,7 @@ void PlayerController::requestPlayback(const QVariantMap &request)
     pending.awaitedPlaybackInfoIds.insert(itemId);
 
     m_pendingPlaybackRequests.insert(pending.requestId, pending);
-    auto pendingIt = m_pendingPlaybackRequests.find(pending.requestId);
-    if (pendingIt != m_pendingPlaybackRequests.end()) {
-        maybeResolvePendingRequestLibraryId(pendingIt.value());
-    }
+    maybeResolvePendingRequestLibraryId(m_pendingPlaybackRequests[pending.requestId]);
 
     m_playbackService->getPlaybackInfo(itemId);
     m_playbackService->getAdditionalParts(itemId);

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -1702,9 +1702,12 @@ void PlayerController::requestPlayback(const QVariantMap &request)
     pending.useAffinityFallback = request.value(QStringLiteral("useAffinityFallback"), false).toBool();
     pending.restoreFocusTarget = qobject_cast<QObject *>(request.value(QStringLiteral("restoreFocusTarget")).value<QObject *>());
     pending.awaitedPlaybackInfoIds.insert(itemId);
-    maybeResolvePendingRequestLibraryId(pending);
 
     m_pendingPlaybackRequests.insert(pending.requestId, pending);
+    auto pendingIt = m_pendingPlaybackRequests.find(pending.requestId);
+    if (pendingIt != m_pendingPlaybackRequests.end()) {
+        maybeResolvePendingRequestLibraryId(pendingIt.value());
+    }
 
     m_playbackService->getPlaybackInfo(itemId);
     m_playbackService->getAdditionalParts(itemId);

--- a/src/ui/LibraryScreen.qml
+++ b/src/ui/LibraryScreen.qml
@@ -64,7 +64,6 @@ FocusScope {
     property bool showMovieDetails: false
     property var currentMovieData: null
     
-    property var pendingPlaybackRequest: null
     property var pendingEpisodeData: null
     property bool restoringFocusFromSidebar: false
     property bool restoringFocusFromSeriesDetailsReturn: false
@@ -1937,45 +1936,8 @@ FocusScope {
         PlayerController.requestPlayback(normalizedRequest)
     }
 
-    function flushPendingPlaybackRequestIfReady() {
-        if (!pendingPlaybackRequest) {
-            return
-        }
-
-        if (pendingPlaybackRequest.seriesId
-                && currentSeriesId
-                && pendingPlaybackRequest.seriesId !== currentSeriesId) {
-            console.log("[Library] Dropping stale deferred playback request for series:",
-                        pendingPlaybackRequest.seriesId,
-                        "current:", currentSeriesId)
-            pendingPlaybackRequest = null
-            return
-        }
-
-        var playbackLibraryId = resolveLibraryIdForPlayback()
-        if (!playbackLibraryId) {
-            return
-        }
-
-        var request = pendingPlaybackRequest
-        pendingPlaybackRequest = null
-        console.log("[Library] Resolved library ID, starting deferred playback:", request.itemId)
-        dispatchPlaybackRequest(request, playbackLibraryId)
-    }
-
     function requestPlaybackWithResolvedLibrary(request) {
         var playbackLibraryId = resolveLibraryIdForPlayback()
-
-        // Direct navigation can start with no library context (e.g., Home -> Next Up).
-        // Defer playback until series details provide ParentId (library id).
-        if (!playbackLibraryId && directNavigationMode && request.seriesId) {
-            pendingPlaybackRequest = request
-            console.log("[Library] Deferring playback until library ID resolves for series:", request.seriesId)
-            currentSeriesId = request.seriesId
-            LibraryService.getSeriesDetails(request.seriesId)
-            return
-        }
-
         dispatchPlaybackRequest(request, playbackLibraryId)
     }
 
@@ -2087,8 +2049,6 @@ FocusScope {
                     console.log("[Library] Backfilled library ID from series details:", currentLibraryId)
                 }
 
-                flushPendingPlaybackRequestIfReady()
-                
                 // If we came from direct navigation (Home screen), update backdrop now
                 // that we have the series data
                 if (directNavigationMode && showSeriesDetails) {

--- a/tests/PlayerControllerAutoplayContextTest.cpp
+++ b/tests/PlayerControllerAutoplayContextTest.cpp
@@ -263,6 +263,7 @@ private slots:
     void requestPlaybackPromptsForVersionSelection();
     void requestPlaybackRecoversLibraryProfileFromSeriesDetails();
     void requestPlaybackWaitsForSeriesDetailsParentIdBeforeStarting();
+    void requestPlaybackUsesRecoveredLibraryWhenSeriesDetailsArriveBeforePlaybackInfo();
     void requestPlaybackFallsBackWithoutRecoveredLibraryProfileWhenParentIdMissing();
     void requestPlaybackKeepsSeriesProfilePriorityOverRecoveredLibrary();
     void multipartIntermediateEndIsIgnoredUntilFinalSegment();
@@ -1101,6 +1102,77 @@ void PlayerControllerAutoplayContextTest::requestPlaybackWaitsForSeriesDetailsPa
     emit libraryService.seriesDetailsLoaded(QStringLiteral("series-1"),
                                             QJsonObject{{QStringLiteral("Id"), QStringLiteral("series-1")},
                                                         {QStringLiteral("ParentId"), QStringLiteral("library-1")}});
+
+    QCOMPARE(backend.lastStartUrl, QStringLiteral("https://example.invalid/episode-1"));
+    QVERIFY(backend.lastStartArgs.contains(QStringLiteral("--test-library-profile=yes")));
+}
+
+void PlayerControllerAutoplayContextTest::requestPlaybackUsesRecoveredLibraryWhenSeriesDetailsArriveBeforePlaybackInfo()
+{
+    ConfigManager config;
+    config.setMpvProfile(QStringLiteral("Library Preferred"), QVariantMap{
+        {QStringLiteral("hwdecEnabled"), false},
+        {QStringLiteral("hwdecMethod"), QStringLiteral("")},
+        {QStringLiteral("deinterlace"), false},
+        {QStringLiteral("deinterlaceMethod"), QStringLiteral("")},
+        {QStringLiteral("videoOutput"), QStringLiteral("gpu")},
+        {QStringLiteral("interpolation"), false},
+        {QStringLiteral("extraArgs"), QVariantList{QStringLiteral("--test-library-profile=yes")}}
+    });
+    config.setLibraryProfile(QStringLiteral("library-1"), QStringLiteral("Library Preferred"));
+
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+
+    controller.requestPlayback(QVariantMap{
+        {QStringLiteral("itemId"), QStringLiteral("episode-1")},
+        {QStringLiteral("seriesId"), QStringLiteral("series-1")},
+        {QStringLiteral("seasonId"), QStringLiteral("season-1")},
+        {QStringLiteral("allowVersionPrompt"), false}
+    });
+
+    QCOMPARE(libraryService.requestedSeriesDetailsIds, QStringList{QStringLiteral("series-1")});
+
+    emit libraryService.seriesDetailsLoaded(QStringLiteral("series-1"),
+                                            QJsonObject{{QStringLiteral("Id"), QStringLiteral("series-1")},
+                                                        {QStringLiteral("ParentId"), QStringLiteral("library-1")}});
+
+    QVERIFY(backend.lastStartUrl.isEmpty());
+    QVERIFY(backend.lastStartArgs.isEmpty());
+
+    const MediaSourceInfo mediaSource = buildMediaSourceInfo(
+        QStringLiteral("source-1"),
+        QStringLiteral("Default"),
+        QStringLiteral("/library/show/episode-1.mkv"),
+        {QVariantMap{
+            {QStringLiteral("type"), QStringLiteral("Video")},
+            {QStringLiteral("width"), 1920},
+            {QStringLiteral("height"), 1080},
+            {QStringLiteral("codec"), QStringLiteral("h264")},
+            {QStringLiteral("profile"), QStringLiteral("High")},
+            {QStringLiteral("videoRange"), QStringLiteral("SDR")}
+        }},
+        -1,
+        -1,
+        QStringLiteral("mkv"),
+        8000000,
+        1200000000);
+
+    emit playbackService.playbackInfoLoaded(QStringLiteral("episode-1"),
+                                            buildPlaybackInfo({mediaSource}));
+    emit playbackService.additionalPartsLoaded(QStringLiteral("episode-1"), QJsonArray{});
 
     QCOMPARE(backend.lastStartUrl, QStringLiteral("https://example.invalid/episode-1"));
     QVERIFY(backend.lastStartArgs.contains(QStringLiteral("--test-library-profile=yes")));


### PR DESCRIPTION
## Summary
- remove QML-side deferred playback for Home/Next Up items without a library id
- make PlayerController own library context recovery before mpv startup
- add regression coverage for series details arriving before playback info
- document playback profile resolution when libraryId is omitted

## Tests
- ./scripts/build-docker.sh
- ./build-docker/tests/PlayerControllerAutoplayContextTest requestPlaybackRecoversLibraryProfileFromSeriesDetails requestPlaybackWaitsForSeriesDetailsParentIdBeforeStarting requestPlaybackUsesRecoveredLibraryWhenSeriesDetailsArriveBeforePlaybackInfo requestPlaybackFallsBackWithoutRecoveredLibraryProfileWhenParentIdMissing requestPlaybackKeepsSeriesProfilePriorityOverRecoveredLibrary

## Notes
- The full PlayerControllerAutoplayContextTest binary still has 4 unrelated existing failures in early terminal/autoplay tests. The focused profile-resolution tests pass.
- scripts/build-docker.sh has an unrelated local modification and is not included in this PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix home library profile resolution in `PlayerController::requestPlayback`
> - `PlayerController::requestPlayback` previously called `maybeResolvePendingRequestLibraryId` on a transient local copy of the request before inserting it into `m_pendingPlaybackRequests`, so resolved fields were never stored. It now calls the resolver on the stored map entry after insertion.
> - `LibraryScreen` no longer defers playback when a `libraryId` is unavailable; it dispatches immediately with whatever library context is resolvable, delegating recovery to `PlayerController`, which recovers episodic library context from the series `ParentId` before starting mpv.
> - A new test in [PlayerControllerAutoplayContextTest.cpp](https://github.com/crowquillx/Bloom/pull/43/files#diff-7f6c93fc79e270a1be8ad73fa80840e1e09942f0cc4bd1f403253a1547169a3f) verifies that series details arriving before `playbackInfo` correctly supply the library profile to the mpv backend.
> - Behavioral Change: playback requests that previously stalled waiting for a `libraryId` in `LibraryScreen` will now proceed immediately, falling back to the default mpv profile if no library mapping can be recovered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c895835.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->