### PR TITLE
fix(tests): add missing include paths + docs: Cursor Cloud setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,3 +66,40 @@ See also:
 - docs/conventional-commits.md — commit messages must follow the Conventional Commits spec so tooling and changelogs stay accurate
 
 License: See `LICENSE`.
+
+## Cursor Cloud specific instructions
+
+### Building
+- Docker must be running before building. Start the daemon with `dockerd &` and wait a few seconds.
+- Run `xhost +local:` before launching the app inside a Docker container so it can access the X display.
+- The canonical build command is `./scripts/build-docker.sh`. For development iteration where you only need the main binary (no tests), you can build faster inside the container with `-DBUILD_TESTING=OFF`:
+  ```
+  docker run --rm --network=host -v "$(pwd):/workspace" bloom-build bash -c \
+    'cd /workspace && mkdir -p build-docker && cd build-docker && cmake .. -G Ninja -DBUILD_TESTING=OFF && ninja'
+  ```
+- A full build with tests uses the same command without `-DBUILD_TESTING=OFF` (or simply `./scripts/build-docker.sh`).
+
+### Running tests
+- Tests must be run inside the Docker container since the binary is linked against the container's Qt6/mpv libraries.
+- Set `QT_QPA_PLATFORM=offscreen` when running tests in a headless environment:
+  ```
+  docker run --rm --network=host -e QT_QPA_PLATFORM=offscreen -v "$(pwd):/workspace" bloom-build \
+    bash -c 'cd /workspace/build-docker && ctest --output-on-failure'
+  ```
+- `VisualRegressionTest` golden image mismatches are expected in different environments (pixel-perfect comparisons).
+- `SeriesDetailsCacheTest` has two known pre-existing failures (`seriesCacheRespectsFreshness`, `itemsCacheRespectsFreshness`).
+
+### Running the application
+- Launch inside the container with display forwarding:
+  ```
+  docker run --rm --network=host -e DISPLAY=:1 -e QT_QPA_PLATFORM=xcb -e XDG_RUNTIME_DIR=/tmp \
+    -v /tmp/.X11-unix:/tmp/.X11-unix -v "$(pwd):/workspace" bloom-build /workspace/build-docker/src/Bloom
+  ```
+- The app requires a Jellyfin server to be fully functional beyond the login screen.
+
+### QML lint
+- QML lint runs as part of `./scripts/build-docker.sh` automatically. To run it manually:
+  ```
+  docker run --rm -v "$(pwd):/workspace" bloom-build bash -c \
+    'qmllint -I /workspace/build-docker/src -I /usr/lib/qt6/qml $(find /workspace/build-docker/src/BloomUI/ui -name "*.qml" | sort)'
+  ```

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ add_executable(SeriesDetailsCacheTest
     ${CMAKE_SOURCE_DIR}/src/utils/DetailViewCache.cpp
 )
 
-target_include_directories(SeriesDetailsCacheTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(SeriesDetailsCacheTest PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/src)
 
 target_link_libraries(SeriesDetailsCacheTest
     PRIVATE
@@ -117,7 +117,7 @@ add_executable(PlayerControllerAutoplayContextTest
     ${CMAKE_SOURCE_DIR}/src/utils/DisplayManager.cpp
 )
 
-target_include_directories(PlayerControllerAutoplayContextTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(PlayerControllerAutoplayContextTest PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/src)
 
 target_compile_definitions(PlayerControllerAutoplayContextTest PRIVATE BLOOM_TESTING=1)
 
@@ -206,7 +206,7 @@ add_executable(SimilarItemsRetryTest
     ${CMAKE_SOURCE_DIR}/src/test/TestModeController.cpp
 )
 
-target_include_directories(SimilarItemsRetryTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(SimilarItemsRetryTest PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/src)
 
 target_link_libraries(SimilarItemsRetryTest
     PRIVATE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### Build fix
Several test targets (`SeriesDetailsCacheTest`, `PlayerControllerAutoplayContextTest`, `SimilarItemsRetryTest`) were missing `${CMAKE_BINARY_DIR}/src` in their include directories. This caused build failures because `AuthenticationService.cpp` includes `config/version.h`, which is a generated header located in the build tree.

### Cursor Cloud instructions
Added `## Cursor Cloud specific instructions` section to `AGENTS.md` with:
- Docker daemon startup requirements for the Cloud VM
- Build commands (with and without tests)
- Running tests with `QT_QPA_PLATFORM=offscreen` in headless environments
- Known pre-existing test failures
- Application launch with X11 display forwarding from inside Docker
- QML lint instructions

## Testing

**Build**: Full build with all 234 targets (app + 11 test executables) completes successfully.

**Tests** (9/11 pass, 2 pre-existing failures):

| Test | Status |
|---|---|
| BaseViewModelTest | Pass |
| SeriesDetailsCacheTest | Fail (pre-existing cache freshness logic) |
| LibraryCacheStoreTest | Pass |
| PlayerBackendFactoryTest | Pass |
| PlayerControllerAutoplayContextTest | Pass |
| NextEpisodeResolverTest | Pass |
| EpisodeSelectionScriptTest | Pass |
| TrackPreferencesManagerTest | Pass |
| SimilarItemsRetryTest | Pass |
| UpdateServiceTest | Pass |
| VisualRegressionTest | Fail (golden image mismatches expected in different environments) |

**QML lint**: Passes with warnings only (exit code 0).

**Application launch**: Bloom starts and displays the login screen.

[bloom_login_interaction_demo.mp4](https://cursor.com/agents/bc-b3d87120-632a-4058-a557-ff9a294dc4df/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbloom_login_interaction_demo.mp4)

[Bloom login screen with connection error](https://cursor.com/agents/bc-b3d87120-632a-4058-a557-ff9a294dc4df/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbloom_login_error_demo.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3d87120-632a-4058-a557-ff9a294dc4df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3d87120-632a-4058-a557-ff9a294dc4df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing include paths for test targets and add Cursor Cloud setup instructions
> - Adds `${CMAKE_BINARY_DIR}/src` to `target_include_directories` for `SeriesDetailsCacheTest`, `PlayerControllerAutoplayContextTest`, and `SimilarItemsRetryTest` in [tests/CMakeLists.txt](https://github.com/crowquillx/Bloom/pull/49/files#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0d) so generated headers are found at build time.
> - Adds a new "Cursor Cloud specific instructions" section to [AGENTS.md](https://github.com/crowquillx/Bloom/pull/49/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) covering Docker builds, headless test execution with `QT_QPA_PLATFORM=offscreen`, X display forwarding, QML lint, and known test failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c3cdd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->