### PR TITLE
feat: add media segment providers in app and support on server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ If unsure whether a change requires `AGENTS.md` or `docs/` updates, open an issu
 See also:
 - docs/build.md     — Build instructions for Linux, Docker, and Windows
 - docs/playback.md  — mpv and playback/reporting integration
+- docs/media-segments.md — External intro/recap/credits provider integration and precedence
 - docs/theme.md     — Theme.qml tokens and design system
 - docs/services.md  — ServiceLocator pattern & initialization order
 - docs/updates.md   — Windows updater flow, release manifests, channels, and notify-only behavior

--- a/config/app.example.json
+++ b/config/app.example.json
@@ -87,9 +87,7 @@
             "provider_order": [
                 "theintrodb",
                 "introdb"
-            ],
-            "theintrodb_api_key": "",
-            "introdb_api_key": ""
+            ]
         }
     }
 }

--- a/config/app.example.json
+++ b/config/app.example.json
@@ -1,5 +1,5 @@
 {
-    "version": 14,
+    "version": 19,
     "settings": {
         "mpv": {
             "path": "mpv",
@@ -81,6 +81,15 @@
         "seerr": {
             "base_url": "",
             "api_key": ""
+        },
+        "media_segments": {
+            "external_providers_enabled": true,
+            "provider_order": [
+                "theintrodb",
+                "introdb"
+            ],
+            "theintrodb_api_key": "",
+            "introdb_api_key": ""
         }
     }
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -38,7 +38,7 @@ Config API sample (high level)
 - `uiSoundsEnabled` / `uiSoundsVolume` keep the remote/keyboard navigation sounds available (default on at level 3) or let you mute them without touching the media volume slider.
 - `performanceModeEnabled` allows the player backend to trim VRAM more aggressively when true (default false).
 - `seerrBaseUrl` and `seerrApiKey` persist Seerr/Jellyseerr connection details (`settings.seerr.base_url`, `settings.seerr.api_key`).
-- `externalSegmentProvidersEnabled`, `theIntroDbApiKey`, `introDbApiKey`, and `mediaSegmentProviderOrder` persist external intro/recap/credits provider settings under `settings.media_segments`. Defaults: enabled, provider order `["theintrodb", "introdb"]`, empty API keys.
+- `externalSegmentProvidersEnabled` and `mediaSegmentProviderOrder` persist external intro/recap/credits provider settings under `settings.media_segments`. Defaults: enabled, provider order `["theintrodb", "introdb"]`. External provider reads are anonymous.
 
 MPV profile management
 - `settings.mpv_profiles` contains the base set of profiles (`Default`, `High Quality`, plus any user-created profiles) and their structured options (hwdec, interpolation, extra args).

--- a/docs/config.md
+++ b/docs/config.md
@@ -38,6 +38,7 @@ Config API sample (high level)
 - `uiSoundsEnabled` / `uiSoundsVolume` keep the remote/keyboard navigation sounds available (default on at level 3) or let you mute them without touching the media volume slider.
 - `performanceModeEnabled` allows the player backend to trim VRAM more aggressively when true (default false).
 - `seerrBaseUrl` and `seerrApiKey` persist Seerr/Jellyseerr connection details (`settings.seerr.base_url`, `settings.seerr.api_key`).
+- `externalSegmentProvidersEnabled`, `theIntroDbApiKey`, `introDbApiKey`, and `mediaSegmentProviderOrder` persist external intro/recap/credits provider settings under `settings.media_segments`. Defaults: enabled, provider order `["theintrodb", "introdb"]`, empty API keys.
 
 MPV profile management
 - `settings.mpv_profiles` contains the base set of profiles (`Default`, `High Quality`, plus any user-created profiles) and their structured options (hwdec, interpolation, extra args).

--- a/docs/media-segments.md
+++ b/docs/media-segments.md
@@ -1,0 +1,24 @@
+Media Segment Providers
+
+Overview
+- `PlaybackService::getMediaSegments()` is the only playback-facing entry point.
+- Jellyfin server segments are loaded first from Intro Skipper when available.
+- `MediaSegmentProviderService` can then query external providers and merge only missing segment types.
+
+Precedence
+- Jellyfin server segments always win for their type.
+- Provider order defaults to TheIntroDB, then IntroDB.
+- If Jellyfin provides an intro and TheIntroDB provides intro plus credits, Bloom keeps Jellyfin's intro and adds TheIntroDB credits.
+
+Provider parsing
+- TheIntroDB v2 uses `GET https://api.theintrodb.org/v2/media?tmdb_id=...`; TV requests also include `season` and `episode`. The configured API key is sent as `Authorization: Bearer ...`.
+- TheIntroDB segment arrays map `intro` to Intro, `recap` to Recap, `credits` to Outro, and `preview` to Preview. `start_ms: null` means zero; `end_ms: null` uses the item duration if known or the segment is dropped.
+- IntroDB uses `GET https://api.introdb.app/segments?imdb_id=...&season=...&episode=...`. Reads are anonymous. It maps `intro`, `recap`, and `outro` to Bloom segment types.
+- Invalid external segments are dropped when the end is missing, the end is not after the start, or a timestamp is negative.
+
+Adding a provider
+- Add request and parser code to `MediaSegmentProviderService`.
+- Normalize all times to `MediaSegmentInfo` ticks.
+- Set `source` to a stable lowercase provider id.
+- Add the provider id to `ConfigManager::getMediaSegmentProviderOrder()` defaults only when it is suitable as a default.
+- Add parser and merge tests in `MediaSegmentProviderServiceTest`.

--- a/docs/media-segments.md
+++ b/docs/media-segments.md
@@ -11,7 +11,7 @@ Precedence
 - If Jellyfin provides an intro and TheIntroDB provides intro plus credits, Bloom keeps Jellyfin's intro and adds TheIntroDB credits.
 
 Provider parsing
-- TheIntroDB v2 uses `GET https://api.theintrodb.org/v2/media?tmdb_id=...`; TV requests also include `season` and `episode`. The configured API key is sent as `Authorization: Bearer ...`.
+- TheIntroDB v2 uses `GET https://api.theintrodb.org/v2/media?tmdb_id=...`; TV requests also include `season` and `episode`. Reads are anonymous.
 - TheIntroDB segment arrays map `intro` to Intro, `recap` to Recap, `credits` to Outro, and `preview` to Preview. `start_ms: null` means zero; `end_ms: null` uses the item duration if known or the segment is dropped.
 - IntroDB uses `GET https://api.introdb.app/segments?imdb_id=...&season=...&episode=...`. Reads are anonymous. It maps `intro`, `recap`, and `outro` to Bloom segment types.
 - Invalid external segments are dropped when the end is missing, the end is not after the start, or a timestamp is negative.

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -205,6 +205,8 @@ UI Components for Track Selection
   - Intro/outro skip UX: transient "Skip Intro"/"Skip Credits" pop-up button auto-focuses when a segment window starts, then a compact persistent skip button remains available until that segment ends.
     - Popup timing is controlled by `ConfigManager.skipButtonAutoHideSeconds` (`settings.playback.skip_button_auto_hide_seconds`, range 0-120; 0 disables popup only). The popup is still dismissed as soon as the active intro/outro segment ends.
     - Optional automatic skip is controlled by `ConfigManager.autoSkipIntro` and `ConfigManager.autoSkipOutro`; each auto-skip applies at most once per playback item even if the user seeks back.
+    - Segment source precedence is Jellyfin server data first, then configured external providers. Server segments win per segment type; external providers may fill missing types such as recap, intro, credits, or preview.
+    - External provider order defaults to TheIntroDB then IntroDB. TheIntroDB requires a configured API key and TMDB metadata. IntroDB reads are anonymous and require series IMDb metadata plus season/episode numbers.
 
 Playback overlay metadata
 - `PlayerController` exposes `overlayTitle`, `overlaySubtitle`, `overlayBackdropUrl`, and `overlayLogoUrl` for the native overlay (header, buffering card, and backdrop).

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -206,7 +206,7 @@ UI Components for Track Selection
     - Popup timing is controlled by `ConfigManager.skipButtonAutoHideSeconds` (`settings.playback.skip_button_auto_hide_seconds`, range 0-120; 0 disables popup only). The popup is still dismissed as soon as the active intro/outro segment ends.
     - Optional automatic skip is controlled by `ConfigManager.autoSkipIntro` and `ConfigManager.autoSkipOutro`; each auto-skip applies at most once per playback item even if the user seeks back.
     - Segment source precedence is Jellyfin server data first, then configured external providers. Server segments win per segment type; external providers may fill missing types such as recap, intro, credits, or preview.
-    - External provider order defaults to TheIntroDB then IntroDB. TheIntroDB requires a configured API key and TMDB metadata. IntroDB reads are anonymous and require series IMDb metadata plus season/episode numbers.
+    - External provider order defaults to TheIntroDB then IntroDB. Reads are anonymous. TheIntroDB requires TMDB metadata; IntroDB requires series IMDb metadata plus season/episode numbers.
 
 Playback overlay metadata
 - `PlayerController` exposes `overlayTitle`, `overlaySubtitle`, `overlayBackdropUrl`, and `overlayLogoUrl` for the native overlay (header, buffering card, and backdrop).

--- a/docs/services.md
+++ b/docs/services.md
@@ -13,6 +13,7 @@ Key services
 - `AuthenticationService` — Login, logout, session persistence, token validation; owns shared `QNetworkAccessManager`.
 - `LibraryService` — Library views/items, series details, search, image/theme-song URLs.
 - `PlaybackService` — Playback reporting, stream info, media segments, trickplay URLs and info.
+- `MediaSegmentProviderService` — Fetches and normalizes external intro/recap/credits/preview markers from configured providers; used by `PlaybackService` after server segment lookup.
 - `SeerrService` — Seerr/Jellyseerr search integration, request-option loading, request submission, and similar-title provider endpoints.
 - `PlayerController` — Orchestrates playback using `IPlayerBackend` and services; owns `TrickplayProcessor`.
 - `TrickplayProcessor` — Uses `AuthenticationService` (network) + `PlaybackService` (tile URLs) to build trickplay binaries.
@@ -25,18 +26,19 @@ Initialization order (recommended)
 2. IPlayerBackend — created by `PlayerBackendFactory` (`win-libmpv` on Windows; platform-selected backend elsewhere).
 3. AuthenticationService — handles session management; provides shared `QNetworkAccessManager`.
 4. LibraryService — depends on AuthenticationService.
-5. PlaybackService — depends on AuthenticationService.
-6. SeerrService — depends on AuthenticationService + ConfigManager.
-7. TrackPreferencesManager — no service dependencies; loads versioned track preference state.
-8. PlayerController — depends on IPlayerBackend, ConfigManager, TrackPreferencesManager, DisplayManager, PlaybackService, LibraryService, AuthenticationService.
-9. TrickplayProcessor — created by PlayerController; uses AuthenticationService + PlaybackService.
-10. ThemeSongManager — depends on LibraryService, ConfigManager, PlayerController.
-11. InputModeManager — depends on QGuiApplication.
-12. ViewModels — e.g., LibraryViewModel, SeriesDetailsViewModel (depend on LibraryService).
-13. SidebarSettings — UI preference persistence for the shell/sidebar state.
-14. UiSoundController — depends on ConfigManager for UI sound settings.
-15. SessionManager — shared session reporting/coordination service.
-16. UpdateService — depends on ConfigManager and PlayerController, and owns the current update provider/applier wiring.
+5. MediaSegmentProviderService — depends on AuthenticationService + ConfigManager.
+6. PlaybackService — depends on AuthenticationService + ConfigManager + MediaSegmentProviderService.
+7. SeerrService — depends on AuthenticationService + ConfigManager.
+8. TrackPreferencesManager — no service dependencies; loads versioned track preference state.
+9. PlayerController — depends on IPlayerBackend, ConfigManager, TrackPreferencesManager, DisplayManager, PlaybackService, LibraryService, AuthenticationService.
+10. TrickplayProcessor — created by PlayerController; uses AuthenticationService + PlaybackService.
+11. ThemeSongManager — depends on LibraryService, ConfigManager, PlayerController.
+12. InputModeManager — depends on QGuiApplication.
+13. ViewModels — e.g., LibraryViewModel, SeriesDetailsViewModel (depend on LibraryService).
+14. SidebarSettings — UI preference persistence for the shell/sidebar state.
+15. UiSoundController — depends on ConfigManager for UI sound settings.
+16. SessionManager — shared session reporting/coordination service.
+17. UpdateService — depends on ConfigManager and PlayerController, and owns the current update provider/applier wiring.
 
 Usage
 - Register services at main startup using `ServiceLocator::registerService<T>(&instance);`.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,8 @@ qt_add_executable(Bloom
     network/NextEpisodeResolver.cpp
     network/PlaybackService.h
     network/PlaybackService.cpp
+    network/MediaSegmentProviderService.h
+    network/MediaSegmentProviderService.cpp
     network/SeerrService.h
     network/SeerrService.cpp
     network/Types.h

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -13,6 +13,7 @@
 #include "network/AuthenticationService.h"
 #include "network/LibraryService.h"
 #include "network/PlaybackService.h"
+#include "network/MediaSegmentProviderService.h"
 #include "network/SeerrService.h"
 #include "utils/InputModeManager.h"
 #include "viewmodels/LibraryViewModel.h"
@@ -164,7 +165,11 @@ void ApplicationInitializer::registerServices()
         ServiceLocator::registerService<LibraryService>(m_mockLibraryService.get());
         
         // 3.2 PlaybackService - Still use real service but with mock auth
-        m_playbackService = std::make_unique<PlaybackService>(m_mockAuthService.get());
+        m_mediaSegmentProviderService = std::make_unique<MediaSegmentProviderService>(m_mockAuthService.get(), m_configManager.get());
+        ServiceLocator::registerService<MediaSegmentProviderService>(m_mediaSegmentProviderService.get());
+        m_playbackService = std::make_unique<PlaybackService>(m_mockAuthService.get(),
+                                                              m_configManager.get(),
+                                                              m_mediaSegmentProviderService.get());
         ServiceLocator::registerService<PlaybackService>(m_playbackService.get());
         
         // 3.3 SeerrService - Third-party search/request integration
@@ -205,7 +210,11 @@ void ApplicationInitializer::registerServices()
         ServiceLocator::registerService<LibraryService>(m_libraryService.get());
         
         // 3.2 PlaybackService - Depends on AuthenticationService
-        m_playbackService = std::make_unique<PlaybackService>(m_authService.get());
+        m_mediaSegmentProviderService = std::make_unique<MediaSegmentProviderService>(m_authService.get(), m_configManager.get());
+        ServiceLocator::registerService<MediaSegmentProviderService>(m_mediaSegmentProviderService.get());
+        m_playbackService = std::make_unique<PlaybackService>(m_authService.get(),
+                                                              m_configManager.get(),
+                                                              m_mediaSegmentProviderService.get());
         ServiceLocator::registerService<PlaybackService>(m_playbackService.get());
         
         // 3.3 SeerrService - Depends on AuthenticationService + ConfigManager

--- a/src/core/ApplicationInitializer.h
+++ b/src/core/ApplicationInitializer.h
@@ -13,6 +13,7 @@ class SecretStore;
 class AuthenticationService;
 class LibraryService;
 class PlaybackService;
+class MediaSegmentProviderService;
 class SeerrService;
 class PlayerController;
 class ThemeSongManager;
@@ -101,6 +102,7 @@ private:
     std::unique_ptr<AuthenticationService> m_authService;
     std::unique_ptr<LibraryService> m_libraryService;
     std::unique_ptr<PlaybackService> m_playbackService;
+    std::unique_ptr<MediaSegmentProviderService> m_mediaSegmentProviderService;
     std::unique_ptr<SeerrService> m_seerrService;
     std::unique_ptr<PlayerController> m_playerController;
     std::unique_ptr<ThemeSongManager> m_themeSongManager;

--- a/src/network/MediaSegmentProviderService.cpp
+++ b/src/network/MediaSegmentProviderService.cpp
@@ -18,13 +18,18 @@ Q_LOGGING_CATEGORY(mediaSegmentProviders, "bloom.mediaSegments")
 
 namespace {
 constexpr double kTicksPerSecond = 10000000.0;
+constexpr int kProviderTransferTimeoutMs = 30000;
+
+const QSet<MediaSegmentType> kSupportedFillTypes = {
+    MediaSegmentType::Intro,
+    MediaSegmentType::Outro,
+    MediaSegmentType::Recap,
+    MediaSegmentType::Preview
+};
 
 bool isSupportedFillType(MediaSegmentType type)
 {
-    return type == MediaSegmentType::Intro
-        || type == MediaSegmentType::Outro
-        || type == MediaSegmentType::Recap
-        || type == MediaSegmentType::Preview;
+    return kSupportedFillTypes.contains(type);
 }
 
 QString normalizeProviderId(const QString &providerId)
@@ -133,6 +138,7 @@ void MediaSegmentProviderService::fetchTheIntroDbSegments(const MediaSegmentLook
     url.setQuery(query);
 
     QNetworkRequest request(url);
+    request.setTransferTimeout(kProviderTransferTimeoutMs);
     request.setRawHeader("Authorization", QStringLiteral("Bearer %1").arg(apiKey).toUtf8());
 
     QNetworkReply *reply = m_authService->networkManager()->get(request);
@@ -171,7 +177,14 @@ void MediaSegmentProviderService::fetchIntroDbSegments(const MediaSegmentLookupC
     query.addQueryItem(QStringLiteral("episode"), QString::number(context.episodeNumber));
     url.setQuery(query);
 
-    QNetworkReply *reply = m_authService->networkManager()->get(QNetworkRequest(url));
+    QNetworkRequest request(url);
+    request.setTransferTimeout(kProviderTransferTimeoutMs);
+    const QString apiKey = m_configManager ? m_configManager->getIntroDbApiKey().trimmed() : QString();
+    if (!apiKey.isEmpty()) {
+        request.setRawHeader("X-API-Key", apiKey.toUtf8());
+    }
+
+    QNetworkReply *reply = m_authService->networkManager()->get(request);
     connect(reply, &QNetworkReply::finished, this, [reply, context, callback, result]() mutable {
         reply->deleteLater();
         result.networkOk = reply->error() == QNetworkReply::NoError;
@@ -216,6 +229,7 @@ QList<MediaSegmentInfo> MediaSegmentProviderService::parseTheIntroDbSegments(con
             bool hasEnd = false;
             double startSeconds = secondsFromMillisecondsValue(segment.value(QStringLiteral("start_ms")), &hasStart);
             double endSeconds = secondsFromMillisecondsValue(segment.value(QStringLiteral("end_ms")), &hasEnd);
+            if (!hasStart && !hasEnd) continue;
             if (!hasStart) startSeconds = 0.0;
             if (!hasEnd && durationSeconds > 0.0) endSeconds = durationSeconds;
             if (!hasEnd && durationSeconds <= 0.0) continue;
@@ -283,7 +297,7 @@ bool MediaSegmentProviderService::hasMissingSupportedSegmentTypes(const QList<Me
     for (const MediaSegmentInfo &segment : segments) {
         if (isSupportedFillType(segment.type)) presentTypes.insert(segment.type);
     }
-    return presentTypes.size() < 4;
+    return presentTypes.size() < kSupportedFillTypes.size();
 }
 
 MediaSegmentInfo MediaSegmentProviderService::buildSegment(const MediaSegmentLookupContext &context,

--- a/src/network/MediaSegmentProviderService.cpp
+++ b/src/network/MediaSegmentProviderService.cpp
@@ -171,13 +171,6 @@ void MediaSegmentProviderService::fetchTheIntroDbSegments(const MediaSegmentLook
         return;
     }
 
-    const QString apiKey = m_configManager ? m_configManager->getTheIntroDbApiKey().trimmed() : QString();
-    if (apiKey.isEmpty()) {
-        qCDebug(mediaSegmentProviders) << "Skipping TheIntroDB media segments: API key is not configured";
-        callback(result);
-        return;
-    }
-
     QUrl url(QStringLiteral("https://api.theintrodb.org/v2/media"));
     QUrlQuery query;
     query.addQueryItem(QStringLiteral("tmdb_id"), context.tmdbId.trimmed());
@@ -190,7 +183,6 @@ void MediaSegmentProviderService::fetchTheIntroDbSegments(const MediaSegmentLook
 
     QNetworkRequest request(url);
     request.setTransferTimeout(kProviderTransferTimeoutMs);
-    request.setRawHeader("Authorization", QStringLiteral("Bearer %1").arg(apiKey).toUtf8());
 
     QNetworkReply *reply = m_authService->networkManager()->get(request);
     connect(reply, &QNetworkReply::finished, this, [reply, context, callback, result]() mutable {
@@ -230,10 +222,6 @@ void MediaSegmentProviderService::fetchIntroDbSegments(const MediaSegmentLookupC
 
     QNetworkRequest request(url);
     request.setTransferTimeout(kProviderTransferTimeoutMs);
-    const QString apiKey = m_configManager ? m_configManager->getIntroDbApiKey().trimmed() : QString();
-    if (!apiKey.isEmpty()) {
-        request.setRawHeader("X-API-Key", apiKey.toUtf8());
-    }
 
     QNetworkReply *reply = m_authService->networkManager()->get(request);
     connect(reply, &QNetworkReply::finished, this, [reply, context, callback, result]() mutable {

--- a/src/network/MediaSegmentProviderService.cpp
+++ b/src/network/MediaSegmentProviderService.cpp
@@ -1,0 +1,313 @@
+#include "MediaSegmentProviderService.h"
+
+#include "AuthenticationService.h"
+#include "../utils/ConfigManager.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonValue>
+#include <QLoggingCategory>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QSet>
+#include <QUrl>
+#include <QUrlQuery>
+
+Q_LOGGING_CATEGORY(mediaSegmentProviders, "bloom.mediaSegments")
+
+namespace {
+constexpr double kTicksPerSecond = 10000000.0;
+
+bool isSupportedFillType(MediaSegmentType type)
+{
+    return type == MediaSegmentType::Intro
+        || type == MediaSegmentType::Outro
+        || type == MediaSegmentType::Recap
+        || type == MediaSegmentType::Preview;
+}
+
+QString normalizeProviderId(const QString &providerId)
+{
+    return providerId.trimmed().toLower().remove(QLatin1Char('-')).remove(QLatin1Char('_'));
+}
+
+double secondsFromMillisecondsValue(const QJsonValue &value, bool *ok)
+{
+    if (value.isNull() || value.isUndefined()) {
+        *ok = false;
+        return 0.0;
+    }
+    *ok = true;
+    return value.toDouble() / 1000.0;
+}
+
+double secondsFromProviderObject(const QJsonObject &segment, const QString &secondsKey,
+                                 const QString &millisecondsKey, bool *ok)
+{
+    if (segment.contains(secondsKey) && !segment.value(secondsKey).isNull()) {
+        *ok = true;
+        return segment.value(secondsKey).toDouble();
+    }
+    return secondsFromMillisecondsValue(segment.value(millisecondsKey), ok);
+}
+}
+
+MediaSegmentProviderService::MediaSegmentProviderService(AuthenticationService *authService,
+                                                         ConfigManager *configManager,
+                                                         QObject *parent)
+    : QObject(parent)
+    , m_authService(authService)
+    , m_configManager(configManager)
+{
+}
+
+void MediaSegmentProviderService::fetchExternalSegments(const MediaSegmentLookupContext &context,
+                                                        const QList<MediaSegmentInfo> &existingSegments,
+                                                        SegmentsCallback callback)
+{
+    if (!m_configManager || !m_configManager->getExternalSegmentProvidersEnabled()
+        || !hasMissingSupportedSegmentTypes(existingSegments)) {
+        callback(existingSegments);
+        return;
+    }
+
+    fetchProviderAtIndex(context, existingSegments, m_configManager->getMediaSegmentProviderOrder(), 0, std::move(callback));
+}
+
+void MediaSegmentProviderService::fetchProviderAtIndex(const MediaSegmentLookupContext &context,
+                                                       const QList<MediaSegmentInfo> &currentSegments,
+                                                       const QStringList &providerOrder,
+                                                       int providerIndex,
+                                                       SegmentsCallback callback)
+{
+    if (providerIndex >= providerOrder.size() || !hasMissingSupportedSegmentTypes(currentSegments)) {
+        callback(currentSegments);
+        return;
+    }
+
+    const QString providerId = normalizeProviderId(providerOrder.at(providerIndex));
+    auto continueWith = [this, context, currentSegments, providerOrder, providerIndex, callback](const MediaSegmentProviderResult &result) mutable {
+        const QList<MediaSegmentInfo> merged = result.used
+            ? mergeSegmentsByType(currentSegments, result.segments)
+            : currentSegments;
+        fetchProviderAtIndex(context, merged, providerOrder, providerIndex + 1, std::move(callback));
+    };
+
+    if (providerId == QStringLiteral("theintrodb")) {
+        fetchTheIntroDbSegments(context, continueWith);
+    } else if (providerId == QStringLiteral("introdb")) {
+        fetchIntroDbSegments(context, continueWith);
+    } else {
+        qCDebug(mediaSegmentProviders) << "Skipping unknown media segment provider" << providerOrder.at(providerIndex);
+        continueWith(MediaSegmentProviderResult{providerId, {}, false, false});
+    }
+}
+
+void MediaSegmentProviderService::fetchTheIntroDbSegments(const MediaSegmentLookupContext &context,
+                                                          std::function<void(const MediaSegmentProviderResult&)> callback)
+{
+    MediaSegmentProviderResult result;
+    result.providerId = QStringLiteral("theintrodb");
+
+    if (!m_authService || !m_authService->networkManager() || context.tmdbId.trimmed().isEmpty()) {
+        callback(result);
+        return;
+    }
+
+    const QString apiKey = m_configManager ? m_configManager->getTheIntroDbApiKey().trimmed() : QString();
+    if (apiKey.isEmpty()) {
+        qCDebug(mediaSegmentProviders) << "Skipping TheIntroDB media segments: API key is not configured";
+        callback(result);
+        return;
+    }
+
+    QUrl url(QStringLiteral("https://api.theintrodb.org/v2/media"));
+    QUrlQuery query;
+    query.addQueryItem(QStringLiteral("tmdb_id"), context.tmdbId.trimmed());
+    if (context.type.compare(QStringLiteral("Episode"), Qt::CaseInsensitive) == 0
+        && context.seasonNumber > 0 && context.episodeNumber > 0) {
+        query.addQueryItem(QStringLiteral("season"), QString::number(context.seasonNumber));
+        query.addQueryItem(QStringLiteral("episode"), QString::number(context.episodeNumber));
+    }
+    url.setQuery(query);
+
+    QNetworkRequest request(url);
+    request.setRawHeader("Authorization", QStringLiteral("Bearer %1").arg(apiKey).toUtf8());
+
+    QNetworkReply *reply = m_authService->networkManager()->get(request);
+    connect(reply, &QNetworkReply::finished, this, [reply, context, callback, result]() mutable {
+        reply->deleteLater();
+        result.networkOk = reply->error() == QNetworkReply::NoError;
+        if (result.networkOk) {
+            const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+            if (doc.isObject()) {
+                result.segments = parseTheIntroDbSegments(doc.object(), context);
+                result.used = !result.segments.isEmpty();
+            }
+        }
+        callback(result);
+    });
+}
+
+void MediaSegmentProviderService::fetchIntroDbSegments(const MediaSegmentLookupContext &context,
+                                                       std::function<void(const MediaSegmentProviderResult&)> callback)
+{
+    MediaSegmentProviderResult result;
+    result.providerId = QStringLiteral("introdb");
+
+    if (!m_authService || !m_authService->networkManager()
+        || context.type.compare(QStringLiteral("Episode"), Qt::CaseInsensitive) != 0
+        || context.imdbId.trimmed().isEmpty()
+        || context.seasonNumber <= 0 || context.episodeNumber <= 0) {
+        callback(result);
+        return;
+    }
+
+    QUrl url(QStringLiteral("https://api.introdb.app/segments"));
+    QUrlQuery query;
+    query.addQueryItem(QStringLiteral("imdb_id"), context.imdbId.trimmed());
+    query.addQueryItem(QStringLiteral("season"), QString::number(context.seasonNumber));
+    query.addQueryItem(QStringLiteral("episode"), QString::number(context.episodeNumber));
+    url.setQuery(query);
+
+    QNetworkReply *reply = m_authService->networkManager()->get(QNetworkRequest(url));
+    connect(reply, &QNetworkReply::finished, this, [reply, context, callback, result]() mutable {
+        reply->deleteLater();
+        result.networkOk = reply->error() == QNetworkReply::NoError;
+        if (result.networkOk) {
+            const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+            if (doc.isObject()) {
+                result.segments = parseIntroDbSegments(doc.object(), context);
+                result.used = !result.segments.isEmpty();
+            }
+        }
+        callback(result);
+    });
+}
+
+QList<MediaSegmentInfo> MediaSegmentProviderService::parseTheIntroDbSegments(const QJsonObject &obj,
+                                                                             const MediaSegmentLookupContext &context)
+{
+    const struct Mapping { QString key; MediaSegmentType type; QString label; } mappings[] = {
+        {QStringLiteral("intro"), MediaSegmentType::Intro, QStringLiteral("Intro")},
+        {QStringLiteral("recap"), MediaSegmentType::Recap, QStringLiteral("Recap")},
+        {QStringLiteral("credits"), MediaSegmentType::Outro, QStringLiteral("Outro")},
+        {QStringLiteral("preview"), MediaSegmentType::Preview, QStringLiteral("Preview")}
+    };
+
+    QList<MediaSegmentInfo> segments;
+    const double durationSeconds = context.durationTicks > 0
+        ? static_cast<double>(context.durationTicks) / kTicksPerSecond
+        : 0.0;
+
+    for (const Mapping &mapping : mappings) {
+        const QJsonValue value = obj.value(mapping.key);
+        QJsonArray values;
+        if (value.isArray()) {
+            values = value.toArray();
+        } else if (value.isObject()) {
+            values.append(value);
+        }
+
+        for (const QJsonValue &entry : values) {
+            const QJsonObject segment = entry.toObject();
+            bool hasStart = false;
+            bool hasEnd = false;
+            double startSeconds = secondsFromMillisecondsValue(segment.value(QStringLiteral("start_ms")), &hasStart);
+            double endSeconds = secondsFromMillisecondsValue(segment.value(QStringLiteral("end_ms")), &hasEnd);
+            if (!hasStart) startSeconds = 0.0;
+            if (!hasEnd && durationSeconds > 0.0) endSeconds = durationSeconds;
+            if (!hasEnd && durationSeconds <= 0.0) continue;
+
+            const MediaSegmentInfo info = buildSegment(context, mapping.type, mapping.label, QStringLiteral("theintrodb"),
+                                                       startSeconds, endSeconds);
+            if (info.type != MediaSegmentType::Unknown) segments.append(info);
+        }
+    }
+
+    return segments;
+}
+
+QList<MediaSegmentInfo> MediaSegmentProviderService::parseIntroDbSegments(const QJsonObject &obj,
+                                                                          const MediaSegmentLookupContext &context)
+{
+    const struct Mapping { QString key; MediaSegmentType type; QString label; } mappings[] = {
+        {QStringLiteral("intro"), MediaSegmentType::Intro, QStringLiteral("Intro")},
+        {QStringLiteral("recap"), MediaSegmentType::Recap, QStringLiteral("Recap")},
+        {QStringLiteral("outro"), MediaSegmentType::Outro, QStringLiteral("Outro")}
+    };
+
+    QList<MediaSegmentInfo> segments;
+    for (const Mapping &mapping : mappings) {
+        const QJsonValue value = obj.value(mapping.key);
+        if (!value.isObject()) continue;
+
+        const QJsonObject segment = value.toObject();
+        bool hasStart = false;
+        bool hasEnd = false;
+        const double startSeconds = secondsFromProviderObject(segment, QStringLiteral("start_sec"),
+                                                              QStringLiteral("start_ms"), &hasStart);
+        const double endSeconds = secondsFromProviderObject(segment, QStringLiteral("end_sec"),
+                                                            QStringLiteral("end_ms"), &hasEnd);
+        if (!hasStart || !hasEnd) continue;
+
+        const MediaSegmentInfo info = buildSegment(context, mapping.type, mapping.label, QStringLiteral("introdb"),
+                                                   startSeconds, endSeconds,
+                                                   segment.value(QStringLiteral("confidence")).toDouble(),
+                                                   segment.value(QStringLiteral("submission_count")).toInt());
+        if (info.type != MediaSegmentType::Unknown) segments.append(info);
+    }
+    return segments;
+}
+
+QList<MediaSegmentInfo> MediaSegmentProviderService::mergeSegmentsByType(const QList<MediaSegmentInfo> &baseSegments,
+                                                                         const QList<MediaSegmentInfo> &candidateSegments)
+{
+    QList<MediaSegmentInfo> merged = baseSegments;
+    QSet<MediaSegmentType> presentTypes;
+    for (const MediaSegmentInfo &segment : baseSegments) {
+        if (isSupportedFillType(segment.type)) presentTypes.insert(segment.type);
+    }
+    for (const MediaSegmentInfo &segment : candidateSegments) {
+        if (!isSupportedFillType(segment.type) || presentTypes.contains(segment.type)) continue;
+        merged.append(segment);
+        presentTypes.insert(segment.type);
+    }
+    return merged;
+}
+
+bool MediaSegmentProviderService::hasMissingSupportedSegmentTypes(const QList<MediaSegmentInfo> &segments)
+{
+    QSet<MediaSegmentType> presentTypes;
+    for (const MediaSegmentInfo &segment : segments) {
+        if (isSupportedFillType(segment.type)) presentTypes.insert(segment.type);
+    }
+    return presentTypes.size() < 4;
+}
+
+MediaSegmentInfo MediaSegmentProviderService::buildSegment(const MediaSegmentLookupContext &context,
+                                                           MediaSegmentType type,
+                                                           const QString &typeString,
+                                                           const QString &source,
+                                                           double startSeconds,
+                                                           double endSeconds,
+                                                           double confidence,
+                                                           int submissionCount)
+{
+    MediaSegmentInfo info;
+    info.itemId = context.itemId;
+    info.type = type;
+    info.typeString = typeString;
+    info.source = source;
+    info.confidence = confidence;
+    info.submissionCount = submissionCount;
+
+    if (startSeconds < 0.0 || endSeconds <= startSeconds) {
+        return {};
+    }
+
+    info.startTicks = static_cast<qint64>(startSeconds * kTicksPerSecond);
+    info.endTicks = static_cast<qint64>(endSeconds * kTicksPerSecond);
+    return info;
+}

--- a/src/network/MediaSegmentProviderService.cpp
+++ b/src/network/MediaSegmentProviderService.cpp
@@ -32,6 +32,63 @@ bool isSupportedFillType(MediaSegmentType type)
     return kSupportedFillTypes.contains(type);
 }
 
+double parseClockOrNumberSeconds(const QString &raw, bool *ok)
+{
+    const QString value = raw.trimmed();
+    if (value.isEmpty()) {
+        *ok = false;
+        return 0.0;
+    }
+
+    const QStringList parts = value.split(QLatin1Char(':'));
+    if (parts.size() == 2 || parts.size() == 3) {
+        double totalSeconds = 0.0;
+        for (const QString &part : parts) {
+            bool partOk = false;
+            const double parsed = part.toDouble(&partOk);
+            if (!partOk || parsed < 0.0) {
+                *ok = false;
+                return 0.0;
+            }
+            totalSeconds = (totalSeconds * 60.0) + parsed;
+        }
+        *ok = true;
+        return totalSeconds;
+    }
+
+    bool numberOk = false;
+    const double seconds = value.toDouble(&numberOk);
+    *ok = numberOk;
+    return numberOk ? seconds : 0.0;
+}
+
+double secondsFromValue(const QJsonValue &value, bool milliseconds, bool *ok)
+{
+    if (value.isNull() || value.isUndefined()) {
+        *ok = false;
+        return 0.0;
+    }
+
+    if (value.isDouble()) {
+        *ok = true;
+        const double parsed = value.toDouble();
+        return milliseconds ? parsed / 1000.0 : parsed;
+    }
+
+    if (value.isString()) {
+        bool stringOk = false;
+        const double parsed = parseClockOrNumberSeconds(value.toString(), &stringOk);
+        *ok = stringOk;
+        if (!stringOk) return 0.0;
+        return milliseconds && !value.toString().contains(QLatin1Char(':'))
+            ? parsed / 1000.0
+            : parsed;
+    }
+
+    *ok = false;
+    return 0.0;
+}
+
 QString normalizeProviderId(const QString &providerId)
 {
     return providerId.trimmed().toLower().remove(QLatin1Char('-')).remove(QLatin1Char('_'));
@@ -39,20 +96,14 @@ QString normalizeProviderId(const QString &providerId)
 
 double secondsFromMillisecondsValue(const QJsonValue &value, bool *ok)
 {
-    if (value.isNull() || value.isUndefined()) {
-        *ok = false;
-        return 0.0;
-    }
-    *ok = true;
-    return value.toDouble() / 1000.0;
+    return secondsFromValue(value, true, ok);
 }
 
 double secondsFromProviderObject(const QJsonObject &segment, const QString &secondsKey,
                                  const QString &millisecondsKey, bool *ok)
 {
     if (segment.contains(secondsKey) && !segment.value(secondsKey).isNull()) {
-        *ok = true;
-        return segment.value(secondsKey).toDouble();
+        return secondsFromValue(segment.value(secondsKey), false, ok);
     }
     return secondsFromMillisecondsValue(segment.value(millisecondsKey), ok);
 }

--- a/src/network/MediaSegmentProviderService.h
+++ b/src/network/MediaSegmentProviderService.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "Types.h"
+
+#include <QJsonObject>
+#include <QList>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <functional>
+
+class AuthenticationService;
+class ConfigManager;
+
+struct MediaSegmentLookupContext
+{
+    QString itemId;
+    QString type;
+    QString seriesId;
+    QString imdbId;
+    QString tmdbId;
+    QString tvdbId;
+    int seasonNumber = -1;
+    int episodeNumber = -1;
+    qint64 durationTicks = 0;
+};
+
+struct MediaSegmentProviderResult
+{
+    QString providerId;
+    QList<MediaSegmentInfo> segments;
+    bool networkOk = false;
+    bool used = false;
+};
+
+class MediaSegmentProviderService : public QObject
+{
+    Q_OBJECT
+
+public:
+    using SegmentsCallback = std::function<void(const QList<MediaSegmentInfo>&)>;
+
+    explicit MediaSegmentProviderService(AuthenticationService *authService,
+                                         ConfigManager *configManager,
+                                         QObject *parent = nullptr);
+
+    void fetchExternalSegments(const MediaSegmentLookupContext &context,
+                               const QList<MediaSegmentInfo> &existingSegments,
+                               SegmentsCallback callback);
+
+    static QList<MediaSegmentInfo> parseTheIntroDbSegments(const QJsonObject &obj,
+                                                           const MediaSegmentLookupContext &context);
+    static QList<MediaSegmentInfo> parseIntroDbSegments(const QJsonObject &obj,
+                                                        const MediaSegmentLookupContext &context);
+    static QList<MediaSegmentInfo> mergeSegmentsByType(const QList<MediaSegmentInfo> &baseSegments,
+                                                       const QList<MediaSegmentInfo> &candidateSegments);
+    static bool hasMissingSupportedSegmentTypes(const QList<MediaSegmentInfo> &segments);
+
+private:
+    AuthenticationService *m_authService = nullptr;
+    ConfigManager *m_configManager = nullptr;
+
+    void fetchProviderAtIndex(const MediaSegmentLookupContext &context,
+                              const QList<MediaSegmentInfo> &currentSegments,
+                              const QStringList &providerOrder,
+                              int providerIndex,
+                              SegmentsCallback callback);
+    void fetchTheIntroDbSegments(const MediaSegmentLookupContext &context,
+                                 std::function<void(const MediaSegmentProviderResult&)> callback);
+    void fetchIntroDbSegments(const MediaSegmentLookupContext &context,
+                              std::function<void(const MediaSegmentProviderResult&)> callback);
+
+    static MediaSegmentInfo buildSegment(const MediaSegmentLookupContext &context,
+                                         MediaSegmentType type,
+                                         const QString &typeString,
+                                         const QString &source,
+                                         double startSeconds,
+                                         double endSeconds,
+                                         double confidence = 0.0,
+                                         int submissionCount = 0);
+};

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -306,6 +306,10 @@ void PlaybackService::maybeLoadExternalMediaSegments(const QString &itemId, cons
         return;
     }
 
+    if (!serverSegments.isEmpty()) {
+        finishMediaSegments(itemId, serverSegments);
+    }
+
     loadMediaSegmentLookupContext(itemId, serverSegments);
 }
 
@@ -342,9 +346,9 @@ void PlaybackService::loadMediaSegmentLookupContext(const QString &itemId, const
             if (!needsSeriesProviderIds) {
                 QPointer<PlaybackService> self(this);
                 m_mediaSegmentProviderService->fetchExternalSegments(context, serverSegments,
-                    [self, itemId](const QList<MediaSegmentInfo> &segments) {
+                    [self, itemId, serverSegments](const QList<MediaSegmentInfo> &segments) {
                         if (!self) return;
-                        self->finishMediaSegments(itemId, segments);
+                        self->finishExternalMediaSegments(itemId, serverSegments, segments);
                     });
                 return;
             }
@@ -365,9 +369,9 @@ void PlaybackService::loadMediaSegmentLookupContext(const QString &itemId, const
 
                     QPointer<PlaybackService> self(this);
                     m_mediaSegmentProviderService->fetchExternalSegments(context, serverSegments,
-                        [self, itemId](const QList<MediaSegmentInfo> &segments) {
+                        [self, itemId, serverSegments](const QList<MediaSegmentInfo> &segments) {
                             if (!self) return;
-                            self->finishMediaSegments(itemId, segments);
+                            self->finishExternalMediaSegments(itemId, serverSegments, segments);
                         });
                 },
                 [this, context, serverSegments, itemId]() mutable {
@@ -375,15 +379,26 @@ void PlaybackService::loadMediaSegmentLookupContext(const QString &itemId, const
                                              << "- external segment lookup may be incomplete";
                     QPointer<PlaybackService> self(this);
                     m_mediaSegmentProviderService->fetchExternalSegments(context, serverSegments,
-                        [self, itemId](const QList<MediaSegmentInfo> &segments) {
+                        [self, itemId, serverSegments](const QList<MediaSegmentInfo> &segments) {
                             if (!self) return;
-                            self->finishMediaSegments(itemId, segments);
+                            self->finishExternalMediaSegments(itemId, serverSegments, segments);
                         });
                 });
         },
         [this, itemId, serverSegments]() {
-            finishMediaSegments(itemId, serverSegments);
+            if (serverSegments.isEmpty()) {
+                finishMediaSegments(itemId, serverSegments);
+            }
         });
+}
+
+void PlaybackService::finishExternalMediaSegments(const QString &itemId,
+                                                  const QList<MediaSegmentInfo> &serverSegments,
+                                                  const QList<MediaSegmentInfo> &mergedSegments)
+{
+    if (mergedSegments.size() > serverSegments.size() || serverSegments.isEmpty()) {
+        finishMediaSegments(itemId, mergedSegments);
+    }
 }
 
 void PlaybackService::finishMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &segments)

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -1,9 +1,13 @@
 #include "PlaybackService.h"
 #include "AuthenticationService.h"
+#include "MediaSegmentProviderService.h"
+#include "../utils/ConfigManager.h"
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QTimer>
+#include <QUrl>
+#include <QUrlQuery>
 #include <QLoggingCategory>
 #include <cmath>
 
@@ -40,9 +44,14 @@ QJsonObject buildPlaybackPayload(const QString &itemId, qint64 positionTicks,
 }
 }
 
-PlaybackService::PlaybackService(AuthenticationService *authService, QObject *parent)
+PlaybackService::PlaybackService(AuthenticationService *authService,
+                                 ConfigManager *configManager,
+                                 MediaSegmentProviderService *mediaSegmentProviderService,
+                                 QObject *parent)
     : QObject(parent)
     , m_authService(authService)
+    , m_configManager(configManager)
+    , m_mediaSegmentProviderService(mediaSegmentProviderService)
     , m_retryPolicy{3, 1000, true}
 {
 }
@@ -208,7 +217,7 @@ void PlaybackService::getMediaSegments(const QString &itemId)
         if (httpStatus == 401) {
             qCWarning(playbackService) << "Session expired while fetching media segments for" << itemId;
             m_authService->checkForSessionExpiry(reply, true);
-            emit mediaSegmentsLoaded(itemId, QList<MediaSegmentInfo>());
+            finishMediaSegments(itemId, QList<MediaSegmentInfo>());
             return;
         }
         
@@ -216,14 +225,14 @@ void PlaybackService::getMediaSegments(const QString &itemId)
         // Just emit empty segments silently
         if (httpStatus == 404) {
             qCDebug(playbackService) << "Intro Skipper plugin not available for" << itemId;
-            emit mediaSegmentsLoaded(itemId, QList<MediaSegmentInfo>());
+            maybeLoadExternalMediaSegments(itemId, QList<MediaSegmentInfo>());
             return;
         }
         
         if (reply->error() != QNetworkReply::NoError) {
             qCWarning(playbackService) << "Failed to get media segments for" << itemId
                                        << "Error:" << reply->errorString();
-            emit mediaSegmentsLoaded(itemId, QList<MediaSegmentInfo>());
+            maybeLoadExternalMediaSegments(itemId, QList<MediaSegmentInfo>());
             return;
         }
         
@@ -231,64 +240,144 @@ void PlaybackService::getMediaSegments(const QString &itemId)
         QJsonDocument doc = QJsonDocument::fromJson(data);
         QJsonObject obj = doc.object();
         
-        QList<MediaSegmentInfo> segments;
-        
-        // Intro Skipper returns a dictionary with segment type names as keys:
-        // { "Introduction": { "EpisodeId": "...", "Start": 114.114, "End": 204.204, "Valid": true },
-        //   "Credits": { "EpisodeId": "...", "Start": 1329.328, "End": 1427.426, "Valid": true } }
-        // Note: Start/End are in seconds, not ticks
-        
-        // Map of Intro Skipper type names to our types
-        static const QMap<QString, QPair<MediaSegmentType, QString>> typeMapping = {
-            {"Introduction", {MediaSegmentType::Intro, "Intro"}},
-            {"Credits", {MediaSegmentType::Outro, "Outro"}},
-            {"Recap", {MediaSegmentType::Recap, "Recap"}},
-            {"Preview", {MediaSegmentType::Preview, "Preview"}},
-            {"Commercial", {MediaSegmentType::Commercial, "Commercial"}}
-        };
-        
-        for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
-            QString typeName = it.key();
-            QJsonObject segmentObj = it.value().toObject();
-            
-            // Only process valid segments
-            if (!segmentObj["Valid"].toBool(false)) {
-                continue;
-            }
-            
-            MediaSegmentInfo info;
-            info.itemId = segmentObj["EpisodeId"].toString();
-            
-            // Convert seconds to ticks (1 tick = 100 nanoseconds = 0.0000001 seconds)
-            double startSeconds = segmentObj["Start"].toDouble();
-            double endSeconds = segmentObj["End"].toDouble();
-            info.startTicks = static_cast<qint64>(startSeconds * 10000000.0);
-            info.endTicks = static_cast<qint64>(endSeconds * 10000000.0);
-            
-            // Map the type
-            if (typeMapping.contains(typeName)) {
-                auto mapping = typeMapping[typeName];
-                info.type = mapping.first;
-                info.typeString = mapping.second;
-            } else {
-                info.type = MediaSegmentType::Unknown;
-                info.typeString = typeName;
-            }
-            
-            segments.append(info);
-        }
-        
-        qCDebug(playbackService) << "Media segments loaded for" << itemId 
-                                  << "- Count:" << segments.size();
-        
-        for (const auto &segment : segments) {
-            qCDebug(playbackService) << "  Segment:" << segment.typeString
-                                      << "Start:" << segment.startSeconds() << "s"
-                                      << "End:" << segment.endSeconds() << "s";
-        }
-        
-        emit mediaSegmentsLoaded(itemId, segments);
+        maybeLoadExternalMediaSegments(itemId, parseIntroSkipperSegments(itemId, obj));
     });
+}
+
+QList<MediaSegmentInfo> PlaybackService::parseIntroSkipperSegments(const QString &itemId, const QJsonObject &obj) const
+{
+    QList<MediaSegmentInfo> segments;
+
+    static const QMap<QString, QPair<MediaSegmentType, QString>> typeMapping = {
+        {"Introduction", {MediaSegmentType::Intro, "Intro"}},
+        {"Credits", {MediaSegmentType::Outro, "Outro"}},
+        {"Recap", {MediaSegmentType::Recap, "Recap"}},
+        {"Preview", {MediaSegmentType::Preview, "Preview"}},
+        {"Commercial", {MediaSegmentType::Commercial, "Commercial"}}
+    };
+
+    for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
+        const QString typeName = it.key();
+        const QJsonObject segmentObj = it.value().toObject();
+
+        if (!segmentObj["Valid"].toBool(false)) {
+            continue;
+        }
+
+        MediaSegmentInfo info;
+        info.itemId = segmentObj["EpisodeId"].toString(itemId);
+        info.source = QStringLiteral("jellyfin");
+
+        const double startSeconds = segmentObj["Start"].toDouble();
+        const double endSeconds = segmentObj["End"].toDouble();
+        if (startSeconds < 0.0 || endSeconds <= startSeconds) {
+            continue;
+        }
+        info.startTicks = static_cast<qint64>(startSeconds * 10000000.0);
+        info.endTicks = static_cast<qint64>(endSeconds * 10000000.0);
+
+        if (typeMapping.contains(typeName)) {
+            const auto mapping = typeMapping[typeName];
+            info.type = mapping.first;
+            info.typeString = mapping.second;
+        } else {
+            info.type = MediaSegmentType::Unknown;
+            info.typeString = typeName;
+        }
+
+        segments.append(info);
+    }
+
+    return segments;
+}
+
+void PlaybackService::maybeLoadExternalMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &serverSegments)
+{
+    if (!m_mediaSegmentProviderService || !m_configManager
+        || !m_configManager->getExternalSegmentProvidersEnabled()
+        || !MediaSegmentProviderService::hasMissingSupportedSegmentTypes(serverSegments)) {
+        finishMediaSegments(itemId, serverSegments);
+        return;
+    }
+
+    loadMediaSegmentLookupContext(itemId, serverSegments);
+}
+
+void PlaybackService::loadMediaSegmentLookupContext(const QString &itemId, const QList<MediaSegmentInfo> &serverSegments)
+{
+    const QString fields = QStringLiteral("ProviderIds,ParentIndexNumber,IndexNumber,SeriesId,RunTimeTicks,Type");
+    const QString endpoint = QString("/Users/%1/Items/%2?Fields=%3")
+        .arg(m_authService->getUserId(), itemId, fields);
+
+    QNetworkRequest request = m_authService->createRequest(endpoint);
+    QNetworkReply *reply = m_authService->networkManager()->get(request);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId, serverSegments]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            finishMediaSegments(itemId, serverSegments);
+            return;
+        }
+
+        const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+        const QJsonObject item = doc.object();
+        MediaSegmentLookupContext context;
+        context.itemId = itemId;
+        context.type = item.value(QStringLiteral("Type")).toString();
+        context.seriesId = item.value(QStringLiteral("SeriesId")).toString();
+        context.seasonNumber = item.value(QStringLiteral("ParentIndexNumber")).toInt(-1);
+        context.episodeNumber = item.value(QStringLiteral("IndexNumber")).toInt(-1);
+        context.durationTicks = static_cast<qint64>(item.value(QStringLiteral("RunTimeTicks")).toDouble());
+
+        const QJsonObject providerIds = item.value(QStringLiteral("ProviderIds")).toObject();
+        context.imdbId = providerIds.value(QStringLiteral("Imdb")).toString();
+        context.tmdbId = providerIds.value(QStringLiteral("Tmdb")).toString();
+        context.tvdbId = providerIds.value(QStringLiteral("Tvdb")).toString();
+
+        const bool needsSeriesProviderIds = context.type.compare(QStringLiteral("Episode"), Qt::CaseInsensitive) == 0
+            && !context.seriesId.isEmpty()
+            && (context.imdbId.isEmpty() || context.tmdbId.isEmpty() || context.tvdbId.isEmpty());
+        if (!needsSeriesProviderIds) {
+            m_mediaSegmentProviderService->fetchExternalSegments(context, serverSegments,
+                [this, itemId](const QList<MediaSegmentInfo> &segments) {
+                    finishMediaSegments(itemId, segments);
+                });
+            return;
+        }
+
+        const QString seriesEndpoint = QString("/Users/%1/Items/%2?Fields=ProviderIds")
+            .arg(m_authService->getUserId(), context.seriesId);
+        QNetworkReply *seriesReply = m_authService->networkManager()->get(m_authService->createRequest(seriesEndpoint));
+        connect(seriesReply, &QNetworkReply::finished, this, [this, seriesReply, context, serverSegments, itemId]() mutable {
+            seriesReply->deleteLater();
+            if (seriesReply->error() == QNetworkReply::NoError) {
+                const QJsonDocument seriesDoc = QJsonDocument::fromJson(seriesReply->readAll());
+                const QJsonObject seriesProviderIds = seriesDoc.object().value(QStringLiteral("ProviderIds")).toObject();
+                if (context.imdbId.isEmpty()) context.imdbId = seriesProviderIds.value(QStringLiteral("Imdb")).toString();
+                if (context.tmdbId.isEmpty()) context.tmdbId = seriesProviderIds.value(QStringLiteral("Tmdb")).toString();
+                if (context.tvdbId.isEmpty()) context.tvdbId = seriesProviderIds.value(QStringLiteral("Tvdb")).toString();
+            }
+
+            m_mediaSegmentProviderService->fetchExternalSegments(context, serverSegments,
+                [this, itemId](const QList<MediaSegmentInfo> &segments) {
+                    finishMediaSegments(itemId, segments);
+                });
+        });
+    });
+}
+
+void PlaybackService::finishMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &segments)
+{
+    qCDebug(playbackService) << "Media segments loaded for" << itemId
+                             << "- Count:" << segments.size();
+
+    for (const auto &segment : segments) {
+        qCDebug(playbackService) << "  Segment:" << segment.typeString
+                                 << "Source:" << segment.source
+                                 << "Start:" << segment.startSeconds() << "s"
+                                 << "End:" << segment.endSeconds() << "s";
+    }
+
+    emit mediaSegmentsLoaded(itemId, segments);
 }
 
 void PlaybackService::getTrickplayInfo(const QString &itemId)

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -5,6 +5,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QPointer>
 #include <QTimer>
 #include <QUrl>
 #include <QUrlQuery>
@@ -63,6 +64,7 @@ PlaybackService::PlaybackService(AuthenticationService *authService,
 void PlaybackService::sendRequestWithRetry(const QString &endpoint,
                                             RequestFactory requestFactory,
                                             ResponseHandler responseHandler,
+                                            FailureHandler failureHandler,
                                             int attemptNumber)
 {
     qCDebug(playbackService) << "Sending request to:" << endpoint 
@@ -70,8 +72,8 @@ void PlaybackService::sendRequestWithRetry(const QString &endpoint,
     
     QNetworkReply *reply = requestFactory();
     
-    connect(reply, &QNetworkReply::finished, this, [this, reply, endpoint, requestFactory, responseHandler, attemptNumber]() {
-        handleReplyWithRetry(reply, endpoint, requestFactory, responseHandler, attemptNumber);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, endpoint, requestFactory, responseHandler, failureHandler, attemptNumber]() {
+        handleReplyWithRetry(reply, endpoint, requestFactory, responseHandler, failureHandler, attemptNumber);
     });
 }
 
@@ -79,6 +81,7 @@ void PlaybackService::handleReplyWithRetry(QNetworkReply *reply,
                                             const QString &endpoint,
                                             RequestFactory requestFactory,
                                             ResponseHandler responseHandler,
+                                            FailureHandler failureHandler,
                                             int attemptNumber)
 {
     reply->deleteLater();
@@ -93,6 +96,7 @@ void PlaybackService::handleReplyWithRetry(QNetworkReply *reply,
     
     if (httpStatus == 401) {
         qCWarning(playbackService) << "Session expired (401) for endpoint:" << endpoint;
+        if (failureHandler) failureHandler();
         return;
     }
     
@@ -112,11 +116,12 @@ void PlaybackService::handleReplyWithRetry(QNetworkReply *reply,
         int delayMs = ErrorHandler::calculateBackoffDelay(attemptNumber, m_retryPolicy);
         qCInfo(playbackService) << "Retrying request to:" << endpoint << "in" << delayMs << "ms";
         
-        QTimer::singleShot(delayMs, this, [this, endpoint, requestFactory, responseHandler, attemptNumber]() {
-            sendRequestWithRetry(endpoint, requestFactory, responseHandler, attemptNumber + 1);
+        QTimer::singleShot(delayMs, this, [this, endpoint, requestFactory, responseHandler, failureHandler, attemptNumber]() {
+            sendRequestWithRetry(endpoint, requestFactory, responseHandler, failureHandler, attemptNumber + 1);
         });
     } else {
         emitError(netError);
+        if (failureHandler) failureHandler();
     }
 }
 
@@ -309,60 +314,75 @@ void PlaybackService::loadMediaSegmentLookupContext(const QString &itemId, const
     const QString endpoint = QString("/Users/%1/Items/%2?Fields=%3")
         .arg(m_authService->getUserId(), itemId, fields);
 
-    QNetworkRequest request = m_authService->createRequest(endpoint);
-    QNetworkReply *reply = m_authService->networkManager()->get(request);
-    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId, serverSegments]() {
-        reply->deleteLater();
-        if (reply->error() != QNetworkReply::NoError) {
-            finishMediaSegments(itemId, serverSegments);
-            return;
-        }
+    sendRequestWithRetry(endpoint,
+        [this, endpoint]() {
+            QNetworkRequest request = m_authService->createRequest(endpoint);
+            return m_authService->networkManager()->get(request);
+        },
+        [this, itemId, serverSegments](QNetworkReply *reply) {
+            const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+            const QJsonObject item = doc.object();
+            MediaSegmentLookupContext context;
+            context.itemId = itemId;
+            context.type = item.value(QStringLiteral("Type")).toString();
+            context.seriesId = item.value(QStringLiteral("SeriesId")).toString();
+            context.seasonNumber = item.value(QStringLiteral("ParentIndexNumber")).toInt(-1);
+            context.episodeNumber = item.value(QStringLiteral("IndexNumber")).toInt(-1);
+            context.durationTicks = static_cast<qint64>(item.value(QStringLiteral("RunTimeTicks")).toDouble());
 
-        const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-        const QJsonObject item = doc.object();
-        MediaSegmentLookupContext context;
-        context.itemId = itemId;
-        context.type = item.value(QStringLiteral("Type")).toString();
-        context.seriesId = item.value(QStringLiteral("SeriesId")).toString();
-        context.seasonNumber = item.value(QStringLiteral("ParentIndexNumber")).toInt(-1);
-        context.episodeNumber = item.value(QStringLiteral("IndexNumber")).toInt(-1);
-        context.durationTicks = static_cast<qint64>(item.value(QStringLiteral("RunTimeTicks")).toDouble());
+            const QJsonObject providerIds = item.value(QStringLiteral("ProviderIds")).toObject();
+            context.imdbId = providerIds.value(QStringLiteral("Imdb")).toString();
+            context.tmdbId = providerIds.value(QStringLiteral("Tmdb")).toString();
+            context.tvdbId = providerIds.value(QStringLiteral("Tvdb")).toString();
 
-        const QJsonObject providerIds = item.value(QStringLiteral("ProviderIds")).toObject();
-        context.imdbId = providerIds.value(QStringLiteral("Imdb")).toString();
-        context.tmdbId = providerIds.value(QStringLiteral("Tmdb")).toString();
-        context.tvdbId = providerIds.value(QStringLiteral("Tvdb")).toString();
-
-        const bool needsSeriesProviderIds = context.type.compare(QStringLiteral("Episode"), Qt::CaseInsensitive) == 0
-            && !context.seriesId.isEmpty()
-            && (context.imdbId.isEmpty() || context.tmdbId.isEmpty() || context.tvdbId.isEmpty());
-        if (!needsSeriesProviderIds) {
-            m_mediaSegmentProviderService->fetchExternalSegments(context, serverSegments,
-                [this, itemId](const QList<MediaSegmentInfo> &segments) {
-                    finishMediaSegments(itemId, segments);
-                });
-            return;
-        }
-
-        const QString seriesEndpoint = QString("/Users/%1/Items/%2?Fields=ProviderIds")
-            .arg(m_authService->getUserId(), context.seriesId);
-        QNetworkReply *seriesReply = m_authService->networkManager()->get(m_authService->createRequest(seriesEndpoint));
-        connect(seriesReply, &QNetworkReply::finished, this, [this, seriesReply, context, serverSegments, itemId]() mutable {
-            seriesReply->deleteLater();
-            if (seriesReply->error() == QNetworkReply::NoError) {
-                const QJsonDocument seriesDoc = QJsonDocument::fromJson(seriesReply->readAll());
-                const QJsonObject seriesProviderIds = seriesDoc.object().value(QStringLiteral("ProviderIds")).toObject();
-                if (context.imdbId.isEmpty()) context.imdbId = seriesProviderIds.value(QStringLiteral("Imdb")).toString();
-                if (context.tmdbId.isEmpty()) context.tmdbId = seriesProviderIds.value(QStringLiteral("Tmdb")).toString();
-                if (context.tvdbId.isEmpty()) context.tvdbId = seriesProviderIds.value(QStringLiteral("Tvdb")).toString();
+            const bool needsSeriesProviderIds = context.type.compare(QStringLiteral("Episode"), Qt::CaseInsensitive) == 0
+                && !context.seriesId.isEmpty()
+                && (context.imdbId.isEmpty() || context.tmdbId.isEmpty());
+            if (!needsSeriesProviderIds) {
+                QPointer<PlaybackService> self(this);
+                m_mediaSegmentProviderService->fetchExternalSegments(context, serverSegments,
+                    [self, itemId](const QList<MediaSegmentInfo> &segments) {
+                        if (!self) return;
+                        self->finishMediaSegments(itemId, segments);
+                    });
+                return;
             }
 
-            m_mediaSegmentProviderService->fetchExternalSegments(context, serverSegments,
-                [this, itemId](const QList<MediaSegmentInfo> &segments) {
-                    finishMediaSegments(itemId, segments);
+            const QString seriesEndpoint = QString("/Users/%1/Items/%2?Fields=ProviderIds")
+                .arg(m_authService->getUserId(), context.seriesId);
+            sendRequestWithRetry(seriesEndpoint,
+                [this, seriesEndpoint]() {
+                    QNetworkRequest request = m_authService->createRequest(seriesEndpoint);
+                    return m_authService->networkManager()->get(request);
+                },
+                [this, context, serverSegments, itemId](QNetworkReply *seriesReply) mutable {
+                    const QJsonDocument seriesDoc = QJsonDocument::fromJson(seriesReply->readAll());
+                    const QJsonObject seriesProviderIds = seriesDoc.object().value(QStringLiteral("ProviderIds")).toObject();
+                    if (context.imdbId.isEmpty()) context.imdbId = seriesProviderIds.value(QStringLiteral("Imdb")).toString();
+                    if (context.tmdbId.isEmpty()) context.tmdbId = seriesProviderIds.value(QStringLiteral("Tmdb")).toString();
+                    if (context.tvdbId.isEmpty()) context.tvdbId = seriesProviderIds.value(QStringLiteral("Tvdb")).toString();
+
+                    QPointer<PlaybackService> self(this);
+                    m_mediaSegmentProviderService->fetchExternalSegments(context, serverSegments,
+                        [self, itemId](const QList<MediaSegmentInfo> &segments) {
+                            if (!self) return;
+                            self->finishMediaSegments(itemId, segments);
+                        });
+                },
+                [this, context, serverSegments, itemId]() mutable {
+                    qCDebug(playbackService) << "Failed to fetch series provider IDs for" << context.seriesId
+                                             << "- external segment lookup may be incomplete";
+                    QPointer<PlaybackService> self(this);
+                    m_mediaSegmentProviderService->fetchExternalSegments(context, serverSegments,
+                        [self, itemId](const QList<MediaSegmentInfo> &segments) {
+                            if (!self) return;
+                            self->finishMediaSegments(itemId, segments);
+                        });
                 });
+        },
+        [this, itemId, serverSegments]() {
+            finishMediaSegments(itemId, serverSegments);
         });
-    });
 }
 
 void PlaybackService::finishMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &segments)

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -93,9 +93,10 @@ void PlaybackService::handleReplyWithRetry(QNetworkReply *reply,
     }
     
     int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    
+
     if (httpStatus == 401) {
         qCWarning(playbackService) << "Session expired (401) for endpoint:" << endpoint;
+        m_authService->checkForSessionExpiry(reply, true);
         if (failureHandler) failureHandler();
         return;
     }

--- a/src/network/PlaybackService.h
+++ b/src/network/PlaybackService.h
@@ -112,16 +112,19 @@ private:
     // Retry mechanism types  
     using ResponseHandler = std::function<void(QNetworkReply*)>;
     using RequestFactory = std::function<QNetworkReply*()>;
+    using FailureHandler = std::function<void()>;
     
     void sendRequestWithRetry(const QString &endpoint,
                                RequestFactory requestFactory,
                                ResponseHandler responseHandler,
+                               FailureHandler failureHandler = FailureHandler(),
                                int attemptNumber = 0);
     
     void handleReplyWithRetry(QNetworkReply *reply,
                                const QString &endpoint,
                                RequestFactory requestFactory,
                                ResponseHandler responseHandler,
+                               FailureHandler failureHandler,
                                int attemptNumber);
     
     void emitError(const NetworkError &error);

--- a/src/network/PlaybackService.h
+++ b/src/network/PlaybackService.h
@@ -131,5 +131,8 @@ private:
     QList<MediaSegmentInfo> parseIntroSkipperSegments(const QString &itemId, const QJsonObject &obj) const;
     void maybeLoadExternalMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &serverSegments);
     void loadMediaSegmentLookupContext(const QString &itemId, const QList<MediaSegmentInfo> &serverSegments);
+    void finishExternalMediaSegments(const QString &itemId,
+                                     const QList<MediaSegmentInfo> &serverSegments,
+                                     const QList<MediaSegmentInfo> &mergedSegments);
     void finishMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &segments);
 };

--- a/src/network/PlaybackService.h
+++ b/src/network/PlaybackService.h
@@ -7,6 +7,8 @@
 #include "Types.h"  // For data structs (PlaybackInfoResponse, MediaSegmentInfo, TrickplayTileInfo, etc.)
 
 class AuthenticationService;
+class ConfigManager;
+class MediaSegmentProviderService;
 
 /**
  * @brief Handles playback reporting and playback-related metadata.
@@ -25,7 +27,10 @@ class PlaybackService : public QObject
     Q_OBJECT
 
 public:
-    explicit PlaybackService(AuthenticationService *authService, QObject *parent = nullptr);
+    explicit PlaybackService(AuthenticationService *authService,
+                             ConfigManager *configManager = nullptr,
+                             MediaSegmentProviderService *mediaSegmentProviderService = nullptr,
+                             QObject *parent = nullptr);
     
     // Playback Info - Get media streams and track information
     Q_INVOKABLE void getPlaybackInfo(const QString &itemId);
@@ -100,6 +105,8 @@ signals:
 
 private:
     AuthenticationService *m_authService;
+    ConfigManager *m_configManager = nullptr;
+    MediaSegmentProviderService *m_mediaSegmentProviderService = nullptr;
     RetryPolicy m_retryPolicy;
     
     // Retry mechanism types  
@@ -118,4 +125,8 @@ private:
                                int attemptNumber);
     
     void emitError(const NetworkError &error);
+    QList<MediaSegmentInfo> parseIntroSkipperSegments(const QString &itemId, const QJsonObject &obj) const;
+    void maybeLoadExternalMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &serverSegments);
+    void loadMediaSegmentLookupContext(const QString &itemId, const QList<MediaSegmentInfo> &serverSegments);
+    void finishMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &segments);
 };

--- a/src/network/Types.cpp
+++ b/src/network/Types.cpp
@@ -303,6 +303,13 @@ MediaSegmentInfo MediaSegmentInfo::fromJson(const QJsonObject &json)
     info.itemId = json["ItemId"].toString();
     info.startTicks = static_cast<qint64>(json["StartTicks"].toDouble());
     info.endTicks = static_cast<qint64>(json["EndTicks"].toDouble());
+    info.source = json.value("Source").toString(json.value("source").toString());
+    info.confidence = json.value("Confidence").toDouble(json.value("confidence").toDouble());
+    if (json.contains("SubmissionCount")) {
+        info.submissionCount = json.value("SubmissionCount").toInt();
+    } else {
+        info.submissionCount = json.value("submission_count").toInt();
+    }
     
     QString typeStr = json["Type"].toString();
     info.typeString = typeStr;

--- a/src/network/Types.h
+++ b/src/network/Types.h
@@ -146,6 +146,9 @@ public:
     QString typeString;
     qint64 startTicks = 0;
     qint64 endTicks = 0;
+    QString source;
+    double confidence = 0.0;
+    int submissionCount = 0;
 
     [[nodiscard]] static MediaSegmentInfo fromJson(const QJsonObject &json);
     [[nodiscard]] constexpr double startSeconds() const { return static_cast<double>(startTicks) / 10000000.0; }

--- a/src/ui/settings/IntegrationsSettings.qml
+++ b/src/ui/settings/IntegrationsSettings.qml
@@ -153,8 +153,65 @@ FocusScope {
                     text: ConfigManager.seerrApiKey
                     ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
                     keyUpTarget: seerrUrlInput.input
-                    keyDownTarget: null
+                    keyDownTarget: externalSegmentsToggle
                     onEditingFinished: ConfigManager.seerrApiKey = text
+                    onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
+                }
+
+                SettingsGroupDivider { Layout.fillWidth: true }
+
+                // --- Media Segments Section ---
+                Text {
+                    text: qsTr("Media Segments")
+                    font.pixelSize: Theme.fontSizeBody
+                    font.family: Theme.fontPrimary
+                    color: Theme.textPrimary
+                }
+
+                Text {
+                    text: qsTr("Use external segment providers to fill missing intro, recap, and credits markers when Jellyfin does not provide them.")
+                    font.pixelSize: Theme.fontSizeSmall
+                    font.family: Theme.fontPrimary
+                    color: Theme.textSecondary
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
+                }
+
+                SettingsToggleRow {
+                    id: externalSegmentsToggle
+                    label: qsTr("Use External Segment Providers")
+                    description: qsTr("Jellyfin server segments are always preferred; providers only fill missing segment types.")
+                    checked: ConfigManager.externalSegmentProvidersEnabled
+                    ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
+                    KeyNavigation.up: seerrApiKeyInput.input
+                    KeyNavigation.down: theIntroDbApiKeyInput.input
+                    onToggled: function(value) { ConfigManager.externalSegmentProvidersEnabled = value }
+                    onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
+                }
+
+                SettingsTextInputRow {
+                    id: theIntroDbApiKeyInput
+                    label: qsTr("TheIntroDB API Key")
+                    placeholderText: qsTr("API Key")
+                    echoMode: TextInput.Password
+                    text: ConfigManager.theIntroDbApiKey
+                    ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
+                    keyUpTarget: externalSegmentsToggle
+                    keyDownTarget: introDbApiKeyInput.input
+                    onEditingFinished: ConfigManager.theIntroDbApiKey = text
+                    onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
+                }
+
+                SettingsTextInputRow {
+                    id: introDbApiKeyInput
+                    label: qsTr("IntroDB API Key")
+                    placeholderText: qsTr("Optional")
+                    echoMode: TextInput.Password
+                    text: ConfigManager.introDbApiKey
+                    ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
+                    keyUpTarget: theIntroDbApiKeyInput.input
+                    keyDownTarget: null
+                    onEditingFinished: ConfigManager.introDbApiKey = text
                     onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
                 }
             }

--- a/src/ui/settings/IntegrationsSettings.qml
+++ b/src/ui/settings/IntegrationsSettings.qml
@@ -184,34 +184,8 @@ FocusScope {
                     checked: ConfigManager.externalSegmentProvidersEnabled
                     ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
                     KeyNavigation.up: seerrApiKeyInput.input
-                    KeyNavigation.down: theIntroDbApiKeyInput.input
+                    KeyNavigation.down: null
                     onToggled: function(value) { ConfigManager.externalSegmentProvidersEnabled = value }
-                    onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
-                }
-
-                SettingsTextInputRow {
-                    id: theIntroDbApiKeyInput
-                    label: qsTr("TheIntroDB API Key")
-                    placeholderText: qsTr("API Key")
-                    echoMode: TextInput.Password
-                    text: ConfigManager.theIntroDbApiKey
-                    ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
-                    keyUpTarget: externalSegmentsToggle
-                    keyDownTarget: introDbApiKeyInput.input
-                    onEditingFinished: ConfigManager.theIntroDbApiKey = text
-                    onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
-                }
-
-                SettingsTextInputRow {
-                    id: introDbApiKeyInput
-                    label: qsTr("IntroDB API Key")
-                    placeholderText: qsTr("Optional")
-                    echoMode: TextInput.Password
-                    text: ConfigManager.introDbApiKey
-                    ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
-                    keyUpTarget: theIntroDbApiKeyInput.input
-                    keyDownTarget: null
-                    onEditingFinished: ConfigManager.introDbApiKey = text
                     onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
                 }
             }

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -1547,14 +1547,18 @@ QString ConfigManager::getIntroDbApiKey() const
 
 void ConfigManager::setMediaSegmentProviderOrder(const QStringList &order)
 {
-    if (order == getMediaSegmentProviderOrder()) return;
-
-    QJsonArray array;
+    QStringList normalizedProviders;
     for (const QString &provider : order) {
         const QString normalized = provider.trimmed().toLower();
         if (!normalized.isEmpty()) {
-            array.append(normalized);
+            normalizedProviders.append(normalized);
         }
+    }
+    if (normalizedProviders == getMediaSegmentProviderOrder()) return;
+
+    QJsonArray array;
+    for (const QString &provider : normalizedProviders) {
+        array.append(provider);
     }
 
     QJsonObject settings = m_config.value("settings").toObject();

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -1480,6 +1480,108 @@ QString ConfigManager::getSeerrApiKey() const
     return QString();
 }
 
+void ConfigManager::setExternalSegmentProvidersEnabled(bool enabled)
+{
+    if (enabled == getExternalSegmentProvidersEnabled()) return;
+
+    QJsonObject settings = m_config.value("settings").toObject();
+    QJsonObject mediaSegments = settings.value("media_segments").toObject();
+    mediaSegments["external_providers_enabled"] = enabled;
+    settings["media_segments"] = mediaSegments;
+    m_config["settings"] = settings;
+    save();
+    emit externalSegmentProvidersEnabledChanged();
+}
+
+bool ConfigManager::getExternalSegmentProvidersEnabled() const
+{
+    const QJsonObject settings = m_config.value("settings").toObject();
+    const QJsonObject mediaSegments = settings.value("media_segments").toObject();
+    if (mediaSegments.contains("external_providers_enabled")) {
+        return mediaSegments.value("external_providers_enabled").toBool(true);
+    }
+    return true;
+}
+
+void ConfigManager::setTheIntroDbApiKey(const QString &key)
+{
+    const QString normalized = key.trimmed();
+    if (normalized == getTheIntroDbApiKey()) return;
+
+    QJsonObject settings = m_config.value("settings").toObject();
+    QJsonObject mediaSegments = settings.value("media_segments").toObject();
+    mediaSegments["theintrodb_api_key"] = normalized;
+    settings["media_segments"] = mediaSegments;
+    m_config["settings"] = settings;
+    save();
+    emit theIntroDbApiKeyChanged();
+}
+
+QString ConfigManager::getTheIntroDbApiKey() const
+{
+    const QJsonObject settings = m_config.value("settings").toObject();
+    const QJsonObject mediaSegments = settings.value("media_segments").toObject();
+    return mediaSegments.value("theintrodb_api_key").toString();
+}
+
+void ConfigManager::setIntroDbApiKey(const QString &key)
+{
+    const QString normalized = key.trimmed();
+    if (normalized == getIntroDbApiKey()) return;
+
+    QJsonObject settings = m_config.value("settings").toObject();
+    QJsonObject mediaSegments = settings.value("media_segments").toObject();
+    mediaSegments["introdb_api_key"] = normalized;
+    settings["media_segments"] = mediaSegments;
+    m_config["settings"] = settings;
+    save();
+    emit introDbApiKeyChanged();
+}
+
+QString ConfigManager::getIntroDbApiKey() const
+{
+    const QJsonObject settings = m_config.value("settings").toObject();
+    const QJsonObject mediaSegments = settings.value("media_segments").toObject();
+    return mediaSegments.value("introdb_api_key").toString();
+}
+
+void ConfigManager::setMediaSegmentProviderOrder(const QStringList &order)
+{
+    if (order == getMediaSegmentProviderOrder()) return;
+
+    QJsonArray array;
+    for (const QString &provider : order) {
+        const QString normalized = provider.trimmed().toLower();
+        if (!normalized.isEmpty()) {
+            array.append(normalized);
+        }
+    }
+
+    QJsonObject settings = m_config.value("settings").toObject();
+    QJsonObject mediaSegments = settings.value("media_segments").toObject();
+    mediaSegments["provider_order"] = array;
+    settings["media_segments"] = mediaSegments;
+    m_config["settings"] = settings;
+    save();
+    emit mediaSegmentProviderOrderChanged();
+}
+
+QStringList ConfigManager::getMediaSegmentProviderOrder() const
+{
+    const QJsonObject settings = m_config.value("settings").toObject();
+    const QJsonObject mediaSegments = settings.value("media_segments").toObject();
+    const QJsonArray order = mediaSegments.value("provider_order").toArray();
+    QStringList providers;
+    for (const QJsonValue &value : order) {
+        const QString provider = value.toString().trimmed().toLower();
+        if (!provider.isEmpty()) providers.append(provider);
+    }
+    if (providers.isEmpty()) {
+        return {QStringLiteral("theintrodb"), QStringLiteral("introdb")};
+    }
+    return providers;
+}
+
 void ConfigManager::setManualDpiScaleOverride(qreal scale)
 {
     // Clamp to reasonable range (0.5 to 2.0)
@@ -2447,6 +2549,34 @@ public:
         newConfig["settings"] = settings;
         return newConfig;
     }
+
+    static QJsonObject migrateV18ToV19(const QJsonObject &oldConfig)
+    {
+        QJsonObject newConfig = oldConfig;
+        newConfig["version"] = 19;
+
+        QJsonObject settings = newConfig["settings"].toObject();
+        QJsonObject mediaSegments = settings.value("media_segments").toObject();
+        if (!mediaSegments.contains("external_providers_enabled")) {
+            mediaSegments["external_providers_enabled"] = true;
+        }
+        if (!mediaSegments.contains("provider_order")) {
+            mediaSegments["provider_order"] = QJsonArray{
+                QStringLiteral("theintrodb"),
+                QStringLiteral("introdb")
+            };
+        }
+        if (!mediaSegments.contains("theintrodb_api_key")) {
+            mediaSegments["theintrodb_api_key"] = QString();
+        }
+        if (!mediaSegments.contains("introdb_api_key")) {
+            mediaSegments["introdb_api_key"] = QString();
+        }
+
+        settings["media_segments"] = mediaSegments;
+        newConfig["settings"] = settings;
+        return newConfig;
+    }
 };
 }
 
@@ -2611,6 +2741,14 @@ bool ConfigManager::migrateConfig()
                 qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
+        } else if (version == 18) {
+            m_config = ConfigMigrator::migrateV18ToV19(m_config);
+            if (m_config.contains("version") && m_config["version"].isDouble()) {
+                version = m_config["version"].toInt();
+            } else {
+                qWarning() << "Migration produced invalid config (no version)";
+                return false;
+            }
         } else {
             qWarning() << "Unknown config version during migration:" << version;
             return false;
@@ -2711,6 +2849,16 @@ QJsonObject ConfigManager::defaultConfig() const
     seerr["base_url"] = "";
     seerr["api_key"] = "";
     settings["seerr"] = seerr;
+
+    QJsonObject mediaSegments;
+    mediaSegments["external_providers_enabled"] = true;
+    mediaSegments["provider_order"] = QJsonArray{
+        QStringLiteral("theintrodb"),
+        QStringLiteral("introdb")
+    };
+    mediaSegments["theintrodb_api_key"] = QString();
+    mediaSegments["introdb_api_key"] = QString();
+    settings["media_segments"] = mediaSegments;
 
     QJsonObject updates;
     updates["channel"] = QStringLiteral("stable");

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -1503,48 +1503,6 @@ bool ConfigManager::getExternalSegmentProvidersEnabled() const
     return true;
 }
 
-void ConfigManager::setTheIntroDbApiKey(const QString &key)
-{
-    const QString normalized = key.trimmed();
-    if (normalized == getTheIntroDbApiKey()) return;
-
-    QJsonObject settings = m_config.value("settings").toObject();
-    QJsonObject mediaSegments = settings.value("media_segments").toObject();
-    mediaSegments["theintrodb_api_key"] = normalized;
-    settings["media_segments"] = mediaSegments;
-    m_config["settings"] = settings;
-    save();
-    emit theIntroDbApiKeyChanged();
-}
-
-QString ConfigManager::getTheIntroDbApiKey() const
-{
-    const QJsonObject settings = m_config.value("settings").toObject();
-    const QJsonObject mediaSegments = settings.value("media_segments").toObject();
-    return mediaSegments.value("theintrodb_api_key").toString();
-}
-
-void ConfigManager::setIntroDbApiKey(const QString &key)
-{
-    const QString normalized = key.trimmed();
-    if (normalized == getIntroDbApiKey()) return;
-
-    QJsonObject settings = m_config.value("settings").toObject();
-    QJsonObject mediaSegments = settings.value("media_segments").toObject();
-    mediaSegments["introdb_api_key"] = normalized;
-    settings["media_segments"] = mediaSegments;
-    m_config["settings"] = settings;
-    save();
-    emit introDbApiKeyChanged();
-}
-
-QString ConfigManager::getIntroDbApiKey() const
-{
-    const QJsonObject settings = m_config.value("settings").toObject();
-    const QJsonObject mediaSegments = settings.value("media_segments").toObject();
-    return mediaSegments.value("introdb_api_key").toString();
-}
-
 void ConfigManager::setMediaSegmentProviderOrder(const QStringList &order)
 {
     QStringList normalizedProviders;
@@ -2570,12 +2528,6 @@ public:
                 QStringLiteral("introdb")
             };
         }
-        if (!mediaSegments.contains("theintrodb_api_key")) {
-            mediaSegments["theintrodb_api_key"] = QString();
-        }
-        if (!mediaSegments.contains("introdb_api_key")) {
-            mediaSegments["introdb_api_key"] = QString();
-        }
 
         settings["media_segments"] = mediaSegments;
         newConfig["settings"] = settings;
@@ -2860,8 +2812,6 @@ QJsonObject ConfigManager::defaultConfig() const
         QStringLiteral("theintrodb"),
         QStringLiteral("introdb")
     };
-    mediaSegments["theintrodb_api_key"] = QString();
-    mediaSegments["introdb_api_key"] = QString();
     settings["media_segments"] = mediaSegments;
 
     QJsonObject updates;

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -118,8 +118,6 @@ class ConfigManager : public QObject
 
     // Media Segment Providers
     Q_PROPERTY(bool externalSegmentProvidersEnabled READ getExternalSegmentProvidersEnabled WRITE setExternalSegmentProvidersEnabled NOTIFY externalSegmentProvidersEnabledChanged)
-    Q_PROPERTY(QString theIntroDbApiKey READ getTheIntroDbApiKey WRITE setTheIntroDbApiKey NOTIFY theIntroDbApiKeyChanged)
-    Q_PROPERTY(QString introDbApiKey READ getIntroDbApiKey WRITE setIntroDbApiKey NOTIFY introDbApiKeyChanged)
     Q_PROPERTY(QStringList mediaSegmentProviderOrder READ getMediaSegmentProviderOrder WRITE setMediaSegmentProviderOrder NOTIFY mediaSegmentProviderOrderChanged)
     
     // Manual DPI Scale Override
@@ -389,10 +387,6 @@ public:
     // Media Segment Providers
     void setExternalSegmentProvidersEnabled(bool enabled);
     bool getExternalSegmentProvidersEnabled() const;
-    void setTheIntroDbApiKey(const QString &key);
-    QString getTheIntroDbApiKey() const;
-    void setIntroDbApiKey(const QString &key);
-    QString getIntroDbApiKey() const;
     void setMediaSegmentProviderOrder(const QStringList &order);
     QStringList getMediaSegmentProviderOrder() const;
     
@@ -458,8 +452,6 @@ signals:
     void seerrBaseUrlChanged();
     void seerrApiKeyChanged();
     void externalSegmentProvidersEnabledChanged();
-    void theIntroDbApiKeyChanged();
-    void introDbApiKeyChanged();
     void mediaSegmentProviderOrderChanged();
     void manualDpiScaleOverrideChanged();
     void uiAnimationsEnabledChanged();

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -115,6 +115,12 @@ class ConfigManager : public QObject
     // Seerr Integration
     Q_PROPERTY(QString seerrBaseUrl READ getSeerrBaseUrl WRITE setSeerrBaseUrl NOTIFY seerrBaseUrlChanged)
     Q_PROPERTY(QString seerrApiKey READ getSeerrApiKey WRITE setSeerrApiKey NOTIFY seerrApiKeyChanged)
+
+    // Media Segment Providers
+    Q_PROPERTY(bool externalSegmentProvidersEnabled READ getExternalSegmentProvidersEnabled WRITE setExternalSegmentProvidersEnabled NOTIFY externalSegmentProvidersEnabledChanged)
+    Q_PROPERTY(QString theIntroDbApiKey READ getTheIntroDbApiKey WRITE setTheIntroDbApiKey NOTIFY theIntroDbApiKeyChanged)
+    Q_PROPERTY(QString introDbApiKey READ getIntroDbApiKey WRITE setIntroDbApiKey NOTIFY introDbApiKeyChanged)
+    Q_PROPERTY(QStringList mediaSegmentProviderOrder READ getMediaSegmentProviderOrder WRITE setMediaSegmentProviderOrder NOTIFY mediaSegmentProviderOrderChanged)
     
     // Manual DPI Scale Override
     Q_PROPERTY(qreal manualDpiScaleOverride READ getManualDpiScaleOverride WRITE setManualDpiScaleOverride NOTIFY manualDpiScaleOverrideChanged)
@@ -379,6 +385,16 @@ public:
     void setSeerrApiKey(const QString &key);
     /// @brief Returns the configured Seerr API key, or an empty string if unset.
     QString getSeerrApiKey() const;
+
+    // Media Segment Providers
+    void setExternalSegmentProvidersEnabled(bool enabled);
+    bool getExternalSegmentProvidersEnabled() const;
+    void setTheIntroDbApiKey(const QString &key);
+    QString getTheIntroDbApiKey() const;
+    void setIntroDbApiKey(const QString &key);
+    QString getIntroDbApiKey() const;
+    void setMediaSegmentProviderOrder(const QStringList &order);
+    QStringList getMediaSegmentProviderOrder() const;
     
     // Manual DPI Scale Override
     void setManualDpiScaleOverride(qreal scale);
@@ -441,6 +457,10 @@ signals:
     void mdbListApiKeyChanged();
     void seerrBaseUrlChanged();
     void seerrApiKeyChanged();
+    void externalSegmentProvidersEnabledChanged();
+    void theIntroDbApiKeyChanged();
+    void introDbApiKeyChanged();
+    void mediaSegmentProviderOrderChanged();
     void manualDpiScaleOverrideChanged();
     void uiAnimationsEnabledChanged();
     void updateChannelChanged();
@@ -455,6 +475,6 @@ private:
 
     QJsonObject m_config;
 
-    static constexpr int kCurrentConfigVersion = 18;
+    static constexpr int kCurrentConfigVersion = 19;
     QJsonObject defaultConfig() const;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,6 +111,7 @@ add_executable(PlayerControllerAutoplayContextTest
     ${CMAKE_SOURCE_DIR}/src/player/PlayerController.cpp
     ${CMAKE_SOURCE_DIR}/src/player/TrickplayProcessor.cpp
     ${CMAKE_SOURCE_DIR}/src/network/PlaybackService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/MediaSegmentProviderService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
@@ -137,6 +138,29 @@ target_link_libraries(PlayerControllerAutoplayContextTest
 )
 
 add_test(NAME PlayerControllerAutoplayContextTest COMMAND PlayerControllerAutoplayContextTest)
+
+add_executable(MediaSegmentProviderServiceTest
+    MediaSegmentProviderServiceTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/MediaSegmentProviderService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/ConfigManager.cpp
+)
+
+target_include_directories(MediaSegmentProviderServiceTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+target_link_libraries(MediaSegmentProviderServiceTest
+    PRIVATE
+        Qt6::Core
+        Qt6::Concurrent
+        Qt6::Network
+        Qt6::Test
+)
+
+add_test(NAME MediaSegmentProviderServiceTest COMMAND MediaSegmentProviderServiceTest)
 
 add_executable(NextEpisodeResolverTest
     NextEpisodeResolverTest.cpp
@@ -336,6 +360,7 @@ qt_add_executable(VisualRegressionTest
     ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/network/PlaybackService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/MediaSegmentProviderService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/SeerrService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/SessionManager.cpp
     ${CMAKE_SOURCE_DIR}/src/network/SessionService.cpp

--- a/tests/MediaSegmentProviderServiceTest.cpp
+++ b/tests/MediaSegmentProviderServiceTest.cpp
@@ -56,43 +56,63 @@ void MediaSegmentProviderServiceTest::parsesTheIntroDbV2Arrays()
 
     const QList<MediaSegmentInfo> segments = MediaSegmentProviderService::parseTheIntroDbSegments(payload, context);
     QCOMPARE(segments.size(), 4);
-    QCOMPARE(segments.at(0).type, MediaSegmentType::Intro);
-    QCOMPARE(segments.at(1).type, MediaSegmentType::Recap);
-    QCOMPARE(segments.at(2).type, MediaSegmentType::Outro);
-    QCOMPARE(segments.at(3).type, MediaSegmentType::Preview);
-    QCOMPARE(segments.at(0).source, QStringLiteral("theintrodb"));
-    QCOMPARE(segments.at(0).startSeconds(), 30.0);
-    QCOMPARE(segments.at(0).endSeconds(), 90.0);
+
+    const auto findSegment = [&segments](MediaSegmentType type) -> MediaSegmentInfo {
+        for (const MediaSegmentInfo &segment : segments) {
+            if (segment.type == type) return segment;
+        }
+        return {};
+    };
+
+    const MediaSegmentInfo intro = findSegment(MediaSegmentType::Intro);
+    const MediaSegmentInfo recap = findSegment(MediaSegmentType::Recap);
+    const MediaSegmentInfo outro = findSegment(MediaSegmentType::Outro);
+    const MediaSegmentInfo preview = findSegment(MediaSegmentType::Preview);
+    QCOMPARE(intro.type, MediaSegmentType::Intro);
+    QCOMPARE(recap.type, MediaSegmentType::Recap);
+    QCOMPARE(outro.type, MediaSegmentType::Outro);
+    QCOMPARE(preview.type, MediaSegmentType::Preview);
+    QCOMPARE(intro.source, QStringLiteral("theintrodb"));
+    QCOMPARE(intro.startSeconds(), 30.0);
+    QCOMPARE(intro.endSeconds(), 90.0);
 }
 
 void MediaSegmentProviderServiceTest::handlesNullStartAndDurationEnd()
 {
     const MediaSegmentLookupContext context = episodeContext();
     const QJsonObject payload{
-        {QStringLiteral("credits"), QJsonArray{QJsonObject{
+        {QStringLiteral("recap"), QJsonArray{QJsonObject{
             {QStringLiteral("start_ms"), QJsonValue::Null},
+            {QStringLiteral("end_ms"), 10000}
+        }}},
+        {QStringLiteral("credits"), QJsonArray{QJsonObject{
+            {QStringLiteral("start_ms"), 3300000},
             {QStringLiteral("end_ms"), QJsonValue::Null}
         }}}
     };
 
     const QList<MediaSegmentInfo> segments = MediaSegmentProviderService::parseTheIntroDbSegments(payload, context);
-    QCOMPARE(segments.size(), 1);
-    QCOMPARE(segments.first().type, MediaSegmentType::Outro);
-    QCOMPARE(segments.first().startSeconds(), 0.0);
-    QCOMPARE(segments.first().endSeconds(), 3600.0);
+    QCOMPARE(segments.size(), 2);
+    QCOMPARE(segments.at(0).type, MediaSegmentType::Recap);
+    QCOMPARE(segments.at(0).startSeconds(), 0.0);
+    QCOMPARE(segments.at(0).endSeconds(), 10.0);
+    QCOMPARE(segments.at(1).type, MediaSegmentType::Outro);
+    QCOMPARE(segments.at(1).startSeconds(), 3300.0);
+    QCOMPARE(segments.at(1).endSeconds(), 3600.0);
 }
 
 void MediaSegmentProviderServiceTest::dropsOpenEndedSegmentsWithoutDuration()
 {
     MediaSegmentLookupContext context = episodeContext();
-    context.durationTicks = 0;
     const QJsonObject payload{
+        {QStringLiteral("intro"), QJsonArray{QJsonObject{}}},
         {QStringLiteral("credits"), QJsonArray{QJsonObject{
             {QStringLiteral("start_ms"), 1000},
             {QStringLiteral("end_ms"), QJsonValue::Null}
         }}}
     };
 
+    context.durationTicks = 0;
     const QList<MediaSegmentInfo> segments = MediaSegmentProviderService::parseTheIntroDbSegments(payload, context);
     QVERIFY(segments.isEmpty());
 }

--- a/tests/MediaSegmentProviderServiceTest.cpp
+++ b/tests/MediaSegmentProviderServiceTest.cpp
@@ -13,6 +13,8 @@ private slots:
     void handlesNullStartAndDurationEnd();
     void dropsOpenEndedSegmentsWithoutDuration();
     void parsesIntroDbSegments();
+    void parsesIntroDbClockStringSegments();
+    void dropsIntroDbInvalidStringSegments();
     void mergeKeepsServerSegmentAndFillsMissingType();
     void emptyProviderIdsProduceNoSegments();
 };
@@ -140,6 +142,37 @@ void MediaSegmentProviderServiceTest::parsesIntroDbSegments()
     QCOMPARE(segments.at(0).source, QStringLiteral("introdb"));
     QCOMPARE(segments.at(0).startSeconds(), 5.5);
     QCOMPARE(segments.at(0).submissionCount, 8);
+}
+
+void MediaSegmentProviderServiceTest::parsesIntroDbClockStringSegments()
+{
+    const MediaSegmentLookupContext context = episodeContext();
+    const QJsonObject payload{
+        {QStringLiteral("intro"), QJsonObject{
+            {QStringLiteral("start_sec"), QStringLiteral("1:05")},
+            {QStringLiteral("end_sec"), QStringLiteral("0:02:15")}
+        }}
+    };
+
+    const QList<MediaSegmentInfo> segments = MediaSegmentProviderService::parseIntroDbSegments(payload, context);
+    QCOMPARE(segments.size(), 1);
+    QCOMPARE(segments.first().type, MediaSegmentType::Intro);
+    QCOMPARE(segments.first().startSeconds(), 65.0);
+    QCOMPARE(segments.first().endSeconds(), 135.0);
+}
+
+void MediaSegmentProviderServiceTest::dropsIntroDbInvalidStringSegments()
+{
+    const MediaSegmentLookupContext context = episodeContext();
+    const QJsonObject payload{
+        {QStringLiteral("intro"), QJsonObject{
+            {QStringLiteral("start_sec"), QStringLiteral("not-a-time")},
+            {QStringLiteral("end_sec"), QStringLiteral("1:00")}
+        }}
+    };
+
+    const QList<MediaSegmentInfo> segments = MediaSegmentProviderService::parseIntroDbSegments(payload, context);
+    QVERIFY(segments.isEmpty());
 }
 
 void MediaSegmentProviderServiceTest::mergeKeepsServerSegmentAndFillsMissingType()

--- a/tests/MediaSegmentProviderServiceTest.cpp
+++ b/tests/MediaSegmentProviderServiceTest.cpp
@@ -1,0 +1,171 @@
+#include "network/MediaSegmentProviderService.h"
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QtTest/QtTest>
+
+class MediaSegmentProviderServiceTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void parsesTheIntroDbV2Arrays();
+    void handlesNullStartAndDurationEnd();
+    void dropsOpenEndedSegmentsWithoutDuration();
+    void parsesIntroDbSegments();
+    void mergeKeepsServerSegmentAndFillsMissingType();
+    void emptyProviderIdsProduceNoSegments();
+};
+
+namespace {
+MediaSegmentLookupContext episodeContext()
+{
+    MediaSegmentLookupContext context;
+    context.itemId = QStringLiteral("episode-1");
+    context.type = QStringLiteral("Episode");
+    context.imdbId = QStringLiteral("tt0903747");
+    context.tmdbId = QStringLiteral("1396");
+    context.seasonNumber = 1;
+    context.episodeNumber = 1;
+    context.durationTicks = 3600LL * 10000000LL;
+    return context;
+}
+}
+
+void MediaSegmentProviderServiceTest::parsesTheIntroDbV2Arrays()
+{
+    const MediaSegmentLookupContext context = episodeContext();
+    const QJsonObject payload{
+        {QStringLiteral("intro"), QJsonArray{QJsonObject{
+            {QStringLiteral("start_ms"), 30000},
+            {QStringLiteral("end_ms"), 90000}
+        }}},
+        {QStringLiteral("recap"), QJsonArray{QJsonObject{
+            {QStringLiteral("start_ms"), 0},
+            {QStringLiteral("end_ms"), 25000}
+        }}},
+        {QStringLiteral("credits"), QJsonArray{QJsonObject{
+            {QStringLiteral("start_ms"), 3300000},
+            {QStringLiteral("end_ms"), 3600000}
+        }}},
+        {QStringLiteral("preview"), QJsonArray{QJsonObject{
+            {QStringLiteral("start_ms"), 3200000},
+            {QStringLiteral("end_ms"), 3250000}
+        }}}
+    };
+
+    const QList<MediaSegmentInfo> segments = MediaSegmentProviderService::parseTheIntroDbSegments(payload, context);
+    QCOMPARE(segments.size(), 4);
+    QCOMPARE(segments.at(0).type, MediaSegmentType::Intro);
+    QCOMPARE(segments.at(1).type, MediaSegmentType::Recap);
+    QCOMPARE(segments.at(2).type, MediaSegmentType::Outro);
+    QCOMPARE(segments.at(3).type, MediaSegmentType::Preview);
+    QCOMPARE(segments.at(0).source, QStringLiteral("theintrodb"));
+    QCOMPARE(segments.at(0).startSeconds(), 30.0);
+    QCOMPARE(segments.at(0).endSeconds(), 90.0);
+}
+
+void MediaSegmentProviderServiceTest::handlesNullStartAndDurationEnd()
+{
+    const MediaSegmentLookupContext context = episodeContext();
+    const QJsonObject payload{
+        {QStringLiteral("credits"), QJsonArray{QJsonObject{
+            {QStringLiteral("start_ms"), QJsonValue::Null},
+            {QStringLiteral("end_ms"), QJsonValue::Null}
+        }}}
+    };
+
+    const QList<MediaSegmentInfo> segments = MediaSegmentProviderService::parseTheIntroDbSegments(payload, context);
+    QCOMPARE(segments.size(), 1);
+    QCOMPARE(segments.first().type, MediaSegmentType::Outro);
+    QCOMPARE(segments.first().startSeconds(), 0.0);
+    QCOMPARE(segments.first().endSeconds(), 3600.0);
+}
+
+void MediaSegmentProviderServiceTest::dropsOpenEndedSegmentsWithoutDuration()
+{
+    MediaSegmentLookupContext context = episodeContext();
+    context.durationTicks = 0;
+    const QJsonObject payload{
+        {QStringLiteral("credits"), QJsonArray{QJsonObject{
+            {QStringLiteral("start_ms"), 1000},
+            {QStringLiteral("end_ms"), QJsonValue::Null}
+        }}}
+    };
+
+    const QList<MediaSegmentInfo> segments = MediaSegmentProviderService::parseTheIntroDbSegments(payload, context);
+    QVERIFY(segments.isEmpty());
+}
+
+void MediaSegmentProviderServiceTest::parsesIntroDbSegments()
+{
+    const MediaSegmentLookupContext context = episodeContext();
+    const QJsonObject payload{
+        {QStringLiteral("intro"), QJsonObject{
+            {QStringLiteral("start_sec"), 5.5},
+            {QStringLiteral("end_sec"), 75.0},
+            {QStringLiteral("confidence"), 0.91},
+            {QStringLiteral("submission_count"), 8}
+        }},
+        {QStringLiteral("outro"), QJsonObject{
+            {QStringLiteral("start_ms"), 3300000},
+            {QStringLiteral("end_ms"), 3600000}
+        }}
+    };
+
+    const QList<MediaSegmentInfo> segments = MediaSegmentProviderService::parseIntroDbSegments(payload, context);
+    QCOMPARE(segments.size(), 2);
+    QCOMPARE(segments.at(0).type, MediaSegmentType::Intro);
+    QCOMPARE(segments.at(1).type, MediaSegmentType::Outro);
+    QCOMPARE(segments.at(0).source, QStringLiteral("introdb"));
+    QCOMPARE(segments.at(0).startSeconds(), 5.5);
+    QCOMPARE(segments.at(0).submissionCount, 8);
+}
+
+void MediaSegmentProviderServiceTest::mergeKeepsServerSegmentAndFillsMissingType()
+{
+    MediaSegmentInfo serverIntro;
+    serverIntro.itemId = QStringLiteral("episode-1");
+    serverIntro.type = MediaSegmentType::Intro;
+    serverIntro.typeString = QStringLiteral("Intro");
+    serverIntro.source = QStringLiteral("jellyfin");
+    serverIntro.startTicks = 10 * 10000000LL;
+    serverIntro.endTicks = 70 * 10000000LL;
+
+    MediaSegmentInfo externalIntro = serverIntro;
+    externalIntro.source = QStringLiteral("theintrodb");
+    externalIntro.startTicks = 30 * 10000000LL;
+    externalIntro.endTicks = 90 * 10000000LL;
+
+    MediaSegmentInfo externalOutro;
+    externalOutro.itemId = QStringLiteral("episode-1");
+    externalOutro.type = MediaSegmentType::Outro;
+    externalOutro.typeString = QStringLiteral("Outro");
+    externalOutro.source = QStringLiteral("theintrodb");
+    externalOutro.startTicks = 3300 * 10000000LL;
+    externalOutro.endTicks = 3600 * 10000000LL;
+
+    const QList<MediaSegmentInfo> merged = MediaSegmentProviderService::mergeSegmentsByType(
+        {serverIntro},
+        {externalIntro, externalOutro});
+
+    QCOMPARE(merged.size(), 2);
+    QCOMPARE(merged.at(0).source, QStringLiteral("jellyfin"));
+    QCOMPARE(merged.at(0).startSeconds(), 10.0);
+    QCOMPARE(merged.at(1).type, MediaSegmentType::Outro);
+    QCOMPARE(merged.at(1).source, QStringLiteral("theintrodb"));
+}
+
+void MediaSegmentProviderServiceTest::emptyProviderIdsProduceNoSegments()
+{
+    MediaSegmentLookupContext context = episodeContext();
+    context.imdbId.clear();
+    context.tmdbId.clear();
+
+    const QList<MediaSegmentInfo> segments = MediaSegmentProviderService::parseIntroDbSegments(QJsonObject{}, context);
+    QVERIFY(segments.isEmpty());
+}
+
+QTEST_MAIN(MediaSegmentProviderServiceTest)
+
+#include "MediaSegmentProviderServiceTest.moc"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added external media segment provider support (TheIntroDB and IntroDB) for enhanced intro/outro/recap/preview detection
  * New **Media Segments** settings section to enable/disable external providers and configure API keys

* **Documentation**
  * Added comprehensive guides covering media segment fetching, provider integration, and service architecture

* **Tests**
  * Added test suite for media segment provider functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crowquillx/Bloom/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add external media segment providers (TheIntroDB and IntroDB) with in-app configuration
> - Introduces `MediaSegmentProviderService` to fetch intro/outro/recap/preview segments from external APIs when the Jellyfin server does not supply them or supplies incomplete coverage.
> - Adds two providers: TheIntroDB (`api.theintrodb.org`) using TMDB IDs, and IntroDB (`api.introdb.app`) using IMDB IDs for episodic content; provider order is configurable.
> - Extends `PlaybackService` to call external providers after server segment lookup fails or returns gaps, merging results without overwriting server-supplied types.
> - Adds a toggle in Integrations Settings bound to `ConfigManager.externalSegmentProvidersEnabled` and bumps config schema to version 19 with a `media_segments` default block.
> - Risk: External segment fetches are additional network requests on every playback start when server segments are absent or incomplete; fetches are anonymous but require valid TMDB/IMDB metadata on the item.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8608eec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->