### PR TITLE
fix(playback): handle missing next episode

### DIFF
--- a/docs/playback.md
+++ b/docs/playback.md
@@ -183,6 +183,7 @@ Track Preference Persistence
 - Tie-breakers when play dates are missing or equal prefer later canonical position, then larger `PlaybackPositionTicks`.
 - `excludeItemId` is used by autoplay/prefetch so the player can advance from the current item even before Jellyfin has updated watch state on the server.
 - If no next episode is available, post-playback navigation still opens `UpNextScreen.qml` in an empty state. The screen must keep keyboard focus and offer actions back to Home or the series.
+- The no-next empty state may show up to six TV-series recommendations via `UpNextRecommendationsViewModel`. Jellyfin similar series are listed first; Seerr TV recommendations are appended when the source series has a TMDB id and Seerr is configured. Recommendation provider failures are silent on this screen.
 - Leaving the Up Next interstitial keeps the exact resolved episode context, including season-0 specials, by carrying the resolved episode id plus its `ParentId`/`SeasonId` back into `SeriesSeasonEpisodeView`.
 
 UI Components for Track Selection

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -182,6 +182,7 @@ Track Preference Persistence
   - If no anchor exists, fall back to the first unplayed regular episode, then to the first unplayed special.
 - Tie-breakers when play dates are missing or equal prefer later canonical position, then larger `PlaybackPositionTicks`.
 - `excludeItemId` is used by autoplay/prefetch so the player can advance from the current item even before Jellyfin has updated watch state on the server.
+- If no next episode is available, post-playback navigation still opens `UpNextScreen.qml` in an empty state. The screen must keep keyboard focus and offer actions back to Home or the series.
 - Leaving the Up Next interstitial keeps the exact resolved episode context, including season-0 specials, by carrying the resolved episode id plus its `ParentId`/`SeasonId` back into `SeriesSeasonEpisodeView`.
 
 UI Components for Track Selection

--- a/docs/seerr.md
+++ b/docs/seerr.md
@@ -7,6 +7,7 @@ Overview
   - Selecting a Seerr result opens a request dialog.
   - Request dialog supports server/profile/root-folder selection and TV season selection.
   - Series details can render a Seerr recommendations shelf when the current series has a TMDB id and Seerr is configured.
+  - The post-playback no-next screen can append Seerr TV recommendations to local Jellyfin recommendations.
 - Future scope:
   - Similar-title provider hook is now rendered in series details; movie details can reuse the same service later.
 
@@ -23,6 +24,7 @@ Runtime behavior
   - Jellyfin results render first.
   - Seerr search runs independently and appears later when available.
 - Seerr cards include source/status metadata and open the Seerr request dialog.
+- On the post-playback no-next screen, Seerr similar-title failures are ignored and the screen remains focused on Back to Series/Home actions.
 
 API endpoints used
 - Validation:
@@ -52,9 +54,10 @@ Code map
 - `src/ui/SeerrRequestDialog.qml`: keyboard-first request dialog.
 - `src/ui/SearchResultCard.qml`: Seerr-aware card rendering (TMDB posters/source-status badge).
 - `src/ui/SeriesDetailsView.qml`: Seerr recommendations shelf for series details, reusing the request dialog.
+- `src/viewmodels/UpNextRecommendationsViewModel.{h,cpp}` and `src/ui/UpNextScreen.qml`: no-next recommendation shelf that merges Jellyfin similar series with Seerr TV results.
 
 Similar Titles
-- `SeerrService::getSimilar(mediaType, tmdbId, page)` and `similarResultsLoaded(...)` drive the recommendations shelf in series details.
+- `SeerrService::getSimilar(mediaType, tmdbId, page)` and `similarResultsLoaded(...)` drive recommendations in series details and the no-next Up Next screen.
 - Endpoints:
   - `GET /api/v1/movie/{movieId}/similar`
   - `GET /api/v1/tv/{tvId}/similar`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,8 @@ qt_add_executable(Bloom
     viewmodels/SeriesDetailsViewModel.cpp
     viewmodels/MovieDetailsViewModel.h
     viewmodels/MovieDetailsViewModel.cpp
+    viewmodels/UpNextRecommendationsViewModel.h
+    viewmodels/UpNextRecommendationsViewModel.cpp
     ui/ImageCacheProvider.h
     ui/ImageCacheProvider.cpp
     ui/UiSoundController.h

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -18,6 +18,7 @@
 #include "viewmodels/LibraryViewModel.h"
 #include "viewmodels/SeriesDetailsViewModel.h"
 #include "viewmodels/MovieDetailsViewModel.h"
+#include "viewmodels/UpNextRecommendationsViewModel.h"
 #include "utils/SidebarSettings.h"
 #include "ui/UiSoundController.h"
 #include "utils/GpuMemoryTrimmer.h"
@@ -247,6 +248,10 @@ void ApplicationInitializer::registerServices()
     // 7.5 MovieDetailsViewModel
     m_movieDetailsViewModel = std::make_unique<MovieDetailsViewModel>();
     ServiceLocator::registerService<MovieDetailsViewModel>(m_movieDetailsViewModel.get());
+
+    // 7.6 UpNextRecommendationsViewModel
+    m_upNextRecommendationsViewModel = std::make_unique<UpNextRecommendationsViewModel>();
+    ServiceLocator::registerService<UpNextRecommendationsViewModel>(m_upNextRecommendationsViewModel.get());
 
     // 8. SidebarSettings
     m_sidebarSettings = std::make_unique<SidebarSettings>();

--- a/src/core/ApplicationInitializer.h
+++ b/src/core/ApplicationInitializer.h
@@ -20,6 +20,7 @@ class InputModeManager;
 class LibraryViewModel;
 class SeriesDetailsViewModel;
 class MovieDetailsViewModel;
+class UpNextRecommendationsViewModel;
 class ISecretStore;
 class SidebarSettings;
 class UiSoundController;
@@ -107,6 +108,7 @@ private:
     std::unique_ptr<LibraryViewModel> m_libraryViewModel;
     std::unique_ptr<SeriesDetailsViewModel> m_seriesDetailsViewModel;
     std::unique_ptr<MovieDetailsViewModel> m_movieDetailsViewModel;
+    std::unique_ptr<UpNextRecommendationsViewModel> m_upNextRecommendationsViewModel;
     std::unique_ptr<SidebarSettings> m_sidebarSettings;
     std::unique_ptr<UiSoundController> m_uiSoundController;
     std::unique_ptr<SessionManager> m_sessionManager;

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -1640,9 +1640,22 @@ void PlayerController::onNextEpisodeLoaded(const QString &seriesId,
     
     m_shouldAutoplay = false;
     m_waitingForNextEpisodeAtPlaybackEnd = false;
+
+    const int lastAudioIndex = m_pendingAutoplayAudioTrack;
+    const int lastSubtitleIndex = pendingAutoplaySubtitleOverrideIndex();
     
     if (episodeData.isEmpty()) {
         qDebug() << "PlayerController: No next episode available";
+        QJsonObject noNextEpisodeData;
+        noNextEpisodeData.insert(QStringLiteral("SeriesId"), seriesId);
+        noNextEpisodeData.insert(QStringLiteral("SeasonId"), m_pendingAutoplaySeasonId);
+        noNextEpisodeData.insert(QStringLiteral("NoNextEpisode"), true);
+        setAwaitingNextEpisodeResolution(false);
+        emitNavigateToNextEpisodeQueued(noNextEpisodeData,
+                                        seriesId,
+                                        lastAudioIndex,
+                                        lastSubtitleIndex,
+                                        false);
         clearPendingAutoplayContext();
         clearNextEpisodePrefetchState();
         return;
@@ -1669,8 +1682,6 @@ void PlayerController::onNextEpisodeLoaded(const QString &seriesId,
     // Always emit navigateToNextEpisode to show the Up Next screen
     // The QML screen will handle autoplay countdown vs manual play
     bool autoplay = m_config->getAutoplayNextEpisode();
-    int lastAudioIndex = m_pendingAutoplayAudioTrack;
-    int lastSubtitleIndex = pendingAutoplaySubtitleOverrideIndex();
     
     qDebug() << "PlayerController: Emitting navigateToNextEpisode signal with autoplay:" 
              << autoplay << "audio:" << lastAudioIndex << "subtitle:" << lastSubtitleIndex;

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -841,8 +841,10 @@ Window {
         target: PlayerController
         
         function onNavigateToNextEpisode(episodeData, seriesId, lastAudioIndex, lastSubtitleIndex, autoplay) {
-            console.log("[Main] Up Next screen for:", 
-                        episodeData.SeriesName, "S" + episodeData.ParentIndexNumber + "E" + episodeData.IndexNumber,
+            var hasNextEpisode = episodeData && episodeData.Id && !episodeData.NoNextEpisode
+            console.log("[Main] Up Next screen for:",
+                        hasNextEpisode ? episodeData.SeriesName : "(no next episode)",
+                        hasNextEpisode ? ("S" + episodeData.ParentIndexNumber + "E" + episodeData.IndexNumber) : "",
                         "Autoplay:", autoplay)
             
             // Pop back to the root level (home screen) first
@@ -867,6 +869,10 @@ Window {
                 })
                 // Play the next episode
                 upNextScreen.playRequested.connect(function() {
+                    if (!hasNextEpisode) {
+                        console.warn("[Main] Up Next: Ignoring play request without a next episode")
+                        return
+                    }
                     console.log("[Main] Up Next: Play requested")
                     stackView.pop(null, StackView.Immediate)
                     PlayerController.playNextEpisode(episodeData, seriesId)
@@ -877,6 +883,29 @@ Window {
                     console.log("[Main] Up Next: More episodes requested")
                     stackView.pop(null, StackView.Immediate)
                     PlayerController.clearPendingAutoplayContext()
+
+                    if (!hasNextEpisode) {
+                        var seasonId = episodeData ? (episodeData.SeasonId || episodeData.ParentId || "") : ""
+                        var seriesScreen = stackView.push("LibraryScreen.qml", {
+                            currentParentId: "",
+                            currentLibraryId: "",
+                            currentLibraryName: "",
+                            currentSeriesId: seriesId,
+                            currentSeasonId: seasonId,
+                            showSeriesDetails: true,
+                            directNavigationMode: true,
+                            preferStackPopOnDirectBack: true
+                        }, StackView.Immediate)
+                        LibraryService.getSeriesDetails(seriesId)
+                        if (seriesScreen) {
+                            Qt.callLater(function() {
+                                if (seriesScreen && seriesScreen.forceActiveFocus) {
+                                    seriesScreen.forceActiveFocus()
+                                }
+                            })
+                        }
+                        return
+                    }
 
                     var targetEpisodeData = Object.assign({}, episodeData || {})
                     if (!targetEpisodeData.itemId && targetEpisodeData.Id) {

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -965,6 +965,31 @@ Window {
                     PlayerController.clearPendingAutoplayContext()
                     stackView.pop(null, StackView.Immediate)
                 })
+
+                upNextScreen.recommendationSelected.connect(function(itemData) {
+                    var recommendedSeriesId = itemData ? (itemData.Id || itemData.itemId || "") : ""
+                    if (!recommendedSeriesId || recommendedSeriesId.indexOf("seerr:") === 0) {
+                        console.warn("[Main] Up Next: Ignoring invalid Jellyfin recommendation selection")
+                        return
+                    }
+
+                    console.log("[Main] Up Next: Recommendation selected", recommendedSeriesId)
+                    PlayerController.clearPendingAutoplayContext()
+                    stackView.pop(null, StackView.Immediate)
+                    stackView.push("LibraryScreen.qml", {
+                        currentParentId: "",
+                        currentLibraryId: "",
+                        currentLibraryName: "",
+                        currentSeriesId: recommendedSeriesId,
+                        currentSeriesData: itemData,
+                        showSeriesDetails: true,
+                        directNavigationMode: true,
+                        preferStackPopOnDirectBack: true
+                    }, StackView.Immediate)
+                    LibraryService.getSeriesDetails(recommendedSeriesId)
+                    LibraryService.getItems(recommendedSeriesId, 0, 0)
+                    LibraryService.getNextUnplayedEpisode(recommendedSeriesId)
+                })
             } else {
                 console.warn("[Main] Failed to create Up Next screen, clearing pending autoplay context")
                 PlayerController.clearPendingAutoplayContext()

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -897,6 +897,8 @@ Window {
                             preferStackPopOnDirectBack: true
                         }, StackView.Immediate)
                         LibraryService.getSeriesDetails(seriesId)
+                        LibraryService.getItems(seriesId, 0, 0)
+                        LibraryService.getNextUnplayedEpisode(seriesId)
                         if (seriesScreen) {
                             Qt.callLater(function() {
                                 if (seriesScreen && seriesScreen.forceActiveFocus) {
@@ -968,8 +970,12 @@ Window {
 
                 upNextScreen.recommendationSelected.connect(function(itemData) {
                     var recommendedSeriesId = itemData ? (itemData.Id || itemData.itemId || "") : ""
-                    if (!recommendedSeriesId || recommendedSeriesId.indexOf("seerr:") === 0) {
-                        console.warn("[Main] Up Next: Ignoring invalid Jellyfin recommendation selection")
+                    if (!recommendedSeriesId) {
+                        console.warn("[Main] Up Next: Ignoring recommendation with missing id")
+                        return
+                    }
+                    if (recommendedSeriesId.indexOf("seerr:") === 0) {
+                        console.warn("[Main] Up Next: Ignoring Seerr recommendation that bypassed dialog")
                         return
                     }
 

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -841,6 +841,8 @@ Window {
         target: PlayerController
         
         function onNavigateToNextEpisode(episodeData, seriesId, lastAudioIndex, lastSubtitleIndex, autoplay) {
+            var normalizedSeriesId = seriesId
+                || (episodeData ? (episodeData.SeriesId || episodeData.ParentId || "") : "")
             var hasNextEpisode = episodeData && episodeData.Id && !episodeData.NoNextEpisode
             console.log("[Main] Up Next screen for:",
                         hasNextEpisode ? episodeData.SeriesName : "(no next episode)",
@@ -855,7 +857,7 @@ Window {
             // Push the Up Next interstitial screen
             var upNextScreen = stackView.push("UpNextScreen.qml", {
                 episodeData: episodeData,
-                seriesId: seriesId,
+                seriesId: normalizedSeriesId,
                 lastAudioIndex: lastAudioIndex,
                 lastSubtitleIndex: lastSubtitleIndex,
                 autoplay: autoplay
@@ -875,7 +877,7 @@ Window {
                     }
                     console.log("[Main] Up Next: Play requested")
                     stackView.pop(null, StackView.Immediate)
-                    PlayerController.playNextEpisode(episodeData, seriesId)
+                    PlayerController.playNextEpisode(episodeData, normalizedSeriesId)
                 })
                 
                 // Navigate to the episode list (same as ESC)
@@ -890,15 +892,15 @@ Window {
                             currentParentId: "",
                             currentLibraryId: "",
                             currentLibraryName: "",
-                            currentSeriesId: seriesId,
+                            currentSeriesId: normalizedSeriesId,
                             currentSeasonId: seasonId,
                             showSeriesDetails: true,
                             directNavigationMode: true,
                             preferStackPopOnDirectBack: true
                         }, StackView.Immediate)
-                        LibraryService.getSeriesDetails(seriesId)
-                        LibraryService.getItems(seriesId, 0, 0)
-                        LibraryService.getNextUnplayedEpisode(seriesId)
+                        LibraryService.getSeriesDetails(normalizedSeriesId)
+                        LibraryService.getItems(normalizedSeriesId, 0, 0)
+                        LibraryService.getNextUnplayedEpisode(normalizedSeriesId)
                         if (seriesScreen) {
                             Qt.callLater(function() {
                                 if (seriesScreen && seriesScreen.forceActiveFocus) {
@@ -926,8 +928,8 @@ Window {
                         console.log("[Main] Up Next: Reusing existing LibraryScreen for episode navigation")
                         destinationScreen.pendingAudioTrackIndex = lastAudioIndex
                         destinationScreen.pendingSubtitleTrackIndex = lastSubtitleIndex
-                        if (seriesId) {
-                            destinationScreen.currentSeriesId = seriesId
+                        if (normalizedSeriesId) {
+                            destinationScreen.currentSeriesId = normalizedSeriesId
                         }
                         if (targetSeasonId) {
                             destinationScreen.currentSeasonId = targetSeasonId
@@ -944,7 +946,7 @@ Window {
                         currentParentId: "",
                         currentLibraryId: "",
                         currentLibraryName: "",
-                        currentSeriesId: seriesId,
+                        currentSeriesId: normalizedSeriesId,
                         currentSeasonId: targetSeasonId,
                         showSeasonView: true,
                         directNavigationMode: true,
@@ -953,7 +955,7 @@ Window {
                         pendingSubtitleTrackIndex: lastSubtitleIndex
                     })
 
-                    LibraryService.getSeriesDetails(seriesId)
+                    LibraryService.getSeriesDetails(normalizedSeriesId)
                     if (libraryScreen) {
                         libraryScreen.pendingEpisodeData = targetEpisodeData
                     } else {

--- a/src/ui/SeriesSeasonEpisodeView.qml
+++ b/src/ui/SeriesSeasonEpisodeView.qml
@@ -493,13 +493,13 @@ FocusScope {
     Connections {
         target: PlayerController
         function onPlaybackStopped() {
-            if (PlayerController.awaitingNextEpisodeResolution) {
-                return
-            }
             if (SeriesDetailsViewModel.selectedSeasonId) {
                 playbackSelectionRestorePending = true
                 playbackAnchorEpisodeId = selectedEpisodeId
                 pendingPlaybackSelectionEpisodeId = ""
+                if (PlayerController.awaitingNextEpisodeResolution) {
+                    return
+                }
                 refreshEpisodesTimer.start()
             }
         }
@@ -2314,8 +2314,15 @@ FocusScope {
         }
 
         function onAwaitingNextEpisodeResolutionChanged() {
-            if (PlayerController.awaitingNextEpisodeResolution) {
-                root.resetPlaybackReturnFocusState()
+            if (!PlayerController.awaitingNextEpisodeResolution) {
+                if (root.playbackSelectionRestorePending && SeriesDetailsViewModel.selectedSeasonId) {
+                    refreshEpisodesTimer.start()
+                }
+                if (root.playbackReturnFocusPending
+                        && root.playbackReturnFocusActivated
+                        && !PlayerController.isPlaybackActive) {
+                    Qt.callLater(root.restoreFocusAfterPlaybackExit)
+                }
             }
         }
     }

--- a/src/ui/UpNextScreen.qml
+++ b/src/ui/UpNextScreen.qml
@@ -34,6 +34,7 @@ FocusScope {
     signal playRequested()
     signal moreEpisodesRequested()
     signal backToHomeRequested()
+    signal recommendationSelected(var itemData)
 
     // ---- Derived episode metadata ----
     readonly property string episodeName: episodeData.Name || ""
@@ -44,6 +45,9 @@ FocusScope {
     readonly property var runtimeTicks: episodeData.RunTimeTicks || 0
     readonly property double communityRating: episodeData.CommunityRating || 0
     readonly property string premiereDate: episodeData.PremiereDate || ""
+    readonly property var recommendationItems: (typeof UpNextRecommendationsViewModel !== "undefined")
+        ? UpNextRecommendationsViewModel.items : []
+    readonly property bool hasRecommendations: !root.hasNextEpisode && recommendationItems.length > 0
 
     // ---- Thumbnail URL construction ----
     readonly property string episodeId: episodeData.Id || ""
@@ -118,6 +122,27 @@ FocusScope {
         })
     }
 
+    function loadRecommendationsIfNeeded() {
+        if (root.hasNextEpisode || !root.seriesId
+                || typeof UpNextRecommendationsViewModel === "undefined") {
+            if (typeof UpNextRecommendationsViewModel !== "undefined") {
+                UpNextRecommendationsViewModel.clear()
+            }
+            return
+        }
+
+        UpNextRecommendationsViewModel.loadForSeries(root.seriesId, 6)
+    }
+
+    function activateRecommendation(itemData, focusTarget) {
+        cancelCountdown()
+        if (itemData && itemData.Source === "Seerr") {
+            seerrRequestDialog.openForItem(itemData, focusTarget)
+            return
+        }
+        recommendationSelected(itemData)
+    }
+
     onActiveFocusChanged: {
         if (activeFocus) {
             focusPrimaryAction()
@@ -126,9 +151,16 @@ FocusScope {
 
     StackView.onStatusChanged: {
         if (StackView.status === StackView.Active) {
+            loadRecommendationsIfNeeded()
             focusPrimaryAction()
+        } else if (StackView.status === StackView.Deactivating
+                   && typeof UpNextRecommendationsViewModel !== "undefined") {
+            UpNextRecommendationsViewModel.clear()
         }
     }
+
+    onSeriesIdChanged: loadRecommendationsIfNeeded()
+    onHasNextEpisodeChanged: loadRecommendationsIfNeeded()
 
     // ---- Background ----
     Rectangle {
@@ -490,6 +522,7 @@ FocusScope {
 
                 KeyNavigation.up: root.hasNextEpisode ? thumbnailFocus : moreEpisodesBtn
                 KeyNavigation.right: moreEpisodesBtn
+                KeyNavigation.down: root.hasRecommendations ? recommendationsList : null
 
                 Keys.onReturnPressed: function(event) {
                     if (event.isAutoRepeat) { event.accepted = true; return }
@@ -502,6 +535,13 @@ FocusScope {
                     root.cancelCountdown()
                     root.backToHomeRequested()
                     event.accepted = true
+                }
+                Keys.onDownPressed: function(event) {
+                    if (root.hasRecommendations) {
+                        recommendationsList.forceActiveFocus()
+                        recommendationsList.currentIndex = Math.max(0, recommendationsList.currentIndex)
+                        event.accepted = true
+                    }
                 }
 
                 onClicked: {
@@ -547,6 +587,7 @@ FocusScope {
 
                 KeyNavigation.up: root.hasNextEpisode ? thumbnailFocus : backToHomeBtn
                 KeyNavigation.left: backToHomeBtn
+                KeyNavigation.down: root.hasRecommendations ? recommendationsList : null
 
                 Keys.onReturnPressed: function(event) {
                     if (event.isAutoRepeat) { event.accepted = true; return }
@@ -559,6 +600,13 @@ FocusScope {
                     root.cancelCountdown()
                     root.moreEpisodesRequested()
                     event.accepted = true
+                }
+                Keys.onDownPressed: function(event) {
+                    if (root.hasRecommendations) {
+                        recommendationsList.forceActiveFocus()
+                        recommendationsList.currentIndex = Math.max(0, recommendationsList.currentIndex)
+                        event.accepted = true
+                    }
                 }
 
                 onClicked: {
@@ -597,6 +645,106 @@ FocusScope {
 
             Item { Layout.fillWidth: true }
         }
+
+        ColumnLayout {
+            id: recommendationsSection
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.hasRecommendations ? Math.round(300 * Theme.layoutScale) : 0
+            spacing: Theme.spacingSmall
+            visible: root.hasRecommendations
+
+            Text {
+                text: qsTr("Recommended Next")
+                font.pixelSize: Theme.fontSizeTitle
+                font.family: Theme.fontPrimary
+                font.weight: Font.DemiBold
+                color: Theme.textPrimary
+                Layout.fillWidth: true
+            }
+
+            ListView {
+                id: recommendationsList
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                orientation: ListView.Horizontal
+                spacing: Theme.spacingMedium
+                clip: false
+                focus: false
+                currentIndex: 0
+                model: root.recommendationItems
+                boundsBehavior: Flickable.StopAtBounds
+
+                delegate: FocusScope {
+                    id: recommendationDelegateScope
+                    width: Math.round(150 * Theme.layoutScale)
+                    height: recommendationsList.height
+
+                    required property var modelData
+                    required property int index
+
+                    SearchResultCard {
+                        id: recommendationCard
+                        anchors.fill: parent
+                        anchors.margins: Theme.spacingSmall
+                        itemData: recommendationDelegateScope.modelData
+                        isFocused: recommendationDelegateScope.activeFocus
+
+                        onClicked: root.activateRecommendation(recommendationDelegateScope.modelData,
+                                                               recommendationDelegateScope)
+                    }
+
+                    Keys.onReturnPressed: function(event) {
+                        if (event.isAutoRepeat) { event.accepted = true; return }
+                        recommendationCard.clicked()
+                        event.accepted = true
+                    }
+                    Keys.onEnterPressed: function(event) {
+                        if (event.isAutoRepeat) { event.accepted = true; return }
+                        recommendationCard.clicked()
+                        event.accepted = true
+                    }
+                    Keys.onSpacePressed: function(event) {
+                        if (event.isAutoRepeat) { event.accepted = true; return }
+                        recommendationCard.clicked()
+                        event.accepted = true
+                    }
+                    Keys.onUpPressed: function(event) {
+                        moreEpisodesBtn.forceActiveFocus()
+                        event.accepted = true
+                    }
+                    Keys.onLeftPressed: function(event) {
+                        if (recommendationsList.currentIndex > 0) {
+                            recommendationsList.currentIndex--
+                            event.accepted = true
+                        }
+                    }
+                    Keys.onRightPressed: function(event) {
+                        if (recommendationsList.currentIndex + 1 < recommendationsList.count) {
+                            recommendationsList.currentIndex++
+                            event.accepted = true
+                        }
+                    }
+
+                    onActiveFocusChanged: {
+                        if (activeFocus) {
+                            recommendationsList.currentIndex = index
+                        }
+                    }
+                }
+
+                onActiveFocusChanged: {
+                    if (activeFocus && currentItem) {
+                        currentItem.forceActiveFocus()
+                    }
+                }
+
+                onCurrentIndexChanged: {
+                    if (activeFocus && currentItem) {
+                        currentItem.forceActiveFocus()
+                    }
+                }
+            }
+        }
     }
 
     // ESC/Back cancels countdown and navigates to episode list or series.
@@ -611,6 +759,12 @@ FocusScope {
 
     // Initial focus
     Component.onCompleted: {
+        loadRecommendationsIfNeeded()
         focusPrimaryAction()
+    }
+
+    SeerrRequestDialog {
+        id: seerrRequestDialog
+        parent: Overlay.overlay
     }
 }

--- a/src/ui/UpNextScreen.qml
+++ b/src/ui/UpNextScreen.qml
@@ -25,6 +25,7 @@ FocusScope {
     property int lastAudioIndex: -1
     property int lastSubtitleIndex: -1
     property bool autoplay: false
+    readonly property bool hasNextEpisode: episodeId !== "" && !episodeData.NoNextEpisode
     
     // Tell Main.qml's global ESC shortcut to skip this screen
     readonly property bool handlesOwnBackNavigation: true
@@ -63,10 +64,10 @@ FocusScope {
     }
 
     // ---- Countdown timer ----
-    property int countdown: autoplay
+    property int countdown: hasNextEpisode && autoplay
         ? Math.max(1, (typeof ConfigManager !== 'undefined' ? ConfigManager.autoplayCountdownSeconds : 10))
         : -1
-    readonly property bool countdownActive: autoplay && countdown > 0
+    readonly property bool countdownActive: hasNextEpisode && autoplay && countdown > 0
 
     Timer {
         id: countdownTimer
@@ -102,9 +103,18 @@ FocusScope {
         root.countdown = -1
     }
 
+    function returnToSeries() {
+        cancelCountdown()
+        moreEpisodesRequested()
+    }
+
     function focusPrimaryAction() {
         Qt.callLater(function() {
-            thumbnailFocus.forceActiveFocus()
+            if (root.hasNextEpisode) {
+                thumbnailFocus.forceActiveFocus()
+            } else {
+                moreEpisodesBtn.forceActiveFocus()
+            }
         })
     }
 
@@ -169,7 +179,7 @@ FocusScope {
             Text {
                 anchors.left: parent.left
                 anchors.verticalCenter: parent.verticalCenter
-                visible: root.autoplay && root.countdown > 0
+                visible: root.hasNextEpisode && root.autoplay && root.countdown > 0
                 text: qsTr("Next episode in %1").arg(root.countdown)
                 font.pixelSize: Theme.fontSizeHeader
                 font.family: Theme.fontPrimary
@@ -180,7 +190,7 @@ FocusScope {
             Text {
                 anchors.left: parent.left
                 anchors.verticalCenter: parent.verticalCenter
-                visible: root.autoplay && root.countdown <= 0 && root.countdown !== -1
+                visible: root.hasNextEpisode && root.autoplay && root.countdown <= 0 && root.countdown !== -1
                 text: qsTr("Starting…")
                 font.pixelSize: Theme.fontSizeHeader
                 font.family: Theme.fontPrimary
@@ -191,8 +201,8 @@ FocusScope {
             Text {
                 anchors.left: parent.left
                 anchors.verticalCenter: parent.verticalCenter
-                visible: !root.autoplay || root.countdown === -1
-                text: qsTr("Up Next")
+                visible: !root.hasNextEpisode || !root.autoplay || root.countdown === -1
+                text: root.hasNextEpisode ? qsTr("Up Next") : qsTr("No Next Episode")
                 font.pixelSize: Theme.fontSizeHeader
                 font.family: Theme.fontPrimary
                 font.weight: Font.Bold
@@ -209,6 +219,7 @@ FocusScope {
             // Episode thumbnail card (focusable – acts as Play button)
             FocusScope {
                 id: thumbnailFocus
+                visible: root.hasNextEpisode
                 Layout.preferredWidth: Math.min(root.width * 0.45, Math.round(800 * Theme.layoutScale))
                 Layout.preferredHeight: Layout.preferredWidth * 9 / 16
                 Layout.alignment: Qt.AlignVCenter
@@ -359,7 +370,7 @@ FocusScope {
 
                 // Series name
                 Text {
-                    visible: root.seriesName !== ""
+                    visible: root.hasNextEpisode && root.seriesName !== ""
                     text: root.seriesName
                     font.pixelSize: Theme.fontSizeMedium
                     font.family: Theme.fontPrimary
@@ -371,6 +382,7 @@ FocusScope {
 
                 // Episode identifier
                 Text {
+                    visible: root.hasNextEpisode
                     text: {
                         var prefix = "S" + root.seasonNumber + " E" + root.episodeNumber
                         if (root.episodeNumber === 0) prefix = "Special"
@@ -389,6 +401,7 @@ FocusScope {
 
                 // Metadata row: runtime, rating, year
                 RowLayout {
+                    visible: root.hasNextEpisode
                     spacing: Theme.spacingMedium
 
                     Text {
@@ -422,7 +435,7 @@ FocusScope {
 
                 // Overview
                 Text {
-                    visible: root.overview !== ""
+                    visible: root.hasNextEpisode && root.overview !== ""
                     text: root.overview
                     font.pixelSize: Theme.fontSizeBody
                     font.family: Theme.fontPrimary
@@ -433,6 +446,29 @@ FocusScope {
                     elide: Text.ElideRight
                     lineHeight: 1.2
                     Layout.topMargin: Theme.spacingSmall
+                }
+
+                Text {
+                    visible: !root.hasNextEpisode
+                    text: qsTr("There isn't another unwatched episode available right now.")
+                    font.pixelSize: Theme.fontSizeTitle
+                    font.family: Theme.fontPrimary
+                    font.bold: true
+                    color: Theme.textPrimary
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
+                    maximumLineCount: 3
+                }
+
+                Text {
+                    visible: !root.hasNextEpisode
+                    text: qsTr("You can return to the series or head back home.")
+                    font.pixelSize: Theme.fontSizeBody
+                    font.family: Theme.fontPrimary
+                    color: Theme.textSecondary
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
+                    maximumLineCount: 2
                 }
 
                 Item { Layout.fillHeight: true }
@@ -452,7 +488,7 @@ FocusScope {
                 Layout.preferredWidth: Math.round(240 * Theme.layoutScale)
                 focusPolicy: Qt.StrongFocus
 
-                KeyNavigation.up: thumbnailFocus
+                KeyNavigation.up: root.hasNextEpisode ? thumbnailFocus : moreEpisodesBtn
                 KeyNavigation.right: moreEpisodesBtn
 
                 Keys.onReturnPressed: function(event) {
@@ -509,7 +545,7 @@ FocusScope {
                 Layout.preferredWidth: Math.round(260 * Theme.layoutScale)
                 focusPolicy: Qt.StrongFocus
 
-                KeyNavigation.up: thumbnailFocus
+                KeyNavigation.up: root.hasNextEpisode ? thumbnailFocus : backToHomeBtn
                 KeyNavigation.left: backToHomeBtn
 
                 Keys.onReturnPressed: function(event) {
@@ -551,7 +587,7 @@ FocusScope {
                         color: Theme.textPrimary
                     }
                     Text {
-                        text: qsTr("More Episodes")
+                        text: root.hasNextEpisode ? qsTr("More Episodes") : qsTr("Back to Series")
                         font.pixelSize: Theme.fontSizeBody
                         font.family: Theme.fontPrimary
                         color: Theme.textPrimary
@@ -563,10 +599,13 @@ FocusScope {
         }
     }
 
-    // ESC cancels countdown and navigates to episode list
+    // ESC/Back cancels countdown and navigates to episode list or series.
     Keys.onEscapePressed: function(event) {
-        cancelCountdown()
-        moreEpisodesRequested()
+        returnToSeries()
+        event.accepted = true
+    }
+    Keys.onBackPressed: function(event) {
+        returnToSeries()
         event.accepted = true
     }
 

--- a/src/ui/WindowManager.cpp
+++ b/src/ui/WindowManager.cpp
@@ -13,6 +13,7 @@
 #include "viewmodels/LibraryViewModel.h"
 #include "viewmodels/SeriesDetailsViewModel.h"
 #include "viewmodels/MovieDetailsViewModel.h"
+#include "viewmodels/UpNextRecommendationsViewModel.h"
 #include "network/AuthenticationService.h"
 #include "network/LibraryService.h"
 #include "network/PlaybackService.h"
@@ -147,6 +148,7 @@ void WindowManager::exposeContextProperties(ApplicationInitializer& appInit)
     context->setContextProperty("LibraryViewModel", ServiceLocator::get<LibraryViewModel>());
     context->setContextProperty("SeriesDetailsViewModel", ServiceLocator::get<SeriesDetailsViewModel>());
     context->setContextProperty("MovieDetailsViewModel", ServiceLocator::get<MovieDetailsViewModel>());
+    context->setContextProperty("UpNextRecommendationsViewModel", ServiceLocator::get<UpNextRecommendationsViewModel>());
     context->setContextProperty("ThemeSongManager", ServiceLocator::get<ThemeSongManager>());
     context->setContextProperty("InputModeManager", ServiceLocator::get<InputModeManager>());
     context->setContextProperty("SidebarSettings", ServiceLocator::get<SidebarSettings>());

--- a/src/viewmodels/UpNextRecommendationsViewModel.cpp
+++ b/src/viewmodels/UpNextRecommendationsViewModel.cpp
@@ -1,0 +1,321 @@
+#include "UpNextRecommendationsViewModel.h"
+
+#include "core/ServiceLocator.h"
+#include "network/LibraryService.h"
+#include "network/SeerrService.h"
+
+#include <QRegularExpression>
+#include <QVariantMap>
+#include <QDebug>
+
+UpNextRecommendationsViewModel::UpNextRecommendationsViewModel(QObject *parent)
+    : QObject(parent)
+{
+    m_libraryService = ServiceLocator::tryGet<LibraryService>();
+    m_seerrService = ServiceLocator::tryGet<SeerrService>();
+
+    if (m_libraryService) {
+        connect(m_libraryService, &LibraryService::similarItemsLoaded,
+                this, &UpNextRecommendationsViewModel::onSimilarItemsLoaded);
+        connect(m_libraryService, &LibraryService::similarItemsFailed,
+                this, &UpNextRecommendationsViewModel::onSimilarItemsFailed);
+        connect(m_libraryService, &LibraryService::seriesDetailsLoaded,
+                this, &UpNextRecommendationsViewModel::onSeriesDetailsLoaded);
+        connect(m_libraryService, &LibraryService::seriesDetailsNotModified,
+                this, &UpNextRecommendationsViewModel::onSeriesDetailsNotModified);
+        connect(m_libraryService, &LibraryService::errorOccurred,
+                this, &UpNextRecommendationsViewModel::onLibraryErrorOccurred);
+    } else {
+        qWarning() << "UpNextRecommendationsViewModel: LibraryService not available";
+    }
+
+    if (m_seerrService) {
+        connect(m_seerrService, &SeerrService::similarResultsLoaded,
+                this, &UpNextRecommendationsViewModel::onSeerrSimilarResultsLoaded);
+        connect(m_seerrService, &SeerrService::similarResultsFailed,
+                this, &UpNextRecommendationsViewModel::onSeerrSimilarResultsFailed);
+    }
+}
+
+QVariantList UpNextRecommendationsViewModel::items() const
+{
+    QVariantList list;
+    list.reserve(m_jellyfinItems.size() + m_seerrItems.size());
+    const QJsonArray merged = mergeRecommendations(m_jellyfinItems, m_seerrItems, m_limit);
+    for (const QJsonValue &value : merged) {
+        list.append(value.toObject().toVariantMap());
+    }
+    return list;
+}
+
+void UpNextRecommendationsViewModel::loadForSeries(const QString &seriesId, int limit)
+{
+    if (seriesId.trimmed().isEmpty() || !m_libraryService) {
+        clear();
+        return;
+    }
+
+    if (m_seriesId == seriesId && m_loading) {
+        return;
+    }
+
+    resetRequestState(seriesId, limit);
+    setLoading(true);
+
+    m_waitingForJellyfin = true;
+    m_libraryService->getSimilarItems(m_seriesId, m_limit);
+
+    m_waitingForSeriesDetails = true;
+    m_libraryService->getSeriesDetails(m_seriesId);
+}
+
+void UpNextRecommendationsViewModel::clear()
+{
+    const bool hadItems = !m_jellyfinItems.isEmpty() || !m_seerrItems.isEmpty();
+    m_seriesId.clear();
+    m_limit = 6;
+    m_pendingSeerrTmdbId = -1;
+    m_jellyfinItems = {};
+    m_seerrItems = {};
+    m_waitingForJellyfin = false;
+    m_waitingForSeriesDetails = false;
+    m_waitingForSeerr = false;
+    setLoading(false);
+    if (hadItems) {
+        emit itemsChanged();
+    }
+}
+
+QJsonArray UpNextRecommendationsViewModel::mergeRecommendations(const QJsonArray &jellyfinItems,
+                                                                const QJsonArray &seerrItems,
+                                                                int limit)
+{
+    QJsonArray merged;
+    QSet<QString> seen;
+    const int cappedLimit = qMax(0, limit);
+
+    const auto appendSeries = [&merged, &seen, cappedLimit](const QJsonArray &items) {
+        for (const QJsonValue &value : items) {
+            if (cappedLimit > 0 && merged.size() >= cappedLimit) {
+                return;
+            }
+
+            const QJsonObject item = value.toObject();
+            if (!isSeriesItem(item)) {
+                continue;
+            }
+
+            const QString key = dedupeKey(item);
+            if (!key.isEmpty() && seen.contains(key)) {
+                continue;
+            }
+
+            if (!key.isEmpty()) {
+                seen.insert(key);
+            }
+            merged.append(item);
+        }
+    };
+
+    appendSeries(jellyfinItems);
+    appendSeries(seerrItems);
+    return merged;
+}
+
+bool UpNextRecommendationsViewModel::isSeriesItem(const QJsonObject &item)
+{
+    const QString type = item.value(QStringLiteral("Type")).toString();
+    const QString seerrType = item.value(QStringLiteral("SeerrMediaType")).toString().toLower();
+    return type.compare(QStringLiteral("Series"), Qt::CaseInsensitive) == 0
+        || seerrType == QStringLiteral("tv");
+}
+
+QString UpNextRecommendationsViewModel::dedupeKey(const QJsonObject &item)
+{
+    const QJsonObject providerIds = item.value(QStringLiteral("ProviderIds")).toObject();
+    const QString tmdb = providerIds.value(QStringLiteral("Tmdb")).toVariant().toString().trimmed();
+    if (!tmdb.isEmpty()) {
+        return QStringLiteral("tmdb:%1").arg(tmdb);
+    }
+
+    const QString imdb = providerIds.value(QStringLiteral("Imdb")).toVariant().toString().trimmed().toLower();
+    if (!imdb.isEmpty()) {
+        return QStringLiteral("imdb:%1").arg(imdb);
+    }
+
+    const int seerrTmdb = item.value(QStringLiteral("SeerrTmdbId")).toInt(-1);
+    if (seerrTmdb > 0) {
+        return QStringLiteral("tmdb:%1").arg(seerrTmdb);
+    }
+
+    const QString title = normalizedTitle(item.value(QStringLiteral("Name")).toString());
+    if (title.isEmpty()) {
+        return {};
+    }
+
+    const int year = itemYear(item);
+    return QStringLiteral("title:%1:%2").arg(title).arg(year > 0 ? QString::number(year) : QString());
+}
+
+QString UpNextRecommendationsViewModel::normalizedTitle(const QString &title)
+{
+    QString normalized = title.toLower().trimmed();
+    normalized.replace(QRegularExpression(QStringLiteral("[^\\p{L}\\p{N}]+")), QStringLiteral(" "));
+    normalized = normalized.simplified();
+    return normalized;
+}
+
+int UpNextRecommendationsViewModel::itemYear(const QJsonObject &item)
+{
+    const int productionYear = item.value(QStringLiteral("ProductionYear")).toInt(0);
+    if (productionYear > 0) {
+        return productionYear;
+    }
+
+    const QString premiereDate = item.value(QStringLiteral("PremiereDate")).toString();
+    bool ok = false;
+    const int year = premiereDate.left(4).toInt(&ok);
+    return ok ? year : 0;
+}
+
+void UpNextRecommendationsViewModel::setLoading(bool loading)
+{
+    if (m_loading == loading) {
+        return;
+    }
+    m_loading = loading;
+    emit loadingChanged();
+}
+
+void UpNextRecommendationsViewModel::finishProviderIfComplete()
+{
+    notifyItemsChanged();
+    if (!m_waitingForJellyfin && !m_waitingForSeriesDetails && !m_waitingForSeerr) {
+        setLoading(false);
+    }
+}
+
+void UpNextRecommendationsViewModel::notifyItemsChanged()
+{
+    emit itemsChanged();
+}
+
+void UpNextRecommendationsViewModel::resetRequestState(const QString &seriesId, int limit)
+{
+    m_seriesId = seriesId;
+    m_limit = qBound(1, limit, 24);
+    m_pendingSeerrTmdbId = -1;
+    m_jellyfinItems = {};
+    m_seerrItems = {};
+    m_waitingForJellyfin = false;
+    m_waitingForSeriesDetails = false;
+    m_waitingForSeerr = false;
+    emit itemsChanged();
+}
+
+void UpNextRecommendationsViewModel::requestSeerrSimilarIfPossible(const QJsonObject &seriesData)
+{
+    m_waitingForSeriesDetails = false;
+
+    if (!m_seerrService || !m_seerrService->isConfigured()) {
+        finishProviderIfComplete();
+        return;
+    }
+
+    const QJsonObject providerIds = seriesData.value(QStringLiteral("ProviderIds")).toObject();
+    bool ok = false;
+    const int tmdbId = providerIds.value(QStringLiteral("Tmdb")).toVariant().toString().toInt(&ok);
+    if (!ok || tmdbId <= 0) {
+        finishProviderIfComplete();
+        return;
+    }
+
+    m_pendingSeerrTmdbId = tmdbId;
+    m_waitingForSeerr = true;
+    m_seerrService->getSimilar(QStringLiteral("tv"), tmdbId, 1);
+    finishProviderIfComplete();
+}
+
+void UpNextRecommendationsViewModel::onSimilarItemsLoaded(const QString &itemId, const QJsonArray &items)
+{
+    if (itemId != m_seriesId || !m_waitingForJellyfin) {
+        return;
+    }
+
+    m_jellyfinItems = items;
+    m_waitingForJellyfin = false;
+    finishProviderIfComplete();
+}
+
+void UpNextRecommendationsViewModel::onSimilarItemsFailed(const QString &itemId, const QString &error)
+{
+    if (itemId != m_seriesId || !m_waitingForJellyfin) {
+        return;
+    }
+
+    qWarning() << "UpNextRecommendationsViewModel Jellyfin recommendations failed:" << error;
+    m_jellyfinItems = {};
+    m_waitingForJellyfin = false;
+    finishProviderIfComplete();
+}
+
+void UpNextRecommendationsViewModel::onSeriesDetailsLoaded(const QString &seriesId, const QJsonObject &seriesData)
+{
+    if (seriesId != m_seriesId || !m_waitingForSeriesDetails) {
+        return;
+    }
+
+    requestSeerrSimilarIfPossible(seriesData);
+}
+
+void UpNextRecommendationsViewModel::onSeriesDetailsNotModified(const QString &seriesId)
+{
+    if (seriesId != m_seriesId || !m_waitingForSeriesDetails) {
+        return;
+    }
+
+    m_waitingForSeriesDetails = false;
+    finishProviderIfComplete();
+}
+
+void UpNextRecommendationsViewModel::onSeerrSimilarResultsLoaded(const QString &mediaType,
+                                                                 int tmdbId,
+                                                                 const QJsonArray &results)
+{
+    if (!m_waitingForSeerr
+            || mediaType != QStringLiteral("tv")
+            || tmdbId != m_pendingSeerrTmdbId) {
+        return;
+    }
+
+    m_seerrItems = results;
+    m_waitingForSeerr = false;
+    finishProviderIfComplete();
+}
+
+void UpNextRecommendationsViewModel::onSeerrSimilarResultsFailed(const QString &mediaType,
+                                                                 int tmdbId,
+                                                                 const QString &error)
+{
+    if (!m_waitingForSeerr
+            || mediaType != QStringLiteral("tv")
+            || tmdbId != m_pendingSeerrTmdbId) {
+        return;
+    }
+
+    qWarning() << "UpNextRecommendationsViewModel Seerr recommendations failed:" << error;
+    m_seerrItems = {};
+    m_waitingForSeerr = false;
+    finishProviderIfComplete();
+}
+
+void UpNextRecommendationsViewModel::onLibraryErrorOccurred(const QString &endpoint, const QString &error)
+{
+    if (endpoint != QStringLiteral("getSeriesDetails") || !m_waitingForSeriesDetails) {
+        return;
+    }
+
+    qWarning() << "UpNextRecommendationsViewModel series details failed:" << error;
+    m_waitingForSeriesDetails = false;
+    finishProviderIfComplete();
+}

--- a/src/viewmodels/UpNextRecommendationsViewModel.cpp
+++ b/src/viewmodels/UpNextRecommendationsViewModel.cpp
@@ -23,6 +23,14 @@ UpNextRecommendationsViewModel::UpNextRecommendationsViewModel(QObject *parent)
                 this, &UpNextRecommendationsViewModel::onSeriesDetailsLoaded);
         connect(m_libraryService, &LibraryService::seriesDetailsNotModified,
                 this, &UpNextRecommendationsViewModel::onSeriesDetailsNotModified);
+        connect(m_libraryService,
+                qOverload<const QString &, const QJsonObject &, const QString &>(&LibraryService::itemLoaded),
+                this, &UpNextRecommendationsViewModel::onSeriesDetailsFallbackLoaded);
+        connect(m_libraryService,
+                qOverload<const QString &, const QString &>(&LibraryService::itemNotModified),
+                this, &UpNextRecommendationsViewModel::onSeriesDetailsFallbackNotModified);
+        connect(m_libraryService, &LibraryService::itemFailed,
+                this, &UpNextRecommendationsViewModel::onSeriesDetailsFallbackFailed);
         connect(m_libraryService, &LibraryService::errorOccurred,
                 this, &UpNextRecommendationsViewModel::onLibraryErrorOccurred);
     } else {
@@ -75,6 +83,7 @@ void UpNextRecommendationsViewModel::clear()
     m_seriesId.clear();
     m_limit = 6;
     m_pendingSeerrTmdbId = -1;
+    m_seriesDetailsFallbackContext.clear();
     m_jellyfinItems = {};
     m_seerrItems = {};
     m_waitingForJellyfin = false;
@@ -189,8 +198,8 @@ void UpNextRecommendationsViewModel::setLoading(bool loading)
 
 void UpNextRecommendationsViewModel::finishProviderIfComplete()
 {
-    notifyItemsChanged();
     if (!m_waitingForJellyfin && !m_waitingForSeriesDetails && !m_waitingForSeerr) {
+        notifyItemsChanged();
         setLoading(false);
     }
 }
@@ -205,6 +214,7 @@ void UpNextRecommendationsViewModel::resetRequestState(const QString &seriesId, 
     m_seriesId = seriesId;
     m_limit = qBound(1, limit, 24);
     m_pendingSeerrTmdbId = -1;
+    m_seriesDetailsFallbackContext.clear();
     m_jellyfinItems = {};
     m_seerrItems = {};
     m_waitingForJellyfin = false;
@@ -233,7 +243,28 @@ void UpNextRecommendationsViewModel::requestSeerrSimilarIfPossible(const QJsonOb
     m_pendingSeerrTmdbId = tmdbId;
     m_waitingForSeerr = true;
     m_seerrService->getSimilar(QStringLiteral("tv"), tmdbId, 1);
-    finishProviderIfComplete();
+}
+
+void UpNextRecommendationsViewModel::requestSeriesDetailsFallback()
+{
+    if (!m_libraryService || m_seriesId.isEmpty()) {
+        m_waitingForSeriesDetails = false;
+        finishProviderIfComplete();
+        return;
+    }
+
+    m_seriesDetailsFallbackContext = QStringLiteral("UpNextRecommendations:%1").arg(m_seriesId);
+    m_libraryService->clearItemCacheValidation(m_seriesId);
+    m_libraryService->getItem(m_seriesId, m_seriesDetailsFallbackContext);
+}
+
+bool UpNextRecommendationsViewModel::matchesSeriesDetailsFallback(const QString &itemId,
+                                                                  const QString &requestContext) const
+{
+    return m_waitingForSeriesDetails
+        && itemId == m_seriesId
+        && requestContext == m_seriesDetailsFallbackContext
+        && !m_seriesDetailsFallbackContext.isEmpty();
 }
 
 void UpNextRecommendationsViewModel::onSimilarItemsLoaded(const QString &itemId, const QJsonArray &items)
@@ -274,6 +305,44 @@ void UpNextRecommendationsViewModel::onSeriesDetailsNotModified(const QString &s
         return;
     }
 
+    requestSeriesDetailsFallback();
+}
+
+void UpNextRecommendationsViewModel::onSeriesDetailsFallbackLoaded(const QString &itemId,
+                                                                   const QJsonObject &itemData,
+                                                                   const QString &requestContext)
+{
+    if (!matchesSeriesDetailsFallback(itemId, requestContext)) {
+        return;
+    }
+
+    m_seriesDetailsFallbackContext.clear();
+    requestSeerrSimilarIfPossible(itemData);
+}
+
+void UpNextRecommendationsViewModel::onSeriesDetailsFallbackNotModified(const QString &itemId,
+                                                                        const QString &requestContext)
+{
+    if (!matchesSeriesDetailsFallback(itemId, requestContext)) {
+        return;
+    }
+
+    qWarning() << "UpNextRecommendationsViewModel series details fallback returned not modified";
+    m_seriesDetailsFallbackContext.clear();
+    m_waitingForSeriesDetails = false;
+    finishProviderIfComplete();
+}
+
+void UpNextRecommendationsViewModel::onSeriesDetailsFallbackFailed(const QString &itemId,
+                                                                   const QString &error,
+                                                                   const QString &requestContext)
+{
+    if (!matchesSeriesDetailsFallback(itemId, requestContext)) {
+        return;
+    }
+
+    qWarning() << "UpNextRecommendationsViewModel series details fallback failed:" << error;
+    m_seriesDetailsFallbackContext.clear();
     m_waitingForSeriesDetails = false;
     finishProviderIfComplete();
 }
@@ -311,7 +380,13 @@ void UpNextRecommendationsViewModel::onSeerrSimilarResultsFailed(const QString &
 
 void UpNextRecommendationsViewModel::onLibraryErrorOccurred(const QString &endpoint, const QString &error)
 {
-    if (endpoint != QStringLiteral("getSeriesDetails") || !m_waitingForSeriesDetails) {
+    if (!m_waitingForSeriesDetails || !m_seriesDetailsFallbackContext.isEmpty()) {
+        return;
+    }
+
+    const bool isSeriesDetailsError = endpoint == QStringLiteral("getSeriesDetails")
+        || endpoint.contains(QStringLiteral("/Items/%1").arg(m_seriesId));
+    if (!isSeriesDetailsError) {
         return;
     }
 

--- a/src/viewmodels/UpNextRecommendationsViewModel.cpp
+++ b/src/viewmodels/UpNextRecommendationsViewModel.cpp
@@ -105,7 +105,7 @@ QJsonArray UpNextRecommendationsViewModel::mergeRecommendations(const QJsonArray
 
     const auto appendSeries = [&merged, &seen, cappedLimit](const QJsonArray &items) {
         for (const QJsonValue &value : items) {
-            if (cappedLimit > 0 && merged.size() >= cappedLimit) {
+            if (merged.size() >= cappedLimit) {
                 return;
             }
 
@@ -384,8 +384,10 @@ void UpNextRecommendationsViewModel::onLibraryErrorOccurred(const QString &endpo
         return;
     }
 
+    const QRegularExpression seriesIdRegex(
+        QStringLiteral("/Items/%1(?:\\D|$)").arg(QRegularExpression::escape(m_seriesId)));
     const bool isSeriesDetailsError = endpoint == QStringLiteral("getSeriesDetails")
-        || endpoint.contains(QStringLiteral("/Items/%1").arg(m_seriesId));
+        || seriesIdRegex.match(endpoint).hasMatch();
     if (!isSeriesDetailsError) {
         return;
     }

--- a/src/viewmodels/UpNextRecommendationsViewModel.cpp
+++ b/src/viewmodels/UpNextRecommendationsViewModel.cpp
@@ -47,13 +47,18 @@ UpNextRecommendationsViewModel::UpNextRecommendationsViewModel(QObject *parent)
 
 QVariantList UpNextRecommendationsViewModel::items() const
 {
-    QVariantList list;
-    list.reserve(m_jellyfinItems.size() + m_seerrItems.size());
+    if (!m_itemsDirty) {
+        return m_cachedItems;
+    }
+
+    m_cachedItems.clear();
+    m_cachedItems.reserve(m_limit);
     const QJsonArray merged = mergeRecommendations(m_jellyfinItems, m_seerrItems, m_limit);
     for (const QJsonValue &value : merged) {
-        list.append(value.toObject().toVariantMap());
+        m_cachedItems.append(value.toObject().toVariantMap());
     }
-    return list;
+    m_itemsDirty = false;
+    return m_cachedItems;
 }
 
 void UpNextRecommendationsViewModel::loadForSeries(const QString &seriesId, int limit)
@@ -89,6 +94,8 @@ void UpNextRecommendationsViewModel::clear()
     m_waitingForJellyfin = false;
     m_waitingForSeriesDetails = false;
     m_waitingForSeerr = false;
+    m_itemsDirty = true;
+    m_cachedItems.clear();
     setLoading(false);
     if (hadItems) {
         emit itemsChanged();
@@ -168,8 +175,9 @@ QString UpNextRecommendationsViewModel::dedupeKey(const QJsonObject &item)
 
 QString UpNextRecommendationsViewModel::normalizedTitle(const QString &title)
 {
+    static const QRegularExpression kNonAlnumRegex(QStringLiteral("[^\\p{L}\\p{N}]+"));
     QString normalized = title.toLower().trimmed();
-    normalized.replace(QRegularExpression(QStringLiteral("[^\\p{L}\\p{N}]+")), QStringLiteral(" "));
+    normalized.replace(kNonAlnumRegex, QStringLiteral(" "));
     normalized = normalized.simplified();
     return normalized;
 }
@@ -206,6 +214,7 @@ void UpNextRecommendationsViewModel::finishProviderIfComplete()
 
 void UpNextRecommendationsViewModel::notifyItemsChanged()
 {
+    m_itemsDirty = true;
     emit itemsChanged();
 }
 
@@ -220,6 +229,8 @@ void UpNextRecommendationsViewModel::resetRequestState(const QString &seriesId, 
     m_waitingForJellyfin = false;
     m_waitingForSeriesDetails = false;
     m_waitingForSeerr = false;
+    m_itemsDirty = true;
+    m_cachedItems.clear();
     emit itemsChanged();
 }
 

--- a/src/viewmodels/UpNextRecommendationsViewModel.h
+++ b/src/viewmodels/UpNextRecommendationsViewModel.h
@@ -76,6 +76,8 @@ private:
     QJsonArray m_seerrItems;
     QString m_seriesId;
     QString m_seriesDetailsFallbackContext;
+    mutable QVariantList m_cachedItems;
+    mutable bool m_itemsDirty = true;
     int m_limit = 6;
     int m_pendingSeerrTmdbId = -1;
     bool m_loading = false;

--- a/src/viewmodels/UpNextRecommendationsViewModel.h
+++ b/src/viewmodels/UpNextRecommendationsViewModel.h
@@ -45,6 +45,13 @@ private slots:
     void onSimilarItemsFailed(const QString &itemId, const QString &error);
     void onSeriesDetailsLoaded(const QString &seriesId, const QJsonObject &seriesData);
     void onSeriesDetailsNotModified(const QString &seriesId);
+    void onSeriesDetailsFallbackLoaded(const QString &itemId,
+                                       const QJsonObject &itemData,
+                                       const QString &requestContext);
+    void onSeriesDetailsFallbackNotModified(const QString &itemId, const QString &requestContext);
+    void onSeriesDetailsFallbackFailed(const QString &itemId,
+                                       const QString &error,
+                                       const QString &requestContext);
     void onSeerrSimilarResultsLoaded(const QString &mediaType, int tmdbId, const QJsonArray &results);
     void onSeerrSimilarResultsFailed(const QString &mediaType, int tmdbId, const QString &error);
     void onLibraryErrorOccurred(const QString &endpoint, const QString &error);
@@ -60,12 +67,15 @@ private:
     void finishProviderIfComplete();
     void resetRequestState(const QString &seriesId, int limit);
     void requestSeerrSimilarIfPossible(const QJsonObject &seriesData);
+    void requestSeriesDetailsFallback();
+    bool matchesSeriesDetailsFallback(const QString &itemId, const QString &requestContext) const;
 
     LibraryService *m_libraryService = nullptr;
     SeerrService *m_seerrService = nullptr;
     QJsonArray m_jellyfinItems;
     QJsonArray m_seerrItems;
     QString m_seriesId;
+    QString m_seriesDetailsFallbackContext;
     int m_limit = 6;
     int m_pendingSeerrTmdbId = -1;
     bool m_loading = false;

--- a/src/viewmodels/UpNextRecommendationsViewModel.h
+++ b/src/viewmodels/UpNextRecommendationsViewModel.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <QObject>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QSet>
+#include <QVariantList>
+
+class LibraryService;
+class SeerrService;
+
+/**
+ * @brief Loads post-playback TV-series recommendations for the no-next-episode state.
+ *
+ * Jellyfin similar series are preferred because they are immediately available in the
+ * local library. Seerr results are appended as discovery/request options when a TMDB
+ * id can be resolved from the source series details.
+ */
+class UpNextRecommendationsViewModel : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QVariantList items READ items NOTIFY itemsChanged)
+    Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+
+public:
+    explicit UpNextRecommendationsViewModel(QObject *parent = nullptr);
+
+    QVariantList items() const;
+    bool loading() const { return m_loading; }
+
+    Q_INVOKABLE void loadForSeries(const QString &seriesId, int limit = 6);
+    Q_INVOKABLE void clear();
+
+    static QJsonArray mergeRecommendations(const QJsonArray &jellyfinItems,
+                                           const QJsonArray &seerrItems,
+                                           int limit);
+
+signals:
+    void itemsChanged();
+    void loadingChanged();
+
+private slots:
+    void onSimilarItemsLoaded(const QString &itemId, const QJsonArray &items);
+    void onSimilarItemsFailed(const QString &itemId, const QString &error);
+    void onSeriesDetailsLoaded(const QString &seriesId, const QJsonObject &seriesData);
+    void onSeriesDetailsNotModified(const QString &seriesId);
+    void onSeerrSimilarResultsLoaded(const QString &mediaType, int tmdbId, const QJsonArray &results);
+    void onSeerrSimilarResultsFailed(const QString &mediaType, int tmdbId, const QString &error);
+    void onLibraryErrorOccurred(const QString &endpoint, const QString &error);
+
+private:
+    static bool isSeriesItem(const QJsonObject &item);
+    static QString dedupeKey(const QJsonObject &item);
+    static QString normalizedTitle(const QString &title);
+    static int itemYear(const QJsonObject &item);
+
+    void notifyItemsChanged();
+    void setLoading(bool loading);
+    void finishProviderIfComplete();
+    void resetRequestState(const QString &seriesId, int limit);
+    void requestSeerrSimilarIfPossible(const QJsonObject &seriesData);
+
+    LibraryService *m_libraryService = nullptr;
+    SeerrService *m_seerrService = nullptr;
+    QJsonArray m_jellyfinItems;
+    QJsonArray m_seerrItems;
+    QString m_seriesId;
+    int m_limit = 6;
+    int m_pendingSeerrTmdbId = -1;
+    bool m_loading = false;
+    bool m_waitingForJellyfin = false;
+    bool m_waitingForSeriesDetails = false;
+    bool m_waitingForSeerr = false;
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,10 @@ add_executable(SeriesDetailsCacheTest
     ${CMAKE_SOURCE_DIR}/src/utils/DetailViewCache.cpp
 )
 
-target_include_directories(SeriesDetailsCacheTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(SeriesDetailsCacheTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
 
 target_link_libraries(SeriesDetailsCacheTest
     PRIVATE
@@ -117,7 +120,10 @@ add_executable(PlayerControllerAutoplayContextTest
     ${CMAKE_SOURCE_DIR}/src/utils/DisplayManager.cpp
 )
 
-target_include_directories(PlayerControllerAutoplayContextTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(PlayerControllerAutoplayContextTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
 
 target_compile_definitions(PlayerControllerAutoplayContextTest PRIVATE BLOOM_TESTING=1)
 
@@ -206,7 +212,10 @@ add_executable(SimilarItemsRetryTest
     ${CMAKE_SOURCE_DIR}/src/test/TestModeController.cpp
 )
 
-target_include_directories(SimilarItemsRetryTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(SimilarItemsRetryTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
 
 target_link_libraries(SimilarItemsRetryTest
     PRIVATE
@@ -217,6 +226,33 @@ target_link_libraries(SimilarItemsRetryTest
 )
 
 add_test(NAME SimilarItemsRetryTest COMMAND SimilarItemsRetryTest)
+
+add_executable(UpNextRecommendationsViewModelTest
+    UpNextRecommendationsViewModelTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/viewmodels/UpNextRecommendationsViewModel.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/ServiceLocator.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/SeerrService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/ConfigManager.cpp
+)
+
+target_include_directories(UpNextRecommendationsViewModelTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+target_link_libraries(UpNextRecommendationsViewModelTest
+    PRIVATE
+        Qt6::Core
+        Qt6::Concurrent
+        Qt6::Network
+        Qt6::Test
+)
+
+add_test(NAME UpNextRecommendationsViewModelTest COMMAND UpNextRecommendationsViewModelTest)
 
 add_executable(UpdateServiceTest
     UpdateServiceTest.cpp
@@ -327,6 +363,7 @@ qt_add_executable(VisualRegressionTest
     ${CMAKE_SOURCE_DIR}/src/viewmodels/LibraryViewModel.cpp
     ${CMAKE_SOURCE_DIR}/src/viewmodels/SeriesDetailsViewModel.cpp
     ${CMAKE_SOURCE_DIR}/src/viewmodels/MovieDetailsViewModel.cpp
+    ${CMAKE_SOURCE_DIR}/src/viewmodels/UpNextRecommendationsViewModel.cpp
     ${CMAKE_SOURCE_DIR}/src/viewmodels/BaseViewModel.cpp
     # Test mode sources
     ${CMAKE_SOURCE_DIR}/src/test/TestModeController.cpp

--- a/tests/UpNextRecommendationsViewModelTest.cpp
+++ b/tests/UpNextRecommendationsViewModelTest.cpp
@@ -2,6 +2,63 @@
 
 #include "../src/viewmodels/UpNextRecommendationsViewModel.h"
 #include "../src/core/ServiceLocator.h"
+#include "../src/network/LibraryService.h"
+
+class UpNextTestLibraryService : public LibraryService
+{
+    Q_OBJECT
+
+public:
+    explicit UpNextTestLibraryService(QObject *parent = nullptr)
+        : LibraryService(nullptr, parent)
+    {
+    }
+
+    void getSimilarItems(const QString &itemId, int limit = 12) override
+    {
+        Q_UNUSED(limit)
+        similarRequests.append(itemId);
+        emit similarItemsLoaded(itemId, similarItems);
+    }
+
+    void getSeriesDetails(const QString &seriesId) override
+    {
+        seriesDetailsRequests.append(seriesId);
+        if (emitNotModifiedForSeriesDetails) {
+            emit seriesDetailsNotModified(seriesId);
+            return;
+        }
+        if (emitPathErrorForSeriesDetails) {
+            emit errorOccurred(QStringLiteral("/Users/user-1/Items/%1?Fields=ProviderIds").arg(seriesId),
+                               QStringLiteral("timeout"));
+            return;
+        }
+        emit seriesDetailsLoaded(seriesId, seriesDetails);
+    }
+
+    void getItem(const QString &itemId, const QString &requestContext) override
+    {
+        itemRequests.append(itemId);
+        itemRequestContexts.append(requestContext);
+        emit itemLoaded(itemId, fallbackItem, requestContext);
+    }
+
+    void clearItemCacheValidation(const QString &itemId) override
+    {
+        clearedItemCacheIds.append(itemId);
+    }
+
+    QJsonArray similarItems;
+    QJsonObject seriesDetails;
+    QJsonObject fallbackItem;
+    QStringList similarRequests;
+    QStringList seriesDetailsRequests;
+    QStringList itemRequests;
+    QStringList itemRequestContexts;
+    QStringList clearedItemCacheIds;
+    bool emitNotModifiedForSeriesDetails = false;
+    bool emitPathErrorForSeriesDetails = false;
+};
 
 class UpNextRecommendationsViewModelTest : public QObject
 {
@@ -14,6 +71,8 @@ private slots:
     void duplicateTitlesCollapseToJellyfinItem();
     void resultCountIsCapped();
     void unavailableProvidersLeaveEmptyNotLoading();
+    void seriesDetailsNotModifiedUsesFallbackItem();
+    void seriesDetailsPathErrorClearsLoading();
 };
 
 void UpNextRecommendationsViewModelTest::cleanup()
@@ -95,6 +154,38 @@ void UpNextRecommendationsViewModelTest::unavailableProvidersLeaveEmptyNotLoadin
     vm.loadForSeries(QStringLiteral("series-1"), 6);
 
     QVERIFY(vm.items().isEmpty());
+    QVERIFY(!vm.loading());
+}
+
+void UpNextRecommendationsViewModelTest::seriesDetailsNotModifiedUsesFallbackItem()
+{
+    auto *libraryService = new UpNextTestLibraryService(this);
+    libraryService->emitNotModifiedForSeriesDetails = true;
+    libraryService->fallbackItem = QJsonObject{
+        {"Id", "series-1"},
+        {"Type", "Series"},
+        {"ProviderIds", QJsonObject{{"Tmdb", "1234"}}}
+    };
+    ServiceLocator::registerService<LibraryService>(libraryService);
+
+    UpNextRecommendationsViewModel vm;
+    vm.loadForSeries(QStringLiteral("series-1"), 6);
+
+    QCOMPARE(libraryService->clearedItemCacheIds, QStringList{QStringLiteral("series-1")});
+    QCOMPARE(libraryService->itemRequests, QStringList{QStringLiteral("series-1")});
+    QVERIFY(libraryService->itemRequestContexts.first().startsWith(QStringLiteral("UpNextRecommendations:")));
+    QVERIFY(!vm.loading());
+}
+
+void UpNextRecommendationsViewModelTest::seriesDetailsPathErrorClearsLoading()
+{
+    auto *libraryService = new UpNextTestLibraryService(this);
+    libraryService->emitPathErrorForSeriesDetails = true;
+    ServiceLocator::registerService<LibraryService>(libraryService);
+
+    UpNextRecommendationsViewModel vm;
+    vm.loadForSeries(QStringLiteral("series-1"), 6);
+
     QVERIFY(!vm.loading());
 }
 

--- a/tests/UpNextRecommendationsViewModelTest.cpp
+++ b/tests/UpNextRecommendationsViewModelTest.cpp
@@ -1,0 +1,102 @@
+#include <QtTest/QtTest>
+
+#include "../src/viewmodels/UpNextRecommendationsViewModel.h"
+#include "../src/core/ServiceLocator.h"
+
+class UpNextRecommendationsViewModelTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void cleanup();
+    void jellyfinResultsAppearBeforeSeerrResults();
+    void nonSeriesResultsAreFiltered();
+    void duplicateTitlesCollapseToJellyfinItem();
+    void resultCountIsCapped();
+    void unavailableProvidersLeaveEmptyNotLoading();
+};
+
+void UpNextRecommendationsViewModelTest::cleanup()
+{
+    ServiceLocator::clear();
+}
+
+void UpNextRecommendationsViewModelTest::jellyfinResultsAppearBeforeSeerrResults()
+{
+    const QJsonArray jellyfin{
+        QJsonObject{{"Id", "jf-1"}, {"Type", "Series"}, {"Name", "Local First"}}
+    };
+    const QJsonArray seerr{
+        QJsonObject{{"Id", "seerr:tv:2"}, {"Source", "Seerr"}, {"SeerrMediaType", "tv"}, {"Name", "Discovery Second"}}
+    };
+
+    const QJsonArray merged = UpNextRecommendationsViewModel::mergeRecommendations(jellyfin, seerr, 6);
+
+    QCOMPARE(merged.size(), 2);
+    QCOMPARE(merged.at(0).toObject().value("Id").toString(), QStringLiteral("jf-1"));
+    QCOMPARE(merged.at(1).toObject().value("Id").toString(), QStringLiteral("seerr:tv:2"));
+}
+
+void UpNextRecommendationsViewModelTest::nonSeriesResultsAreFiltered()
+{
+    const QJsonArray jellyfin{
+        QJsonObject{{"Id", "movie-1"}, {"Type", "Movie"}, {"Name", "A Movie"}},
+        QJsonObject{{"Id", "series-1"}, {"Type", "Series"}, {"Name", "A Series"}}
+    };
+    const QJsonArray seerr{
+        QJsonObject{{"Id", "seerr:movie:1"}, {"Source", "Seerr"}, {"SeerrMediaType", "movie"}, {"Name", "A Seerr Movie"}},
+        QJsonObject{{"Id", "seerr:tv:1"}, {"Source", "Seerr"}, {"SeerrMediaType", "tv"}, {"Name", "A Seerr Series"}}
+    };
+
+    const QJsonArray merged = UpNextRecommendationsViewModel::mergeRecommendations(jellyfin, seerr, 6);
+
+    QCOMPARE(merged.size(), 2);
+    QCOMPARE(merged.at(0).toObject().value("Id").toString(), QStringLiteral("series-1"));
+    QCOMPARE(merged.at(1).toObject().value("Id").toString(), QStringLiteral("seerr:tv:1"));
+}
+
+void UpNextRecommendationsViewModelTest::duplicateTitlesCollapseToJellyfinItem()
+{
+    const QJsonArray jellyfin{
+        QJsonObject{{"Id", "jf-1"}, {"Type", "Series"}, {"Name", "Same Show"}, {"ProductionYear", 2020}}
+    };
+    const QJsonArray seerr{
+        QJsonObject{{"Id", "seerr:tv:10"}, {"Source", "Seerr"}, {"SeerrMediaType", "tv"}, {"Name", "Same Show!"}, {"ProductionYear", 2020}}
+    };
+
+    const QJsonArray merged = UpNextRecommendationsViewModel::mergeRecommendations(jellyfin, seerr, 6);
+
+    QCOMPARE(merged.size(), 1);
+    QCOMPARE(merged.at(0).toObject().value("Id").toString(), QStringLiteral("jf-1"));
+}
+
+void UpNextRecommendationsViewModelTest::resultCountIsCapped()
+{
+    QJsonArray jellyfin;
+    for (int i = 0; i < 8; ++i) {
+        jellyfin.append(QJsonObject{
+            {"Id", QStringLiteral("jf-%1").arg(i)},
+            {"Type", "Series"},
+            {"Name", QStringLiteral("Series %1").arg(i)}
+        });
+    }
+
+    const QJsonArray merged = UpNextRecommendationsViewModel::mergeRecommendations(jellyfin, {}, 6);
+
+    QCOMPARE(merged.size(), 6);
+    QCOMPARE(merged.at(5).toObject().value("Id").toString(), QStringLiteral("jf-5"));
+}
+
+void UpNextRecommendationsViewModelTest::unavailableProvidersLeaveEmptyNotLoading()
+{
+    ServiceLocator::clear();
+    UpNextRecommendationsViewModel vm;
+
+    vm.loadForSeries(QStringLiteral("series-1"), 6);
+
+    QVERIFY(vm.items().isEmpty());
+    QVERIFY(!vm.loading());
+}
+
+QTEST_MAIN(UpNextRecommendationsViewModelTest)
+#include "UpNextRecommendationsViewModelTest.moc"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle missing next episode in Up Next screen with series recommendations
> - When `PlayerController` loads no next episode, it now emits `navigateToNextEpisode` with a `NoNextEpisode=true` payload instead of silently clearing state.
> - `UpNextScreen` gains a `hasNextEpisode` gate: autoplay countdown, episode fields, and play logic are suppressed when there is no next episode; the secondary button becomes "Back to Series" and ESC returns to the series.
> - Introduces `UpNextRecommendationsViewModel` which merges Jellyfin similar-series and Seerr similar-TV results (up to 6 items, deduplicated by TMDB/IMDB id or normalized title/year) and exposes them to QML; provider failures are silent.
> - `SeriesSeasonEpisodeView` defers episode refresh until next-episode resolution completes, then restores focus and selection state.
> - The `onNavigateToNextEpisode` handler in `Main.qml` routes "More episodes" to the series details screen when no next episode exists and handles `recommendationSelected` to open a recommended series.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cca6081.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Up Next shows up to six series recommendations when no next unwatched episode exists, merging Jellyfin then Seerr results.
  * Recommendations are navigable from the Up Next screen and can navigate to series details.

* **User Experience**
  * Up Next remains focusable with tailored messaging when no next episode; Back/ESC and autoplay cancellation behavior improved.

* **Documentation**
  * Playback and Seerr integration docs updated to reflect new Up Next and backend behaviors.

* **Tests**
  * Unit tests added for recommendation merging and view-model behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->