### PR TITLE
feat: chapter support

### DIFF
--- a/docs/playback.md
+++ b/docs/playback.md
@@ -202,6 +202,9 @@ UI Components for Track Selection
   - Progress row: clickable seek track, current/total time labels, and keyboard seek via left/right.
   - Escape first dismisses visible playback chrome (full controls, seek preview, skip-intro popup, or open track/volume panels); a second Escape stops playback when the overlay is already hidden. The header back control exits playback immediately while controls are visible.
   - Trickplay preview bubble: renders processed Jellyfin trickplay thumbnails from `PlayerController` and is hidden entirely when trickplay images are unavailable.
+  - Chapter mode: `Down` enters a Jellyfin-backed horizontal chapter rail when the active item exposes `Chapters`; `Up` returns to transport controls and `Escape`/`Back` hides the overlay. `Left`/`Right` browse chapter cards, while `Enter`/`Space` seeks to the focused chapter and keeps the rail open until normal inactivity dismissal.
+  - Chapter cards use the item chapter thumbnail when Jellyfin provides usable chapter image metadata. Missing chapter artwork renders a neutral themed placeholder tile instead of reusing episode/poster artwork.
+  - Chapter thumbnail diagnostics are logged during playback chapter normalization: loaded chapter metadata, generated Jellyfin chapter-image URLs, and image-cache transport/decode failures. These logs are intended for server/client compatibility debugging when the rail falls back to placeholders.
   - Intro/outro skip UX: transient "Skip Intro"/"Skip Credits" pop-up button auto-focuses when a segment window starts, then a compact persistent skip button remains available until that segment ends.
     - Popup timing is controlled by `ConfigManager.skipButtonAutoHideSeconds` (`settings.playback.skip_button_auto_hide_seconds`, range 0-120; 0 disables popup only). The popup is still dismissed as soon as the active intro/outro segment ends.
     - Optional automatic skip is controlled by `ConfigManager.autoSkipIntro` and `ConfigManager.autoSkipOutro`; each auto-skip applies at most once per playback item even if the user seeks back.
@@ -212,6 +215,7 @@ Playback overlay metadata
 - `PlayerController` exposes `overlayTitle`, `overlaySubtitle`, `overlayBackdropUrl`, and `overlayLogoUrl` for the native overlay (header, buffering card, and backdrop).
 - Optional `overlayLogoUrl` is a Jellyfin logo image URL (typically the `image://cached/...` form from `LibraryService::getCachedImageUrlWithWidth`). `EmbeddedPlaybackOverlay.qml` shows the logo when the URL is non-empty and the image reaches `Image.Ready`; on load failure (`Image.Error`) or when the URL is empty, the overlay falls back to `overlayTitle` text.
 - When a logo is present, the overlay metadata block keeps `overlaySubtitle` visually centered beneath it in both the buffering card and the active playback header; text fallbacks use a heavier weight for readability.
+- `PlayerController` also exposes normalized playback chapters, the currently playing chapter index derived from live playback position, and a seek-by-chapter action. Focused rail selection remains local UI state so playback progress never steals navigation focus while browsing.
 - Detail views set metadata before playback starts:
   - Movies: title + production year.
   - Episodes: series title + `Sxx Exx - Episode Name`.

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -129,6 +129,8 @@ Track Preference Persistence
 - When navigating to a new episode in the same season, explicit preferences are restored. If they are missing or invalid for the new source, Bloom falls back through the standard resolution order.
 - Use `PlayerController.getLastAudioTrackForSeason(seasonId)` and `getLastSubtitleTrackForSeason(seasonId)` to retrieve.
 - Use `PlayerController.setExplicitSeasonAudioPreference(seasonId, index)` and `setExplicitSeasonSubtitlePreference(seasonId, index)` to save.
+- `SeriesSeasonEpisodeView` preloads Jellyfin chapter metadata for the highlighted episode and inserts a contextual `Chapters` rail between `Episodes` and `Cast & Crew` when chapter data exists.
+- Activating a chapter card reuses the normal episode playback request, including track preference/version-prompt handling, but sets `startPositionTicks` to that chapter’s start tick so playback begins at the selected chapter.
 
 ### Movies (Per-Movie)
 - Preferences are stored by movie ID for rewatches.

--- a/docs/responsive.md
+++ b/docs/responsive.md
@@ -441,7 +441,7 @@ A `Connections` block on `ResponsiveLayoutManager.onBreakpointChanged` saves the
 
 ## SeriesSeasonEpisodeView Responsive Layout
 
-[`SeriesSeasonEpisodeView.qml`](../src/ui/SeriesSeasonEpisodeView.qml) uses the responsive layout system for the episode browsing experience with seasons tabs, episode thumbnails, metadata, action buttons, and audio/subtitle track selection.
+[`SeriesSeasonEpisodeView.qml`](../src/ui/SeriesSeasonEpisodeView.qml) uses the responsive layout system for the episode browsing experience with seasons tabs, episode thumbnails, the selected-episode `Chapters` shelf, cast metadata, action buttons, and audio/subtitle track selection.
 
 ### Token usage
 
@@ -452,6 +452,7 @@ A `Connections` block on `ResponsiveLayoutManager.onBreakpointChanged` saves the
 | Series logo / name | Max height uses `Math.round(180 * Theme.layoutScale)` with viewport-relative capping |
 | Episode metadata typography | `Theme.fontSizeHeader`, `Theme.fontSizeBody`, `Theme.fontSizeCaption` |
 | Episode thumbnail delegate | Margins/spacing via `Theme.spacingSmall`, `Math.round(2 * Theme.layoutScale)` |
+| Chapter rail cards | Existing card/background/radius tokens, `Theme.spacingSmall`/`Theme.spacingMedium`, and focus border tokens |
 | Focus border width | `Theme.buttonFocusBorderWidth` |
 | Played indicator icon | `Theme.fontSizeIcon` |
 | Read More button | Height/width via `Math.round(N * Theme.layoutScale)` |

--- a/docs/services.md
+++ b/docs/services.md
@@ -11,7 +11,7 @@ Key services
 - `ExternalMpvBackend` — External mpv process/IPC backend adapter (primary rollback path on Linux/non-Windows).
 - `PlayerProcessManager` — Manages external mpv process & IPC (used by `ExternalMpvBackend`).
 - `AuthenticationService` — Login, logout, session persistence, token validation; owns shared `QNetworkAccessManager`.
-- `LibraryService` — Library views/items, series details, search, image/theme-song URLs.
+- `LibraryService` — Library views/items, series details, search, reusable chapter metadata, image/theme-song URLs.
 - `PlaybackService` — Playback reporting, stream info, media segments, trickplay URLs and info.
 - `MediaSegmentProviderService` — Fetches and normalizes external intro/recap/credits/preview markers from configured providers; used by `PlaybackService` after server segment lookup.
 - `SeerrService` — Seerr/Jellyseerr search integration, request-option loading, request submission, and similar-title provider endpoints.
@@ -63,5 +63,6 @@ Note: Avoid tightly coupling multiple services. Prefer small, single-purpose ser
 
 Series/Season detail caching (December 2025)
 - `LibraryService::getSeriesDetails` and `getItems` honor `ETag/If-None-Match` and `If-Modified-Since` when `useCacheValidation=true` (SeriesDetailsViewModel uses this for series + season episode lists). 304 responses are surfaced via `seriesDetailsNotModified` / `itemsNotModified`.
+- `LibraryService::getChapters(itemId)` fetches Jellyfin item `Chapters`, requests chapter image metadata, normalizes missing titles to `Chapter N`, and emits typed chapter data reusable outside playback. `getCachedChapterThumbnailUrl(...)` mirrors the Jellyfin client pattern of requesting `/Items/{itemId}/Images/Chapter/{chapterIndex}` with the chapter image tag when present; the UI keeps a neutral placeholder visible until the image provider reports a ready frame.
 - Series details and season/episode lists are cached in-memory (≈5 min TTL) and on disk under `cache/series` (≈1 hour TTL). Cache is served immediately (SWR) and revalidated in the background; stale data stays visible until refresh completes.
 - Prefetch: when navigating seasons, the view model prefetches the next two seasons' episodes (bounded, cancelable) to reduce focus-to-episodes latency.

--- a/docs/viewmodels.md
+++ b/docs/viewmodels.md
@@ -41,6 +41,7 @@ Column {
 ## Current migrations
 - `LibraryViewModel` now inherits `BaseViewModel`; loading/error wiring is centralized while pagination, caching, and signals (`loadComplete`, `loadMoreComplete`) remain intact.
 - `SeriesDetailsViewModel` inherits `BaseViewModel` for standardized loading/error properties; nested `SeasonsModel`/`EpisodesModel` keep their role-focused implementations.
+- `SeriesDetailsViewModel` also owns focused-episode chapter shelf state for the season view. It normalizes `LibraryService::getChapters(...)` results into QML-ready chapter maps with cached thumbnail URLs, hides stale episode responses, and keeps a small in-memory per-episode cache for quick return navigation.
 
 ## Async work and setBusyWhile
 Use `setBusyWhile` to keep loading flags accurate for Qt Concurrent tasks:

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -637,11 +637,12 @@ void LibraryService::getChapters(const QString &itemId)
             qInfo() << "LibraryService: Loaded raw chapter array for item" << itemId
                     << "count" << array.size();
             chapters.reserve(array.size());
-            for (const QJsonValue &value : array) {
+            for (qsizetype i = 0; i < array.size(); ++i) {
+                const QJsonValue value = array.at(i);
                 if (!value.isObject()) {
                     continue;
                 }
-                ChapterInfo chapter = ChapterInfo::fromJson(value.toObject(), chapters.size());
+                ChapterInfo chapter = ChapterInfo::fromJson(value.toObject(), i);
                 if (chapter.startPositionTicks < 0) {
                     chapter.startPositionTicks = 0;
                 }
@@ -1253,8 +1254,7 @@ QString LibraryService::getCachedChapterThumbnailUrl(const QString &itemId, int 
             << "item" << itemId
             << "index" << chapterIndex
             << "imageTagEmpty" << imageTag.trimmed().isEmpty()
-            << "imagePathEmpty" << imagePath.trimmed().isEmpty()
-            << "url" << originalUrl;
+            << "imagePathEmpty" << imagePath.trimmed().isEmpty();
     return cachedUrl;
 }
 

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -618,6 +618,12 @@ void LibraryService::getChapters(const QString &itemId)
         return;
     }
 
+    if (m_inFlightChapterRequests.contains(itemId)) {
+        qDebug() << "LibraryService: Skipping duplicate chapter request for item" << itemId;
+        return;
+    }
+    m_inFlightChapterRequests.insert(itemId);
+
     const QString endpoint = buildChaptersEndpoint(m_authService->getUserId(), itemId);
     sendRequestWithRetry(endpoint,
         [this, endpoint]() {
@@ -625,6 +631,7 @@ void LibraryService::getChapters(const QString &itemId)
             return m_authService->networkManager()->get(request);
         },
         [this, itemId](QNetworkReply *reply) {
+            m_inFlightChapterRequests.remove(itemId);
             const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
             if (!doc.isObject()) {
                 qWarning() << "LibraryService: Invalid chapter response for item" << itemId;
@@ -658,6 +665,7 @@ void LibraryService::getChapters(const QString &itemId)
             emit chaptersLoaded(itemId, chapters);
         },
         [this, itemId](const NetworkError &error) {
+            m_inFlightChapterRequests.remove(itemId);
             emit chaptersFailed(itemId, error.userMessage);
         });
 }
@@ -1236,6 +1244,10 @@ QString LibraryService::getCachedChapterThumbnailUrl(const QString &itemId, int 
                    << "index" << chapterIndex;
         return QString();
     }
+    if (imageTag.trimmed().isEmpty() && imagePath.trimmed().isEmpty()) {
+        return QString();
+    }
+
     if (width <= 0) {
         width = 480;
     }

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -25,6 +25,12 @@ QString buildItemEndpoint(const QString &userId, const QString &itemId)
         .arg(userId, itemId, kItemFields.join(","));
 }
 
+QString buildChaptersEndpoint(const QString &userId, const QString &itemId)
+{
+    return QString("/Users/%1/Items/%2?Fields=Chapters&EnableImages=true&EnableImageTypes=Chapter&ImageTypeLimit=100")
+        .arg(userId, itemId);
+}
+
 }
 
 LibraryService::LibraryService(AuthenticationService *authService, QObject *parent)
@@ -601,6 +607,60 @@ void LibraryService::clearItemCacheValidation(const QString &itemId)
     m_lastModified.remove(endpoint);
 }
 
+void LibraryService::getChapters(const QString &itemId)
+{
+    if (!m_authService->isAuthenticated()) {
+        emit chaptersFailed(itemId, tr("Not authenticated"));
+        return;
+    }
+    if (itemId.isEmpty()) {
+        emit chaptersFailed(itemId, tr("Item ID is empty"));
+        return;
+    }
+
+    const QString endpoint = buildChaptersEndpoint(m_authService->getUserId(), itemId);
+    sendRequestWithRetry(endpoint,
+        [this, endpoint]() {
+            QNetworkRequest request = m_authService->createRequest(endpoint);
+            return m_authService->networkManager()->get(request);
+        },
+        [this, itemId](QNetworkReply *reply) {
+            const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+            if (!doc.isObject()) {
+                qWarning() << "LibraryService: Invalid chapter response for item" << itemId;
+                emit chaptersFailed(itemId, tr("Invalid chapter response"));
+                return;
+            }
+
+            QList<ChapterInfo> chapters;
+            const QJsonArray array = doc.object().value(QStringLiteral("Chapters")).toArray();
+            qInfo() << "LibraryService: Loaded raw chapter array for item" << itemId
+                    << "count" << array.size();
+            chapters.reserve(array.size());
+            for (const QJsonValue &value : array) {
+                if (!value.isObject()) {
+                    continue;
+                }
+                ChapterInfo chapter = ChapterInfo::fromJson(value.toObject(), chapters.size());
+                if (chapter.startPositionTicks < 0) {
+                    chapter.startPositionTicks = 0;
+                }
+                qInfo() << "LibraryService: Chapter metadata"
+                        << "item" << itemId
+                        << "index" << chapter.index
+                        << "title" << chapter.title
+                        << "ticks" << chapter.startPositionTicks
+                        << "imageTagEmpty" << chapter.imageTag.isEmpty()
+                        << "imagePathEmpty" << chapter.imagePath.isEmpty();
+                chapters.append(chapter);
+            }
+            emit chaptersLoaded(itemId, chapters);
+        },
+        [this, itemId](const NetworkError &error) {
+            emit chaptersFailed(itemId, error.userMessage);
+        });
+}
+
 void LibraryService::resolveLibraryForItem(const QString &itemId)
 {
     if (!m_authService->isAuthenticated()) {
@@ -1165,6 +1225,37 @@ QString LibraryService::getCachedImageUrlWithWidth(const QString &itemId, const 
 {
     QString originalUrl = getImageUrlWithWidth(itemId, imageType, width);
     return QString("image://cached/%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(originalUrl)));
+}
+
+QString LibraryService::getCachedChapterThumbnailUrl(const QString &itemId, int chapterIndex, const QString &imageTag, const QString &imagePath, int width)
+{
+    if (itemId.isEmpty() || chapterIndex < 0) {
+        qWarning() << "LibraryService: Refusing chapter thumbnail URL"
+                   << "item" << itemId
+                   << "index" << chapterIndex;
+        return QString();
+    }
+    if (width <= 0) {
+        width = 480;
+    }
+
+    QString originalUrl = QString("%1/Items/%2/Images/Chapter/%3?maxWidth=%4&api_key=%5")
+        .arg(m_authService->getServerUrl(),
+             itemId,
+             QString::number(chapterIndex),
+             QString::number(width),
+             m_authService->getAccessToken());
+    if (!imageTag.trimmed().isEmpty()) {
+        originalUrl += QString("&tag=%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(imageTag)));
+    }
+    const QString cachedUrl = QString("image://cached/%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(originalUrl)));
+    qInfo() << "LibraryService: Chapter thumbnail request"
+            << "item" << itemId
+            << "index" << chapterIndex
+            << "imageTagEmpty" << imageTag.trimmed().isEmpty()
+            << "imagePathEmpty" << imagePath.trimmed().isEmpty()
+            << "url" << originalUrl;
+    return cachedUrl;
 }
 
 QNetworkReply* LibraryService::pingServer()

--- a/src/network/LibraryService.h
+++ b/src/network/LibraryService.h
@@ -59,6 +59,7 @@ public:
     // Generic Item Details
     Q_INVOKABLE virtual void getItem(const QString &itemId);
     virtual void getItem(const QString &itemId, const QString &requestContext);
+    Q_INVOKABLE virtual void getChapters(const QString &itemId);
     virtual void clearItemCacheValidation(const QString &itemId);
     Q_INVOKABLE virtual void resolveLibraryForItem(const QString &itemId);
 
@@ -89,6 +90,7 @@ public:
     Q_INVOKABLE virtual QString getImageUrlWithWidth(const QString &itemId, const QString &imageType, int width);
     Q_INVOKABLE virtual QString getCachedImageUrl(const QString &itemId, const QString &imageType);
     Q_INVOKABLE virtual QString getCachedImageUrlWithWidth(const QString &itemId, const QString &imageType, int width);
+    Q_INVOKABLE virtual QString getCachedChapterThumbnailUrl(const QString &itemId, int chapterIndex, const QString &imageTag, const QString &imagePath = QString(), int width = 480);
 
     QNetworkReply* pingServer();
 
@@ -107,6 +109,8 @@ signals:
     void itemNotModified(const QString &itemId, const QString &requestContext);
     void itemFailed(const QString &itemId, const QString &error, const QString &requestContext);
     void itemUserDataChanged(const QString &itemId, const QJsonObject &userData);
+    void chaptersLoaded(const QString &itemId, const QList<ChapterInfo> &chapters);
+    void chaptersFailed(const QString &itemId, const QString &error);
 
     void nextUpLoaded(const QJsonArray &items);
     void latestMediaLoaded(const QString &parentId, const QJsonArray &items);

--- a/src/network/LibraryService.h
+++ b/src/network/LibraryService.h
@@ -9,6 +9,7 @@
 #include <QFutureWatcher>
 #include <QtConcurrent>
 #include <QHash>
+#include <QSet>
 #include <functional>
 #include "Types.h"  // Shared data structs and error helpers
 
@@ -164,6 +165,9 @@ private:
                                int attemptNumber);
     
     void emitError(const NetworkError &error);
+
+    // In-flight deduplication for chapter requests
+    QSet<QString> m_inFlightChapterRequests;
 
     // Cache validation state (per endpoint/parent)
     QHash<QString, QString> m_etags;

--- a/src/network/Types.cpp
+++ b/src/network/Types.cpp
@@ -23,9 +23,11 @@ void registerNetworkMetaTypes()
     qRegisterMetaType<MediaStreamInfo>("MediaStreamInfo");
     qRegisterMetaType<MediaSourceInfo>("MediaSourceInfo");
     qRegisterMetaType<PlaybackInfoResponse>("PlaybackInfoResponse");
+    qRegisterMetaType<ChapterInfo>("ChapterInfo");
     qRegisterMetaType<MediaSegmentInfo>("MediaSegmentInfo");
     qRegisterMetaType<TrickplayTileInfo>("TrickplayTileInfo");
     qRegisterMetaType<QList<MediaSegmentInfo>>("QList<MediaSegmentInfo>");
+    qRegisterMetaType<QList<ChapterInfo>>("QList<ChapterInfo>");
     qRegisterMetaType<TrickplayTileInfoMap>("QMap<int,TrickplayTileInfo>");
 }
 
@@ -271,6 +273,37 @@ QVariantList PlaybackInfoResponse::getMediaSourcesVariant() const
         result.append(sourceMap);
     }
     return result;
+}
+
+// ============================================================================
+// ChapterInfo Implementation
+// ============================================================================
+
+ChapterInfo ChapterInfo::fromJson(const QJsonObject &json, int chapterIndex)
+{
+    ChapterInfo info;
+    info.index = chapterIndex;
+    info.startPositionTicks = static_cast<qint64>(json.value(QStringLiteral("StartPositionTicks")).toDouble());
+    info.imageTag = json.value(QStringLiteral("ImageTag")).toString().trimmed();
+    info.imagePath = json.value(QStringLiteral("ImagePath")).toString().trimmed();
+    info.title = json.value(QStringLiteral("Name")).toString().trimmed();
+    if (info.title.isEmpty()) {
+        info.title = QStringLiteral("Chapter %1").arg(chapterIndex + 1);
+    }
+    return info;
+}
+
+QVariantMap ChapterInfo::toVariantMap(const QString &thumbnailUrl) const
+{
+    QVariantMap chapterMap;
+    chapterMap[QStringLiteral("title")] = title;
+    chapterMap[QStringLiteral("startPositionTicks")] = startPositionTicks;
+    chapterMap[QStringLiteral("startSeconds")] = startSeconds();
+    chapterMap[QStringLiteral("imageTag")] = imageTag;
+    chapterMap[QStringLiteral("imagePath")] = imagePath;
+    chapterMap[QStringLiteral("thumbnailUrl")] = thumbnailUrl;
+    chapterMap[QStringLiteral("index")] = index;
+    return chapterMap;
 }
 
 // ============================================================================

--- a/src/network/Types.h
+++ b/src/network/Types.h
@@ -114,6 +114,35 @@ public:
 };
 
 // ============================================================================
+// Chapters
+// ============================================================================
+
+struct ChapterInfo
+{
+    Q_GADGET
+    Q_PROPERTY(QString title MEMBER title)
+    Q_PROPERTY(qint64 startPositionTicks MEMBER startPositionTicks)
+    Q_PROPERTY(QString imageTag MEMBER imageTag)
+    Q_PROPERTY(QString imagePath MEMBER imagePath)
+    Q_PROPERTY(int index MEMBER index)
+
+public:
+    QString title;
+    qint64 startPositionTicks = 0;
+    QString imageTag;
+    QString imagePath;
+    int index = -1;
+
+    [[nodiscard]] static ChapterInfo fromJson(const QJsonObject &json, int chapterIndex);
+    [[nodiscard]] QVariantMap toVariantMap(const QString &thumbnailUrl = QString()) const;
+    [[nodiscard]] constexpr double startSeconds() const
+    {
+        return static_cast<double>(startPositionTicks) / 10000000.0;
+    }
+    [[nodiscard]] bool hasUsableImage() const { return !imageTag.trimmed().isEmpty() || !imagePath.trimmed().isEmpty(); }
+};
+
+// ============================================================================
 // Media Segments / Trickplay
 // ============================================================================
 
@@ -262,7 +291,9 @@ using TrickplayTileInfoMap = QMap<int, TrickplayTileInfo>;
 Q_DECLARE_METATYPE(MediaStreamInfo)
 Q_DECLARE_METATYPE(MediaSourceInfo)
 Q_DECLARE_METATYPE(PlaybackInfoResponse)
+Q_DECLARE_METATYPE(ChapterInfo)
 Q_DECLARE_METATYPE(MediaSegmentInfo)
 Q_DECLARE_METATYPE(TrickplayTileInfo)
 Q_DECLARE_METATYPE(QList<MediaSegmentInfo>)
+Q_DECLARE_METATYPE(QList<ChapterInfo>)
 Q_DECLARE_METATYPE(TrickplayTileInfoMap)

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -5133,8 +5133,8 @@ void PlayerController::onChaptersLoaded(const QString &itemId, const QList<Chapt
     }
 
     m_playbackChapters = chapterModels;
-    emit playbackChaptersChanged();
     updateCurrentPlaybackChapterIndex();
+    emit playbackChaptersChanged();
 }
 
 void PlayerController::onChaptersFailed(const QString &itemId, const QString &error)

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -332,6 +332,10 @@ PlayerController::PlayerController(IPlayerBackend *playerBackend, ConfigManager 
             this, &PlayerController::onItemLibraryResolved);
     connect(m_libraryService, &LibraryService::itemLibraryResolutionFailed,
             this, &PlayerController::onItemLibraryResolutionFailed);
+    connect(m_libraryService, &LibraryService::chaptersLoaded,
+            this, &PlayerController::onChaptersLoaded);
+    connect(m_libraryService, &LibraryService::chaptersFailed,
+            this, &PlayerController::onChaptersFailed);
     
     // Connect to PlaybackService for media segments and trickplay info signals
     connect(m_playbackService, &PlaybackService::playbackInfoLoaded,
@@ -719,6 +723,7 @@ void PlayerController::enterIdleStateImmediate()
     m_contentIsHDR = false;
     m_playMethod = QStringLiteral("DirectPlay");
     clearOverlayMetadata();
+    clearPlaybackChapters();
     setBufferingProgress(0);
     
     // Clear track selection state (but keep m_seriesTrackPreferences)
@@ -1040,6 +1045,7 @@ void PlayerController::onPositionChanged(double seconds)
         m_reportProgressOnNextPositionUpdate = false;
     }
     updateSkipSegmentState();
+    updateCurrentPlaybackChapterIndex();
     if (!qFuzzyCompare(previousPosition + 1.0, aggregatePosition + 1.0)) {
         emit timelineChanged();
     }
@@ -2760,6 +2766,7 @@ void PlayerController::playTestVideo()
         m_hasEvaluatedCompletionForAttempt = false;
         cancelPendingDisplayRestore(true);
         clearPlaybackSegments();
+        clearPlaybackChapters();
         if (!m_currentItemId.isEmpty()) {
             m_currentItemId.clear();
             emit currentItemIdChanged();
@@ -2889,6 +2896,7 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
         emit skipSegmentsChanged();
         emit trickplayStateChanged();
         if (!itemId.isEmpty()) {
+            m_libraryService->getChapters(itemId);
             m_playbackService->getMediaSegments(itemId);
             m_playbackService->getTrickplayInfo(itemId);
         }
@@ -3336,6 +3344,16 @@ void PlayerController::nextChapter()
     if (m_playbackState == Playing || m_playbackState == Paused) {
         m_playerBackend->sendCommand({"add", "chapter", "1"});
     }
+}
+
+void PlayerController::seekToPlaybackChapter(int index)
+{
+    if (index < 0 || index >= m_playbackChapters.size()) {
+        return;
+    }
+    const QVariantMap chapter = m_playbackChapters.at(index).toMap();
+    const double startSeconds = chapter.value(QStringLiteral("startSeconds")).toDouble();
+    seek(startSeconds);
 }
 
 void PlayerController::toggleMute()
@@ -5061,6 +5079,70 @@ void PlayerController::clearOverlayMetadata()
     m_overlayBackdropUrl.clear();
     m_overlayLogoUrl.clear();
     emit overlayMetadataChanged();
+}
+
+void PlayerController::clearPlaybackChapters()
+{
+    const bool hadChapters = !m_playbackChapters.isEmpty();
+    const bool hadCurrentIndex = m_currentPlaybackChapterIndex != -1;
+    m_playbackChapters.clear();
+    m_currentPlaybackChapterIndex = -1;
+    if (hadChapters) {
+        emit playbackChaptersChanged();
+    }
+    if (hadCurrentIndex) {
+        emit currentPlaybackChapterIndexChanged();
+    }
+}
+
+void PlayerController::updateCurrentPlaybackChapterIndex()
+{
+    int nextIndex = -1;
+    for (int index = 0; index < m_playbackChapters.size(); ++index) {
+        const QVariantMap chapter = m_playbackChapters.at(index).toMap();
+        if (chapter.value(QStringLiteral("startSeconds")).toDouble() <= m_currentPosition) {
+            nextIndex = index;
+        } else {
+            break;
+        }
+    }
+    if (nextIndex != m_currentPlaybackChapterIndex) {
+        m_currentPlaybackChapterIndex = nextIndex;
+        emit currentPlaybackChapterIndexChanged();
+    }
+}
+
+void PlayerController::onChaptersLoaded(const QString &itemId, const QList<ChapterInfo> &chapters)
+{
+    if (itemId != m_currentItemId) {
+        return;
+    }
+
+    QVariantList chapterModels;
+    chapterModels.reserve(chapters.size());
+    qInfo() << "PlayerController: Normalizing playback chapters for item" << itemId
+            << "count" << chapters.size();
+    for (const ChapterInfo &chapter : chapters) {
+        const QString thumbnailUrl = m_libraryService->getCachedChapterThumbnailUrl(
+            itemId, chapter.index, chapter.imageTag, chapter.imagePath);
+        qInfo() << "PlayerController: Playback chapter thumbnail"
+                << "item" << itemId
+                << "index" << chapter.index
+                << "hasThumbnailUrl" << !thumbnailUrl.isEmpty();
+        chapterModels.append(chapter.toVariantMap(thumbnailUrl));
+    }
+
+    m_playbackChapters = chapterModels;
+    emit playbackChaptersChanged();
+    updateCurrentPlaybackChapterIndex();
+}
+
+void PlayerController::onChaptersFailed(const QString &itemId, const QString &error)
+{
+    if (itemId == m_currentItemId) {
+        qDebug() << "PlayerController: Chapter metadata unavailable for item" << itemId << error;
+        clearPlaybackChapters();
+    }
 }
 
 void PlayerController::onMediaSegmentsLoaded(const QString &itemId, const QList<MediaSegmentInfo> &segments)

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -89,6 +89,9 @@ class PlayerController : public QObject
     Q_PROPERTY(QString overlaySubtitle READ overlaySubtitle NOTIFY overlayMetadataChanged)
     Q_PROPERTY(QString overlayBackdropUrl READ overlayBackdropUrl NOTIFY overlayMetadataChanged)
     Q_PROPERTY(QString overlayLogoUrl READ overlayLogoUrl NOTIFY overlayMetadataChanged)
+    Q_PROPERTY(QVariantList playbackChapters READ playbackChapters NOTIFY playbackChaptersChanged)
+    Q_PROPERTY(bool hasPlaybackChapters READ hasPlaybackChapters NOTIFY playbackChaptersChanged)
+    Q_PROPERTY(int currentPlaybackChapterIndex READ currentPlaybackChapterIndex NOTIFY currentPlaybackChapterIndexChanged)
     
     // Track selection properties
     Q_PROPERTY(int selectedAudioTrack READ selectedAudioTrack WRITE setSelectedAudioTrack NOTIFY selectedAudioTrackChanged)
@@ -199,6 +202,9 @@ public:
     QString overlaySubtitle() const { return m_overlaySubtitle; }
     QString overlayBackdropUrl() const { return m_overlayBackdropUrl; }
     QString overlayLogoUrl() const { return m_overlayLogoUrl; }
+    QVariantList playbackChapters() const { return m_playbackChapters; }
+    bool hasPlaybackChapters() const { return !m_playbackChapters.isEmpty(); }
+    int currentPlaybackChapterIndex() const { return m_currentPlaybackChapterIndex; }
     Q_INVOKABLE void setAudioDelay(int ms);
     Q_INVOKABLE bool attachEmbeddedVideoTarget(QObject *target);
     Q_INVOKABLE void detachEmbeddedVideoTarget(QObject *target = nullptr);
@@ -270,6 +276,7 @@ public:
     Q_INVOKABLE void cycleSubtitleTrack();
     Q_INVOKABLE void previousChapter();
     Q_INVOKABLE void nextChapter();
+    Q_INVOKABLE void seekToPlaybackChapter(int index);
     Q_INVOKABLE void toggleMute();
     Q_INVOKABLE void setMuted(bool muted);
     Q_INVOKABLE void setVolume(int volume);
@@ -329,6 +336,8 @@ signals:
     void trickplayPreviewChanged();
     void currentItemIdChanged();
     void overlayMetadataChanged();
+    void playbackChaptersChanged();
+    void currentPlaybackChapterIndexChanged();
     
     // Track selection signals
     void selectedAudioTrackChanged();
@@ -389,6 +398,8 @@ private slots:
     void onScriptMessage(const QString &messageName, const QStringList &args);
     void onMediaSegmentsLoaded(const QString &itemId, const QList<MediaSegmentInfo> &segments);
     void onTrickplayInfoLoaded(const QString &itemId, const QMap<int, TrickplayTileInfo> &trickplayInfo);
+    void onChaptersLoaded(const QString &itemId, const QList<ChapterInfo> &chapters);
+    void onChaptersFailed(const QString &itemId, const QString &error);
     
     // TrickplayProcessor handlers
     void onTrickplayProcessingComplete(const QString &itemId, int count, int intervalMs,
@@ -507,6 +518,8 @@ private:
      * Re-evaluate and update flags that indicate whether the player is currently inside intro/outro or other skip segments.
      */
     void updateSkipSegmentState();
+    void updateCurrentPlaybackChapterIndex();
+    void clearPlaybackChapters();
     /**
      * Seek to the end boundary of the specified media segment type (e.g., intro or outro).
      * @param segmentType Type of media segment whose end should be sought.
@@ -832,6 +845,8 @@ private:
     QString m_overlaySubtitle;
     QString m_overlayBackdropUrl;
     QString m_overlayLogoUrl;
+    QVariantList m_playbackChapters;
+    int m_currentPlaybackChapterIndex = -1;
     
     // OSC and trickplay data
     QList<MediaSegmentInfo> m_currentSegments;

--- a/src/ui/EmbeddedPlaybackOverlay.qml
+++ b/src/ui/EmbeddedPlaybackOverlay.qml
@@ -34,11 +34,13 @@ FocusScope {
     property bool controlsVisible: false
     property bool seekPreviewActive: false
     property bool seekOnlyMode: false
+    property bool chapterMode: false
+    property int focusedChapterIndex: -1
     property bool audioSelectorOpen: false
     property bool subtitleSelectorOpen: false
     property bool volumeSelectorOpen: false
     readonly property bool selectorOpen: audioSelectorOpen || subtitleSelectorOpen || volumeSelectorOpen
-    readonly property bool fullControlsVisible: controlsVisible && !seekOnlyMode
+    readonly property bool fullControlsVisible: controlsVisible && !seekOnlyMode && !chapterMode
     property bool hasPrimedPointerPosition: false
     property real lastPointerY: -1
     readonly property bool introSegmentActive: PlayerController.isInIntroSegment
@@ -60,7 +62,7 @@ FocusScope {
     property int seekPreviewHoldMs: 1800
     property int sideRailWidth: Math.round(300 * Theme.layoutScale)
     property real controlsSlideDistance: Math.round(28 * Theme.layoutScale)
-    property real topControlsOffset: fullControlsVisible ? 0 : -controlsSlideDistance
+    property real topControlsOffset: controlsVisible && !seekOnlyMode ? 0 : -controlsSlideDistance
     property real bottomControlsOffset: controlsVisible ? 0 : controlsSlideDistance
     default property alias overlayContent: overlayRoot.data
 
@@ -129,11 +131,34 @@ FocusScope {
         }
         controlsVisible = true
         seekOnlyMode = false
+        chapterMode = false
         if (paused || seekPreviewActive || selectorOpen) {
             hideTimer.stop()
         } else {
             hideTimer.restart()
         }
+    }
+
+    function enterChapterMode() {
+        if (!overlayActive || !PlayerController.hasPlaybackChapters) {
+            return false
+        }
+        controlsVisible = true
+        seekOnlyMode = false
+        chapterMode = true
+        focusedChapterIndex = PlayerController.currentPlaybackChapterIndex >= 0
+                            ? PlayerController.currentPlaybackChapterIndex
+                            : 0
+        hideTimer.restart()
+        Qt.callLater(function() {
+            chapterList.currentIndex = focusedChapterIndex
+            chapterList.positionViewAtIndex(focusedChapterIndex, ListView.Contain)
+            chapterList.forceActiveFocus(Qt.ShortcutFocusReason)
+            if (chapterList.currentItem) {
+                chapterList.currentItem.forceActiveFocus(Qt.ShortcutFocusReason)
+            }
+        })
+        return true
     }
 
     function activateOverlayFocus() {
@@ -321,6 +346,7 @@ FocusScope {
             seekPreviewActive = false
             controlsVisible = false
             seekOnlyMode = false
+            chapterMode = false
             Qt.callLater(function() { root.suppressSkipPopupReshow = false })
             return true
         }
@@ -373,7 +399,39 @@ FocusScope {
             }
         }
 
+        if (chapterMode) {
+            if (direction === "up") {
+                showControls()
+                focusControl(playPauseButton)
+                return true
+            }
+            if (direction === "down") {
+                return true
+            }
+            if (direction === "left") {
+                if (focusedChapterIndex > 0) {
+                    focusedChapterIndex--
+                    chapterList.currentIndex = focusedChapterIndex
+                    chapterList.positionViewAtIndex(focusedChapterIndex, ListView.Contain)
+                    hideTimer.restart()
+                }
+                return true
+            }
+            if (direction === "right") {
+                if (focusedChapterIndex < PlayerController.playbackChapters.length - 1) {
+                    focusedChapterIndex++
+                    chapterList.currentIndex = focusedChapterIndex
+                    chapterList.positionViewAtIndex(focusedChapterIndex, ListView.Contain)
+                    hideTimer.restart()
+                }
+                return true
+            }
+        }
+
         if (!fullControlsVisible) {
+            if (direction === "down" && PlayerController.hasPlaybackChapters) {
+                return enterChapterMode()
+            }
             showControls()
             focusControl(playPauseButton)
             return true
@@ -401,6 +459,9 @@ FocusScope {
         }
 
         if (direction === "down") {
+            if (PlayerController.hasPlaybackChapters) {
+                return enterChapterMode()
+            }
             if (active === backButton || active === progressFocus) {
                 focusControl(playPauseButton)
             }
@@ -469,6 +530,7 @@ FocusScope {
         }
         controlsVisible = false
         seekOnlyMode = false
+        chapterMode = false
     }
 
     onOverlayActiveChanged: {
@@ -477,6 +539,7 @@ FocusScope {
             seekPreviewTimer.stop()
             controlsVisible = false
             seekOnlyMode = false
+            chapterMode = false
             hasPrimedPointerPosition = false
             lastPointerY = -1
             showSkipPopupIfEligible()
@@ -490,6 +553,7 @@ FocusScope {
             controlsVisible = false
             seekPreviewActive = false
             seekOnlyMode = false
+            chapterMode = false
             skipPopupVisible = false
             skipPopupSegmentType = ""
             skipPopupWindowEndEpochMs = 0
@@ -780,7 +844,7 @@ FocusScope {
         anchors.right: parent.right
         height: Math.round(150 * Theme.layoutScale)
         visible: !root.buffering
-        opacity: root.fullControlsVisible ? 1.0 : 0.0
+        opacity: root.controlsVisible && !root.seekOnlyMode ? 1.0 : 0.0
         gradient: Gradient {
             GradientStop { position: 0.0; color: Qt.rgba(Theme.playbackOverlayTopTint.r, Theme.playbackOverlayTopTint.g, Theme.playbackOverlayTopTint.b, 0.70) }
             GradientStop { position: 1.0; color: "transparent" }
@@ -796,10 +860,10 @@ FocusScope {
         anchors.right: parent.right
         height: Math.round(300 * Theme.layoutScale)
         visible: !root.buffering
-        opacity: root.fullControlsVisible ? 1.0 : 0.0
+        opacity: root.controlsVisible && !root.seekOnlyMode ? 1.0 : 0.0
         gradient: Gradient {
             GradientStop { position: 0.0; color: "transparent" }
-            GradientStop { position: 1.0; color: Qt.rgba(0, 0, 0, 0.60) }
+            GradientStop { position: 1.0; color: Qt.rgba(0, 0, 0, root.chapterMode ? 0.68 : 0.60) }
         }
         Behavior on opacity {
             NumberAnimation { duration: root.controlsHideAnimMs; easing.type: Easing.OutCubic }
@@ -1060,8 +1124,8 @@ FocusScope {
             anchors.topMargin: Math.round(56 * Theme.layoutScale) + root.topControlsOffset
             anchors.leftMargin: Math.round(64 * Theme.layoutScale)
             spacing: Math.round(32 * Theme.layoutScale)
-            opacity: root.fullControlsVisible ? 1.0 : 0.0
-            enabled: root.fullControlsVisible
+            opacity: root.controlsVisible && !root.seekOnlyMode ? 1.0 : 0.0
+            enabled: root.controlsVisible && !root.seekOnlyMode
             Behavior on opacity {
                 NumberAnimation { duration: root.controlsHideAnimMs; easing.type: Easing.OutCubic }
             }
@@ -1148,7 +1212,205 @@ FocusScope {
                         fontLetterSpacing: 0.15
                         textStyle: Text.Outline
                         textStyleColor: Qt.rgba(0, 0, 0, 0.92)
-                        active: root.fullControlsVisible
+                        active: root.controlsVisible && !root.seekOnlyMode
+                    }
+                }
+            }
+        }
+
+        Item {
+            id: chapterRailPanel
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            anchors.leftMargin: Math.round(64 * Theme.layoutScale)
+            anchors.rightMargin: Math.round(64 * Theme.layoutScale)
+            anchors.bottomMargin: Math.round(64 * Theme.layoutScale) - root.bottomControlsOffset
+            height: Math.round(292 * Theme.layoutScale)
+            visible: root.controlsVisible && root.chapterMode
+            opacity: visible ? 1.0 : 0.0
+
+            ListView {
+                id: chapterList
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: Math.round(10 * Theme.layoutScale)
+                height: Math.round(268 * Theme.layoutScale)
+                orientation: ListView.Horizontal
+                spacing: Math.round(16 * Theme.layoutScale)
+                clip: true
+                model: PlayerController.playbackChapters
+                currentIndex: root.focusedChapterIndex
+                activeFocusOnTab: true
+                focus: root.chapterMode
+                Keys.onUpPressed: function(event) {
+                    event.accepted = true
+                    root.handleDirectionalKey("up")
+                }
+                Keys.onDownPressed: function(event) {
+                    event.accepted = true
+                    root.handleDirectionalKey("down")
+                }
+                Keys.onReturnPressed: function(event) { event.accepted = true; PlayerController.seekToPlaybackChapter(root.focusedChapterIndex); hideTimer.restart() }
+                Keys.onEnterPressed: function(event) { event.accepted = true; PlayerController.seekToPlaybackChapter(root.focusedChapterIndex); hideTimer.restart() }
+                Keys.onSpacePressed: function(event) { event.accepted = true; PlayerController.seekToPlaybackChapter(root.focusedChapterIndex); hideTimer.restart() }
+                onCurrentIndexChanged: {
+                    if (activeFocus && currentIndex >= 0) {
+                        root.focusedChapterIndex = currentIndex
+                        positionViewAtIndex(currentIndex, ListView.Contain)
+                    }
+                }
+
+                delegate: FocusScope {
+                    id: chapterDelegate
+                    required property var modelData
+                    required property int index
+                    width: Math.round(292 * Theme.layoutScale)
+                    height: chapterList.height
+                    focus: chapterList.activeFocus && chapterList.currentIndex === index
+
+                    Keys.onLeftPressed: function(event) {
+                        if (index > 0) {
+                            chapterList.currentIndex = index - 1
+                            root.focusedChapterIndex = chapterList.currentIndex
+                            Qt.callLater(function() {
+                                if (chapterList.currentItem) {
+                                    chapterList.currentItem.forceActiveFocus(Qt.ShortcutFocusReason)
+                                }
+                            })
+                            event.accepted = true
+                        } else {
+                            event.accepted = false
+                        }
+                    }
+
+                    Keys.onRightPressed: function(event) {
+                        if (index + 1 < chapterList.count) {
+                            chapterList.currentIndex = index + 1
+                            root.focusedChapterIndex = chapterList.currentIndex
+                            Qt.callLater(function() {
+                                if (chapterList.currentItem) {
+                                    chapterList.currentItem.forceActiveFocus(Qt.ShortcutFocusReason)
+                                }
+                            })
+                            event.accepted = true
+                        } else {
+                            event.accepted = false
+                        }
+                    }
+
+                    Keys.onUpPressed: function(event) {
+                        event.accepted = true
+                        root.handleDirectionalKey("up")
+                    }
+
+                    Keys.onDownPressed: function(event) {
+                        event.accepted = true
+                    }
+
+                    Keys.onReturnPressed: function(event) {
+                        event.accepted = true
+                        PlayerController.seekToPlaybackChapter(index)
+                        hideTimer.restart()
+                    }
+
+                    Keys.onEnterPressed: function(event) {
+                        event.accepted = true
+                        PlayerController.seekToPlaybackChapter(index)
+                        hideTimer.restart()
+                    }
+
+                    Keys.onSpacePressed: function(event) {
+                        event.accepted = true
+                        PlayerController.seekToPlaybackChapter(index)
+                        hideTimer.restart()
+                    }
+
+                    onActiveFocusChanged: {
+                        if (activeFocus) {
+                            chapterList.currentIndex = index
+                            root.focusedChapterIndex = index
+                        }
+                    }
+
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        height: Math.round(248 * Theme.layoutScale)
+                        radius: Theme.radiusLarge
+                        color: index === root.focusedChapterIndex
+                               ? Theme.playbackControlGlassBackgroundHover
+                               : Theme.playbackControlGlassBackground
+                        border.width: index === root.focusedChapterIndex ? Theme.buttonFocusBorderWidth : 1
+                        border.color: index === root.focusedChapterIndex ? Theme.focusBorder : Theme.playbackControlGlassBorder
+                        layer.enabled: true
+                        layer.effect: MultiEffect {
+                            blurEnabled: true
+                            blurMax: 24
+                            blur: 0.24
+                        }
+
+                        Column {
+                            anchors.fill: parent
+                            anchors.margins: Math.round(12 * Theme.layoutScale)
+                            spacing: Math.round(8 * Theme.layoutScale)
+
+                            Rectangle {
+                                width: parent.width
+                                height: Math.round(148 * Theme.layoutScale)
+                                radius: Theme.radiusMedium
+                                color: Qt.rgba(0, 0, 0, 0.30)
+                                border.width: 1
+                                border.color: Qt.rgba(1, 1, 1, 0.10)
+                                clip: true
+
+                                Image {
+                                    id: chapterThumbnail
+                                    anchors.fill: parent
+                                    source: modelData.thumbnailUrl || ""
+                                    fillMode: Image.PreserveAspectCrop
+                                    asynchronous: true
+                                    visible: source.toString().length > 0 && status === Image.Ready
+                                }
+                                Text {
+                                    anchors.centerIn: parent
+                                    visible: chapterThumbnail.status !== Image.Ready
+                                    text: Icons.movie
+                                    font.family: Theme.fontIcon
+                                    font.pixelSize: Math.round(40 * Theme.layoutScale)
+                                    color: Theme.playbackTimeSecondary
+                                }
+                                Rectangle {
+                                    anchors.top: parent.top
+                                    anchors.right: parent.right
+                                    anchors.margins: Math.round(10 * Theme.layoutScale)
+                                    width: Math.round(14 * Theme.layoutScale)
+                                    height: width
+                                    radius: width / 2
+                                    color: Theme.playbackProgressFill
+                                    visible: index === PlayerController.currentPlaybackChapterIndex
+                                }
+                            }
+
+                            Text {
+                                width: parent.width
+                                text: modelData.title
+                                color: Theme.playbackTimePrimary
+                                font.family: Theme.fontPrimary
+                                font.pixelSize: Math.round(19 * Theme.layoutScale)
+                                font.weight: Font.DemiBold
+                                elide: Text.ElideRight
+                            }
+                            Text {
+                                width: parent.width
+                                text: root.formatTime(modelData.startSeconds)
+                                color: Theme.playbackTimeSecondary
+                                font.family: Theme.fontPrimary
+                                font.pixelSize: Math.round(16 * Theme.layoutScale)
+                            }
+                        }
                     }
                 }
             }
@@ -1162,8 +1424,8 @@ FocusScope {
             anchors.rightMargin: Math.round(64 * Theme.layoutScale)
             anchors.bottomMargin: Math.round(64 * Theme.layoutScale) - root.bottomControlsOffset
             spacing: Math.round(32 * Theme.layoutScale)
-            opacity: root.controlsVisible ? 1.0 : 0.0
-            enabled: root.controlsVisible
+            opacity: root.controlsVisible && !root.chapterMode ? 1.0 : 0.0
+            enabled: root.controlsVisible && !root.chapterMode
             Behavior on opacity {
                 NumberAnimation { duration: root.controlsHideAnimMs; easing.type: Easing.OutCubic }
             }

--- a/src/ui/EmbeddedPlaybackOverlay.qml
+++ b/src/ui/EmbeddedPlaybackOverlay.qml
@@ -409,6 +409,10 @@ FocusScope {
                 return true
             }
             if (direction === "left") {
+                var leftChapters = PlayerController.playbackChapters
+                if (!leftChapters || !leftChapters.length) {
+                    return true
+                }
                 if (focusedChapterIndex > 0) {
                     focusedChapterIndex--
                     chapterList.currentIndex = focusedChapterIndex
@@ -418,7 +422,11 @@ FocusScope {
                 return true
             }
             if (direction === "right") {
-                if (focusedChapterIndex < PlayerController.playbackChapters.length - 1) {
+                var rightChapters = PlayerController.playbackChapters
+                if (!rightChapters || !rightChapters.length) {
+                    return true
+                }
+                if (focusedChapterIndex < rightChapters.length - 1) {
                     focusedChapterIndex++
                     chapterList.currentIndex = focusedChapterIndex
                     chapterList.positionViewAtIndex(focusedChapterIndex, ListView.Contain)

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -63,7 +63,8 @@ Window {
     readonly property bool embeddedPlaybackActive: PlayerController.supportsEmbeddedVideo && PlayerController.isPlaybackActive
     readonly property bool useDetachedPlaybackOverlayWindow: Qt.platform.os === "windows"
     readonly property bool playbackOverlayNavigationActive: embeddedPlaybackActive
-                                                         && activeEmbeddedPlaybackOverlay.fullControlsVisible
+                                                         && (activeEmbeddedPlaybackOverlay.fullControlsVisible
+                                                             || activeEmbeddedPlaybackOverlay.chapterMode)
     readonly property bool playbackSelectorOpen: embeddedPlaybackActive
                                               && activeEmbeddedPlaybackOverlay.selectorOpen
     readonly property bool awaitingUpNextTransition: PlayerController.awaitingNextEpisodeResolution

--- a/src/ui/SeriesSeasonEpisodeView.qml
+++ b/src/ui/SeriesSeasonEpisodeView.qml
@@ -2072,6 +2072,13 @@ FocusScope {
                         }
                     }
                 }
+
+                WheelStepScroller {
+                    anchors.fill: parent
+                    target: chapterList
+                    orientation: Qt.Horizontal
+                    stepPx: Math.round(248 * Theme.layoutScale) + Theme.spacingMedium
+                }
             }
 
             FocusScope {

--- a/src/ui/SeriesSeasonEpisodeView.qml
+++ b/src/ui/SeriesSeasonEpisodeView.qml
@@ -121,7 +121,9 @@ FocusScope {
     onSelectedEpisodeIdChanged: {
         overviewExpanded = false
         clearEpisodePlaybackState()
-        chapterPreloadTimer.restart()
+        chapterPreloadTimer.stop()
+        SeriesDetailsViewModel.clearFocusedEpisodeChapters()
+        chapterPreloadTimer.start()
     }
 
     // Guard initial episode focusing/selection so async reloads do not override user input.

--- a/src/ui/SeriesSeasonEpisodeView.qml
+++ b/src/ui/SeriesSeasonEpisodeView.qml
@@ -31,6 +31,8 @@ FocusScope {
     readonly property int peopleCardHeight: Math.round(320 * Theme.layoutScale)
     readonly property var focusedEpisodePeople: SeriesDetailsViewModel.focusedEpisodePeople || []
     readonly property bool focusedEpisodeDetailsLoading: SeriesDetailsViewModel.focusedEpisodeDetailsLoading
+    readonly property var focusedEpisodeChapters: SeriesDetailsViewModel.focusedEpisodeChapters || []
+    readonly property bool focusedEpisodeChaptersLoading: SeriesDetailsViewModel.focusedEpisodeChaptersLoading
     readonly property string selectedEpisodeImageUrl: selectedEpisodeData
                                                      ? (selectedEpisodeData.imageUrl || selectedEpisodeData.ImageUrl || "")
                                                      : ""
@@ -119,6 +121,7 @@ FocusScope {
     onSelectedEpisodeIdChanged: {
         overviewExpanded = false
         clearEpisodePlaybackState()
+        chapterPreloadTimer.restart()
     }
 
     // Guard initial episode focusing/selection so async reloads do not override user input.
@@ -154,6 +157,19 @@ FocusScope {
         pendingPlaybackRestoreFocusTarget = null
         waitingForContextInfo = false
         lastLoadedPlaybackInfo = null
+    }
+
+    Timer {
+        id: chapterPreloadTimer
+        interval: 300
+        repeat: false
+        onTriggered: {
+            if (selectedEpisodeId) {
+                SeriesDetailsViewModel.loadFocusedEpisodeChapters(selectedEpisodeId)
+            } else {
+                SeriesDetailsViewModel.clearFocusedEpisodeChapters()
+            }
+        }
     }
     
     // Playback info storage - keeps the last loaded playback info
@@ -486,6 +502,7 @@ FocusScope {
         } else {
             selectedEpisodeData = null
             SeriesDetailsViewModel.clearFocusedEpisodeDetails()
+            SeriesDetailsViewModel.clearFocusedEpisodeChapters()
         }
     }
     
@@ -580,6 +597,16 @@ FocusScope {
         var runtimeMs = runtimeTicks / 10000
         var endTime = new Date(now.getTime() + runtimeMs)
         return "Ends at " + endTime.toLocaleTimeString(Qt.locale(), "h:mm AP")
+    }
+
+    function formatChapterTime(seconds) {
+        var total = Math.max(0, Math.floor(seconds || 0))
+        var hours = Math.floor(total / 3600)
+        var minutes = Math.floor((total % 3600) / 60)
+        var remainder = total % 60
+        function pad(value) { return value < 10 ? "0" + value : "" + value }
+        return hours > 0 ? hours + ":" + pad(minutes) + ":" + pad(remainder)
+                         : minutes + ":" + pad(remainder)
     }
     
     // Debounce timer for preloading playback info on episode selection
@@ -795,7 +822,7 @@ FocusScope {
     }
     
     // Playback actions
-    function startPlayback(fromBeginning, restoreFocusTarget) {
+    function startPlayback(fromBeginning, restoreFocusTarget, chapterStartTicks) {
         if (!selectedEpisodeId) return
         
         console.log("[SeriesSeasonEpisodeView] startPlayback - Episode:", selectedEpisodeName,
@@ -812,13 +839,14 @@ FocusScope {
         }
         
         // Playback info is ready, proceed with playback
-        performPlayback(fromBeginning, restoreFocusTarget)
+        performPlayback(fromBeginning, restoreFocusTarget, chapterStartTicks)
     }
     
-    function performPlayback(fromBeginning, restoreFocusTarget) {
+    function performPlayback(fromBeginning, restoreFocusTarget, chapterStartTicks) {
         if (!selectedEpisodeId) return
         
-        var startPos = fromBeginning ? 0 : selectedEpisodePlaybackPosition
+        var hasChapterStart = chapterStartTicks !== undefined && chapterStartTicks !== null
+        var startPos = hasChapterStart ? chapterStartTicks : (fromBeginning ? 0 : selectedEpisodePlaybackPosition)
         var framerate = getVideoFramerate()
         var isHDR = isVideoHDR()
         
@@ -1639,7 +1667,9 @@ FocusScope {
                     highlightMoveVelocity: -1
                     model: SeriesDetailsViewModel.episodesModel
                     KeyNavigation.up: playResumeButton
-                    KeyNavigation.down: castSection.visible && castList.count > 0 ? castList : null
+                    KeyNavigation.down: chapterSection.visible && chapterList.count > 0
+                                        ? chapterList
+                                        : (castSection.visible && castList.count > 0 ? castList : null)
 
                     onActiveFocusChanged: {
                         if (activeFocus) {
@@ -1658,6 +1688,11 @@ FocusScope {
                     }
 
                     Keys.onDownPressed: (event) => {
+                        if (chapterSection.visible && chapterList.count > 0) {
+                            chapterSection.focusCurrentOrFirst()
+                            event.accepted = true
+                            return
+                        }
                         if (castSection.visible && castList.count > 0) {
                             castSection.focusCurrentOrFirst()
                             event.accepted = true
@@ -1822,6 +1857,222 @@ FocusScope {
             }
 
             FocusScope {
+                id: chapterSection
+                Layout.fillWidth: true
+                Layout.preferredHeight: implicitHeight
+                visible: focusedEpisodeChaptersLoading || focusedEpisodeChapters.length > 0
+                implicitHeight: chapterSectionContent.implicitHeight
+
+                function focusCurrentOrFirst() {
+                    if (chapterList.count <= 0) {
+                        if (castSection.visible && castList.count > 0) {
+                            castSection.focusCurrentOrFirst()
+                        } else {
+                            episodesList.forceActiveFocus()
+                        }
+                        return
+                    }
+                    chapterList.currentIndex = Math.max(0, chapterList.currentIndex)
+                    chapterList.forceActiveFocus()
+                    Qt.callLater(function() {
+                        if (chapterList.currentItem) {
+                            chapterList.currentItem.forceActiveFocus()
+                        }
+                    })
+                }
+
+                ColumnLayout {
+                    id: chapterSectionContent
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    spacing: Theme.spacingMedium
+
+                    Text {
+                        text: qsTr("Chapters")
+                        font.pixelSize: Theme.fontSizeHeader
+                        font.family: Theme.fontPrimary
+                        font.weight: Font.Black
+                        color: Theme.textPrimary
+                    }
+
+                    RowLayout {
+                        visible: focusedEpisodeChaptersLoading && focusedEpisodeChapters.length === 0
+                        spacing: Theme.spacingSmall
+
+                        BusyIndicator {
+                            Layout.preferredWidth: Math.round(32 * Theme.layoutScale)
+                            Layout.preferredHeight: Math.round(32 * Theme.layoutScale)
+                            running: parent.visible
+                        }
+
+                        Text {
+                            text: qsTr("Loading chapters…")
+                            font.pixelSize: Theme.fontSizeBody
+                            font.family: Theme.fontPrimary
+                            color: Theme.textSecondary
+                        }
+                    }
+
+                    ListView {
+                        id: chapterList
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Math.round(224 * Theme.layoutScale)
+                        orientation: ListView.Horizontal
+                        spacing: Theme.spacingMedium
+                        model: focusedEpisodeChapters
+                        visible: focusedEpisodeChapters.length > 0
+                        clip: true
+                        interactive: false
+                        boundsBehavior: Flickable.StopAtBounds
+
+                        onActiveFocusChanged: {
+                            if (activeFocus) {
+                                mainContentFlickable.ensureVisible(chapterSection)
+                            }
+                        }
+
+                        onCurrentIndexChanged: {
+                            if (activeFocus && currentIndex >= 0) {
+                                positionViewAtIndex(currentIndex, ListView.Contain)
+                            }
+                        }
+
+                        Keys.onUpPressed: (event) => {
+                            episodesList.forceActiveFocus()
+                            event.accepted = true
+                        }
+
+                        Keys.onDownPressed: (event) => {
+                            if (castSection.visible && castList.count > 0) {
+                                castSection.focusCurrentOrFirst()
+                                event.accepted = true
+                            } else {
+                                event.accepted = false
+                            }
+                        }
+
+                        delegate: FocusScope {
+                            id: chapterDelegate
+                            required property int index
+                            required property var modelData
+                            width: Math.round(248 * Theme.layoutScale)
+                            height: chapterList.height
+                            focus: chapterList.activeFocus && chapterList.currentIndex === index
+
+                            Keys.onLeftPressed: (event) => {
+                                if (index > 0) {
+                                    chapterList.currentIndex = index - 1
+                                    Qt.callLater(function() {
+                                        if (chapterList.currentItem) chapterList.currentItem.forceActiveFocus()
+                                    })
+                                    event.accepted = true
+                                } else {
+                                    event.accepted = false
+                                }
+                            }
+
+                            Keys.onRightPressed: (event) => {
+                                if (index + 1 < chapterList.count) {
+                                    chapterList.currentIndex = index + 1
+                                    Qt.callLater(function() {
+                                        if (chapterList.currentItem) chapterList.currentItem.forceActiveFocus()
+                                    })
+                                    event.accepted = true
+                                } else {
+                                    event.accepted = false
+                                }
+                            }
+
+                            Keys.onUpPressed: (event) => {
+                                episodesList.forceActiveFocus()
+                                event.accepted = true
+                            }
+
+                            Keys.onDownPressed: (event) => {
+                                if (castSection.visible && castList.count > 0) {
+                                    castSection.focusCurrentOrFirst()
+                                    event.accepted = true
+                                } else {
+                                    event.accepted = false
+                                }
+                            }
+
+                            Keys.onReturnPressed: (event) => {
+                                if (!event.isAutoRepeat) {
+                                    startPlayback(false, chapterDelegate, modelData.startPositionTicks || 0)
+                                }
+                                event.accepted = true
+                            }
+                            Keys.onEnterPressed: (event) => {
+                                if (!event.isAutoRepeat) {
+                                    startPlayback(false, chapterDelegate, modelData.startPositionTicks || 0)
+                                }
+                                event.accepted = true
+                            }
+
+                            Rectangle {
+                                anchors.fill: parent
+                                radius: Theme.radiusMedium
+                                color: Theme.cardBackground
+                                border.width: chapterDelegate.activeFocus ? Theme.buttonFocusBorderWidth : 0
+                                border.color: Theme.accentPrimary
+
+                                ColumnLayout {
+                                    anchors.fill: parent
+                                    anchors.margins: Theme.spacingSmall
+                                    spacing: Theme.spacingSmall
+
+                                    Rectangle {
+                                        Layout.fillWidth: true
+                                        Layout.preferredHeight: Math.round(132 * Theme.layoutScale)
+                                        radius: Theme.radiusMedium
+                                        color: Theme.cardBackgroundHover
+                                        clip: true
+
+                                        Image {
+                                            id: chapterThumbnail
+                                            anchors.fill: parent
+                                            source: modelData.thumbnailUrl || ""
+                                            fillMode: Image.PreserveAspectCrop
+                                            asynchronous: true
+                                            visible: source.toString().length > 0 && status === Image.Ready
+                                        }
+
+                                        Text {
+                                            anchors.centerIn: parent
+                                            visible: chapterThumbnail.status !== Image.Ready
+                                            text: Icons.movie
+                                            font.family: Theme.fontIcon
+                                            font.pixelSize: Math.round(32 * Theme.layoutScale)
+                                            color: Theme.textSecondary
+                                        }
+                                    }
+
+                                    Text {
+                                        Layout.fillWidth: true
+                                        text: modelData.title || qsTr("Chapter")
+                                        font.pixelSize: Theme.fontSizeBody
+                                        font.family: Theme.fontPrimary
+                                        font.bold: true
+                                        color: Theme.textPrimary
+                                        elide: Text.ElideRight
+                                    }
+
+                                    Text {
+                                        Layout.fillWidth: true
+                                        text: formatChapterTime(modelData.startSeconds || 0)
+                                        font.pixelSize: Theme.fontSizeCaption
+                                        font.family: Theme.fontPrimary
+                                        color: Theme.textSecondary
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            FocusScope {
                 id: castSection
                 Layout.fillWidth: true
                 Layout.preferredHeight: implicitHeight
@@ -1920,7 +2171,11 @@ FocusScope {
                             }
 
                             Keys.onUpPressed: {
-                                episodesList.forceActiveFocus()
+                                if (chapterSection.visible && chapterList.count > 0) {
+                                    chapterSection.focusCurrentOrFirst()
+                                } else {
+                                    episodesList.forceActiveFocus()
+                                }
                             }
 
                             Keys.onReturnPressed: (event) => {

--- a/src/viewmodels/SeriesDetailsViewModel.cpp
+++ b/src/viewmodels/SeriesDetailsViewModel.cpp
@@ -511,6 +511,10 @@ SeriesDetailsViewModel::SeriesDetailsViewModel(QObject *parent)
                 this, &SeriesDetailsViewModel::onSimilarItemsLoaded);
         connect(m_libraryService, &LibraryService::similarItemsFailed,
                 this, &SeriesDetailsViewModel::onSimilarItemsFailed);
+        connect(m_libraryService, &LibraryService::chaptersLoaded,
+                this, &SeriesDetailsViewModel::onFocusedEpisodeChaptersLoaded);
+        connect(m_libraryService, &LibraryService::chaptersFailed,
+                this, &SeriesDetailsViewModel::onFocusedEpisodeChaptersFailed);
         connect(m_libraryService, &LibraryService::errorOccurred,
                 this, &SeriesDetailsViewModel::onErrorOccurred);
     } else {
@@ -819,6 +823,48 @@ void SeriesDetailsViewModel::clearFocusedEpisodeDetails()
     }
 }
 
+void SeriesDetailsViewModel::loadFocusedEpisodeChapters(const QString &episodeId)
+{
+    if (!m_libraryService || episodeId.isEmpty()) {
+        clearFocusedEpisodeChapters();
+        return;
+    }
+
+    m_focusedEpisodeChapterId = episodeId;
+
+    if (m_episodeChapterCache.contains(episodeId)) {
+        applyFocusedEpisodeChapters(episodeId, m_episodeChapterCache.value(episodeId));
+        return;
+    }
+
+    m_focusedEpisodeChapters.clear();
+    emit focusedEpisodeChaptersChanged();
+    setFocusedEpisodeChaptersLoading(true);
+
+    if (m_pendingEpisodeChapterIds.contains(episodeId)) {
+        return;
+    }
+
+    m_pendingEpisodeChapterIds.insert(episodeId);
+    m_libraryService->getChapters(episodeId);
+}
+
+void SeriesDetailsViewModel::clearFocusedEpisodeChapters()
+{
+    const bool hadFocusedChapters = !m_focusedEpisodeChapterId.isEmpty()
+                                    || !m_focusedEpisodeChapters.isEmpty()
+                                    || m_focusedEpisodeChaptersLoading;
+
+    m_focusedEpisodeChapterId.clear();
+    m_focusedEpisodeChapters.clear();
+    m_pendingEpisodeChapterIds.clear();
+    setFocusedEpisodeChaptersLoading(false);
+
+    if (hadFocusedChapters) {
+        emit focusedEpisodeChaptersChanged();
+    }
+}
+
 void SeriesDetailsViewModel::clear(bool preserveArtwork)
 {
     m_seriesId.clear();
@@ -860,10 +906,15 @@ void SeriesDetailsViewModel::clear(bool preserveArtwork)
     m_focusedEpisodeDetails = QJsonObject();
     m_focusedEpisodePeople.clear();
     m_focusedEpisodeDetailsLoading = false;
+    m_focusedEpisodeChapterId.clear();
+    m_focusedEpisodeChapters.clear();
+    m_focusedEpisodeChaptersLoading = false;
     m_episodeDetailsCache.clear();
     m_pendingEpisodeDetailIds.clear();
     m_episodeDetailRequestTokens.clear();
     m_episodeDetailRetried.clear();
+    m_episodeChapterCache.clear();
+    m_pendingEpisodeChapterIds.clear();
 
     m_selectedSeasonIndex = -1;
     m_selectedSeasonId.clear();
@@ -897,6 +948,8 @@ void SeriesDetailsViewModel::clear(bool preserveArtwork)
     emit nextEpisodeChanged();
     emit focusedEpisodeDetailsChanged();
     emit focusedEpisodeDetailsLoadingChanged();
+    emit focusedEpisodeChaptersChanged();
+    emit focusedEpisodeChaptersLoadingChanged();
     emit selectedSeasonIndexChanged();
     emit selectedSeasonIdChanged();
     emit officialRatingChanged();
@@ -1480,6 +1533,47 @@ void SeriesDetailsViewModel::onEpisodeDetailsFailed(const QString &itemId,
     }
 }
 
+void SeriesDetailsViewModel::onFocusedEpisodeChaptersLoaded(const QString &itemId,
+                                                            const QList<ChapterInfo> &chapters)
+{
+    if (!m_pendingEpisodeChapterIds.contains(itemId)) {
+        return;
+    }
+
+    m_pendingEpisodeChapterIds.remove(itemId);
+
+    QVariantList normalized;
+    normalized.reserve(chapters.size());
+    for (const ChapterInfo &chapter : chapters) {
+        const QString thumbnailUrl = m_libraryService
+            ? m_libraryService->getCachedChapterThumbnailUrl(
+                  itemId, chapter.index, chapter.imageTag, chapter.imagePath)
+            : QString();
+        normalized.append(chapter.toVariantMap(thumbnailUrl));
+    }
+    m_episodeChapterCache.insert(itemId, normalized);
+
+    if (itemId == m_focusedEpisodeChapterId) {
+        applyFocusedEpisodeChapters(itemId, normalized);
+    }
+}
+
+void SeriesDetailsViewModel::onFocusedEpisodeChaptersFailed(const QString &itemId, const QString &error)
+{
+    if (!m_pendingEpisodeChapterIds.contains(itemId)) {
+        return;
+    }
+
+    m_pendingEpisodeChapterIds.remove(itemId);
+    qWarning() << "SeriesDetailsViewModel focused episode chapters error for" << itemId << ":" << error;
+
+    if (itemId == m_focusedEpisodeChapterId) {
+        m_focusedEpisodeChapters.clear();
+        setFocusedEpisodeChaptersLoading(false);
+        emit focusedEpisodeChaptersChanged();
+    }
+}
+
 void SeriesDetailsViewModel::updateSeriesMetadata(const QJsonObject &data)
 {
     const auto common = DetailMetadataHelper::extractCommonMetadata(
@@ -1640,6 +1734,28 @@ void SeriesDetailsViewModel::setFocusedEpisodeDetailsLoading(bool loading)
 
     m_focusedEpisodeDetailsLoading = loading;
     emit focusedEpisodeDetailsLoadingChanged();
+}
+
+void SeriesDetailsViewModel::applyFocusedEpisodeChapters(const QString &episodeId,
+                                                         const QVariantList &chapters)
+{
+    if (episodeId != m_focusedEpisodeChapterId) {
+        return;
+    }
+
+    m_focusedEpisodeChapters = chapters;
+    setFocusedEpisodeChaptersLoading(false);
+    emit focusedEpisodeChaptersChanged();
+}
+
+void SeriesDetailsViewModel::setFocusedEpisodeChaptersLoading(bool loading)
+{
+    if (m_focusedEpisodeChaptersLoading == loading) {
+        return;
+    }
+
+    m_focusedEpisodeChaptersLoading = loading;
+    emit focusedEpisodeChaptersLoadingChanged();
 }
 
 void SeriesDetailsViewModel::updateNextEpisode(const QJsonObject &episodeData)

--- a/src/viewmodels/SeriesDetailsViewModel.h
+++ b/src/viewmodels/SeriesDetailsViewModel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "BaseViewModel.h"
+#include "network/Types.h"
 #include <QAbstractListModel>
 #include <QJsonArray>
 #include <QJsonObject>
@@ -179,6 +180,8 @@ class SeriesDetailsViewModel : public BaseViewModel
     Q_PROPERTY(QVariantList focusedEpisodePeople READ focusedEpisodePeople NOTIFY focusedEpisodeDetailsChanged)
     Q_PROPERTY(QString focusedEpisodeDetailId READ focusedEpisodeDetailId NOTIFY focusedEpisodeDetailsChanged)
     Q_PROPERTY(bool focusedEpisodeDetailsLoading READ focusedEpisodeDetailsLoading NOTIFY focusedEpisodeDetailsLoadingChanged)
+    Q_PROPERTY(QVariantList focusedEpisodeChapters READ focusedEpisodeChapters NOTIFY focusedEpisodeChaptersChanged)
+    Q_PROPERTY(bool focusedEpisodeChaptersLoading READ focusedEpisodeChaptersLoading NOTIFY focusedEpisodeChaptersLoadingChanged)
 
     // Models
     Q_PROPERTY(SeasonsModel* seasonsModel READ seasonsModel CONSTANT)
@@ -230,6 +233,8 @@ public:
     QVariantList focusedEpisodePeople() const { return m_focusedEpisodePeople; }
     QString focusedEpisodeDetailId() const { return m_focusedEpisodeDetailId; }
     bool focusedEpisodeDetailsLoading() const { return m_focusedEpisodeDetailsLoading; }
+    QVariantList focusedEpisodeChapters() const { return m_focusedEpisodeChapters; }
+    bool focusedEpisodeChaptersLoading() const { return m_focusedEpisodeChaptersLoading; }
 
     // Property accessors - State
     // Property accessors - Models
@@ -290,6 +295,8 @@ public:
     Q_INVOKABLE void toggleFavorite();
     Q_INVOKABLE void loadFocusedEpisodeDetails(const QString &episodeId);
     Q_INVOKABLE void clearFocusedEpisodeDetails();
+    Q_INVOKABLE void loadFocusedEpisodeChapters(const QString &episodeId);
+    Q_INVOKABLE void clearFocusedEpisodeChapters();
 
     /**
      * @brief Clear all data and reset state.
@@ -357,6 +364,8 @@ signals:
     void nextEpisodeChanged();
     void focusedEpisodeDetailsChanged();
     void focusedEpisodeDetailsLoadingChanged();
+    void focusedEpisodeChaptersChanged();
+    void focusedEpisodeChaptersLoadingChanged();
 
     // Selected season signals
     void selectedSeasonIndexChanged();
@@ -388,6 +397,8 @@ private slots:
     void onEpisodeDetailsLoaded(const QString &itemId, const QJsonObject &data, const QString &requestContext);
     void onEpisodeDetailsNotModified(const QString &itemId, const QString &requestContext);
     void onEpisodeDetailsFailed(const QString &itemId, const QString &error, const QString &requestContext);
+    void onFocusedEpisodeChaptersLoaded(const QString &itemId, const QList<ChapterInfo> &chapters);
+    void onFocusedEpisodeChaptersFailed(const QString &itemId, const QString &error);
 
 private:
     void updateSeriesMetadata(const QJsonObject &data);
@@ -399,6 +410,8 @@ private:
     void finishEpisodeDetailsRequest(const QString &itemId);
     void stopFocusedEpisodeDetailsLoadingFor(const QString &itemId);
     void setFocusedEpisodeDetailsLoading(bool loading);
+    void applyFocusedEpisodeChapters(const QString &episodeId, const QVariantList &chapters);
+    void setFocusedEpisodeChaptersLoading(bool loading);
 
 private:
     LibraryService *m_libraryService = nullptr;
@@ -449,11 +462,16 @@ private:
     QJsonObject m_focusedEpisodeDetails;
     QVariantList m_focusedEpisodePeople;
     bool m_focusedEpisodeDetailsLoading = false;
+    QString m_focusedEpisodeChapterId;
+    QVariantList m_focusedEpisodeChapters;
+    bool m_focusedEpisodeChaptersLoading = false;
     QHash<QString, QJsonObject> m_episodeDetailsCache;
     QSet<QString> m_pendingEpisodeDetailIds;
     QHash<QString, QString> m_episodeDetailRequestTokens;
     QSet<QString> m_episodeDetailRetried;
     quint64 m_episodeDetailRequestSequence = 0;
+    QHash<QString, QVariantList> m_episodeChapterCache;
+    QSet<QString> m_pendingEpisodeChapterIds;
 
     // State
     bool m_loadingSeries = false;

--- a/tests/SimilarItemsRetryTest.cpp
+++ b/tests/SimilarItemsRetryTest.cpp
@@ -77,6 +77,35 @@ public:
     QStringList clearItemCacheValidationCalls;
 };
 
+class EpisodeChaptersLibraryService : public LibraryService
+{
+    Q_OBJECT
+
+public:
+    explicit EpisodeChaptersLibraryService(QObject *parent = nullptr)
+        : LibraryService(nullptr, parent)
+    {
+    }
+
+    void getChapters(const QString &itemId) override
+    {
+        requests.append(itemId);
+    }
+
+    QString getCachedChapterThumbnailUrl(const QString &itemId,
+                                         int chapterIndex,
+                                         const QString &imageTag,
+                                         const QString &imagePath,
+                                         int width) override
+    {
+        Q_UNUSED(imageTag)
+        Q_UNUSED(imagePath)
+        return QStringLiteral("chapter://%1/%2/%3").arg(itemId).arg(chapterIndex).arg(width);
+    }
+
+    QStringList requests;
+};
+
 class SimilarItemsRetryTest : public QObject
 {
     Q_OBJECT
@@ -89,6 +118,8 @@ private slots:
     void seriesEpisodeDetailsFailureIsTargeted();
     void seriesEpisodeDetailsNotModifiedRetriesOnce();
     void seriesEpisodeDetailsIgnoreForeignTokens();
+    void seriesEpisodeChaptersLoadNormalizeCacheAndIgnoreStale();
+    void seriesEpisodeChaptersFailureClearsVisibleState();
     void mockLibraryServiceTracksItemCacheInvalidation();
 
 private:
@@ -210,6 +241,63 @@ void SimilarItemsRetryTest::seriesEpisodeDetailsIgnoreForeignTokens()
     QVERIFY(secondVm.focusedEpisodeDetails().isEmpty());
     QVERIFY(secondVm.focusedEpisodeDetailsLoading());
     QVERIFY(secondVm.m_pendingEpisodeDetailIds.contains(QStringLiteral("shared-episode")));
+}
+
+void SimilarItemsRetryTest::seriesEpisodeChaptersLoadNormalizeCacheAndIgnoreStale()
+{
+    ServiceLocator::clear();
+    auto *service = new EpisodeChaptersLibraryService(this);
+    ServiceLocator::registerService<LibraryService>(service);
+
+    SeriesDetailsViewModel vm;
+    vm.loadFocusedEpisodeChapters(QStringLiteral("ep-1"));
+    QCOMPARE(service->requests, QStringList{QStringLiteral("ep-1")});
+    QVERIFY(vm.focusedEpisodeChaptersLoading());
+
+    vm.loadFocusedEpisodeChapters(QStringLiteral("ep-2"));
+    QCOMPARE(service->requests, QStringList({QStringLiteral("ep-1"), QStringLiteral("ep-2")}));
+
+    ChapterInfo first;
+    first.index = 0;
+    first.title = QStringLiteral("Cold Open");
+    first.startPositionTicks = 1234;
+    first.imageTag = QStringLiteral("tag");
+    emit service->chaptersLoaded(QStringLiteral("ep-1"), QList<ChapterInfo>{first});
+    QVERIFY(vm.focusedEpisodeChapters().isEmpty());
+
+    ChapterInfo second;
+    second.index = 1;
+    second.title = QStringLiteral("Act One");
+    second.startPositionTicks = 9876;
+    second.imagePath = QStringLiteral("/Images/Chapter/1");
+    emit service->chaptersLoaded(QStringLiteral("ep-2"), QList<ChapterInfo>{second});
+
+    QCOMPARE(vm.focusedEpisodeChapters().size(), 1);
+    const QVariantMap chapter = vm.focusedEpisodeChapters().first().toMap();
+    QCOMPARE(chapter.value(QStringLiteral("title")).toString(), QStringLiteral("Act One"));
+    QCOMPARE(chapter.value(QStringLiteral("startPositionTicks")).toLongLong(), 9876LL);
+    QCOMPARE(chapter.value(QStringLiteral("thumbnailUrl")).toString(),
+             QStringLiteral("chapter://ep-2/1/480"));
+    QVERIFY(!vm.focusedEpisodeChaptersLoading());
+
+    vm.loadFocusedEpisodeChapters(QStringLiteral("ep-1"));
+    QCOMPARE(service->requests.size(), 2);
+    QCOMPARE(vm.focusedEpisodeChapters().first().toMap().value(QStringLiteral("title")).toString(),
+             QStringLiteral("Cold Open"));
+}
+
+void SimilarItemsRetryTest::seriesEpisodeChaptersFailureClearsVisibleState()
+{
+    ServiceLocator::clear();
+    auto *service = new EpisodeChaptersLibraryService(this);
+    ServiceLocator::registerService<LibraryService>(service);
+
+    SeriesDetailsViewModel vm;
+    vm.loadFocusedEpisodeChapters(QStringLiteral("ep-9"));
+    emit service->chaptersFailed(QStringLiteral("ep-9"), QStringLiteral("network"));
+
+    QVERIFY(vm.focusedEpisodeChapters().isEmpty());
+    QVERIFY(!vm.focusedEpisodeChaptersLoading());
 }
 
 void SimilarItemsRetryTest::mockLibraryServiceTracksItemCacheInvalidation()


### PR DESCRIPTION
## Summary

  This PR adds Jellyfin-backed playback chapter support to Bloom’s embedded playback overlay.

  ## What changed

  - Added reusable chapter metadata loading through LibraryService
  - Normalized Jellyfin chapter data for UI consumers
  - Exposed playback chapter state through PlayerController
      - chapter list
      - currently playing chapter index
      - seek-to-chapter action
  - Added a dedicated chapter mode to the embedded playback overlay
      - Down enters chapter mode when chapters exist
      - Left / Right moves across chapter cards
      - Enter / Space seeks to the selected chapter
      - Up returns to transport controls
      - Back / Escape dismisses the overlay
  - Added chapter thumbnails with placeholder fallback behavior
  - Added targeted debug logging for chapter metadata and thumbnail requests
  - Updated playback and services documentation

  ## Still needed

  - Chapter support on SeriesSeasonEpisodeView.qml

  ## Notes

  - Chapter data comes from Jellyfin item Chapters
  - Thumbnail URLs follow Jellyfin’s chapter image endpoint pattern:
      - /Items/{itemId}/Images/Chapter/{chapterIndex}
  - If no chapter thumbnail is available, the overlay shows a neutral placeholder tile

  ## Validation

  - Built successfully with:
      - ./scripts/build-docker.sh
  - Manually validated chapter navigation in the embedded playback overlay on Linux / Assumed to work on Windows but will test more heavily later

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add chapter browsing and playback support to the embedded overlay and series detail view
> - Adds a `ChapterInfo` type and `LibraryService::getChapters` to fetch and normalize Jellyfin chapter metadata, with deduplication of in-flight requests and thumbnail URL generation via `getCachedChapterThumbnailUrl`.
> - `PlayerController` now loads chapters for the current item, tracks the active chapter index as playback position changes, and exposes `seekToPlaybackChapter(int)` to QML.
> - The embedded playback overlay gains a `chapterMode` state with a horizontal chapter rail; directional down enters chapter mode, up returns to main controls, and selecting a chapter seeks immediately.
> - `SeriesDetailsViewModel` preloads chapter metadata for the focused episode with a small per-episode cache, and `SeriesSeasonEpisodeView` renders a chapter carousel that starts playback at the selected chapter's `startPositionTicks`.
> - Risk: Chapter mode suppresses bottom playback controls and alters `fullControlsVisible` logic; existing overlays relying on those bindings will behave differently when chapters are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff7120f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chapter browsing for episodes: preloaded chapter rails between Episodes and Cast & Crew, thumbnails (artwork or themed placeholder), and chapter-based playback/seek.
  * Playback overlay chapter mode with keyboard navigation, focused chapter rail, and persistent browsing focus.
  * Series view exposes focused-episode chapter lists for fast navigation.

* **Documentation**
  * Docs expanded for chapter flows, controls, thumbnail behavior, caching, and logging.

* **Tests**
  * Tests added for chapter loading, cache normalization, thumbnail URL handling, and failure clearing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crowquillx/Bloom/pull/54)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->