### PR TITLE
feat(home): split Continue Watching from Next Up with merge setting

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -34,6 +34,7 @@ Config API sample (high level)
 - `defaultAudioTrackSelection` and `defaultSubtitleTrackSelection` are Q_PROPERTY strings stored at `settings.playback.default_audio_track_selection` and `settings.playback.default_subtitle_track_selection`. Defaults are `jellyfin-default`. Valid values are `jellyfin-default`, `file-default`, supported language codes such as `eng`/`jpn`/`spa`, and subtitle-only `off` or `forced`.
 - `playbackVolume` and `playbackMuted` persist the last playback volume/mute state across app restarts (`settings.playback.playback_volume`, `settings.playback.playback_muted`).
 - `autoplayCountdownSeconds` drives the countdown shown before autoplay launches the next episode; the default is 10 seconds and disabling autoplay simply skips the timer.
+- `mergeContinueWatchingWithNextUp` controls Home row grouping (default false): when false, in-progress episodes render in a separate **Continue Watching** row above **Next Up**; when true they are merged back into **Next Up**.
 - `uiSoundsEnabled` / `uiSoundsVolume` keep the remote/keyboard navigation sounds available (default on at level 3) or let you mute them without touching the media volume slider.
 - `performanceModeEnabled` allows the player backend to trim VRAM more aggressively when true (default false).
 - `seerrBaseUrl` and `seerrApiKey` persist Seerr/Jellyseerr connection details (`settings.seerr.base_url`, `settings.seerr.api_key`).

--- a/src/ui/HomeScreen.qml
+++ b/src/ui/HomeScreen.qml
@@ -13,6 +13,8 @@ FocusScope {
 
     property var librariesModel: []
     property var nextUpModel: []
+    property var continueWatchingModel: []
+    property var displayedNextUpModel: []
     property var recentlyAddedMap: ({}) // Map of libraryId -> items array
     // Home card sizing — dynamically fills row based on visible-items breakpoint
     property int homeCardWidth: Math.round((parent.width - Theme.paddingLarge * 2 - Theme.spacingMedium * (Theme.homeRowVisibleItems - 1)) / Theme.homeRowVisibleItems)
@@ -75,13 +77,16 @@ FocusScope {
     }
 
     function hydrateBackdropFallbackFromSections() {
-        for (var i = 0; i < nextUpModel.length; i++) {
-            addBackdropCandidate(nextUpModel[i])
+        for (var i = 0; i < continueWatchingModel.length; i++) {
+            addBackdropCandidate(continueWatchingModel[i])
+        }
+        for (var j = 0; j < displayedNextUpModel.length; j++) {
+            addBackdropCandidate(displayedNextUpModel[j])
         }
         for (var key in recentlyAddedMap) {
             var items = recentlyAddedMap[key] || []
-            for (var j = 0; j < items.length; j++) {
-                addBackdropCandidate(items[j])
+            for (var k = 0; k < items.length; k++) {
+                addBackdropCandidate(items[k])
             }
         }
         if (backdropCandidates.length > 0) {
@@ -160,6 +165,7 @@ FocusScope {
 
     // Breakpoint focus restoration state
     property int savedMyMediaIndex: -1
+    property int savedContinueWatchingIndex: -1
     property int savedNextUpIndex: -1
     property int savedRecentlyAddedIndex: -1
     property string savedRecentlyAddedLibraryId: ""
@@ -177,6 +183,7 @@ FocusScope {
         target: ResponsiveLayoutManager
         function onBreakpointChanged() {
             if (myMediaList.activeFocus) savedMyMediaIndex = myMediaList.currentIndex
+            if (continueWatchingList.activeFocus) savedContinueWatchingIndex = continueWatchingList.currentIndex
             if (nextUpList.activeFocus) savedNextUpIndex = nextUpList.currentIndex
             // Check if a recentlyAddedList has focus and save its state
             for (var i = 0; i < recentlyAddedRepeater.count; i++) {
@@ -196,6 +203,10 @@ FocusScope {
             myMediaList.currentIndex = savedMyMediaIndex
             myMediaList.positionViewAtIndex(savedMyMediaIndex, ListView.Contain)
             myMediaList.forceActiveFocus()
+        } else if (savedContinueWatchingIndex >= 0 && savedContinueWatchingIndex < continueWatchingList.count) {
+            continueWatchingList.currentIndex = savedContinueWatchingIndex
+            continueWatchingList.positionViewAtIndex(savedContinueWatchingIndex, ListView.Contain)
+            continueWatchingList.forceActiveFocus()
         } else if (savedNextUpIndex >= 0 && savedNextUpIndex < nextUpList.count) {
             nextUpList.currentIndex = savedNextUpIndex
             nextUpList.positionViewAtIndex(savedNextUpIndex, ListView.Contain)
@@ -216,6 +227,7 @@ FocusScope {
             }
         }
         savedMyMediaIndex = -1
+        savedContinueWatchingIndex = -1
         savedNextUpIndex = -1
         savedRecentlyAddedIndex = -1
         savedRecentlyAddedLibraryId = ""
@@ -230,6 +242,9 @@ FocusScope {
         if (myMediaList.activeFocus) {
             section = "myMedia"
             index = myMediaList.currentIndex
+        } else if (continueWatchingList.activeFocus) {
+            section = "continueWatching"
+            index = continueWatchingList.currentIndex
         } else if (nextUpList.activeFocus) {
             section = "nextUp"
             index = nextUpList.currentIndex
@@ -264,6 +279,9 @@ FocusScope {
         if (lastFocusedSection === "myMedia") {
             targetList = myMediaList
             targetSection = myMediaSection
+        } else if (lastFocusedSection === "continueWatching") {
+            targetList = continueWatchingList
+            targetSection = continueWatchingSection
         } else if (lastFocusedSection === "nextUp") {
             targetList = nextUpList
             targetSection = nextUpSection
@@ -705,7 +723,10 @@ FocusScope {
                         }
                     }
                     Keys.onDownPressed: {
-                        if (nextUpModel.length > 0) {
+                        if (continueWatchingModel.length > 0) {
+                            console.log("[FocusDebug] myMediaList Down -> continueWatchingList")
+                            continueWatchingList.forceActiveFocus()
+                        } else if (displayedNextUpModel.length > 0) {
                             console.log("[FocusDebug] myMediaList Down -> nextUpList")
                             nextUpList.forceActiveFocus()
                         } else if (recentlyAddedRepeater.count > 0) {
@@ -725,12 +746,46 @@ FocusScope {
                 }
             }
             
+            ColumnLayout {
+                id: continueWatchingSection
+                Layout.fillWidth: true
+                spacing: Theme.spacingMedium
+                visible: continueWatchingModel.length > 0 && !ConfigManager.mergeContinueWatchingWithNextUp
+
+                Text {
+                    text: "Continue Watching"
+                    font.pixelSize: Theme.fontSizeHeader
+                    font.family: Theme.fontPrimary
+                    font.bold: true
+                    color: Theme.textPrimary
+                    leftPadding: Theme.paddingLarge
+                }
+
+                ListView {
+                    id: continueWatchingList
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: homeCardHeight + Theme.spacingLarge * 2
+                    orientation: ListView.Horizontal
+                    spacing: Theme.spacingMedium
+                    leftMargin: Theme.paddingLarge
+                    rightMargin: Theme.paddingLarge
+                    model: continueWatchingModel
+                    delegate: nextUpList.delegate
+                    Keys.onUpPressed: myMediaList.forceActiveFocus()
+                    Keys.onDownPressed: {
+                        if (displayedNextUpModel.length > 0) nextUpList.forceActiveFocus()
+                    }
+                    onCurrentIndexChanged: root.ensureListItemVisible(continueWatchingList)
+                    onActiveFocusChanged: if (activeFocus) root.ensureSectionVisible(continueWatchingSection)
+                }
+            }
+
             // Next Up Section
             ColumnLayout {
                 id: nextUpSection
                 Layout.fillWidth: true
                 spacing: Theme.spacingMedium
-                visible: nextUpModel.length > 0
+                visible: displayedNextUpModel.length > 0
                 
                 Text {
                     text: "Next Up"
@@ -789,13 +844,13 @@ FocusScope {
                         NumberAnimation { properties: "x,y"; duration: Theme.uiAnimationsEnabled ? Theme.durationNormal : 0; easing.type: Easing.OutCubic }
                     }
                     
-                    model: nextUpModel
+                    model: displayedNextUpModel
                     
                     delegate: Item {
                         id: nextUpDelegate
                         width: homeCardWidth
                         height: homeCardHeight + 60
-                        property bool isFocused: nextUpList.currentIndex === index && nextUpList.activeFocus
+                        property bool isFocused: ListView.view.currentIndex === index && ListView.view.activeFocus
                         property bool isHovered: InputModeManager.pointerActive && nextUpMouseArea.containsMouse
                         scale: isFocused ? 1.02 : (isHovered ? 1.01 : 1.0)
                         z: isFocused ? 1 : 0
@@ -951,8 +1006,8 @@ FocusScope {
                             anchors.fill: parent
                             hoverEnabled: true
                             onClicked: {
-                                nextUpList.currentIndex = index
-                                nextUpList.forceActiveFocus()
+                                ListView.view.currentIndex = index
+                                ListView.view.forceActiveFocus()
                                 handleNextUpSelection(modelData)
                             }
                         }
@@ -963,17 +1018,18 @@ FocusScope {
                     }
                     
                     Keys.onReturnPressed: {
-                        if (currentIndex >= 0 && currentIndex < nextUpModel.length) {
-                            handleNextUpSelection(nextUpModel[currentIndex])
+                        if (currentIndex >= 0 && currentIndex < displayedNextUpModel.length) {
+                            handleNextUpSelection(displayedNextUpModel[currentIndex])
                         }
                     }
                     Keys.onEnterPressed: {
-                        if (currentIndex >= 0 && currentIndex < nextUpModel.length) {
-                            handleNextUpSelection(nextUpModel[currentIndex])
+                        if (currentIndex >= 0 && currentIndex < displayedNextUpModel.length) {
+                            handleNextUpSelection(displayedNextUpModel[currentIndex])
                         }
                     }
                     Keys.onUpPressed: {
-                        myMediaList.forceActiveFocus()
+                        if (continueWatchingSection.visible) continueWatchingList.forceActiveFocus()
+                        else myMediaList.forceActiveFocus()
                     }
                     Keys.onDownPressed: {
                         if (recentlyAddedRepeater.count > 0) {
@@ -1279,7 +1335,7 @@ FocusScope {
                             }
                             Keys.onUpPressed: {
                                 if (libraryIndex === 0) {
-                                    if (nextUpModel.length > 0) nextUpList.forceActiveFocus()
+                                    if (nextUpModel.length > 0) ListView.view.forceActiveFocus()
                                     else myMediaList.forceActiveFocus()
                                 } else {
                                     for (var i = libraryIndex - 1; i >= 0; i--) {
@@ -1539,6 +1595,16 @@ FocusScope {
         
         function onNextUpLoaded(items) {
             nextUpModel = items
+            var inProgress = []
+            var nextItems = []
+            for (var i = 0; i < items.length; i++) {
+                var episode = items[i]
+                var pos = episode && episode.UserData ? (episode.UserData.PlaybackPositionTicks || 0) : 0
+                if (pos > 0) inProgress.push(episode)
+                else nextItems.push(episode)
+            }
+            continueWatchingModel = inProgress
+            displayedNextUpModel = ConfigManager.mergeContinueWatchingWithNextUp ? items : nextItems
             
             // Use section fallback only if global pool is unavailable.
             if (useSectionBackdropFallback && !globalBackdropPoolLoaded) {
@@ -1549,7 +1615,7 @@ FocusScope {
             
             // Restore focus if we had focus in Next Up section AND we're still the active screen
             Qt.callLater(function() {
-                if (lastFocusedSection === "nextUp" && root.StackView.status === StackView.Active) {
+                if ((lastFocusedSection === "nextUp" || lastFocusedSection === "continueWatching") && root.StackView.status === StackView.Active) {
                     restoreFocusState()
                 }
             })

--- a/src/ui/HomeScreen.qml
+++ b/src/ui/HomeScreen.qml
@@ -179,6 +179,30 @@ FocusScope {
         }
     }
 
+    function focusFirstVisibleRecentlyAddedList() {
+        for (var i = 0; i < recentlyAddedRepeater.count; i++) {
+            var meta = getRecentlyAddedDelegateMeta(i)
+            if (meta.item && meta.item.visible && meta.recentlyAddedListRef) {
+                meta.recentlyAddedListRef.forceActiveFocus()
+                return true
+            }
+        }
+        return false
+    }
+
+    function updateDisplayedNextUpModel() {
+        var inProgress = []
+        var nextItems = []
+        for (var i = 0; i < nextUpModel.length; i++) {
+            var episode = nextUpModel[i]
+            var pos = episode && episode.UserData ? (episode.UserData.PlaybackPositionTicks || 0) : 0
+            if (pos > 0) inProgress.push(episode)
+            else nextItems.push(episode)
+        }
+        continueWatchingModel = inProgress
+        displayedNextUpModel = ConfigManager.mergeContinueWatchingWithNextUp ? nextUpModel : nextItems
+    }
+
     Connections {
         target: ResponsiveLayoutManager
         function onBreakpointChanged() {
@@ -723,21 +747,14 @@ FocusScope {
                         }
                     }
                     Keys.onDownPressed: {
-                        if (continueWatchingModel.length > 0) {
+                        if (continueWatchingSection.visible) {
                             console.log("[FocusDebug] myMediaList Down -> continueWatchingList")
                             continueWatchingList.forceActiveFocus()
                         } else if (displayedNextUpModel.length > 0) {
                             console.log("[FocusDebug] myMediaList Down -> nextUpList")
                             nextUpList.forceActiveFocus()
                         } else if (recentlyAddedRepeater.count > 0) {
-                            // Find first visible recently added list
-                            for (var i = 0; i < recentlyAddedRepeater.count; i++) {
-                                var firstVisibleMeta = getRecentlyAddedDelegateMeta(i)
-                                if (firstVisibleMeta.item && firstVisibleMeta.item.visible && firstVisibleMeta.recentlyAddedListRef) {
-                                    firstVisibleMeta.recentlyAddedListRef.forceActiveFocus()
-                                    break
-                                }
-                            }
+                            focusFirstVisibleRecentlyAddedList()
                         }
                     }
 
@@ -774,6 +791,17 @@ FocusScope {
                     Keys.onUpPressed: myMediaList.forceActiveFocus()
                     Keys.onDownPressed: {
                         if (displayedNextUpModel.length > 0) nextUpList.forceActiveFocus()
+                        else focusFirstVisibleRecentlyAddedList()
+                    }
+                    Keys.onReturnPressed: {
+                        if (currentIndex >= 0 && currentIndex < continueWatchingModel.length) {
+                            handleNextUpSelection(continueWatchingModel[currentIndex])
+                        }
+                    }
+                    Keys.onEnterPressed: {
+                        if (currentIndex >= 0 && currentIndex < continueWatchingModel.length) {
+                            handleNextUpSelection(continueWatchingModel[currentIndex])
+                        }
                     }
                     onCurrentIndexChanged: root.ensureListItemVisible(continueWatchingList)
                     onActiveFocusChanged: if (activeFocus) root.ensureSectionVisible(continueWatchingSection)
@@ -1033,13 +1061,7 @@ FocusScope {
                     }
                     Keys.onDownPressed: {
                         if (recentlyAddedRepeater.count > 0) {
-                            for (var i = 0; i < recentlyAddedRepeater.count; i++) {
-                                var nextVisibleMeta = getRecentlyAddedDelegateMeta(i)
-                                if (nextVisibleMeta.item && nextVisibleMeta.item.visible && nextVisibleMeta.recentlyAddedListRef) {
-                                    nextVisibleMeta.recentlyAddedListRef.forceActiveFocus()
-                                    break
-                                }
-                            }
+                            focusFirstVisibleRecentlyAddedList()
                         }
                     }
 
@@ -1335,7 +1357,8 @@ FocusScope {
                             }
                             Keys.onUpPressed: {
                                 if (libraryIndex === 0) {
-                                    if (nextUpModel.length > 0) ListView.view.forceActiveFocus()
+                                    if (displayedNextUpModel.length > 0) nextUpList.forceActiveFocus()
+                                    else if (continueWatchingSection.visible) continueWatchingList.forceActiveFocus()
                                     else myMediaList.forceActiveFocus()
                                 } else {
                                     for (var i = libraryIndex - 1; i >= 0; i--) {
@@ -1595,16 +1618,7 @@ FocusScope {
         
         function onNextUpLoaded(items) {
             nextUpModel = items
-            var inProgress = []
-            var nextItems = []
-            for (var i = 0; i < items.length; i++) {
-                var episode = items[i]
-                var pos = episode && episode.UserData ? (episode.UserData.PlaybackPositionTicks || 0) : 0
-                if (pos > 0) inProgress.push(episode)
-                else nextItems.push(episode)
-            }
-            continueWatchingModel = inProgress
-            displayedNextUpModel = ConfigManager.mergeContinueWatchingWithNextUp ? items : nextItems
+            updateDisplayedNextUpModel()
             
             // Use section fallback only if global pool is unavailable.
             if (useSectionBackdropFallback && !globalBackdropPoolLoaded) {
@@ -1668,6 +1682,13 @@ FocusScope {
                 useSectionBackdropFallback = true
                 root.hydrateBackdropFallbackFromSections()
             }
+        }
+    }
+
+    Connections {
+        target: ConfigManager
+        function onMergeContinueWatchingWithNextUpChanged() {
+            updateDisplayedNextUpModel()
         }
     }
 

--- a/src/ui/settings/PlaybackSettings.qml
+++ b/src/ui/settings/PlaybackSettings.qml
@@ -232,7 +232,7 @@ FocusScope {
 
                         Keys.onUpPressed: function(event) {
                             if (!popup.visible) {
-                                autoplaySwitch.forceActiveFocus()
+                                mergeHomeRowsSwitch.forceActiveFocus()
                                 event.accepted = true
                             }
                         }
@@ -357,7 +357,7 @@ FocusScope {
                     ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
                     onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
 
-                    KeyNavigation.up: autoplayCountdownCombo.enabled ? autoplayCountdownCombo : autoplaySwitch
+                    KeyNavigation.up: autoplayCountdownCombo.enabled ? autoplayCountdownCombo : mergeHomeRowsSwitch
                     KeyNavigation.down: audioDelaySpinBox
 
                     onSliderValueChanged: function(newValue) {

--- a/src/ui/settings/PlaybackSettings.qml
+++ b/src/ui/settings/PlaybackSettings.qml
@@ -123,10 +123,27 @@ FocusScope {
                     ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
                     onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
 
-                    KeyNavigation.down: autoplayCountdownCombo.enabled ? autoplayCountdownCombo : thresholdSlider
+                    KeyNavigation.down: mergeHomeRowsSwitch
 
                     onToggled: function(value) {
                         ConfigManager.autoplayNextEpisode = value
+                    }
+                }
+
+                SettingsToggleRow {
+                    id: mergeHomeRowsSwitch
+                    label: qsTr("Merge Continue Watching with Next Up")
+                    description: qsTr("When enabled, in-progress episodes appear in the Next Up row instead of a separate Continue Watching section on Home")
+                    checked: ConfigManager.mergeContinueWatchingWithNextUp
+                    Layout.fillWidth: true
+                    ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
+                    onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
+
+                    KeyNavigation.up: autoplaySwitch
+                    KeyNavigation.down: autoplayCountdownCombo.enabled ? autoplayCountdownCombo : thresholdSlider
+
+                    onToggled: function(value) {
+                        ConfigManager.mergeContinueWatchingWithNextUp = value
                     }
                 }
 

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -1025,6 +1025,39 @@ bool ConfigManager::getAutoplayNextEpisode() const
     return true; // Default to enabled
 }
 
+void ConfigManager::setMergeContinueWatchingWithNextUp(bool enabled)
+{
+    if (enabled == getMergeContinueWatchingWithNextUp()) return;
+
+    QJsonObject settings;
+    if (m_config.contains("settings") && m_config["settings"].isObject()) {
+        settings = m_config["settings"].toObject();
+    }
+    QJsonObject playback;
+    if (settings.contains("playback") && settings["playback"].isObject()) {
+        playback = settings["playback"].toObject();
+    }
+    playback["merge_continue_watching_with_next_up"] = enabled;
+    settings["playback"] = playback;
+    m_config["settings"] = settings;
+    save();
+    emit mergeContinueWatchingWithNextUpChanged();
+}
+
+bool ConfigManager::getMergeContinueWatchingWithNextUp() const
+{
+    if (m_config.contains("settings") && m_config["settings"].isObject()) {
+        QJsonObject settings = m_config["settings"].toObject();
+        if (settings.contains("playback") && settings["playback"].isObject()) {
+            QJsonObject playback = settings["playback"].toObject();
+            if (playback.contains("merge_continue_watching_with_next_up")) {
+                return playback["merge_continue_watching_with_next_up"].toBool();
+            }
+        }
+    }
+    return false; // Default to separated sections
+}
+
 /**
  * @brief Set the autoplay countdown duration used before automatically playing the next episode.
  *

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -64,6 +64,7 @@ class ConfigManager : public QObject
     Q_PROPERTY(int playbackVolume READ getPlaybackVolume WRITE setPlaybackVolume NOTIFY playbackVolumeChanged)
     Q_PROPERTY(bool playbackMuted READ getPlaybackMuted WRITE setPlaybackMuted NOTIFY playbackMutedChanged)
     Q_PROPERTY(bool autoplayNextEpisode READ getAutoplayNextEpisode WRITE setAutoplayNextEpisode NOTIFY autoplayNextEpisodeChanged)
+    Q_PROPERTY(bool mergeContinueWatchingWithNextUp READ getMergeContinueWatchingWithNextUp WRITE setMergeContinueWatchingWithNextUp NOTIFY mergeContinueWatchingWithNextUpChanged)
     Q_PROPERTY(int autoplayCountdownSeconds READ getAutoplayCountdownSeconds WRITE setAutoplayCountdownSeconds NOTIFY autoplayCountdownSecondsChanged)
     Q_PROPERTY(bool autoSkipIntro READ getAutoSkipIntro WRITE setAutoSkipIntro NOTIFY autoSkipIntroChanged)
     Q_PROPERTY(bool autoSkipOutro READ getAutoSkipOutro WRITE setAutoSkipOutro NOTIFY autoSkipOutroChanged)
@@ -196,6 +197,8 @@ public:
     
     void setAutoplayNextEpisode(bool enabled);
     bool getAutoplayNextEpisode() const;
+    void setMergeContinueWatchingWithNextUp(bool enabled);
+    bool getMergeContinueWatchingWithNextUp() const;
     void setAutoplayCountdownSeconds(int seconds);
     int getAutoplayCountdownSeconds() const;
     void setAutoSkipIntro(bool enabled);
@@ -411,6 +414,7 @@ signals:
     void playbackVolumeChanged();
     void playbackMutedChanged();
     void autoplayNextEpisodeChanged();
+    void mergeContinueWatchingWithNextUpChanged();
     void autoplayCountdownSecondsChanged();
     void autoSkipIntroChanged();
     void autoSkipOutroChanged();


### PR DESCRIPTION
### Motivation
- Improve Home UX by surfacing in-progress episodes in their own "Continue Watching" row above "Next Up" so resumable content is more discoverable and the Next Up row only shows truly upcoming episodes.
- Provide a user preference to opt back into the merged behavior for users who prefer a single row (default: separated).

### Description
- Added a new persisted playback setting `mergeContinueWatchingWithNextUp` exposed as a `Q_PROPERTY` with getters/setters and change signal in `ConfigManager` (`src/utils/ConfigManager.h/.cpp`).
- Split Home data in `src/ui/HomeScreen.qml` into `continueWatchingModel` and `displayedNextUpModel`, deriving in-progress items from `UserData.PlaybackPositionTicks > 0`, and render a new `Continue Watching` section above `Next Up` that is hidden when empty; when merge is enabled the original combined list is shown under `Next Up`.
- Updated Home focus and navigation logic (save/restore indices, directional navigation) and backdrop fallback to include both continue-watching and next-up candidates to preserve existing backdrop behavior.
- Added a toggle in playback settings (`src/ui/settings/PlaybackSettings.qml`) and documented the new setting in `docs/config.md`.

### Testing
- Ran `git diff --check`, which reported trailing-whitespace warnings in `src/ui/HomeScreen.qml` that should be cleaned in a follow-up formatting pass (no runtime tests were executed in this rollout).
- Verified repository state with `git status --short` and committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd2ec36ac832d800d65aa3509da41)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Merge Continue Watching with Next Up" toggle in Playback Settings. Users can choose whether in-progress episodes appear in a separate Continue Watching row or are merged into the Next Up row (default: off).
  * Keyboard navigation updated so focus moves intuitively between related playback controls.

* **Documentation**
  * Settings documentation updated to describe the new option and default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split Continue Watching from Next Up on the home screen with a merge setting
> - Adds a new `continueWatchingModel` that filters items with playback progress out of `nextUpModel`, displaying them in a dedicated Continue Watching row above Next Up.
> - When `ConfigManager.mergeContinueWatchingWithNextUp` is `true`, the split is skipped and all items appear in Next Up as before; the setting defaults to `false`.
> - Exposes `mergeContinueWatchingWithNextUp` as a `Q_PROPERTY` in [`ConfigManager`](https://github.com/crowquillx/Bloom/pull/51/files#diff-48152b2fc5d7b898335f4323f6dd026e2711c29e4872ec7ae2694df36dbb2e82) and adds a toggle to [`PlaybackSettings.qml`](https://github.com/crowquillx/Bloom/pull/51/files#diff-102f755f3ebf40752ef46ce305238f5c5324ef9cacd668d6a8089ec92b1ee028).
> - Updates all keyboard navigation paths in [`HomeScreen.qml`](https://github.com/crowquillx/Bloom/pull/51/files#diff-0be0e12a1b7c703bf4ddd884c64b49fd0d92fdd5129671cc412301a91c6787c8) (My Media ↓, Recently Added ↑, breakpoint changes, focus save/restore) to account for the new row.
> - Behavioral Change: homes screens with in-progress items will show a separate Continue Watching row by default; toggling the setting merges them back.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e984b20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->