### PR TITLE
feat: aggressive playback caching and auto-recovery on server outage

### DIFF
--- a/docs/playback.md
+++ b/docs/playback.md
@@ -234,6 +234,21 @@ Important design notes
 - Use PlayerController as a single source for playback state; it should be responsible for reporting state and keeping user-level playback logic (resume, next episode/autoplay, track selection).
 - PlayerProcessManager should accept an mpv config dir and script directory (e.g., `~/.config/Bloom/mpv`) and allow adding `extra_flags` via `app.json`.
 
+Playback caching and network resilience
+- Bloom injects global mpv cache and reconnect flags automatically via `ConfigManager::getMpvConfigArgs()`:
+  - `--cache=yes`
+  - `--demuxer-max-bytes=<playbackCacheSizeMB * 1024 * 1024>`
+  - `--stream-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_delay_max=30`
+- `playbackCacheSizeMB` is exposed in Settings -> Playback as "Playback Cache Size" (range 50–2048 MB, default 500 MB).
+- This allows mpv to buffer aggressively in RAM so brief server outages do not stall playback.
+- For longer server outages, `PlayerController` supports automatic recovery:
+  - When playback hits `Error` because of a network/timeout failure, the controller stashes a `RecoveryContext` with the current item, stream URL, track selections, and last known position.
+  - If `autoRecoverPlayback` is enabled (default `true`, stored in `settings.playback.auto_recover_playback`), the controller enters recovery mode and pings the server every 5 seconds via `LibraryService::pingServer()`.
+  - When the ping succeeds, playback resumes automatically at the last known position using the same stream URL and track state.
+  - Recovery retries indefinitely until the server returns or the user explicitly stops/retries/clears the error.
+  - Manual retry (`retry()` / `Event::Play`) while recovering will resume from the stashed position instead of restarting from the beginning.
+- `autoRecoverPlayback` is not exposed in the settings UI; it can be toggled by editing `app.json` directly.
+
 mpv config hints
 - Create `mpv.conf` and `input.conf` when you need custom behavior (e.g., enable vo, hardware settings) in `~/.config/Bloom/mpv/`.
 - Always pass mpv arguments from `ConfigManager` so users can override behavior at runtime.

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -1166,3 +1166,17 @@ QString LibraryService::getCachedImageUrlWithWidth(const QString &itemId, const 
     QString originalUrl = getImageUrlWithWidth(itemId, imageType, width);
     return QString("image://cached/%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(originalUrl)));
 }
+
+void LibraryService::pingServer()
+{
+    QNetworkRequest request = m_authService->createRequest("/System/Info");
+    QNetworkReply *reply = m_authService->networkManager()->get(request);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        reply->deleteLater();
+        if (reply->error() == QNetworkReply::NoError) {
+            emit serverPingSucceeded();
+        } else {
+            emit serverPingFailed(reply->errorString());
+        }
+    });
+}

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -1167,16 +1167,8 @@ QString LibraryService::getCachedImageUrlWithWidth(const QString &itemId, const 
     return QString("image://cached/%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(originalUrl)));
 }
 
-void LibraryService::pingServer()
+QNetworkReply* LibraryService::pingServer()
 {
     QNetworkRequest request = m_authService->createRequest("/System/Info");
-    QNetworkReply *reply = m_authService->networkManager()->get(request);
-    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
-        reply->deleteLater();
-        if (reply->error() == QNetworkReply::NoError) {
-            emit serverPingSucceeded();
-        } else {
-            emit serverPingFailed(reply->errorString());
-        }
-    });
+    return m_authService->networkManager()->get(request);
 }

--- a/src/network/LibraryService.h
+++ b/src/network/LibraryService.h
@@ -90,7 +90,7 @@ public:
     Q_INVOKABLE virtual QString getCachedImageUrl(const QString &itemId, const QString &imageType);
     Q_INVOKABLE virtual QString getCachedImageUrlWithWidth(const QString &itemId, const QString &imageType, int width);
 
-    Q_INVOKABLE void pingServer();
+    QNetworkReply* pingServer();
 
 signals:
     void viewsLoaded(const QJsonArray &views);
@@ -132,10 +132,6 @@ signals:
     void errorOccurred(const QString &endpoint, const QString &error);
     void networkError(const NetworkError &error);
 
-    // Server reachability signals
-    void serverPingSucceeded();
-    void serverPingFailed(const QString &reason);
-    
     // Progress signals for long-running operations
     void parsingStarted(const QString &operation);
     void parsingProgress(const QString &operation, int processed, int total);

--- a/src/network/LibraryService.h
+++ b/src/network/LibraryService.h
@@ -90,6 +90,8 @@ public:
     Q_INVOKABLE virtual QString getCachedImageUrl(const QString &itemId, const QString &imageType);
     Q_INVOKABLE virtual QString getCachedImageUrlWithWidth(const QString &itemId, const QString &imageType, int width);
 
+    Q_INVOKABLE void pingServer();
+
 signals:
     void viewsLoaded(const QJsonArray &views);
     void itemsLoaded(const QString &parentId, const QJsonArray &items);
@@ -129,6 +131,10 @@ signals:
     // Error signals
     void errorOccurred(const QString &endpoint, const QString &error);
     void networkError(const NetworkError &error);
+
+    // Server reachability signals
+    void serverPingSucceeded();
+    void serverPingFailed(const QString &reason);
     
     // Progress signals for long-running operations
     void parsingStarted(const QString &operation);

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -1160,6 +1160,8 @@ void PlayerController::prepareTerminalTransition(TerminalReason reason)
             m_recoveryContext.activePlaybackSegmentOffsetTicks = m_activePlaybackSegmentOffsetTicks;
             m_recoveryContext.segmentRelativePosition = m_segmentRelativePosition;
             m_recoveryContext.valid = true;
+        } else {
+            m_recoveryContext = RecoveryContext{};
         }
     }
 
@@ -3007,30 +3009,35 @@ void PlayerController::resumeFromRecoveryContext()
                       m_recoveryContext.framerate,
                       m_recoveryContext.isHDR);
 
-    // Restore multipart segment state so aggregate position and reporting are correct
+    // Restore multipart segment state so aggregate position and reporting are correct.
+    // This must be queued because playUrlWithTracks -> playUrl -> scheduleReplacementPlayback
+    // defers clearPlaybackSegments() into a lambda that may fire after we return.
     if (!m_recoveryContext.playbackSegments.isEmpty()
         && m_recoveryContext.activePlaybackSegmentIndex >= 0) {
-        m_playbackSegments = m_recoveryContext.playbackSegments;
-        m_activePlaybackSegmentIndex = m_recoveryContext.activePlaybackSegmentIndex;
-        m_activePlaybackSegmentOffsetTicks = m_recoveryContext.activePlaybackSegmentOffsetTicks;
-        m_segmentRelativePosition = m_recoveryContext.segmentRelativePosition;
-        m_aggregatePlaybackDuration = 0.0;
-        for (const QVariantMap &seg : m_playbackSegments) {
-            m_aggregatePlaybackDuration += static_cast<double>(seg.value(QStringLiteral("runTimeTicks")).toLongLong()) / 10000000.0;
-        }
-
-        // Queue remaining segments for mpv playlist so playback continues across segments
-        m_pendingPlaylistAppendUrls.clear();
-        for (int index = m_activePlaybackSegmentIndex + 1; index < m_playbackSegments.size(); ++index) {
-            const QString url = m_playbackSegments.at(index).value(QStringLiteral("url")).toString();
-            if (!url.isEmpty()) {
-                m_pendingPlaylistAppendUrls.append(url);
+        const RecoveryContext ctx = m_recoveryContext;
+        QMetaObject::invokeMethod(this, [this, ctx]() {
+            m_playbackSegments = ctx.playbackSegments;
+            m_activePlaybackSegmentIndex = ctx.activePlaybackSegmentIndex;
+            m_activePlaybackSegmentOffsetTicks = ctx.activePlaybackSegmentOffsetTicks;
+            m_segmentRelativePosition = ctx.segmentRelativePosition;
+            m_aggregatePlaybackDuration = 0.0;
+            for (const QVariantMap &seg : m_playbackSegments) {
+                m_aggregatePlaybackDuration += static_cast<double>(seg.value(QStringLiteral("runTimeTicks")).toLongLong()) / 10000000.0;
             }
-        }
-        if (!m_pendingPlaylistAppendUrls.isEmpty() && m_playerBackend && m_playerBackend->isRunning()) {
-            m_playerBackend->appendUrlsToPlaylist(m_pendingPlaylistAppendUrls);
+
+            // Queue remaining segments for mpv playlist so playback continues across segments
             m_pendingPlaylistAppendUrls.clear();
-        }
+            for (int index = m_activePlaybackSegmentIndex + 1; index < m_playbackSegments.size(); ++index) {
+                const QString url = m_playbackSegments.at(index).value(QStringLiteral("url")).toString();
+                if (!url.isEmpty()) {
+                    m_pendingPlaylistAppendUrls.append(url);
+                }
+            }
+            if (!m_pendingPlaylistAppendUrls.isEmpty() && m_playerBackend && m_playerBackend->isRunning()) {
+                m_playerBackend->appendUrlsToPlaylist(m_pendingPlaylistAppendUrls);
+                m_pendingPlaylistAppendUrls.clear();
+            }
+        }, Qt::QueuedConnection);
     }
 
     m_recoveryContext = RecoveryContext{};

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -227,6 +227,7 @@ PlayerController::PlayerController(IPlayerBackend *playerBackend, ConfigManager 
     , m_volumePersistTimer(new QTimer(this))
     , m_startDelayTimer(new QTimer(this))
     , m_autoplayPlaybackInfoTimeoutTimer(new QTimer(this))
+    , m_recoveryTimer(new QTimer(this))
 {
     if (!m_playerBackend) {
         qCWarning(lcPlayback) << "PlayerController initialized without backend; falling back to null backend";
@@ -296,6 +297,16 @@ PlayerController::PlayerController(IPlayerBackend *playerBackend, ConfigManager 
     m_autoplayPlaybackInfoTimeoutTimer->setInterval(kAutoplayPlaybackInfoTimeoutMs);
     connect(m_autoplayPlaybackInfoTimeoutTimer, &QTimer::timeout,
             this, &PlayerController::onAutoplayPlaybackInfoTimeout);
+
+    // Recovery timer for transient server loss
+    m_recoveryTimer->setSingleShot(true);
+    m_recoveryTimer->setInterval(kRecoveryPingIntervalMs);
+    connect(m_recoveryTimer, &QTimer::timeout,
+            this, &PlayerController::onRecoveryTick);
+    connect(m_libraryService, &LibraryService::serverPingSucceeded,
+            this, &PlayerController::onServerPingSucceeded);
+    connect(m_libraryService, &LibraryService::serverPingFailed,
+            this, &PlayerController::onServerPingFailed);
             
     // Connect to ConfigManager audio delay signal
     connect(m_config, &ConfigManager::audioDelayChanged,
@@ -325,6 +336,7 @@ PlayerController::~PlayerController()
     m_volumePersistTimer->stop();
     m_startDelayTimer->stop();
     m_autoplayPlaybackInfoTimeoutTimer->stop();
+    m_recoveryTimer->stop();
     cancelPendingDisplayRestore();
     resetTerminalTransitionState(true);
 }
@@ -570,6 +582,7 @@ void PlayerController::onExitPausedState()
 void PlayerController::onExitErrorState()
 {
     setErrorMessage(QString());
+    cancelRecovery();
 }
 
 // === STATE ENTRY HANDLERS ===
@@ -607,6 +620,7 @@ void PlayerController::enterIdleStateImmediate()
     m_currentSeasonId.clear();
     m_currentLibraryId.clear();
     m_pendingUrl.clear();
+    m_recoveryContext = RecoveryContext{};
     m_currentPosition = 0;
     m_duration = 0;
     m_hasReportedStart = false;
@@ -824,6 +838,10 @@ void PlayerController::onEnterErrorState()
 
     clearPendingAutoplayContext();
     clearNextEpisodePrefetchState();
+
+    if (m_recoveryContext.valid) {
+        beginRecovery();
+    }
 }
 
 // === TIMEOUT HANDLERS ===
@@ -1105,6 +1123,26 @@ void PlayerController::prepareTerminalTransition(TerminalReason reason)
         clearPendingAutoplayContext();
         clearNextEpisodePrefetchState();
         m_shouldAutoplay = false;
+
+        // Stash recovery context so we can resume if the server comes back
+        if (m_config && m_config->getAutoRecoverPlayback() && !m_currentItemId.isEmpty()) {
+            m_recoveryContext.url = m_pendingUrl;
+            m_recoveryContext.itemId = m_currentItemId;
+            m_recoveryContext.startPositionTicks = static_cast<qint64>(m_currentPosition * 10000000.0);
+            m_recoveryContext.seriesId = m_currentSeriesId;
+            m_recoveryContext.seasonId = m_currentSeasonId;
+            m_recoveryContext.libraryId = m_currentLibraryId;
+            m_recoveryContext.mediaSourceId = m_mediaSourceId;
+            m_recoveryContext.playSessionId = m_playSessionId;
+            m_recoveryContext.mediaSource = m_activeMediaSource;
+            m_recoveryContext.audioStreamIndex = m_selectedAudioTrack;
+            m_recoveryContext.subtitleStreamIndex = m_selectedSubtitleTrack;
+            m_recoveryContext.availableAudioTracks = m_availableAudioTracks;
+            m_recoveryContext.availableSubtitleTracks = m_availableSubtitleTracks;
+            m_recoveryContext.framerate = m_contentFramerate;
+            m_recoveryContext.isHDR = m_contentIsHDR;
+            m_recoveryContext.valid = true;
+        }
     }
 
     qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
@@ -2837,6 +2875,28 @@ void PlayerController::retry()
     
     if (m_playbackState == Error && !m_pendingUrl.isEmpty()) {
         m_reportProgressOnNextPositionUpdate = false;
+
+        if (m_recoveryContext.valid) {
+            cancelRecovery();
+            playUrlWithTracks(m_recoveryContext.url,
+                              m_recoveryContext.itemId,
+                              m_recoveryContext.startPositionTicks,
+                              m_recoveryContext.seriesId,
+                              m_recoveryContext.seasonId,
+                              m_recoveryContext.libraryId,
+                              m_recoveryContext.mediaSourceId,
+                              m_recoveryContext.playSessionId,
+                              m_recoveryContext.mediaSource,
+                              m_recoveryContext.audioStreamIndex,
+                              m_recoveryContext.subtitleStreamIndex,
+                              m_recoveryContext.availableAudioTracks,
+                              m_recoveryContext.availableSubtitleTracks,
+                              m_recoveryContext.framerate,
+                              m_recoveryContext.isHDR);
+            m_recoveryContext = RecoveryContext{};
+            return;
+        }
+
         processEvent(Event::Play);
     }
 }
@@ -2848,6 +2908,82 @@ void PlayerController::clearError()
     if (m_playbackState == Error) {
         processEvent(Event::Recover);
     }
+}
+
+void PlayerController::beginRecovery()
+{
+    if (m_isRecovering) {
+        return;
+    }
+    m_isRecovering = true;
+    m_recoveryAttemptCount = 0;
+    emit isRecoveringChanged();
+    emit recoveryAttemptCountChanged();
+    setErrorMessage(tr("Connection lost. Attempting to reconnect..."));
+    onRecoveryTick();
+}
+
+void PlayerController::cancelRecovery()
+{
+    if (!m_isRecovering) {
+        return;
+    }
+    m_recoveryTimer->stop();
+    m_isRecovering = false;
+    m_recoveryAttemptCount = 0;
+    emit isRecoveringChanged();
+    emit recoveryAttemptCountChanged();
+}
+
+void PlayerController::onRecoveryTick()
+{
+    if (!m_isRecovering) {
+        return;
+    }
+    ++m_recoveryAttemptCount;
+    emit recoveryAttemptCountChanged();
+    qDebug() << "PlayerController: Recovery ping attempt" << m_recoveryAttemptCount;
+    m_libraryService->pingServer();
+}
+
+void PlayerController::onServerPingSucceeded()
+{
+    qDebug() << "PlayerController: Server ping succeeded, resuming playback";
+    if (!m_isRecovering || m_playbackState != Error) {
+        return;
+    }
+
+    cancelRecovery();
+
+    if (!m_recoveryContext.valid) {
+        return;
+    }
+
+    playUrlWithTracks(m_recoveryContext.url,
+                      m_recoveryContext.itemId,
+                      m_recoveryContext.startPositionTicks,
+                      m_recoveryContext.seriesId,
+                      m_recoveryContext.seasonId,
+                      m_recoveryContext.libraryId,
+                      m_recoveryContext.mediaSourceId,
+                      m_recoveryContext.playSessionId,
+                      m_recoveryContext.mediaSource,
+                      m_recoveryContext.audioStreamIndex,
+                      m_recoveryContext.subtitleStreamIndex,
+                      m_recoveryContext.availableAudioTracks,
+                      m_recoveryContext.availableSubtitleTracks,
+                      m_recoveryContext.framerate,
+                      m_recoveryContext.isHDR);
+    m_recoveryContext = RecoveryContext{};
+}
+
+void PlayerController::onServerPingFailed(const QString &reason)
+{
+    qDebug() << "PlayerController: Server ping failed:" << reason;
+    if (!m_isRecovering) {
+        return;
+    }
+    m_recoveryTimer->start(kRecoveryPingIntervalMs);
 }
 
 // === TRACK SELECTION ===
@@ -4236,7 +4372,7 @@ void PlayerController::initiateMpvStart()
     
     // Build final args: Bloom config args + profile args
     QStringList finalArgs;
-    finalArgs << ConfigManager::getMpvConfigArgs();  // mpv.conf, input.conf, scripts
+    finalArgs << m_config->getMpvConfigArgs();  // mpv.conf, input.conf, scripts
     finalArgs << profileArgs;                        // Profile-specific args
 
     if (m_mpvDisplayFpsOverride > 0.0) {

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -334,6 +334,9 @@ PlayerController::~PlayerController()
     m_startDelayTimer->stop();
     m_autoplayPlaybackInfoTimeoutTimer->stop();
     m_recoveryTimer->stop();
+    if (m_recoveryReply) {
+        m_recoveryReply->abort();
+    }
     cancelPendingDisplayRestore();
     resetTerminalTransitionState(true);
 }
@@ -2803,7 +2806,7 @@ void PlayerController::stop()
                             << "state=" << stateToString(m_playbackState)
                             << "terminalActive=" << m_terminalTransitionActive;
 
-    if (m_playbackState == Idle || m_terminalTransitionActive) {
+    if (m_playbackState == Idle || m_playbackState == Error || m_terminalTransitionActive) {
         return;
     }
 
@@ -2929,6 +2932,10 @@ void PlayerController::cancelRecovery()
         return;
     }
     m_recoveryTimer->stop();
+    if (m_recoveryReply) {
+        m_recoveryReply->abort();
+        m_recoveryReply.clear();
+    }
     m_isRecovering = false;
     m_recoveryAttemptCount = 0;
     emit isRecoveringChanged();
@@ -2949,8 +2956,12 @@ void PlayerController::onRecoveryTick()
         m_recoveryTimer->start(kRecoveryPingIntervalMs);
         return;
     }
+    m_recoveryReply = reply;
 
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        if (m_recoveryReply == reply) {
+            m_recoveryReply.clear();
+        }
         reply->deleteLater();
         int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         if (reply->error() == QNetworkReply::NoError) {
@@ -3006,6 +3017,19 @@ void PlayerController::resumeFromRecoveryContext()
         m_aggregatePlaybackDuration = 0.0;
         for (const QVariantMap &seg : m_playbackSegments) {
             m_aggregatePlaybackDuration += static_cast<double>(seg.value(QStringLiteral("runTimeTicks")).toLongLong()) / 10000000.0;
+        }
+
+        // Queue remaining segments for mpv playlist so playback continues across segments
+        m_pendingPlaylistAppendUrls.clear();
+        for (int index = m_activePlaybackSegmentIndex + 1; index < m_playbackSegments.size(); ++index) {
+            const QString url = m_playbackSegments.at(index).value(QStringLiteral("url")).toString();
+            if (!url.isEmpty()) {
+                m_pendingPlaylistAppendUrls.append(url);
+            }
+        }
+        if (!m_pendingPlaylistAppendUrls.isEmpty() && m_playerBackend && m_playerBackend->isRunning()) {
+            m_playerBackend->appendUrlsToPlaylist(m_pendingPlaylistAppendUrls);
+            m_pendingPlaylistAppendUrls.clear();
         }
     }
 

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -2983,6 +2983,7 @@ void PlayerController::onRecoveryTick()
             if (m_isRecovering) {
                 cancelRecovery();
                 setErrorMessage(tr("Session expired. Please log in again."));
+                m_recoveryContext = RecoveryContext{};
             }
         } else {
             qDebug() << "PlayerController: Recovery ping failed:" << reply->errorString();

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -333,9 +333,12 @@ PlayerController::~PlayerController()
     m_volumePersistTimer->stop();
     m_startDelayTimer->stop();
     m_autoplayPlaybackInfoTimeoutTimer->stop();
+    m_isRecovering = false;
     m_recoveryTimer->stop();
     if (m_recoveryReply) {
+        QObject::disconnect(m_recoveryReply, nullptr, this, nullptr);
         m_recoveryReply->abort();
+        m_recoveryReply.clear();
     }
     cancelPendingDisplayRestore();
     resetTerminalTransitionState(true);
@@ -1137,8 +1140,11 @@ void PlayerController::prepareTerminalTransition(TerminalReason reason)
             QString segmentUrl = m_pendingUrl;
             if (m_activePlaybackSegmentIndex >= 0
                 && m_activePlaybackSegmentIndex < m_playbackSegments.size()) {
-                segmentUrl = m_playbackSegments[m_activePlaybackSegmentIndex]
-                                 .value(QStringLiteral("url")).toString();
+                const QString segUrl = m_playbackSegments[m_activePlaybackSegmentIndex]
+                                           .value(QStringLiteral("url")).toString();
+                if (!segUrl.isEmpty()) {
+                    segmentUrl = segUrl;
+                }
             }
             m_recoveryContext.url = segmentUrl;
             m_recoveryContext.itemId = m_currentItemId;
@@ -2934,14 +2940,14 @@ void PlayerController::cancelRecovery()
         return;
     }
     m_recoveryTimer->stop();
-    if (m_recoveryReply) {
-        m_recoveryReply->abort();
-        m_recoveryReply.clear();
-    }
     m_isRecovering = false;
     m_recoveryAttemptCount = 0;
     emit isRecoveringChanged();
     emit recoveryAttemptCountChanged();
+    if (m_recoveryReply) {
+        m_recoveryReply->abort();
+        m_recoveryReply.clear();
+    }
 }
 
 void PlayerController::onRecoveryTick()

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -2955,7 +2955,7 @@ void PlayerController::onRecoveryTick()
         int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         if (reply->error() == QNetworkReply::NoError) {
             qDebug() << "PlayerController: Recovery ping succeeded";
-            if (m_isRecovering && m_playbackState == Error) {
+            if (m_isRecovering && m_playbackState == Error && !m_terminalTransitionActive) {
                 cancelRecovery();
                 resumeFromRecoveryContext();
             }

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -10,6 +10,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QBuffer>
+#include <QNetworkReply>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -303,11 +304,7 @@ PlayerController::PlayerController(IPlayerBackend *playerBackend, ConfigManager 
     m_recoveryTimer->setInterval(kRecoveryPingIntervalMs);
     connect(m_recoveryTimer, &QTimer::timeout,
             this, &PlayerController::onRecoveryTick);
-    connect(m_libraryService, &LibraryService::serverPingSucceeded,
-            this, &PlayerController::onServerPingSucceeded);
-    connect(m_libraryService, &LibraryService::serverPingFailed,
-            this, &PlayerController::onServerPingFailed);
-            
+
     // Connect to ConfigManager audio delay signal
     connect(m_config, &ConfigManager::audioDelayChanged,
             this, [this]() {
@@ -582,6 +579,7 @@ void PlayerController::onExitPausedState()
 void PlayerController::onExitErrorState()
 {
     setErrorMessage(QString());
+    m_lastErrorWasNetworkRecoverable = false;
     cancelRecovery();
 }
 
@@ -621,6 +619,7 @@ void PlayerController::enterIdleStateImmediate()
     m_currentLibraryId.clear();
     m_pendingUrl.clear();
     m_recoveryContext = RecoveryContext{};
+    m_lastErrorWasNetworkRecoverable = false;
     m_currentPosition = 0;
     m_duration = 0;
     m_hasReportedStart = false;
@@ -849,6 +848,7 @@ void PlayerController::onEnterErrorState()
 void PlayerController::onLoadingTimeout()
 {
     qDebug() << "PlayerController: Loading timeout";
+    m_lastErrorWasNetworkRecoverable = true;
     setErrorMessage(tr("Loading timed out. Please check your connection and try again."));
     requestTerminalTransition(TerminalReason::Error);
 }
@@ -856,6 +856,7 @@ void PlayerController::onLoadingTimeout()
 void PlayerController::onBufferingTimeout()
 {
     qDebug() << "PlayerController: Buffering timeout";
+    m_lastErrorWasNetworkRecoverable = true;
     setErrorMessage(tr("Buffering timed out. Network may be too slow."));
     requestTerminalTransition(TerminalReason::Error);
 }
@@ -920,6 +921,7 @@ void PlayerController::onProcessError(const QString &error)
         return;
     }
 
+    m_lastErrorWasNetworkRecoverable = false;
     setErrorMessage(error);
     requestTerminalTransition(TerminalReason::Error);
 }
@@ -1125,15 +1127,24 @@ void PlayerController::prepareTerminalTransition(TerminalReason reason)
         m_shouldAutoplay = false;
 
         // Stash recovery context so we can resume if the server comes back
-        if (m_config && m_config->getAutoRecoverPlayback() && !m_currentItemId.isEmpty()) {
-            m_recoveryContext.url = m_pendingUrl;
+        if (m_config && m_config->getAutoRecoverPlayback()
+            && m_lastErrorWasNetworkRecoverable
+            && !m_currentItemId.isEmpty()
+            && !m_pendingUrl.isEmpty()) {
+            QString segmentUrl = m_pendingUrl;
+            if (m_activePlaybackSegmentIndex >= 0
+                && m_activePlaybackSegmentIndex < m_playbackSegments.size()) {
+                segmentUrl = m_playbackSegments[m_activePlaybackSegmentIndex]
+                                 .value(QStringLiteral("url")).toString();
+            }
+            m_recoveryContext.url = segmentUrl;
             m_recoveryContext.itemId = m_currentItemId;
-            m_recoveryContext.startPositionTicks = static_cast<qint64>(m_currentPosition * 10000000.0);
+            m_recoveryContext.startPositionTicks = static_cast<qint64>(m_segmentRelativePosition * 10000000.0);
             m_recoveryContext.seriesId = m_currentSeriesId;
             m_recoveryContext.seasonId = m_currentSeasonId;
             m_recoveryContext.libraryId = m_currentLibraryId;
             m_recoveryContext.mediaSourceId = m_mediaSourceId;
-            m_recoveryContext.playSessionId = m_playSessionId;
+            m_recoveryContext.playSessionId = QString(); // avoid stale session
             m_recoveryContext.mediaSource = m_activeMediaSource;
             m_recoveryContext.audioStreamIndex = m_selectedAudioTrack;
             m_recoveryContext.subtitleStreamIndex = m_selectedSubtitleTrack;
@@ -1141,6 +1152,10 @@ void PlayerController::prepareTerminalTransition(TerminalReason reason)
             m_recoveryContext.availableSubtitleTracks = m_availableSubtitleTracks;
             m_recoveryContext.framerate = m_contentFramerate;
             m_recoveryContext.isHDR = m_contentIsHDR;
+            m_recoveryContext.playbackSegments = m_playbackSegments;
+            m_recoveryContext.activePlaybackSegmentIndex = m_activePlaybackSegmentIndex;
+            m_recoveryContext.activePlaybackSegmentOffsetTicks = m_activePlaybackSegmentOffsetTicks;
+            m_recoveryContext.segmentRelativePosition = m_segmentRelativePosition;
             m_recoveryContext.valid = true;
         }
     }
@@ -2788,7 +2803,7 @@ void PlayerController::stop()
                             << "state=" << stateToString(m_playbackState)
                             << "terminalActive=" << m_terminalTransitionActive;
 
-    if (m_playbackState == Idle || m_playbackState == Error || m_terminalTransitionActive) {
+    if (m_playbackState == Idle || m_terminalTransitionActive) {
         return;
     }
 
@@ -2878,22 +2893,7 @@ void PlayerController::retry()
 
         if (m_recoveryContext.valid) {
             cancelRecovery();
-            playUrlWithTracks(m_recoveryContext.url,
-                              m_recoveryContext.itemId,
-                              m_recoveryContext.startPositionTicks,
-                              m_recoveryContext.seriesId,
-                              m_recoveryContext.seasonId,
-                              m_recoveryContext.libraryId,
-                              m_recoveryContext.mediaSourceId,
-                              m_recoveryContext.playSessionId,
-                              m_recoveryContext.mediaSource,
-                              m_recoveryContext.audioStreamIndex,
-                              m_recoveryContext.subtitleStreamIndex,
-                              m_recoveryContext.availableAudioTracks,
-                              m_recoveryContext.availableSubtitleTracks,
-                              m_recoveryContext.framerate,
-                              m_recoveryContext.isHDR);
-            m_recoveryContext = RecoveryContext{};
+            resumeFromRecoveryContext();
             return;
         }
 
@@ -2943,18 +2943,39 @@ void PlayerController::onRecoveryTick()
     ++m_recoveryAttemptCount;
     emit recoveryAttemptCountChanged();
     qDebug() << "PlayerController: Recovery ping attempt" << m_recoveryAttemptCount;
-    m_libraryService->pingServer();
-}
 
-void PlayerController::onServerPingSucceeded()
-{
-    qDebug() << "PlayerController: Server ping succeeded, resuming playback";
-    if (!m_isRecovering || m_playbackState != Error) {
+    QNetworkReply *reply = m_libraryService->pingServer();
+    if (!reply) {
+        m_recoveryTimer->start(kRecoveryPingIntervalMs);
         return;
     }
 
-    cancelRecovery();
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        reply->deleteLater();
+        int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        if (reply->error() == QNetworkReply::NoError) {
+            qDebug() << "PlayerController: Recovery ping succeeded";
+            if (m_isRecovering && m_playbackState == Error) {
+                cancelRecovery();
+                resumeFromRecoveryContext();
+            }
+        } else if (httpStatus == 401) {
+            qDebug() << "PlayerController: Recovery ping got 401, auth expired";
+            if (m_isRecovering) {
+                cancelRecovery();
+                setErrorMessage(tr("Session expired. Please log in again."));
+            }
+        } else {
+            qDebug() << "PlayerController: Recovery ping failed:" << reply->errorString();
+            if (m_isRecovering) {
+                m_recoveryTimer->start(kRecoveryPingIntervalMs);
+            }
+        }
+    });
+}
 
+void PlayerController::resumeFromRecoveryContext()
+{
     if (!m_recoveryContext.valid) {
         return;
     }
@@ -2974,16 +2995,21 @@ void PlayerController::onServerPingSucceeded()
                       m_recoveryContext.availableSubtitleTracks,
                       m_recoveryContext.framerate,
                       m_recoveryContext.isHDR);
-    m_recoveryContext = RecoveryContext{};
-}
 
-void PlayerController::onServerPingFailed(const QString &reason)
-{
-    qDebug() << "PlayerController: Server ping failed:" << reason;
-    if (!m_isRecovering) {
-        return;
+    // Restore multipart segment state so aggregate position and reporting are correct
+    if (!m_recoveryContext.playbackSegments.isEmpty()
+        && m_recoveryContext.activePlaybackSegmentIndex >= 0) {
+        m_playbackSegments = m_recoveryContext.playbackSegments;
+        m_activePlaybackSegmentIndex = m_recoveryContext.activePlaybackSegmentIndex;
+        m_activePlaybackSegmentOffsetTicks = m_recoveryContext.activePlaybackSegmentOffsetTicks;
+        m_segmentRelativePosition = m_recoveryContext.segmentRelativePosition;
+        m_aggregatePlaybackDuration = 0.0;
+        for (const QVariantMap &seg : m_playbackSegments) {
+            m_aggregatePlaybackDuration += static_cast<double>(seg.value(QStringLiteral("runTimeTicks")).toLongLong()) / 10000000.0;
+        }
     }
-    m_recoveryTimer->start(kRecoveryPingIntervalMs);
+
+    m_recoveryContext = RecoveryContext{};
 }
 
 // === TRACK SELECTION ===

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -366,9 +366,8 @@ private slots:
     void onAutoplayPlaybackInfoTimeout();
     void onItemLibraryResolved(const QString &itemId, const QString &libraryId);
     void onItemLibraryResolutionFailed(const QString &itemId, const QString &error);
-    void onServerPingSucceeded();
-    void onServerPingFailed(const QString &reason);
     void onRecoveryTick();
+    void resumeFromRecoveryContext();
     
     // Timeout handlers
     void onLoadingTimeout();
@@ -695,12 +694,17 @@ private:
         QVariantList availableSubtitleTracks;
         double framerate = 0.0;
         bool isHDR = false;
+        QList<QVariantMap> playbackSegments;
+        int activePlaybackSegmentIndex = -1;
+        qint64 activePlaybackSegmentOffsetTicks = 0;
+        double segmentRelativePosition = 0.0;
         bool valid = false;
     };
     RecoveryContext m_recoveryContext;
     QTimer *m_recoveryTimer;
     int m_recoveryAttemptCount = 0;
     bool m_isRecovering = false;
+    bool m_lastErrorWasNetworkRecoverable = false;
     static constexpr int kRecoveryPingIntervalMs = 5000;
     
     // State

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -10,6 +10,7 @@
 #include <QStringList>
 #include <QVariantMap>
 #include <QVariantList>
+#include <QPointer>
 #include <QtGlobal>
 #include <functional>
 #include <memory>
@@ -23,6 +24,7 @@
 class PlaybackService;
 class LibraryService;
 class AuthenticationService;
+class QNetworkReply;
 
 /**
  * @class PlayerController
@@ -702,6 +704,7 @@ private:
     };
     RecoveryContext m_recoveryContext;
     QTimer *m_recoveryTimer;
+    QPointer<QNetworkReply> m_recoveryReply;
     int m_recoveryAttemptCount = 0;
     bool m_isRecovering = false;
     bool m_lastErrorWasNetworkRecoverable = false;

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -63,6 +63,8 @@ class PlayerController : public QObject
     Q_PROPERTY(bool isPaused READ isPaused NOTIFY playbackStateChanged)
     Q_PROPERTY(bool hasError READ hasError NOTIFY hasErrorChanged)
     Q_PROPERTY(QString errorMessage READ errorMessage NOTIFY errorMessageChanged)
+    Q_PROPERTY(bool isRecovering READ isRecovering NOTIFY isRecoveringChanged)
+    Q_PROPERTY(int recoveryAttemptCount READ recoveryAttemptCount NOTIFY recoveryAttemptCountChanged)
     Q_PROPERTY(int bufferingProgress READ bufferingProgress NOTIFY bufferingProgressChanged)
     Q_PROPERTY(int audioDelay READ audioDelay WRITE setAudioDelay NOTIFY audioDelayChanged)
     Q_PROPERTY(bool supportsEmbeddedVideo READ supportsEmbeddedVideo NOTIFY supportsEmbeddedVideoChanged)
@@ -159,6 +161,8 @@ public:
     bool isPaused() const { return m_playbackState == Paused; }
     bool hasError() const;
     QString errorMessage() const;
+    bool isRecovering() const { return m_isRecovering; }
+    int recoveryAttemptCount() const { return m_recoveryAttemptCount; }
     int bufferingProgress() const;
     
     // Track selection getters
@@ -298,6 +302,8 @@ signals:
     void isLoadingChanged();
     void hasErrorChanged();
     void errorMessageChanged();
+    void isRecoveringChanged();
+    void recoveryAttemptCountChanged();
     void bufferingProgressChanged();
     void audioDelayChanged();
     void isPlaybackActiveChanged();
@@ -360,6 +366,9 @@ private slots:
     void onAutoplayPlaybackInfoTimeout();
     void onItemLibraryResolved(const QString &itemId, const QString &libraryId);
     void onItemLibraryResolutionFailed(const QString &itemId, const QString &error);
+    void onServerPingSucceeded();
+    void onServerPingFailed(const QString &reason);
+    void onRecoveryTick();
     
     // Timeout handlers
     void onLoadingTimeout();
@@ -412,6 +421,8 @@ private:
     void setPlaybackState(PlaybackState state);
     void setErrorMessage(const QString &message);
     void setBufferingProgress(int progress);
+    void beginRecovery();
+    void cancelRecovery();
     void reportPlaybackStart();
     void reportPlaybackProgress();
     void reportPlaybackProgressNow();
@@ -666,6 +677,31 @@ private:
     static constexpr int kVolumePersistDebounceMs = 250;
     static constexpr int kAutoplayPlaybackInfoTimeoutMs = 8000;
     static constexpr double kNextEpisodePrefetchTriggerPercent = 70.0;
+
+    // Recovery from transient server loss
+    struct RecoveryContext {
+        QString url;
+        QString itemId;
+        qint64 startPositionTicks = 0;
+        QString seriesId;
+        QString seasonId;
+        QString libraryId;
+        QString mediaSourceId;
+        QString playSessionId;
+        QVariantMap mediaSource;
+        int audioStreamIndex = -1;
+        int subtitleStreamIndex = -1;
+        QVariantList availableAudioTracks;
+        QVariantList availableSubtitleTracks;
+        double framerate = 0.0;
+        bool isHDR = false;
+        bool valid = false;
+    };
+    RecoveryContext m_recoveryContext;
+    QTimer *m_recoveryTimer;
+    int m_recoveryAttemptCount = 0;
+    bool m_isRecovering = false;
+    static constexpr int kRecoveryPingIntervalMs = 5000;
     
     // State
     PlaybackState m_playbackState = Idle;

--- a/src/ui/settings/PlaybackSettings.qml
+++ b/src/ui/settings/PlaybackSettings.qml
@@ -823,9 +823,34 @@ FocusScope {
                     onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
 
                     KeyNavigation.up: themeSongVolumeCombo
+                    KeyNavigation.down: cacheSizeSpinBox
 
                     onToggled: function(value) {
                         ConfigManager.themeSongLoop = value
+                    }
+                }
+
+                // ── Group 7: Playback cache size ──
+
+                SettingsGroupDivider { Layout.fillWidth: true }
+
+                SettingsSpinBoxRow {
+                    id: cacheSizeSpinBox
+                    label: qsTr("Playback Cache Size")
+                    description: qsTr("Amount of memory to use for buffering video during playback")
+                    value: ConfigManager.playbackCacheSizeMB
+                    from: 50
+                    to: 2048
+                    stepSize: 50
+                    unit: "MB"
+                    Layout.fillWidth: true
+                    ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
+                    onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
+
+                    KeyNavigation.up: themeSongLoopToggle
+
+                    onSpinBoxValueChanged: function(newValue) {
+                        ConfigManager.playbackCacheSizeMB = newValue
                     }
                 }
             }

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -219,6 +219,7 @@ QStringList ConfigManager::getMpvConfigArgs() const
     if (cacheSizeMB >= 50) {
         args << "--cache=yes";
         args << QString("--demuxer-max-bytes=%1").arg(static_cast<qint64>(cacheSizeMB) * 1024 * 1024);
+        args << QString("--demuxer-max-back-bytes=%1").arg(static_cast<qint64>(cacheSizeMB / 4) * 1024 * 1024);
         args << "--stream-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_delay_max=30";
     }
     

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -453,7 +453,7 @@ int ConfigManager::getImageCacheSizeMB() const
 
 void ConfigManager::setPlaybackCacheSizeMB(int mb)
 {
-    int clamped = std::max(50, mb);
+    int clamped = std::clamp(mb, 50, 2048);
     if (clamped == getPlaybackCacheSizeMB()) {
         return;
     }
@@ -475,16 +475,17 @@ void ConfigManager::setPlaybackCacheSizeMB(int mb)
 
 int ConfigManager::getPlaybackCacheSizeMB() const
 {
+    int value = 500;
     if (m_config.contains("settings") && m_config["settings"].isObject()) {
         QJsonObject settings = m_config["settings"].toObject();
         if (settings.contains("playback") && settings["playback"].isObject()) {
             QJsonObject playback = settings["playback"].toObject();
             if (playback.contains("playback_cache_size_mb")) {
-                return playback["playback_cache_size_mb"].toInt();
+                value = playback["playback_cache_size_mb"].toInt();
             }
         }
     }
-    return 500; // Default 500MB
+    return std::clamp(value, 50, 2048);
 }
 
 void ConfigManager::setAutoRecoverPlayback(bool enabled)

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -147,7 +147,7 @@ QString ConfigManager::getMpvScriptsDir()
     return QString();
 }
 
-QStringList ConfigManager::getMpvConfigArgs()
+QStringList ConfigManager::getMpvConfigArgs() const
 {
     QStringList args;
     
@@ -212,6 +212,14 @@ QStringList ConfigManager::getMpvConfigArgs()
 
             args << "--script=" + canonicalPath;
         }
+    }
+
+    // Global playback cache and network reconnect settings
+    int cacheSizeMB = getPlaybackCacheSizeMB();
+    if (cacheSizeMB >= 50) {
+        args << "--cache=yes";
+        args << QString("--demuxer-max-bytes=%1").arg(static_cast<qint64>(cacheSizeMB) * 1024 * 1024);
+        args << "--stream-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_delay_max=30";
     }
     
     return args;
@@ -441,6 +449,77 @@ int ConfigManager::getImageCacheSizeMB() const
         }
     }
     return 500; // Default 500MB
+}
+
+void ConfigManager::setPlaybackCacheSizeMB(int mb)
+{
+    int clamped = std::max(50, mb);
+    if (clamped == getPlaybackCacheSizeMB()) {
+        return;
+    }
+
+    QJsonObject settings;
+    if (m_config.contains("settings") && m_config["settings"].isObject()) {
+        settings = m_config["settings"].toObject();
+    }
+    QJsonObject playback;
+    if (settings.contains("playback") && settings["playback"].isObject()) {
+        playback = settings["playback"].toObject();
+    }
+    playback["playback_cache_size_mb"] = clamped;
+    settings["playback"] = playback;
+    m_config["settings"] = settings;
+    save();
+    emit playbackCacheSizeMBChanged();
+}
+
+int ConfigManager::getPlaybackCacheSizeMB() const
+{
+    if (m_config.contains("settings") && m_config["settings"].isObject()) {
+        QJsonObject settings = m_config["settings"].toObject();
+        if (settings.contains("playback") && settings["playback"].isObject()) {
+            QJsonObject playback = settings["playback"].toObject();
+            if (playback.contains("playback_cache_size_mb")) {
+                return playback["playback_cache_size_mb"].toInt();
+            }
+        }
+    }
+    return 500; // Default 500MB
+}
+
+void ConfigManager::setAutoRecoverPlayback(bool enabled)
+{
+    if (enabled == getAutoRecoverPlayback()) {
+        return;
+    }
+
+    QJsonObject settings;
+    if (m_config.contains("settings") && m_config["settings"].isObject()) {
+        settings = m_config["settings"].toObject();
+    }
+    QJsonObject playback;
+    if (settings.contains("playback") && settings["playback"].isObject()) {
+        playback = settings["playback"].toObject();
+    }
+    playback["auto_recover_playback"] = enabled;
+    settings["playback"] = playback;
+    m_config["settings"] = settings;
+    save();
+    emit autoRecoverPlaybackChanged();
+}
+
+bool ConfigManager::getAutoRecoverPlayback() const
+{
+    if (m_config.contains("settings") && m_config["settings"].isObject()) {
+        QJsonObject settings = m_config["settings"].toObject();
+        if (settings.contains("playback") && settings["playback"].isObject()) {
+            QJsonObject playback = settings["playback"].toObject();
+            if (playback.contains("auto_recover_playback")) {
+                return playback["auto_recover_playback"].toBool();
+            }
+        }
+    }
+    return true; // Default enabled
 }
 
 void ConfigManager::setRoundedImageMode(const QString &mode)
@@ -2143,6 +2222,25 @@ public:
         newConfig["settings"] = settings;
         return newConfig;
     }
+
+    static QJsonObject migrateV16ToV17(const QJsonObject &oldConfig)
+    {
+        QJsonObject newConfig = oldConfig;
+        newConfig["version"] = 17;
+
+        QJsonObject settings = newConfig["settings"].toObject();
+        QJsonObject playback = settings.value("playback").toObject();
+        if (!playback.contains("playback_cache_size_mb")) {
+            playback["playback_cache_size_mb"] = 500;
+        }
+        if (!playback.contains("auto_recover_playback")) {
+            playback["auto_recover_playback"] = true;
+        }
+
+        settings["playback"] = playback;
+        newConfig["settings"] = settings;
+        return newConfig;
+    }
 };
 }
 
@@ -2291,6 +2389,14 @@ bool ConfigManager::migrateConfig()
                 qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
+        } else if (version == 16) {
+            m_config = ConfigMigrator::migrateV16ToV17(m_config);
+            if (m_config.contains("version") && m_config["version"].isDouble()) {
+                version = m_config["version"].toInt();
+            } else {
+                qWarning() << "Migration produced invalid config (no version)";
+                return false;
+            }
         } else {
             qWarning() << "Unknown config version during migration:" << version;
             return false;
@@ -2350,6 +2456,8 @@ QJsonObject ConfigManager::defaultConfig() const
     playback["ui_sounds_enabled"] = true;
     playback["ui_sounds_volume"] = 3;
     playback["performance_mode_enabled"] = false;
+    playback["playback_cache_size_mb"] = 500;
+    playback["auto_recover_playback"] = true;
     settings["playback"] = playback;
     
     QJsonObject video;

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -68,6 +68,7 @@ class ConfigManager : public QObject
     Q_PROPERTY(bool autoSkipIntro READ getAutoSkipIntro WRITE setAutoSkipIntro NOTIFY autoSkipIntroChanged)
     Q_PROPERTY(bool autoSkipOutro READ getAutoSkipOutro WRITE setAutoSkipOutro NOTIFY autoSkipOutroChanged)
     Q_PROPERTY(QString playerBackend READ getPlayerBackend WRITE setPlayerBackend NOTIFY playerBackendChanged)
+    Q_PROPERTY(int playbackCacheSizeMB READ getPlaybackCacheSizeMB WRITE setPlaybackCacheSizeMB NOTIFY playbackCacheSizeMBChanged)
     Q_PROPERTY(int backdropRotationInterval READ getBackdropRotationInterval WRITE setBackdropRotationInterval NOTIFY backdropRotationIntervalChanged)
     Q_PROPERTY(bool launchInFullscreen READ getLaunchInFullscreen WRITE setLaunchInFullscreen NOTIFY launchInFullscreenChanged)
     Q_PROPERTY(int themeSongVolume READ getThemeSongVolume WRITE setThemeSongVolume NOTIFY themeSongVolumeChanged)
@@ -201,6 +202,12 @@ public:
 
     void setPlayerBackend(const QString &backendName);
     QString getPlayerBackend() const;
+
+    // Playback Cache Settings
+    void setPlaybackCacheSizeMB(int mb);
+    int getPlaybackCacheSizeMB() const;
+    void setAutoRecoverPlayback(bool enabled);
+    bool getAutoRecoverPlayback() const;
     
     // Theme Song Settings
     void setThemeSongVolume(int level);
@@ -326,7 +333,7 @@ public:
     
     /// Returns mpv command-line arguments for config files (--config-dir, --config, --input-conf, --script)
     /// Only includes arguments for files/directories that actually exist
-    static QStringList getMpvConfigArgs();
+    QStringList getMpvConfigArgs() const;
     
     /// Ensures the config directory structure exists
     static bool ensureConfigDirExists();
@@ -400,6 +407,8 @@ signals:
     void autoSkipIntroChanged();
     void autoSkipOutroChanged();
     void playerBackendChanged();
+    void playbackCacheSizeMBChanged();
+    void autoRecoverPlaybackChanged();
     void themeSongVolumeChanged();
     void themeSongLoopChanged();
     void uiSoundsEnabledChanged();
@@ -432,6 +441,6 @@ private:
 
     QJsonObject m_config;
 
-    static constexpr int kCurrentConfigVersion = 16;
+    static constexpr int kCurrentConfigVersion = 17;
     QJsonObject defaultConfig() const;
 };


### PR DESCRIPTION
## Summary
This PR adds configurable memory-based playback caching and automatic recovery when the Jellyfin server becomes unreachable during playback.

### Changes
- **ConfigManager**: New `playbackCacheSizeMB` setting (default 500MB, range 50–2048) exposed in Settings → Playback. New `autoRecoverPlayback` toggle (default `true`, JSON-only).
- **mpv args**: Bloom now injects `--cache=yes`, `--demuxer-max-bytes`, and `--stream-lavf-o=reconnect=...` globally so mpv buffers aggressively and auto-reconnects HTTP streams.
- **LibraryService**: Added `pingServer()` (`GET /System/Info`) with `serverPingSucceeded` / `serverPingFailed` signals.
- **PlayerController**: When playback errors due to network loss, stash a `RecoveryContext` and ping the server every 5 seconds. On success, automatically resume at the last known position with the same tracks. Retries indefinitely until the server returns or the user stops/retries.
- **Docs**: Updated `docs/playback.md` with caching and recovery behavior details.

### Why
Previously, any server outage during playback would stall or error out with no retry mechanism. With these changes, mpv can survive brief outages via its built-in cache, and longer outages are handled by Bloom polling the server and resuming seamlessly once it comes back.

### Testing
- Verified compilation via `./scripts/build-docker.sh`.
- Manual validation done


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add aggressive mpv playback caching and auto-recovery on server outage
> - `ConfigManager::getMpvConfigArgs` (changed from static to instance method) now appends mpv cache flags (`--cache=yes`, `--demuxer-max-bytes`, `--demuxer-max-back-bytes`) and stream reconnect options based on a configurable `playbackCacheSizeMB` setting (50–2048 MB, default 500 MB).
> - `PlayerController` gains auto-recovery logic: on loading or buffering timeouts, a `RecoveryContext` is stashed capturing the full playback state (URL, item IDs, track selections, segment position). On entering error state, `beginRecovery()` starts pinging `/System/Info` every 5 seconds via `LibraryService::pingServer()` until the server responds.
> - On successful ping, `resumeFromRecoveryContext()` resumes playback at the exact prior position, restoring multipart segment state and progress reporting. A 401 response cancels recovery and sets a session-expired error.
> - A "Playback Cache Size" spin box (50–2048 MB, step 50) is added to [PlaybackSettings.qml](https://github.com/crowquillx/Bloom/pull/47/files#diff-102f755f3ebf40752ef46ce305238f5c5324ef9cacd668d6a8089ec92b1ee028), and an "Auto Recover Playback" toggle is persisted via `ConfigManager`.
> - Risk: `getMpvConfigArgs` is no longer static — any call sites using `ConfigManager::getMpvConfigArgs()` without an instance will break. Config schema bumped from v16 to v17 with a migration adding new defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8bacf16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playback cache size added to Settings (50–2048 MB, default 500 MB) to improve buffering.
  * Automatic playback recovery: on transient network errors the app will ping the server and automatically resume playback from the last position; manual retry also resumes from the stashed position.
* **Documentation**
  * Added guidance on playback caching, recovery behavior, and note that auto-recovery is toggled via app configuration (not exposed in the UI).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->