### PR TITLE
feat(playback): add global track language defaults

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -31,6 +31,7 @@ Config API sample (high level)
 - `playbackCompletionThreshold` is a Q_PROPERTY (default 90) and `autoplayNextEpisode` default true.
 - `skipButtonAutoHideSeconds` is a Q_PROPERTY (default 6; range 0-15) for skip intro/credits popup visibility timing.
 - `autoSkipIntro` and `autoSkipOutro` are Q_PROPERTY booleans (both default false) for one-time-per-playback intro/credits auto-skip.
+- `defaultAudioTrackSelection` and `defaultSubtitleTrackSelection` are Q_PROPERTY strings stored at `settings.playback.default_audio_track_selection` and `settings.playback.default_subtitle_track_selection`. Defaults are `jellyfin-default`. Valid values are `jellyfin-default`, `file-default`, supported language codes such as `eng`/`jpn`/`spa`, and subtitle-only `off` or `forced`.
 - `playbackVolume` and `playbackMuted` persist the last playback volume/mute state across app restarts (`settings.playback.playback_volume`, `settings.playback.playback_muted`).
 - `autoplayCountdownSeconds` drives the countdown shown before autoplay launches the next episode; the default is 10 seconds and disabling autoplay simply skips the timer.
 - `uiSoundsEnabled` / `uiSoundsVolume` keep the remote/keyboard navigation sounds available (default on at level 3) or let you mute them without touching the media volume slider.

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -100,7 +100,7 @@ Audio/Subtitle Track Selection
   - built-in safety fallback
 - Built-in audio fallback uses Jellyfin `defaultAudioStreamIndex`, then file-level `isDefault`, then the first audio stream.
 - Built-in subtitle fallback uses Jellyfin `defaultSubtitleStreamIndex`, then file-level `isDefault`, then forced subtitles, then subtitles off.
-- Global subtitle `Forced` chooses the first forced subtitle track, then uses the built-in subtitle fallback when no forced track exists.
+- Global subtitle `Forced` chooses the first forced subtitle track; when no forced track exists, subtitles stay off (`global-forced-off`) rather than falling through to Jellyfin/file defaults (which could enable full dialogue subtitles).
 - Global language fallbacks match normalized common language aliases (for example `en`/`eng`, `fr`/`fre`/`fra`, `zh`/`chi`/`zho`). Audio prefers matching default streams, then stream order. Subtitles prefer matching default streams, then regular subtitles, then forced, then SDH/hearing-impaired, then stream order.
 - Canonical track mapping contract:
   - UI and reporting state use Jellyfin `MediaStream.index`.

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -94,10 +94,14 @@ Audio/Subtitle Track Selection
 - The server provides `defaultAudioStreamIndex` and `defaultSubtitleStreamIndex` which reflect the user's preferences set on the Jellyfin server.
 - Use `PlayerController::setSelectedAudioTrack(index)` and `setSelectedSubtitleTrack(index)` to change tracks during playback via mpv IPC (`aid`, `sid` properties).
 - Initial selection resolution order:
+  - request-time override from the playback request/autoplay context, if valid
   - explicit saved preference for the current season/movie scope, if still valid
-  - Jellyfin `defaultAudioStreamIndex` / `defaultSubtitleStreamIndex`
-  - file-level defaults from stream metadata (`isDefault`, then forced subtitles when applicable)
-  - fallback to first audio track / subtitles off
+  - global app fallback from Settings > Playback (`Jellyfin Default`, `File Default`, common language, or subtitle `Off`/`Forced`)
+  - built-in safety fallback
+- Built-in audio fallback uses Jellyfin `defaultAudioStreamIndex`, then file-level `isDefault`, then the first audio stream.
+- Built-in subtitle fallback uses Jellyfin `defaultSubtitleStreamIndex`, then file-level `isDefault`, then forced subtitles, then subtitles off.
+- Global subtitle `Forced` chooses the first forced subtitle track, then uses the built-in subtitle fallback when no forced track exists.
+- Global language fallbacks match normalized common language aliases (for example `en`/`eng`, `fr`/`fre`/`fra`, `zh`/`chi`/`zho`). Audio prefers matching default streams, then stream order. Subtitles prefer matching default streams, then regular subtitles, then forced, then SDH/hearing-impaired, then stream order.
 - Canonical track mapping contract:
   - UI and reporting state use Jellyfin `MediaStream.index`.
   - Runtime mpv switching uses mapped mpv track IDs (1-based per media type order).
@@ -110,6 +114,7 @@ Audio/Subtitle Track Selection
 Track Preference Persistence
 - Track preferences are stored separately from the main config in `~/.config/Bloom/track_preferences.json`.
 - The file stores only explicit user intent. Unset preferences fall back to Jellyfin/file defaults and are not written.
+- Global app-level audio/subtitle fallback defaults are stored in the main config, not in `track_preferences.json`.
 - Preferences are loaded at startup and saved with a 1-second delay to batch multiple changes.
 - Schema is versioned. Legacy/unversioned files are intentionally discarded and replaced on the next save.
 

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -35,7 +35,6 @@ Q_LOGGING_CATEGORY(lcPlaybackTrace, "bloom.playback.trace")
 
 namespace {
 std::atomic<quint64> gPlaybackAttemptCounter{0};
-
 bool isLinuxEmbeddedLibmpvBackend(const IPlayerBackend *backend)
 {
     return backend && backend->backendName() == QStringLiteral("linux-libmpv-opengl");
@@ -135,6 +134,86 @@ int firstMatchingStreamIndex(const QVariantList &streams, const std::function<bo
         }
     }
     return -1;
+}
+
+QString normalizedLanguageCode(const QString &language)
+{
+    const QString normalized = language.trimmed().toLower();
+    static const QHash<QString, QString> aliases = {
+        {QStringLiteral("en"), QStringLiteral("eng")}, {QStringLiteral("eng"), QStringLiteral("eng")},
+        {QStringLiteral("ja"), QStringLiteral("jpn")}, {QStringLiteral("jpn"), QStringLiteral("jpn")},
+        {QStringLiteral("es"), QStringLiteral("spa")}, {QStringLiteral("spa"), QStringLiteral("spa")},
+        {QStringLiteral("fr"), QStringLiteral("fre")}, {QStringLiteral("fre"), QStringLiteral("fre")},
+        {QStringLiteral("fra"), QStringLiteral("fre")},
+        {QStringLiteral("de"), QStringLiteral("ger")}, {QStringLiteral("ger"), QStringLiteral("ger")},
+        {QStringLiteral("deu"), QStringLiteral("ger")},
+        {QStringLiteral("it"), QStringLiteral("ita")}, {QStringLiteral("ita"), QStringLiteral("ita")},
+        {QStringLiteral("pt"), QStringLiteral("por")}, {QStringLiteral("por"), QStringLiteral("por")},
+        {QStringLiteral("ru"), QStringLiteral("rus")}, {QStringLiteral("rus"), QStringLiteral("rus")},
+        {QStringLiteral("zh"), QStringLiteral("chi")}, {QStringLiteral("chi"), QStringLiteral("chi")},
+        {QStringLiteral("zho"), QStringLiteral("chi")},
+        {QStringLiteral("ko"), QStringLiteral("kor")}, {QStringLiteral("kor"), QStringLiteral("kor")},
+        {QStringLiteral("ar"), QStringLiteral("ara")}, {QStringLiteral("ara"), QStringLiteral("ara")},
+        {QStringLiteral("hi"), QStringLiteral("hin")}, {QStringLiteral("hin"), QStringLiteral("hin")},
+        {QStringLiteral("nl"), QStringLiteral("dut")}, {QStringLiteral("dut"), QStringLiteral("dut")},
+        {QStringLiteral("nld"), QStringLiteral("dut")},
+        {QStringLiteral("sv"), QStringLiteral("swe")}, {QStringLiteral("swe"), QStringLiteral("swe")},
+        {QStringLiteral("no"), QStringLiteral("nor")}, {QStringLiteral("nor"), QStringLiteral("nor")},
+        {QStringLiteral("da"), QStringLiteral("dan")}, {QStringLiteral("dan"), QStringLiteral("dan")},
+        {QStringLiteral("fi"), QStringLiteral("fin")}, {QStringLiteral("fin"), QStringLiteral("fin")},
+        {QStringLiteral("pl"), QStringLiteral("pol")}, {QStringLiteral("pol"), QStringLiteral("pol")},
+        {QStringLiteral("tr"), QStringLiteral("tur")}, {QStringLiteral("tur"), QStringLiteral("tur")},
+        {QStringLiteral("cs"), QStringLiteral("cze")}, {QStringLiteral("cze"), QStringLiteral("cze")},
+        {QStringLiteral("ces"), QStringLiteral("cze")},
+        {QStringLiteral("el"), QStringLiteral("gre")}, {QStringLiteral("gre"), QStringLiteral("gre")},
+        {QStringLiteral("ell"), QStringLiteral("gre")},
+        {QStringLiteral("he"), QStringLiteral("heb")}, {QStringLiteral("heb"), QStringLiteral("heb")},
+        {QStringLiteral("id"), QStringLiteral("ind")}, {QStringLiteral("ind"), QStringLiteral("ind")},
+        {QStringLiteral("tha"), QStringLiteral("tha")}, {QStringLiteral("th"), QStringLiteral("tha")},
+        {QStringLiteral("vi"), QStringLiteral("vie")}, {QStringLiteral("vie"), QStringLiteral("vie")}
+    };
+    return aliases.value(normalized, normalized);
+}
+
+int bestLanguageStreamIndex(const QVariantList &streams, const QString &language, bool subtitle)
+{
+    const QString normalizedPreference = normalizedLanguageCode(language);
+    if (normalizedPreference.isEmpty()) {
+        return -1;
+    }
+
+    int bestIndex = -1;
+    int bestScore = -1;
+    int ordinal = 0;
+    for (const QVariant &streamVariant : streams) {
+        const QVariantMap stream = streamVariant.toMap();
+        if (normalizedLanguageCode(stream.value(QStringLiteral("language")).toString()) != normalizedPreference) {
+            ++ordinal;
+            continue;
+        }
+
+        int score = 10000 - ordinal;
+        if (stream.value(QStringLiteral("isDefault"), false).toBool()) {
+            score += 100000;
+        } else if (subtitle) {
+            const bool forced = stream.value(QStringLiteral("isForced"), false).toBool();
+            const bool hearingImpaired = stream.value(QStringLiteral("isHearingImpaired"), false).toBool();
+            if (!forced && !hearingImpaired) {
+                score += 50000;
+            } else if (forced) {
+                score += 30000;
+            } else if (hearingImpaired) {
+                score += 10000;
+            }
+        }
+
+        if (score > bestScore) {
+            bestScore = score;
+            bestIndex = stream.value(QStringLiteral("index"), -1).toInt();
+        }
+        ++ordinal;
+    }
+    return bestIndex;
 }
 
 QString trackTitleForStream(const QVariantMap &stream)
@@ -3587,6 +3666,128 @@ PlayerController::ResolvedTrackSelection PlayerController::resolveTrackSelection
     const QVariantList audioStreams = mediaStreamsForType(mediaSource, QStringLiteral("Audio"));
     const QVariantList subtitleStreams = mediaStreamsForType(mediaSource, QStringLiteral("Subtitle"));
 
+    const auto resolveJellyfinAudioDefault = [&]() -> std::pair<int, QString> {
+        const int jellyfinDefault = mediaSource.value(QStringLiteral("defaultAudioStreamIndex"), -1).toInt();
+        if (jellyfinDefault >= 0 && hasStreamIndex(audioStreams, jellyfinDefault)) {
+            return {jellyfinDefault, QStringLiteral("jellyfin-default")};
+        }
+        return {-1, {}};
+    };
+
+    const auto resolveFileAudioDefault = [&]() -> std::pair<int, QString> {
+        const int fileDefault = firstMatchingStreamIndex(audioStreams, [](const QVariantMap &stream) {
+            return stream.value(QStringLiteral("isDefault"), false).toBool();
+        });
+        if (fileDefault >= 0) {
+            return {fileDefault, QStringLiteral("file-default")};
+        }
+        return {-1, {}};
+    };
+
+    const auto resolveBuiltInAudioFallback = [&]() -> std::pair<int, QString> {
+        const auto [jellyfinDefault, jellyfinSource] = resolveJellyfinAudioDefault();
+        if (jellyfinDefault >= 0) {
+            return {jellyfinDefault, jellyfinSource};
+        }
+
+        const auto [fileDefault, fileSource] = resolveFileAudioDefault();
+        if (fileDefault >= 0) {
+            return {fileDefault, fileSource};
+        }
+
+        const int fallback = firstMatchingStreamIndex(audioStreams, [](const QVariantMap &) {
+            return true;
+        });
+        return {fallback, fallback >= 0 ? QStringLiteral("fallback") : QStringLiteral("none")};
+    };
+
+    const auto resolveJellyfinSubtitleDefault = [&]() -> std::pair<int, QString> {
+        const int jellyfinDefault = mediaSource.value(QStringLiteral("defaultSubtitleStreamIndex"), -1).toInt();
+        if (jellyfinDefault >= 0 && hasStreamIndex(subtitleStreams, jellyfinDefault)) {
+            return {jellyfinDefault, QStringLiteral("jellyfin-default")};
+        }
+        return {-1, {}};
+    };
+
+    const auto resolveFileSubtitleDefault = [&]() -> std::pair<int, QString> {
+        const int fileDefault = firstMatchingStreamIndex(subtitleStreams, [](const QVariantMap &stream) {
+            return stream.value(QStringLiteral("isDefault"), false).toBool();
+        });
+        if (fileDefault >= 0) {
+            return {fileDefault, QStringLiteral("file-default")};
+        }
+        return {-1, {}};
+    };
+
+    const auto resolveBuiltInSubtitleFallback = [&]() -> std::pair<int, QString> {
+        const auto [jellyfinDefault, jellyfinSource] = resolveJellyfinSubtitleDefault();
+        if (jellyfinDefault >= 0) {
+            return {jellyfinDefault, jellyfinSource};
+        }
+
+        const auto [fileDefault, fileSource] = resolveFileSubtitleDefault();
+        if (fileDefault >= 0) {
+            return {fileDefault, fileSource};
+        }
+
+        const int forcedDefault = firstMatchingStreamIndex(subtitleStreams, [](const QVariantMap &stream) {
+            return stream.value(QStringLiteral("isForced"), false).toBool();
+        });
+        if (forcedDefault >= 0) {
+            return {forcedDefault, QStringLiteral("forced-default")};
+        }
+
+        return {-1, QStringLiteral("fallback-off")};
+    };
+
+    const auto resolveGlobalAudioDefault = [&]() -> std::pair<int, QString> {
+        const QString selection = m_config ? m_config->getDefaultAudioTrackSelection() : QStringLiteral("jellyfin-default");
+        if (selection == QStringLiteral("file-default")) {
+            const auto [fileDefault, fileSource] = resolveFileAudioDefault();
+            if (fileDefault >= 0) {
+                return {fileDefault, fileSource};
+            }
+            return resolveBuiltInAudioFallback();
+        }
+        if (selection != QStringLiteral("jellyfin-default")) {
+            const int languageDefault = bestLanguageStreamIndex(audioStreams, selection, false);
+            if (languageDefault >= 0) {
+                return {languageDefault, QStringLiteral("global-language")};
+            }
+        }
+        return resolveBuiltInAudioFallback();
+    };
+
+    const auto resolveGlobalSubtitleDefault = [&]() -> std::pair<int, QString> {
+        const QString selection = m_config ? m_config->getDefaultSubtitleTrackSelection() : QStringLiteral("jellyfin-default");
+        if (selection == QStringLiteral("off")) {
+            return {-1, QStringLiteral("global-off")};
+        }
+        if (selection == QStringLiteral("forced")) {
+            const int forcedDefault = firstMatchingStreamIndex(subtitleStreams, [](const QVariantMap &stream) {
+                return stream.value(QStringLiteral("isForced"), false).toBool();
+            });
+            if (forcedDefault >= 0) {
+                return {forcedDefault, QStringLiteral("global-forced")};
+            }
+            return {-1, QStringLiteral("global-forced-off")};
+        }
+        if (selection == QStringLiteral("file-default")) {
+            const auto [fileDefault, fileSource] = resolveFileSubtitleDefault();
+            if (fileDefault >= 0) {
+                return {fileDefault, fileSource};
+            }
+            return resolveBuiltInSubtitleFallback();
+        }
+        if (selection != QStringLiteral("jellyfin-default")) {
+            const int languageDefault = bestLanguageStreamIndex(subtitleStreams, selection, true);
+            if (languageDefault >= 0) {
+                return {languageDefault, QStringLiteral("global-language")};
+            }
+        }
+        return resolveBuiltInSubtitleFallback();
+    };
+
     const auto resolveAudio = [&]() -> std::pair<int, QString> {
         if (preferredAudioIndex >= 0 && hasStreamIndex(audioStreams, preferredAudioIndex)) {
             return {preferredAudioIndex, QStringLiteral("override")};
@@ -3595,23 +3796,7 @@ PlayerController::ResolvedTrackSelection PlayerController::resolveTrackSelection
             && hasStreamIndex(audioStreams, preferences.audio.streamIndex)) {
             return {preferences.audio.streamIndex, QStringLiteral("explicit")};
         }
-
-        const int jellyfinDefault = mediaSource.value(QStringLiteral("defaultAudioStreamIndex"), -1).toInt();
-        if (jellyfinDefault >= 0 && hasStreamIndex(audioStreams, jellyfinDefault)) {
-            return {jellyfinDefault, QStringLiteral("jellyfin-default")};
-        }
-
-        const int fileDefault = firstMatchingStreamIndex(audioStreams, [](const QVariantMap &stream) {
-            return stream.value(QStringLiteral("isDefault"), false).toBool();
-        });
-        if (fileDefault >= 0) {
-            return {fileDefault, QStringLiteral("file-default")};
-        }
-
-        const int fallback = firstMatchingStreamIndex(audioStreams, [](const QVariantMap &) {
-            return true;
-        });
-        return {fallback, fallback >= 0 ? QStringLiteral("fallback") : QStringLiteral("none")};
+        return resolveGlobalAudioDefault();
     };
 
     const auto resolveSubtitle = [&]() -> std::pair<int, QString> {
@@ -3628,27 +3813,7 @@ PlayerController::ResolvedTrackSelection PlayerController::resolveTrackSelection
             && hasStreamIndex(subtitleStreams, preferences.subtitle.streamIndex)) {
             return {preferences.subtitle.streamIndex, QStringLiteral("explicit")};
         }
-
-        const int jellyfinDefault = mediaSource.value(QStringLiteral("defaultSubtitleStreamIndex"), -1).toInt();
-        if (jellyfinDefault >= 0 && hasStreamIndex(subtitleStreams, jellyfinDefault)) {
-            return {jellyfinDefault, QStringLiteral("jellyfin-default")};
-        }
-
-        const int fileDefault = firstMatchingStreamIndex(subtitleStreams, [](const QVariantMap &stream) {
-            return stream.value(QStringLiteral("isDefault"), false).toBool();
-        });
-        if (fileDefault >= 0) {
-            return {fileDefault, QStringLiteral("file-default")};
-        }
-
-        const int forcedDefault = firstMatchingStreamIndex(subtitleStreams, [](const QVariantMap &stream) {
-            return stream.value(QStringLiteral("isForced"), false).toBool();
-        });
-        if (forcedDefault >= 0) {
-            return {forcedDefault, QStringLiteral("forced-default")};
-        }
-
-        return {-1, QStringLiteral("fallback-off")};
+        return resolveGlobalSubtitleDefault();
     };
 
     const auto [audioIndex, audioSource] = resolveAudio();

--- a/src/ui/settings/PlaybackSettings.qml
+++ b/src/ui/settings/PlaybackSettings.qml
@@ -22,6 +22,24 @@ FocusScope {
     }
 
     property Item _lastFocusedItem: null
+    function defaultTrackOptions(includeOff) {
+        var options = [
+            { label: qsTr("Jellyfin Default"), value: "jellyfin-default" },
+            { label: qsTr("File Default"), value: "file-default" }
+        ]
+        if (includeOff) {
+            options.push({ label: qsTr("Off"), value: "off" })
+            options.push({ label: qsTr("Forced"), value: "forced" })
+        }
+        return options.concat(ConfigManager.supportedTrackLanguages)
+    }
+
+    function optionIndexForValue(options, value) {
+        for (var i = 0; i < options.length; ++i) {
+            if (options[i].value === value) return i
+        }
+        return 0
+    }
 
     Keys.priority: Keys.AfterItem
     Keys.onLeftPressed: function(event) {
@@ -348,14 +366,418 @@ FocusScope {
                     onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
 
                     KeyNavigation.up: thresholdSlider
-                    KeyNavigation.down: skipPopupDurationSlider
+                    KeyNavigation.down: defaultAudioTrackCombo
 
                     onSpinBoxValueChanged: function(newValue) {
                         ConfigManager.audioDelay = newValue
                     }
                 }
 
-                // ── Group 4: Skip popup + auto-skip toggles ──
+                // ── Group 4: Default audio/subtitle fallback tracks ──
+
+                SettingsGroupDivider { Layout.fillWidth: true }
+
+                RowLayout {
+                    id: defaultAudioTrackRow
+                    Layout.fillWidth: true
+                    spacing: Theme.spacingMedium
+
+                    ColumnLayout {
+                        spacing: Math.round(4 * Theme.layoutScale)
+                        Layout.fillWidth: true
+
+                        Text {
+                            text: qsTr("Audio Language")
+                            font.pixelSize: Theme.fontSizeBody
+                            font.family: Theme.fontPrimary
+                            color: Theme.textPrimary
+                        }
+
+                        Text {
+                            text: qsTr("Fallback used when no season or movie audio preference is saved")
+                            font.pixelSize: Theme.fontSizeSmall
+                            font.family: Theme.fontPrimary
+                            color: Theme.textSecondary
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
+                    }
+
+                    ComboBox {
+                        id: defaultAudioTrackCombo
+                        readonly property var options: root.defaultTrackOptions(false)
+                        model: options
+                        textRole: "label"
+                        valueRole: "value"
+                        currentIndex: root.optionIndexForValue(options, ConfigManager.defaultAudioTrackSelection)
+                        Layout.preferredWidth: Math.round(260 * Theme.layoutScale)
+                        focusPolicy: Qt.StrongFocus
+                        property bool initialized: false
+                        property bool updatingSelection: false
+
+                        function refreshSelectionFromConfig() {
+                            var idx = root.optionIndexForValue(options, ConfigManager.defaultAudioTrackSelection)
+                            if (currentIndex === idx) return
+                            updatingSelection = true
+                            currentIndex = idx
+                            updatingSelection = false
+                        }
+
+                        Component.onCompleted: {
+                            refreshSelectionFromConfig()
+                            initialized = true
+                        }
+
+                        Connections {
+                            target: ConfigManager
+                            function onDefaultAudioTrackSelectionChanged() {
+                                defaultAudioTrackCombo.refreshSelectionFromConfig()
+                            }
+                        }
+
+                        onActiveFocusChanged: {
+                            if (activeFocus) {
+                                root._lastFocusedItem = this
+                                flickable.ensureFocusVisible(this)
+                                InputModeManager.setNavigationMode("keyboard")
+                                InputModeManager.hideCursor(true)
+                            } else if (!popup.visible) {
+                                InputModeManager.setNavigationMode("pointer")
+                                InputModeManager.hideCursor(false)
+                            }
+                        }
+
+                        onCurrentIndexChanged: {
+                            if (!initialized || updatingSelection || currentIndex < 0) return
+                            var value = options[currentIndex].value
+                            if (value !== ConfigManager.defaultAudioTrackSelection) {
+                                ConfigManager.defaultAudioTrackSelection = value
+                            }
+                        }
+
+                        Keys.onUpPressed: function(event) {
+                            if (!popup.visible) {
+                                audioDelaySpinBox.forceActiveFocus()
+                                event.accepted = true
+                            }
+                        }
+                        Keys.onDownPressed: function(event) {
+                            if (!popup.visible) {
+                                defaultSubtitleTrackCombo.forceActiveFocus()
+                                event.accepted = true
+                            }
+                        }
+                        Keys.onReturnPressed: function(event) {
+                            popup.open()
+                            event.accepted = true
+                        }
+                        Keys.onEnterPressed: function(event) {
+                            popup.open()
+                            event.accepted = true
+                        }
+
+                        background: Rectangle {
+                            implicitHeight: Theme.buttonHeightSmall
+                            radius: Theme.radiusSmall
+                            color: Theme.inputBackground
+                            border.color: defaultAudioTrackCombo.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                            border.width: defaultAudioTrackCombo.activeFocus ? 2 : 1
+                        }
+
+                        contentItem: Text {
+                            text: defaultAudioTrackCombo.displayText
+                            font.pixelSize: Theme.fontSizeBody
+                            font.family: Theme.fontPrimary
+                            color: Theme.textPrimary
+                            verticalAlignment: Text.AlignVCenter
+                            leftPadding: Theme.spacingSmall
+                            elide: Text.ElideRight
+                        }
+
+                        delegate: ItemDelegate {
+                            width: defaultAudioTrackCombo.width
+                            contentItem: Text {
+                                text: modelData.label
+                                color: highlighted ? Theme.textPrimary : Theme.textSecondary
+                                font.pixelSize: Theme.fontSizeBody
+                                font.family: Theme.fontPrimary
+                                verticalAlignment: Text.AlignVCenter
+                                elide: Text.ElideRight
+                            }
+                            background: Rectangle {
+                                color: highlighted ? Theme.buttonPrimaryBackground : "transparent"
+                                radius: Theme.radiusSmall
+                            }
+                            highlighted: ListView.isCurrentItem || defaultAudioTrackCombo.highlightedIndex === index
+                        }
+
+                        popup: Popup {
+                            y: defaultAudioTrackCombo.height + 5
+                            width: defaultAudioTrackCombo.width
+                            implicitHeight: Math.min(contentItem.implicitHeight, Math.round(360 * Theme.layoutScale))
+                            padding: 1
+
+                            onOpened: {
+                                InputModeManager.setNavigationMode("keyboard")
+                                InputModeManager.hideCursor(true)
+                                defaultAudioTrackList.currentIndex = defaultAudioTrackCombo.highlightedIndex >= 0
+                                    ? defaultAudioTrackCombo.highlightedIndex
+                                    : defaultAudioTrackCombo.currentIndex
+                                defaultAudioTrackList.forceActiveFocus()
+                            }
+                            onClosed: {
+                                Qt.callLater(function() {
+                                    defaultAudioTrackCombo.forceActiveFocus()
+                                })
+                                InputModeManager.setNavigationMode("pointer")
+                                InputModeManager.hideCursor(false)
+                            }
+
+                            contentItem: ListView {
+                                id: defaultAudioTrackList
+                                clip: true
+                                implicitHeight: contentHeight
+                                model: defaultAudioTrackCombo.popup.visible ? defaultAudioTrackCombo.delegateModel : null
+                                currentIndex: defaultAudioTrackCombo.highlightedIndex >= 0
+                                    ? defaultAudioTrackCombo.highlightedIndex
+                                    : defaultAudioTrackCombo.currentIndex
+
+                                ScrollIndicator.vertical: ScrollIndicator { }
+
+                                onActiveFocusChanged: {
+                                    if (activeFocus) {
+                                        InputModeManager.setNavigationMode("keyboard")
+                                        InputModeManager.hideCursor(true)
+                                    }
+                                }
+
+                                Keys.onReturnPressed: function(event) {
+                                    defaultAudioTrackCombo.currentIndex = currentIndex
+                                    defaultAudioTrackCombo.popup.close()
+                                    event.accepted = true
+                                }
+                                Keys.onEnterPressed: function(event) {
+                                    defaultAudioTrackCombo.currentIndex = currentIndex
+                                    defaultAudioTrackCombo.popup.close()
+                                    event.accepted = true
+                                }
+                                Keys.onEscapePressed: function(event) {
+                                    defaultAudioTrackCombo.popup.close()
+                                    event.accepted = true
+                                }
+                            }
+
+                            background: Rectangle {
+                                color: Theme.cardBackground
+                                border.color: Theme.focusBorder
+                                border.width: 1
+                                radius: Theme.radiusSmall
+                            }
+                        }
+                    }
+                }
+
+                RowLayout {
+                    id: defaultSubtitleTrackRow
+                    Layout.fillWidth: true
+                    spacing: Theme.spacingMedium
+
+                    ColumnLayout {
+                        spacing: Math.round(4 * Theme.layoutScale)
+                        Layout.fillWidth: true
+
+                        Text {
+                            text: qsTr("Subtitle Language")
+                            font.pixelSize: Theme.fontSizeBody
+                            font.family: Theme.fontPrimary
+                            color: Theme.textPrimary
+                        }
+
+                        Text {
+                            text: qsTr("Fallback used when no season or movie subtitle preference is saved")
+                            font.pixelSize: Theme.fontSizeSmall
+                            font.family: Theme.fontPrimary
+                            color: Theme.textSecondary
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
+                    }
+
+                    ComboBox {
+                        id: defaultSubtitleTrackCombo
+                        readonly property var options: root.defaultTrackOptions(true)
+                        model: options
+                        textRole: "label"
+                        valueRole: "value"
+                        currentIndex: root.optionIndexForValue(options, ConfigManager.defaultSubtitleTrackSelection)
+                        Layout.preferredWidth: Math.round(260 * Theme.layoutScale)
+                        focusPolicy: Qt.StrongFocus
+                        property bool initialized: false
+                        property bool updatingSelection: false
+
+                        function refreshSelectionFromConfig() {
+                            var idx = root.optionIndexForValue(options, ConfigManager.defaultSubtitleTrackSelection)
+                            if (currentIndex === idx) return
+                            updatingSelection = true
+                            currentIndex = idx
+                            updatingSelection = false
+                        }
+
+                        Component.onCompleted: {
+                            refreshSelectionFromConfig()
+                            initialized = true
+                        }
+
+                        Connections {
+                            target: ConfigManager
+                            function onDefaultSubtitleTrackSelectionChanged() {
+                                defaultSubtitleTrackCombo.refreshSelectionFromConfig()
+                            }
+                        }
+
+                        onActiveFocusChanged: {
+                            if (activeFocus) {
+                                root._lastFocusedItem = this
+                                flickable.ensureFocusVisible(this)
+                                InputModeManager.setNavigationMode("keyboard")
+                                InputModeManager.hideCursor(true)
+                            } else if (!popup.visible) {
+                                InputModeManager.setNavigationMode("pointer")
+                                InputModeManager.hideCursor(false)
+                            }
+                        }
+
+                        onCurrentIndexChanged: {
+                            if (!initialized || updatingSelection || currentIndex < 0) return
+                            var value = options[currentIndex].value
+                            if (value !== ConfigManager.defaultSubtitleTrackSelection) {
+                                ConfigManager.defaultSubtitleTrackSelection = value
+                            }
+                        }
+
+                        Keys.onUpPressed: function(event) {
+                            if (!popup.visible) {
+                                defaultAudioTrackCombo.forceActiveFocus()
+                                event.accepted = true
+                            }
+                        }
+                        Keys.onDownPressed: function(event) {
+                            if (!popup.visible) {
+                                skipPopupDurationSlider.forceActiveFocus()
+                                event.accepted = true
+                            }
+                        }
+                        Keys.onReturnPressed: function(event) {
+                            popup.open()
+                            event.accepted = true
+                        }
+                        Keys.onEnterPressed: function(event) {
+                            popup.open()
+                            event.accepted = true
+                        }
+
+                        background: Rectangle {
+                            implicitHeight: Theme.buttonHeightSmall
+                            radius: Theme.radiusSmall
+                            color: Theme.inputBackground
+                            border.color: defaultSubtitleTrackCombo.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                            border.width: defaultSubtitleTrackCombo.activeFocus ? 2 : 1
+                        }
+
+                        contentItem: Text {
+                            text: defaultSubtitleTrackCombo.displayText
+                            font.pixelSize: Theme.fontSizeBody
+                            font.family: Theme.fontPrimary
+                            color: Theme.textPrimary
+                            verticalAlignment: Text.AlignVCenter
+                            leftPadding: Theme.spacingSmall
+                            elide: Text.ElideRight
+                        }
+
+                        delegate: ItemDelegate {
+                            width: defaultSubtitleTrackCombo.width
+                            contentItem: Text {
+                                text: modelData.label
+                                color: highlighted ? Theme.textPrimary : Theme.textSecondary
+                                font.pixelSize: Theme.fontSizeBody
+                                font.family: Theme.fontPrimary
+                                verticalAlignment: Text.AlignVCenter
+                                elide: Text.ElideRight
+                            }
+                            background: Rectangle {
+                                color: highlighted ? Theme.buttonPrimaryBackground : "transparent"
+                                radius: Theme.radiusSmall
+                            }
+                            highlighted: ListView.isCurrentItem || defaultSubtitleTrackCombo.highlightedIndex === index
+                        }
+
+                        popup: Popup {
+                            y: defaultSubtitleTrackCombo.height + 5
+                            width: defaultSubtitleTrackCombo.width
+                            implicitHeight: Math.min(contentItem.implicitHeight, Math.round(360 * Theme.layoutScale))
+                            padding: 1
+
+                            onOpened: {
+                                InputModeManager.setNavigationMode("keyboard")
+                                InputModeManager.hideCursor(true)
+                                defaultSubtitleTrackList.currentIndex = defaultSubtitleTrackCombo.highlightedIndex >= 0
+                                    ? defaultSubtitleTrackCombo.highlightedIndex
+                                    : defaultSubtitleTrackCombo.currentIndex
+                                defaultSubtitleTrackList.forceActiveFocus()
+                            }
+                            onClosed: {
+                                Qt.callLater(function() {
+                                    defaultSubtitleTrackCombo.forceActiveFocus()
+                                })
+                                InputModeManager.setNavigationMode("pointer")
+                                InputModeManager.hideCursor(false)
+                            }
+
+                            contentItem: ListView {
+                                id: defaultSubtitleTrackList
+                                clip: true
+                                implicitHeight: contentHeight
+                                model: defaultSubtitleTrackCombo.popup.visible ? defaultSubtitleTrackCombo.delegateModel : null
+                                currentIndex: defaultSubtitleTrackCombo.highlightedIndex >= 0
+                                    ? defaultSubtitleTrackCombo.highlightedIndex
+                                    : defaultSubtitleTrackCombo.currentIndex
+
+                                ScrollIndicator.vertical: ScrollIndicator { }
+
+                                onActiveFocusChanged: {
+                                    if (activeFocus) {
+                                        InputModeManager.setNavigationMode("keyboard")
+                                        InputModeManager.hideCursor(true)
+                                    }
+                                }
+
+                                Keys.onReturnPressed: function(event) {
+                                    defaultSubtitleTrackCombo.currentIndex = currentIndex
+                                    defaultSubtitleTrackCombo.popup.close()
+                                    event.accepted = true
+                                }
+                                Keys.onEnterPressed: function(event) {
+                                    defaultSubtitleTrackCombo.currentIndex = currentIndex
+                                    defaultSubtitleTrackCombo.popup.close()
+                                    event.accepted = true
+                                }
+                                Keys.onEscapePressed: function(event) {
+                                    defaultSubtitleTrackCombo.popup.close()
+                                    event.accepted = true
+                                }
+                            }
+
+                            background: Rectangle {
+                                color: Theme.cardBackground
+                                border.color: Theme.focusBorder
+                                border.width: 1
+                                radius: Theme.radiusSmall
+                            }
+                        }
+                    }
+                }
+
+                // ── Group 5: Skip popup + auto-skip toggles ──
 
                 SettingsGroupDivider { Layout.fillWidth: true }
 
@@ -372,7 +794,7 @@ FocusScope {
                     ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
                     onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
 
-                    KeyNavigation.up: audioDelaySpinBox
+                    KeyNavigation.up: defaultSubtitleTrackCombo
                     KeyNavigation.down: autoSkipIntroToggle
 
                     onSliderValueChanged: function(newValue) {

--- a/src/ui/settings/SettingsSpinBoxRow.qml
+++ b/src/ui/settings/SettingsSpinBoxRow.qml
@@ -25,6 +25,15 @@ FocusScope {
         return value + (root.unit ? " " + root.unit : "")
     }
 
+    function stepSpinBox(delta) {
+        if (!spinBox.enabled) return
+        var nextValue = Math.max(spinBox.from, Math.min(spinBox.to, spinBox.value + (delta * spinBox.stepSize)))
+        if (nextValue !== spinBox.value) {
+            spinBox.value = nextValue
+            root.spinBoxValueChanged(nextValue)
+        }
+    }
+
     implicitHeight: content.implicitHeight
     Layout.fillWidth: true
 
@@ -33,11 +42,11 @@ FocusScope {
     }
 
     Keys.onLeftPressed: function(event) {
-        if (spinBox.enabled) spinBox.decrease()
+        stepSpinBox(-1)
         event.accepted = true
     }
     Keys.onRightPressed: function(event) {
-        if (spinBox.enabled) spinBox.increase()
+        stepSpinBox(1)
         event.accepted = true
     }
 

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -12,6 +12,8 @@
 #include <QRegularExpression>
 #include <QByteArray>
 #include <QMetaType>
+#include <QHash>
+#include <QSet>
 #include <algorithm>
 
 namespace {
@@ -21,6 +23,106 @@ QString normalizeUpdateChannelValue(const QString &channel)
     return channel.trimmed().compare(QStringLiteral("dev"), Qt::CaseInsensitive) == 0
         ? QStringLiteral("dev")
         : QStringLiteral("stable");
+}
+
+QVariantList supportedTrackLanguageOptions()
+{
+    return {
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("English")}, {QStringLiteral("value"), QStringLiteral("eng")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Japanese")}, {QStringLiteral("value"), QStringLiteral("jpn")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Spanish")}, {QStringLiteral("value"), QStringLiteral("spa")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("French")}, {QStringLiteral("value"), QStringLiteral("fre")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("German")}, {QStringLiteral("value"), QStringLiteral("ger")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Italian")}, {QStringLiteral("value"), QStringLiteral("ita")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Portuguese")}, {QStringLiteral("value"), QStringLiteral("por")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Russian")}, {QStringLiteral("value"), QStringLiteral("rus")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Chinese")}, {QStringLiteral("value"), QStringLiteral("chi")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Korean")}, {QStringLiteral("value"), QStringLiteral("kor")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Arabic")}, {QStringLiteral("value"), QStringLiteral("ara")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Hindi")}, {QStringLiteral("value"), QStringLiteral("hin")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Dutch")}, {QStringLiteral("value"), QStringLiteral("dut")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Swedish")}, {QStringLiteral("value"), QStringLiteral("swe")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Norwegian")}, {QStringLiteral("value"), QStringLiteral("nor")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Danish")}, {QStringLiteral("value"), QStringLiteral("dan")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Finnish")}, {QStringLiteral("value"), QStringLiteral("fin")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Polish")}, {QStringLiteral("value"), QStringLiteral("pol")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Turkish")}, {QStringLiteral("value"), QStringLiteral("tur")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Czech")}, {QStringLiteral("value"), QStringLiteral("cze")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Greek")}, {QStringLiteral("value"), QStringLiteral("gre")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Hebrew")}, {QStringLiteral("value"), QStringLiteral("heb")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Indonesian")}, {QStringLiteral("value"), QStringLiteral("ind")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Thai")}, {QStringLiteral("value"), QStringLiteral("tha")}},
+        QVariantMap{{QStringLiteral("label"), QStringLiteral("Vietnamese")}, {QStringLiteral("value"), QStringLiteral("vie")}}
+    };
+}
+
+QSet<QString> supportedTrackLanguageCodes()
+{
+    QSet<QString> result;
+    for (const QVariant &optionVariant : supportedTrackLanguageOptions()) {
+        result.insert(optionVariant.toMap().value(QStringLiteral("value")).toString());
+    }
+    return result;
+}
+
+QString canonicalTrackLanguageCode(const QString &language)
+{
+    const QString normalized = language.trimmed().toLower();
+    static const QHash<QString, QString> langAliases = {
+        {QStringLiteral("en"), QStringLiteral("eng")}, {QStringLiteral("ja"), QStringLiteral("jpn")},
+        {QStringLiteral("es"), QStringLiteral("spa")}, {QStringLiteral("fr"), QStringLiteral("fre")},
+        {QStringLiteral("fra"), QStringLiteral("fre")}, {QStringLiteral("de"), QStringLiteral("ger")},
+        {QStringLiteral("deu"), QStringLiteral("ger")}, {QStringLiteral("it"), QStringLiteral("ita")},
+        {QStringLiteral("pt"), QStringLiteral("por")}, {QStringLiteral("ru"), QStringLiteral("rus")},
+        {QStringLiteral("zh"), QStringLiteral("chi")}, {QStringLiteral("zho"), QStringLiteral("chi")},
+        {QStringLiteral("ko"), QStringLiteral("kor")}, {QStringLiteral("ar"), QStringLiteral("ara")},
+        {QStringLiteral("hi"), QStringLiteral("hin")}, {QStringLiteral("nl"), QStringLiteral("dut")},
+        {QStringLiteral("nld"), QStringLiteral("dut")}, {QStringLiteral("sv"), QStringLiteral("swe")},
+        {QStringLiteral("no"), QStringLiteral("nor")}, {QStringLiteral("da"), QStringLiteral("dan")},
+        {QStringLiteral("fi"), QStringLiteral("fin")}, {QStringLiteral("pl"), QStringLiteral("pol")},
+        {QStringLiteral("tr"), QStringLiteral("tur")}, {QStringLiteral("cs"), QStringLiteral("cze")},
+        {QStringLiteral("ces"), QStringLiteral("cze")}, {QStringLiteral("el"), QStringLiteral("gre")},
+        {QStringLiteral("ell"), QStringLiteral("gre")}, {QStringLiteral("he"), QStringLiteral("heb")},
+        {QStringLiteral("id"), QStringLiteral("ind")}, {QStringLiteral("th"), QStringLiteral("tha")},
+        {QStringLiteral("vi"), QStringLiteral("vie")}
+    };
+    return langAliases.value(normalized, normalized);
+}
+
+QString normalizeDefaultTrackSelectionValue(const QString &selection, bool allowOff)
+{
+    const QString normalized = selection.trimmed().toLower();
+    if (normalized == QStringLiteral("file-default")) {
+        return QStringLiteral("file-default");
+    }
+    if (allowOff && normalized == QStringLiteral("off")) {
+        return QStringLiteral("off");
+    }
+    if (allowOff && normalized == QStringLiteral("forced")) {
+        return QStringLiteral("forced");
+    }
+
+    const QString canonical = canonicalTrackLanguageCode(normalized);
+    if (supportedTrackLanguageCodes().contains(canonical)) {
+        return canonical;
+    }
+
+    return QStringLiteral("jellyfin-default");
+}
+
+QJsonObject playbackSettingsObject(const QJsonObject &config)
+{
+    const QJsonObject settings = config.value(QStringLiteral("settings")).toObject();
+    return settings.value(QStringLiteral("playback")).toObject();
+}
+
+void setPlaybackSetting(QJsonObject &config, const QString &key, const QJsonValue &value)
+{
+    QJsonObject settings = config.value(QStringLiteral("settings")).toObject();
+    QJsonObject playback = settings.value(QStringLiteral("playback")).toObject();
+    playback[key] = value;
+    settings[QStringLiteral("playback")] = playback;
+    config[QStringLiteral("settings")] = settings;
 }
 
 QString preferredConfigDir()
@@ -1049,6 +1151,51 @@ bool ConfigManager::getAutoSkipOutro() const
         }
     }
     return false; // Default off
+}
+
+void ConfigManager::setDefaultAudioTrackSelection(const QString &selection)
+{
+    const QString normalized = normalizeDefaultTrackSelectionValue(selection, false);
+    if (normalized == getDefaultAudioTrackSelection()) {
+        return;
+    }
+
+    setPlaybackSetting(m_config, QStringLiteral("default_audio_track_selection"), normalized);
+    save();
+    emit defaultAudioTrackSelectionChanged();
+}
+
+QString ConfigManager::getDefaultAudioTrackSelection() const
+{
+    const QJsonObject playback = playbackSettingsObject(m_config);
+    return normalizeDefaultTrackSelectionValue(
+        playback.value(QStringLiteral("default_audio_track_selection")).toString(),
+        false);
+}
+
+void ConfigManager::setDefaultSubtitleTrackSelection(const QString &selection)
+{
+    const QString normalized = normalizeDefaultTrackSelectionValue(selection, true);
+    if (normalized == getDefaultSubtitleTrackSelection()) {
+        return;
+    }
+
+    setPlaybackSetting(m_config, QStringLiteral("default_subtitle_track_selection"), normalized);
+    save();
+    emit defaultSubtitleTrackSelectionChanged();
+}
+
+QString ConfigManager::getDefaultSubtitleTrackSelection() const
+{
+    const QJsonObject playback = playbackSettingsObject(m_config);
+    return normalizeDefaultTrackSelectionValue(
+        playback.value(QStringLiteral("default_subtitle_track_selection")).toString(),
+        true);
+}
+
+QVariantList ConfigManager::getSupportedTrackLanguages() const
+{
+    return supportedTrackLanguageOptions();
 }
 
 void ConfigManager::setPlayerBackend(const QString &backendName)
@@ -2248,6 +2395,25 @@ public:
         newConfig["settings"] = settings;
         return newConfig;
     }
+
+    static QJsonObject migrateV17ToV18(const QJsonObject &oldConfig)
+    {
+        QJsonObject newConfig = oldConfig;
+        newConfig["version"] = 18;
+
+        QJsonObject settings = newConfig["settings"].toObject();
+        QJsonObject playback = settings.value("playback").toObject();
+        if (!playback.contains("default_audio_track_selection")) {
+            playback["default_audio_track_selection"] = QStringLiteral("jellyfin-default");
+        }
+        if (!playback.contains("default_subtitle_track_selection")) {
+            playback["default_subtitle_track_selection"] = QStringLiteral("jellyfin-default");
+        }
+
+        settings["playback"] = playback;
+        newConfig["settings"] = settings;
+        return newConfig;
+    }
 };
 }
 
@@ -2404,6 +2570,14 @@ bool ConfigManager::migrateConfig()
                 qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
+        } else if (version == 17) {
+            m_config = ConfigMigrator::migrateV17ToV18(m_config);
+            if (m_config.contains("version") && m_config["version"].isDouble()) {
+                version = m_config["version"].toInt();
+            } else {
+                qWarning() << "Migration produced invalid config (no version)";
+                return false;
+            }
         } else {
             qWarning() << "Unknown config version during migration:" << version;
             return false;
@@ -2465,6 +2639,8 @@ QJsonObject ConfigManager::defaultConfig() const
     playback["performance_mode_enabled"] = false;
     playback["playback_cache_size_mb"] = 500;
     playback["auto_recover_playback"] = true;
+    playback["default_audio_track_selection"] = QStringLiteral("jellyfin-default");
+    playback["default_subtitle_track_selection"] = QStringLiteral("jellyfin-default");
     settings["playback"] = playback;
     
     QJsonObject video;

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -67,6 +67,8 @@ class ConfigManager : public QObject
     Q_PROPERTY(int autoplayCountdownSeconds READ getAutoplayCountdownSeconds WRITE setAutoplayCountdownSeconds NOTIFY autoplayCountdownSecondsChanged)
     Q_PROPERTY(bool autoSkipIntro READ getAutoSkipIntro WRITE setAutoSkipIntro NOTIFY autoSkipIntroChanged)
     Q_PROPERTY(bool autoSkipOutro READ getAutoSkipOutro WRITE setAutoSkipOutro NOTIFY autoSkipOutroChanged)
+    Q_PROPERTY(QString defaultAudioTrackSelection READ getDefaultAudioTrackSelection WRITE setDefaultAudioTrackSelection NOTIFY defaultAudioTrackSelectionChanged)
+    Q_PROPERTY(QString defaultSubtitleTrackSelection READ getDefaultSubtitleTrackSelection WRITE setDefaultSubtitleTrackSelection NOTIFY defaultSubtitleTrackSelectionChanged)
     Q_PROPERTY(QString playerBackend READ getPlayerBackend WRITE setPlayerBackend NOTIFY playerBackendChanged)
     Q_PROPERTY(int playbackCacheSizeMB READ getPlaybackCacheSizeMB WRITE setPlaybackCacheSizeMB NOTIFY playbackCacheSizeMBChanged)
     Q_PROPERTY(int backdropRotationInterval READ getBackdropRotationInterval WRITE setBackdropRotationInterval NOTIFY backdropRotationIntervalChanged)
@@ -122,6 +124,7 @@ class ConfigManager : public QObject
     Q_PROPERTY(bool autoUpdateCheckEnabled READ getAutoUpdateCheckEnabled WRITE setAutoUpdateCheckEnabled NOTIFY autoUpdateCheckEnabledChanged)
     Q_PROPERTY(QString lastUpdateCheckAt READ getLastUpdateCheckAt WRITE setLastUpdateCheckAt NOTIFY lastUpdateCheckAtChanged)
     Q_PROPERTY(QString skippedUpdateVersion READ getSkippedUpdateVersion WRITE setSkippedUpdateVersion NOTIFY skippedUpdateVersionChanged)
+    Q_PROPERTY(QVariantList supportedTrackLanguages READ getSupportedTrackLanguages CONSTANT)
     
 public:
     explicit ConfigManager(QObject *parent = nullptr);
@@ -199,6 +202,11 @@ public:
     bool getAutoSkipIntro() const;
     void setAutoSkipOutro(bool enabled);
     bool getAutoSkipOutro() const;
+    void setDefaultAudioTrackSelection(const QString &selection);
+    QString getDefaultAudioTrackSelection() const;
+    void setDefaultSubtitleTrackSelection(const QString &selection);
+    QString getDefaultSubtitleTrackSelection() const;
+    QVariantList getSupportedTrackLanguages() const;
 
     void setPlayerBackend(const QString &backendName);
     QString getPlayerBackend() const;
@@ -406,6 +414,8 @@ signals:
     void autoplayCountdownSecondsChanged();
     void autoSkipIntroChanged();
     void autoSkipOutroChanged();
+    void defaultAudioTrackSelectionChanged();
+    void defaultSubtitleTrackSelectionChanged();
     void playerBackendChanged();
     void playbackCacheSizeMBChanged();
     void autoRecoverPlaybackChanged();
@@ -441,6 +451,6 @@ private:
 
     QJsonObject m_config;
 
-    static constexpr int kCurrentConfigVersion = 17;
+    static constexpr int kCurrentConfigVersion = 18;
     QJsonObject defaultConfig() const;
 };

--- a/tests/PlayerControllerAutoplayContextTest.cpp
+++ b/tests/PlayerControllerAutoplayContextTest.cpp
@@ -1,6 +1,8 @@
 #include <QtTest/QtTest>
 #include <QtTest/QSignalSpy>
 #include <QCoreApplication>
+#include <QStandardPaths>
+#include <QTemporaryDir>
 
 #include "player/PlayerController.h"
 
@@ -254,6 +256,8 @@ class PlayerControllerAutoplayContextTest : public QObject
     Q_OBJECT
 
 private slots:
+    void initTestCase();
+    void cleanupTestCase();
     void thresholdMetRequestsNextEpisodeDirectly();
     void userStopPastThresholdRequestsNextEpisode();
     void userStopBelowThresholdWaitsForBackendExit();
@@ -263,6 +267,16 @@ private slots:
     void playbackPrefetchIgnoresGenericNextEpisodeResponses();
     void autoplayPlaybackInfoErrorFallsBackToBasicPlayback();
     void autoplayPlaybackInfoUsesStoredSubtitlePreferenceWhenOverrideUnset();
+    void explicitSeasonPreferencesBeatGlobalTrackDefaults();
+    void globalAudioLanguageSelectsMatchingStream();
+    void configTrackLanguageSelectionCanonicalizesAliases();
+    void globalSubtitleLanguageSelectsMatchingStream();
+    void globalFileDefaultPrefersFileFlagOverJellyfinDefault();
+    void globalSubtitleOffDisablesSubtitles();
+    void globalSubtitleForcedSelectsForcedTrack();
+    void globalSubtitleForcedFallsBackToOffWhenNoForcedTrackExists();
+    void unavailableGlobalLanguageFallsBackToJellyfinDefault();
+    void autoplayPlaybackInfoUsesGlobalSubtitlePreferenceWhenOverrideAndSeasonUnset();
     void staleAutoplayPlaybackInfoResponseFallsBackAfterTimeout();
     void playUrlWithTracksKeepsNewSessionMetadataWhenReplacingPlayback();
     void embeddedVideoShrinkToggleEmitsAndPersists();
@@ -278,7 +292,35 @@ private slots:
     void startupTrackSelectionRespectsPinnedUrlUnlessUserOverride();
     void runtimeTrackSelectionUsesCanonicalMapAndSubtitleNone();
     void backendTrackSyncUsesReverseMap();
+
+private:
+    QTemporaryDir m_configHome;
+    QByteArray m_previousConfigHome;
+    bool m_hadPreviousConfigHome = false;
 };
+
+void PlayerControllerAutoplayContextTest::initTestCase()
+{
+    QStandardPaths::setTestModeEnabled(true);
+#ifdef Q_OS_LINUX
+    QVERIFY(m_configHome.isValid());
+    m_previousConfigHome = qgetenv("XDG_CONFIG_HOME");
+    m_hadPreviousConfigHome = !m_previousConfigHome.isNull();
+    qputenv("XDG_CONFIG_HOME", m_configHome.path().toUtf8());
+#endif
+}
+
+void PlayerControllerAutoplayContextTest::cleanupTestCase()
+{
+#ifdef Q_OS_LINUX
+    if (m_hadPreviousConfigHome) {
+        qputenv("XDG_CONFIG_HOME", m_previousConfigHome);
+    } else {
+        qunsetenv("XDG_CONFIG_HOME");
+    }
+#endif
+    QStandardPaths::setTestModeEnabled(false);
+}
 
 void PlayerControllerAutoplayContextTest::thresholdMetRequestsNextEpisodeDirectly()
 {
@@ -745,6 +787,293 @@ void PlayerControllerAutoplayContextTest::autoplayPlaybackInfoUsesStoredSubtitle
     QCOMPARE(controller.selectedSubtitleTrack(), 12);
     QCOMPARE(controller.m_mediaSourceId, QStringLiteral("media-source-11"));
     QCOMPARE(controller.m_playSessionId, QStringLiteral("play-session-11"));
+}
+
+void PlayerControllerAutoplayContextTest::explicitSeasonPreferencesBeatGlobalTrackDefaults()
+{
+    ConfigManager config;
+    config.setDefaultAudioTrackSelection(QStringLiteral("jpn"));
+    config.setDefaultSubtitleTrackSelection(QStringLiteral("spa"));
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+
+    ScopedTrackPreferences preferences;
+    preferences.audio.mode = TrackPreferenceMode::ExplicitStream;
+    preferences.audio.streamIndex = 2;
+    preferences.subtitle.mode = TrackPreferenceMode::ExplicitStream;
+    preferences.subtitle.streamIndex = 12;
+    trackPrefs.setSeasonPreferences(QStringLiteral("season-override"), preferences);
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+
+    const QVariantMap resolved = controller.resolveTrackSelectionForMediaSource(
+        buildMediaSource({
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 2}, {QStringLiteral("language"), QStringLiteral("eng")}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 4}, {QStringLiteral("language"), QStringLiteral("jpn")}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Subtitle")}, {QStringLiteral("index"), 12}, {QStringLiteral("language"), QStringLiteral("eng")}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Subtitle")}, {QStringLiteral("index"), 14}, {QStringLiteral("language"), QStringLiteral("spa")}}
+        }),
+        QStringLiteral("season-override"),
+        false);
+
+    QCOMPARE(resolved.value(QStringLiteral("audioIndex")).toInt(), 2);
+    QCOMPARE(resolved.value(QStringLiteral("subtitleIndex")).toInt(), 12);
+    QCOMPARE(resolved.value(QStringLiteral("audioSource")).toString(), QStringLiteral("explicit"));
+    QCOMPARE(resolved.value(QStringLiteral("subtitleSource")).toString(), QStringLiteral("explicit"));
+}
+
+void PlayerControllerAutoplayContextTest::globalAudioLanguageSelectsMatchingStream()
+{
+    ConfigManager config;
+    config.setDefaultAudioTrackSelection(QStringLiteral("jpn"));
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+    PlayerController controller(&backend, &config, &trackPrefs, &displayManager, &playbackService, &libraryService, &authService);
+
+    const QVariantMap resolved = controller.resolveTrackSelectionForMediaSource(
+        buildMediaSource({
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 1}, {QStringLiteral("language"), QStringLiteral("eng")}, {QStringLiteral("isDefault"), true}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 2}, {QStringLiteral("language"), QStringLiteral("jpn")}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 3}, {QStringLiteral("language"), QStringLiteral("ja")}, {QStringLiteral("isDefault"), true}}
+        }, 1),
+        QStringLiteral("season-global"),
+        false);
+
+    QCOMPARE(resolved.value(QStringLiteral("audioIndex")).toInt(), 3);
+    QCOMPARE(resolved.value(QStringLiteral("audioSource")).toString(), QStringLiteral("global-language"));
+}
+
+void PlayerControllerAutoplayContextTest::configTrackLanguageSelectionCanonicalizesAliases()
+{
+    ConfigManager config;
+
+    config.setDefaultAudioTrackSelection(QStringLiteral("en"));
+    config.setDefaultSubtitleTrackSelection(QStringLiteral("es"));
+
+    QCOMPARE(config.getDefaultAudioTrackSelection(), QStringLiteral("eng"));
+    QCOMPARE(config.getDefaultSubtitleTrackSelection(), QStringLiteral("spa"));
+}
+
+void PlayerControllerAutoplayContextTest::globalSubtitleLanguageSelectsMatchingStream()
+{
+    ConfigManager config;
+    config.setDefaultSubtitleTrackSelection(QStringLiteral("spa"));
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+    PlayerController controller(&backend, &config, &trackPrefs, &displayManager, &playbackService, &libraryService, &authService);
+
+    const QVariantMap resolved = controller.resolveTrackSelectionForMediaSource(
+        buildMediaSource({
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 1}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Subtitle")}, {QStringLiteral("index"), 5}, {QStringLiteral("language"), QStringLiteral("eng")}, {QStringLiteral("isDefault"), true}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Subtitle")}, {QStringLiteral("index"), 6}, {QStringLiteral("language"), QStringLiteral("spa")}, {QStringLiteral("isForced"), true}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Subtitle")}, {QStringLiteral("index"), 7}, {QStringLiteral("language"), QStringLiteral("es")}}
+        }, 1, 5),
+        QStringLiteral("season-global"),
+        false);
+
+    QCOMPARE(resolved.value(QStringLiteral("subtitleIndex")).toInt(), 7);
+    QCOMPARE(resolved.value(QStringLiteral("subtitleSource")).toString(), QStringLiteral("global-language"));
+}
+
+void PlayerControllerAutoplayContextTest::globalFileDefaultPrefersFileFlagOverJellyfinDefault()
+{
+    ConfigManager config;
+    config.setDefaultAudioTrackSelection(QStringLiteral("file-default"));
+    config.setDefaultSubtitleTrackSelection(QStringLiteral("file-default"));
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+    PlayerController controller(&backend, &config, &trackPrefs, &displayManager, &playbackService, &libraryService, &authService);
+
+    const QVariantMap resolved = controller.resolveTrackSelectionForMediaSource(
+        buildMediaSource({
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 1}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 2}, {QStringLiteral("isDefault"), true}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Subtitle")}, {QStringLiteral("index"), 10}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Subtitle")}, {QStringLiteral("index"), 11}, {QStringLiteral("isDefault"), true}}
+        }, 1, 10),
+        QStringLiteral("season-global"),
+        false);
+
+    QCOMPARE(resolved.value(QStringLiteral("audioIndex")).toInt(), 2);
+    QCOMPARE(resolved.value(QStringLiteral("subtitleIndex")).toInt(), 11);
+    QCOMPARE(resolved.value(QStringLiteral("audioSource")).toString(), QStringLiteral("file-default"));
+    QCOMPARE(resolved.value(QStringLiteral("subtitleSource")).toString(), QStringLiteral("file-default"));
+}
+
+void PlayerControllerAutoplayContextTest::globalSubtitleOffDisablesSubtitles()
+{
+    ConfigManager config;
+    config.setDefaultSubtitleTrackSelection(QStringLiteral("off"));
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+    PlayerController controller(&backend, &config, &trackPrefs, &displayManager, &playbackService, &libraryService, &authService);
+
+    const QVariantMap resolved = controller.resolveTrackSelectionForMediaSource(
+        buildMediaSource({
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 1}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Subtitle")}, {QStringLiteral("index"), 10}, {QStringLiteral("isDefault"), true}}
+        }, 1, 10),
+        QStringLiteral("season-global"),
+        false);
+
+    QCOMPARE(resolved.value(QStringLiteral("subtitleIndex")).toInt(), -1);
+    QCOMPARE(resolved.value(QStringLiteral("subtitleSource")).toString(), QStringLiteral("global-off"));
+}
+
+void PlayerControllerAutoplayContextTest::globalSubtitleForcedSelectsForcedTrack()
+{
+    ConfigManager config;
+    config.setDefaultSubtitleTrackSelection(QStringLiteral("forced"));
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+    PlayerController controller(&backend, &config, &trackPrefs, &displayManager, &playbackService, &libraryService, &authService);
+
+    const QVariantMap resolved = controller.resolveTrackSelectionForMediaSource(
+        buildMediaSource({
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 1}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Subtitle")}, {QStringLiteral("index"), 10}, {QStringLiteral("isDefault"), true}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Subtitle")}, {QStringLiteral("index"), 11}, {QStringLiteral("isForced"), true}}
+        }, 1, 10),
+        QStringLiteral("season-global"),
+        false);
+
+    QCOMPARE(resolved.value(QStringLiteral("subtitleIndex")).toInt(), 11);
+    QCOMPARE(resolved.value(QStringLiteral("subtitleSource")).toString(), QStringLiteral("global-forced"));
+}
+
+void PlayerControllerAutoplayContextTest::globalSubtitleForcedFallsBackToOffWhenNoForcedTrackExists()
+{
+    ConfigManager config;
+    config.setDefaultSubtitleTrackSelection(QStringLiteral("forced"));
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+    PlayerController controller(&backend, &config, &trackPrefs, &displayManager, &playbackService, &libraryService, &authService);
+
+    const QVariantMap resolved = controller.resolveTrackSelectionForMediaSource(
+        buildMediaSource({
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 1}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Subtitle")}, {QStringLiteral("index"), 10}, {QStringLiteral("isDefault"), true}}
+        }, 1, 10),
+        QStringLiteral("season-global"),
+        false);
+
+    QCOMPARE(resolved.value(QStringLiteral("subtitleIndex")).toInt(), -1);
+    QCOMPARE(resolved.value(QStringLiteral("subtitleSource")).toString(), QStringLiteral("global-forced-off"));
+}
+
+void PlayerControllerAutoplayContextTest::unavailableGlobalLanguageFallsBackToJellyfinDefault()
+{
+    ConfigManager config;
+    config.setDefaultAudioTrackSelection(QStringLiteral("jpn"));
+    config.setDefaultSubtitleTrackSelection(QStringLiteral("spa"));
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+    PlayerController controller(&backend, &config, &trackPrefs, &displayManager, &playbackService, &libraryService, &authService);
+
+    const QVariantMap resolved = controller.resolveTrackSelectionForMediaSource(
+        buildMediaSource({
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 1}, {QStringLiteral("language"), QStringLiteral("eng")}},
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("Subtitle")}, {QStringLiteral("index"), 10}, {QStringLiteral("language"), QStringLiteral("eng")}}
+        }, 1, 10),
+        QStringLiteral("season-global"),
+        false);
+
+    QCOMPARE(resolved.value(QStringLiteral("audioIndex")).toInt(), 1);
+    QCOMPARE(resolved.value(QStringLiteral("subtitleIndex")).toInt(), 10);
+    QCOMPARE(resolved.value(QStringLiteral("audioSource")).toString(), QStringLiteral("jellyfin-default"));
+    QCOMPARE(resolved.value(QStringLiteral("subtitleSource")).toString(), QStringLiteral("jellyfin-default"));
+}
+
+void PlayerControllerAutoplayContextTest::autoplayPlaybackInfoUsesGlobalSubtitlePreferenceWhenOverrideAndSeasonUnset()
+{
+    ConfigManager config;
+    config.setDefaultSubtitleTrackSelection(QStringLiteral("spa"));
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+
+    controller.m_pendingAutoplaySeriesId = QStringLiteral("series-12");
+    controller.m_pendingAutoplaySeasonId = QStringLiteral("season-global");
+    controller.m_pendingAutoplayLibraryId = QStringLiteral("library-12");
+    controller.m_pendingAutoplayAudioTrack = 1;
+    controller.m_pendingAutoplaySubtitleTrack = -1;
+    controller.m_pendingAutoplaySubtitleMode = TrackPreferenceMode::Unset;
+    controller.m_pendingAutoplayEpisodeData = QJsonObject{
+        {QStringLiteral("Id"), QStringLiteral("episode-12")},
+        {QStringLiteral("SeasonId"), QStringLiteral("season-global")}
+    };
+    controller.m_waitingForAutoplayPlaybackInfo = true;
+
+    PlaybackInfoResponse playbackInfo;
+    playbackInfo.playSessionId = QStringLiteral("play-session-12");
+    MediaSourceInfo mediaSource;
+    mediaSource.id = QStringLiteral("media-source-12");
+    mediaSource.mediaStreams = {
+        MediaStreamInfo{.index = 1, .type = QStringLiteral("Audio")},
+        MediaStreamInfo{.index = 20, .type = QStringLiteral("Subtitle"), .language = QStringLiteral("eng")},
+        MediaStreamInfo{.index = 21, .type = QStringLiteral("Subtitle"), .language = QStringLiteral("spa")}
+    };
+    playbackInfo.mediaSources.append(mediaSource);
+
+    QVERIFY(QMetaObject::invokeMethod(&controller,
+                                      "onPlaybackInfoLoaded",
+                                      Qt::DirectConnection,
+                                      Q_ARG(QString, QStringLiteral("episode-12")),
+                                      Q_ARG(PlaybackInfoResponse, playbackInfo)));
+
+    QCOMPARE(controller.selectedSubtitleTrack(), 21);
+    QCOMPARE(controller.m_mediaSourceId, QStringLiteral("media-source-12"));
+    QCOMPARE(controller.m_playSessionId, QStringLiteral("play-session-12"));
 }
 
 void PlayerControllerAutoplayContextTest::staleAutoplayPlaybackInfoResponseFallsBackAfterTimeout()

--- a/tests/PlayerControllerAutoplayContextTest.cpp
+++ b/tests/PlayerControllerAutoplayContextTest.cpp
@@ -1,6 +1,7 @@
 #include <QtTest/QtTest>
 #include <QtTest/QSignalSpy>
 #include <QCoreApplication>
+#include <QDir>
 #include <QStandardPaths>
 #include <QTemporaryDir>
 
@@ -295,18 +296,35 @@ private slots:
 
 private:
     QTemporaryDir m_configHome;
+#ifdef Q_OS_LINUX
     QByteArray m_previousConfigHome;
     bool m_hadPreviousConfigHome = false;
+#elif defined(Q_OS_WIN)
+    QByteArray m_previousAppData;
+    bool m_hadPreviousAppData = false;
+#elif defined(Q_OS_MACOS)
+    QByteArray m_previousHome;
+    bool m_hadPreviousHome = false;
+#endif
 };
 
 void PlayerControllerAutoplayContextTest::initTestCase()
 {
+    QVERIFY(m_configHome.isValid());
     QStandardPaths::setTestModeEnabled(true);
 #ifdef Q_OS_LINUX
-    QVERIFY(m_configHome.isValid());
     m_previousConfigHome = qgetenv("XDG_CONFIG_HOME");
     m_hadPreviousConfigHome = !m_previousConfigHome.isNull();
     qputenv("XDG_CONFIG_HOME", m_configHome.path().toUtf8());
+#elif defined(Q_OS_WIN)
+    m_previousAppData = qgetenv("APPDATA");
+    m_hadPreviousAppData = !m_previousAppData.isNull();
+    qputenv("APPDATA", m_configHome.path().toUtf8());
+#elif defined(Q_OS_MACOS)
+    m_previousHome = qgetenv("HOME");
+    m_hadPreviousHome = !m_previousHome.isNull();
+    qputenv("HOME", m_configHome.path().toUtf8());
+    QVERIFY(QDir().mkpath(m_configHome.path() + QStringLiteral("/Library/Preferences")));
 #endif
 }
 
@@ -317,6 +335,18 @@ void PlayerControllerAutoplayContextTest::cleanupTestCase()
         qputenv("XDG_CONFIG_HOME", m_previousConfigHome);
     } else {
         qunsetenv("XDG_CONFIG_HOME");
+    }
+#elif defined(Q_OS_WIN)
+    if (m_hadPreviousAppData) {
+        qputenv("APPDATA", m_previousAppData);
+    } else {
+        qunsetenv("APPDATA");
+    }
+#elif defined(Q_OS_MACOS)
+    if (m_hadPreviousHome) {
+        qputenv("HOME", m_previousHome);
+    } else {
+        qunsetenv("HOME");
     }
 #endif
     QStandardPaths::setTestModeEnabled(false);


### PR DESCRIPTION
## Summary
- Add app-wide audio/subtitle fallback defaults for Jellyfin default, file default, common languages, subtitle off, and forced subtitles.
- Apply the new fallback only after request-time and explicit season/movie preferences.
- Add themed Playback settings selectors and fix the shared settings spinbox keyboard stepping path.
- Document the new config/playback behavior and cover resolver behavior with tests.

## Impact
Users can now configure global audio/subtitle language behavior without overriding season-level track selections. Season/movie explicit preferences remain highest priority after request-time overrides.

## Root Cause / Fix Notes
The cache setting runtime warning came from `SettingsSpinBoxRow` calling `SpinBox.increase()` / `decrease()`, which are not functions in this Qt runtime. Keyboard stepping now updates the bounded value directly and emits the existing settings-change signal.

## Validation
- `./scripts/build-docker.sh`
- `./build-docker/tests/PlayerControllerAutoplayContextTest` (`34 passed, 0 failed`)
- Manual testing was completed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add global audio and subtitle track language defaults to playback settings
> - Adds `defaultAudioTrackSelection` and `defaultSubtitleTrackSelection` properties to `ConfigManager`, persisted under `settings.playback`, defaulting to `jellyfin-default`.
> - Adds UI controls in [PlaybackSettings.qml](https://github.com/crowquillx/Bloom/pull/48/files#diff-102f755f3ebf40752ef46ce305238f5c5324ef9cacd668d6a8089ec92b1ee028) allowing users to choose global fallback track defaults: Jellyfin Default, File Default, a supported language, or (for subtitles) Off/Forced.
> - Refactors `PlayerController.resolveTrackSelection` to consult global defaults after request-time overrides and explicit per-item preferences, but before built-in fallbacks. Adds language normalization (e.g. `en`/`eng`, `ja`/`jpn`) and best-match scoring for multi-stream selection.
> - Bumps config schema to version 18 with a migration that sets both new keys to `jellyfin-default` for existing installs.
> - Behavioral Change: users who previously relied on built-in fallback order for audio/subtitle selection will now go through the new global default step first; existing configs migrate cleanly but the resolution order has changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9dde33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added settings for default audio and subtitle track selection in Playback Settings.
  * Improved track selection logic with language-aware stream matching and fallback resolution.

* **Documentation**
  * Added documentation for default audio/subtitle track selection settings and their configuration options.
  * Updated track selection resolution order documentation.

* **Tests**
  * Added comprehensive tests for track selection resolution and autoplay context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->