### PR TITLE
fix: stabilize detail metadata shelves and playback readiness

### DIFF
--- a/docs/playback.md
+++ b/docs/playback.md
@@ -129,12 +129,14 @@ Track Preference Persistence
 - When navigating to a new episode in the same season, explicit preferences are restored. If they are missing or invalid for the new source, Bloom falls back through the standard resolution order.
 - Use `PlayerController.getLastAudioTrackForSeason(seasonId)` and `getLastSubtitleTrackForSeason(seasonId)` to retrieve.
 - Use `PlayerController.setExplicitSeasonAudioPreference(seasonId, index)` and `setExplicitSeasonSubtitlePreference(seasonId, index)` to save.
-- `SeriesSeasonEpisodeView` preloads Jellyfin chapter metadata for the highlighted episode and inserts a contextual `Chapters` rail between `Episodes` and `Cast & Crew` when chapter data exists.
+- `SeriesSeasonEpisodeView` preloads Jellyfin chapter metadata for the highlighted episode and keeps a `Chapters` rail between `Episodes` and `Cast & Crew`; missing chapters resolve to a quiet reserved empty state.
 - Activating a chapter card reuses the normal episode playback request, including track preference/version-prompt handling, but sets `startPositionTicks` to that chapter’s start tick so playback begins at the selected chapter.
 
 ### Movies (Per-Movie)
 - Preferences are stored by movie ID for rewatches.
 - When the user changes audio/subtitle track in `MovieDetailsView`, the preference is immediately saved.
+- `MovieDetailsView` exposes the same chapter-card playback rail above `Cast & Crew`; activating a chapter starts the movie at that chapter's start tick.
+- Detail-page primary `Play` / `Resume` controls remain pressable while playback info is preparing, show a spinner in place of the normal glyph, and preserve the existing "still preparing" toast on press.
 - When returning to the same movie, explicit preferences are restored instead of server defaults. If none were saved, Bloom uses Jellyfin/file defaults.
 - Use `PlayerController.getLastAudioTrackForMovie(movieId)` and `getLastSubtitleTrackForMovie(movieId)` to retrieve.
 - Use `PlayerController.setExplicitMovieAudioPreference(movieId, index)` and `setExplicitMovieSubtitlePreference(movieId, index)` to save.

--- a/docs/viewmodels.md
+++ b/docs/viewmodels.md
@@ -66,7 +66,7 @@ private:
 ViewModel for the series-style movie details screen.
 
 ### Purpose
-Acts as the data source for `MovieDetailsView.qml`. It aggregates Jellyfin movie metadata, playback progress, cast, similar-library recommendations, and external ratings from MDBList (IMDb, TMDB, Rotten Tomatoes, etc.) plus AniList when available.
+Acts as the data source for `MovieDetailsView.qml`. It aggregates Jellyfin movie metadata, playback progress, chapters, cast, similar-library recommendations, and external ratings from MDBList (IMDb, TMDB, Rotten Tomatoes, etc.) plus AniList when available.
 
 ### Public API
 - **Key Properties**:
@@ -74,6 +74,7 @@ Acts as the data source for `MovieDetailsView.qml`. It aggregates Jellyfin movie
   - `officialRating`, `runtimeTicks`, `communityRating`, `premiereDate`, `genres`: movie metadata used by the hero chips and synopsis area.
   - `isWatched`, `playbackPositionTicks`: sync with Jellyfin `UserData` and drive `Play` vs `Resume` UI.
   - `people`: cast/crew entries used by the lower cast shelf.
+  - `chapters`, `chaptersLoading`: normalized movie chapter cards plus the rail loading state.
   - `similarItems`, `similarItemsLoading`: recommendation shelf data and loading state for similar titles.
   - `mdbListRatings`: `QVariantMap` containing normalized external ratings, including AniList when merged in.
 - **Methods**:
@@ -81,10 +82,11 @@ Acts as the data source for `MovieDetailsView.qml`. It aggregates Jellyfin movie
   - `reload()`: retries the active movie load for error/retry flows.
   - `markAsWatched()` / `markAsUnwatched()`: sync played status to the server.
   - `clear(bool preserveArtwork)`: resets state. Set `preserveArtwork=true` to keep artwork visible during transitions.
+  - `loadMovieChapters(QString movieId)` / `clearMovieChapters()`: load or reset the active movie chapter rail.
 - **Signals**:
   - `movieLoaded()`: metadata is ready for display.
   - `loadError(QString error)`: standardized error notification.
-  - `peopleChanged()`, `similarItemsChanged()`, `similarItemsLoadingChanged()`: update the cast and recommendation shelves.
+  - `peopleChanged()`, `chaptersChanged()`, `chaptersLoadingChanged()`, `similarItemsChanged()`, `similarItemsLoadingChanged()`: update the lower metadata shelves.
 
 ### Integration
 - **Services**: Retrieves `LibraryService` via `ServiceLocator` for movie details, user-data updates, and similar-item requests.
@@ -92,7 +94,7 @@ Acts as the data source for `MovieDetailsView.qml`. It aggregates Jellyfin movie
 - **Config**: Reads `ConfigManager` for API keys and cache storage paths.
 
 ### Lifecycle & Side Effects
-- **Caching**: Uses separate in-memory and disk caches for movie details and similar items. Disk cache resides in `<configDir>/cache/movies/` with a 1-hour TTL.
+- **Caching**: Uses separate in-memory and disk caches for movie details and similar items. Disk cache resides in `<configDir>/cache/movies/` with a 1-hour TTL. Movie chapters keep a small in-memory per-movie cache so returning to a movie does not immediately re-show loading skeletons.
 - **Rating Fetching**: Automatically triggers external rating lookups after metadata loads when provider IDs (IMDb/TMDB) are present.
 - **Recommendation Fetching**: Requests similar items after details load, while still allowing cached empty recommendation results to short-circuit redundant network fetches.
 - **State Cleanup**: `clear()` should be called when navigating away from the view to prevent stale shelves or metadata from lingering.

--- a/src/ui/MovieDetailsView.qml
+++ b/src/ui/MovieDetailsView.qml
@@ -28,6 +28,8 @@ FocusScope {
     readonly property string officialRating: MovieDetailsViewModel.officialRating
     readonly property var genres: MovieDetailsViewModel.genres
     readonly property var castAndCrew: MovieDetailsViewModel.people || []
+    readonly property var chapters: MovieDetailsViewModel.chapters || []
+    readonly property bool chaptersLoading: MovieDetailsViewModel.chaptersLoading
     readonly property var libraryRecommendations: MovieDetailsViewModel.similarItems || []
     readonly property bool libraryRecommendationsLoading: MovieDetailsViewModel.similarItemsLoading
     readonly property bool isLoading: MovieDetailsViewModel.isLoading
@@ -310,7 +312,7 @@ FocusScope {
         return tracks.length > 0 ? shortTrackLabel(tracks[0], qsTr("Auto")) : qsTr("Unavailable")
     }
 
-    function buildPlaybackRequest() {
+    function buildPlaybackRequest(startPositionOverride, restoreFocusTarget) {
         var framerate = getVideoFramerate()
         var hdr = isVideoHDR()
         var overlaySubtitle = productionYear > 0 ? String(productionYear) : ""
@@ -319,7 +321,9 @@ FocusScope {
 
         return {
             itemId: movieId,
-            startPositionTicks: playbackPositionTicks || 0,
+            startPositionTicks: startPositionOverride !== undefined && startPositionOverride !== null
+                                ? startPositionOverride
+                                : (playbackPositionTicks || 0),
             seriesId: "",
             seasonId: "",
             overlayTitle: movieName || qsTr("Now Playing"),
@@ -332,11 +336,15 @@ FocusScope {
             allowVersionPrompt: true,
             framerateHint: framerate,
             isHDRHint: hdr,
-            restoreFocusTarget: playButton
+            restoreFocusTarget: restoreFocusTarget || playButton
         }
     }
 
     function startPlaybackWithTracks() {
+        startPlaybackWithTracksAt(undefined, playButton)
+    }
+
+    function startPlaybackWithTracksAt(startPositionTicks, restoreFocusTarget) {
         resetPlaybackReturnFocusState()
 
         if (playbackInfoLoading || !playbackInfo || !currentMediaSource) {
@@ -348,10 +356,10 @@ FocusScope {
             return
         }
 
-        lastPlaybackRestoreFocusTarget = playButton
+        lastPlaybackRestoreFocusTarget = restoreFocusTarget || playButton
         playbackReturnFocusPending = true
         playbackReturnFocusActivated = false
-        root.playRequested(buildPlaybackRequest())
+        root.playRequested(buildPlaybackRequest(startPositionTicks, lastPlaybackRestoreFocusTarget))
     }
 
     function formatRuntime(ticks) {
@@ -363,6 +371,16 @@ FocusScope {
             return qsTr("%1h %2m").arg(hours).arg(minutes)
         }
         return qsTr("%1m").arg(minutes)
+    }
+
+    function formatChapterTime(seconds) {
+        var total = Math.max(0, Math.floor(seconds || 0))
+        var hours = Math.floor(total / 3600)
+        var minutes = Math.floor((total % 3600) / 60)
+        var remainder = total % 60
+        function pad(value) { return value < 10 ? "0" + value : "" + value }
+        return hours > 0 ? hours + ":" + pad(minutes) + ":" + pad(remainder)
+                         : minutes + ":" + pad(remainder)
     }
 
     function calculateEndTime(ticks) {
@@ -439,6 +457,9 @@ FocusScope {
         if (itemIsDescendant(activeItem, castList)) {
             return "cast"
         }
+        if (itemIsDescendant(activeItem, chapterList)) {
+            return "chapters"
+        }
         if (itemIsDescendant(activeItem, libraryRecommendationsList)) {
             return "libraryRecommendations"
         }
@@ -455,6 +476,7 @@ FocusScope {
             return 0
         }
         if (area === "cast") return Math.max(0, castList.currentIndex)
+        if (area === "chapters") return Math.max(0, chapterList.currentIndex)
         if (area === "libraryRecommendations") return Math.max(0, libraryRecommendationsList.currentIndex)
         return 0
     }
@@ -504,6 +526,13 @@ FocusScope {
             return focusCurrentViewItem(castList)
         }
 
+        if (area === "chapters" && chapterSection.visible && chapterList.count > 0) {
+            chapterList.currentIndex = Math.min(targetIndex, chapterList.count - 1)
+            chapterList.positionViewAtIndex(chapterList.currentIndex, ListView.Contain)
+            ensureItemVisible(chapterSection, Math.round(80 * Theme.layoutScale), Math.round(160 * Theme.layoutScale))
+            return focusCurrentViewItem(chapterList)
+        }
+
         if (area === "libraryRecommendations" && libraryRecommendationsSection.visible && libraryRecommendationsList.count > 0) {
             libraryRecommendationsList.currentIndex = Math.min(targetIndex, libraryRecommendationsList.count - 1)
             libraryRecommendationsList.positionViewAtIndex(libraryRecommendationsList.currentIndex, ListView.Contain)
@@ -546,6 +575,9 @@ FocusScope {
         }
 
         if (restoreFocusToArea("cast", state.focusIndex || 0)) {
+            return true
+        }
+        if (restoreFocusToArea("chapters", state.focusIndex || 0)) {
             return true
         }
 
@@ -617,7 +649,9 @@ FocusScope {
     }
 
     function focusFirstLowerSection() {
-        if (castSection.visible) {
+        if (chapterSection.visible && chapterList.count > 0) {
+            chapterSection.focusCurrentOrFirst()
+        } else if (castSection.visible && castList.count > 0) {
             castSection.focusCurrentOrFirst()
         } else if (libraryRecommendationsSection.visible) {
             libraryRecommendationsSection.focusCurrentOrFirst()
@@ -731,6 +765,10 @@ FocusScope {
     }
 
     onLibraryRecommendationsChanged: {
+        Qt.callLater(root.tryRestorePendingReturnState)
+    }
+
+    onChaptersChanged: {
         Qt.callLater(root.tryRestorePendingReturnState)
     }
 
@@ -1141,6 +1179,7 @@ FocusScope {
                                 }
 
                                 contentItem: Text {
+                                    visible: !playbackInfoLoading
                                     anchors.centerIn: parent
                                     text: Icons.playArrow
                                     font.family: Theme.fontIcon
@@ -1148,6 +1187,14 @@ FocusScope {
                                     color: Theme.textPrimary
                                     horizontalAlignment: Text.AlignHCenter
                                     verticalAlignment: Text.AlignVCenter
+                                }
+
+                                BusyIndicator {
+                                    anchors.centerIn: parent
+                                    width: Math.round(28 * Theme.layoutScale)
+                                    height: Math.round(28 * Theme.layoutScale)
+                                    running: visible
+                                    visible: playbackInfoLoading
                                 }
                             }
 
@@ -1271,10 +1318,158 @@ FocusScope {
             }
 
             FocusScope {
+                id: chapterSection
+                Layout.fillWidth: true
+                Layout.preferredHeight: implicitHeight
+                visible: movieId !== ""
+                implicitHeight: chapterSectionContent.implicitHeight
+
+                function focusCurrentOrFirst() {
+                    if (chapterList.count <= 0) {
+                        if (castList.count > 0) castSection.focusCurrentOrFirst()
+                        return
+                    }
+                    chapterList.currentIndex = Math.max(0, chapterList.currentIndex)
+                    chapterList.forceActiveFocus()
+                    Qt.callLater(function() {
+                        if (chapterList.currentItem) chapterList.currentItem.forceActiveFocus()
+                    })
+                }
+
+                ColumnLayout {
+                    id: chapterSectionContent
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    spacing: Theme.spacingMedium
+
+                    Text {
+                        text: qsTr("Chapters")
+                        font.pixelSize: Theme.fontSizeHeader
+                        font.family: Theme.fontPrimary
+                        font.weight: Font.Black
+                        color: Theme.textPrimary
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Math.round(224 * Theme.layoutScale)
+                        visible: chaptersLoading && chapters.length === 0
+                        radius: Theme.radiusMedium
+                        color: Qt.rgba(1, 1, 1, 0.04)
+                        border.width: 1
+                        border.color: Theme.cardBorder
+                        Row {
+                            anchors.fill: parent
+                            anchors.margins: Theme.spacingMedium
+                            spacing: Theme.spacingMedium
+                            Repeater {
+                                model: 3
+                                Rectangle {
+                                    width: Math.round(248 * Theme.layoutScale)
+                                    height: parent.height
+                                    radius: Theme.radiusMedium
+                                    color: Qt.rgba(1, 1, 1, 0.06)
+                                    opacity: 0.72
+                                    SequentialAnimation on opacity {
+                                        running: Theme.uiAnimationsEnabled && parent.visible
+                                        loops: Animation.Infinite
+                                        NumberAnimation { to: 0.42; duration: Theme.durationNormal }
+                                        NumberAnimation { to: 0.72; duration: Theme.durationNormal }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    ListView {
+                        id: chapterList
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Math.round(224 * Theme.layoutScale)
+                        orientation: ListView.Horizontal
+                        spacing: Theme.spacingMedium
+                        model: chapters
+                        visible: chapters.length > 0
+                        clip: true
+                        interactive: false
+                        boundsBehavior: Flickable.StopAtBounds
+
+                        onActiveFocusChanged: if (activeFocus) root.ensureItemVisible(chapterSection, Math.round(80 * Theme.layoutScale), Math.round(160 * Theme.layoutScale))
+                        onCurrentIndexChanged: if (activeFocus && currentIndex >= 0) positionViewAtIndex(currentIndex, ListView.Contain)
+
+                        delegate: FocusScope {
+                            id: chapterDelegate
+                            required property int index
+                            required property var modelData
+                            width: Math.round(248 * Theme.layoutScale)
+                            height: chapterList.height
+                            focus: chapterList.activeFocus && chapterList.currentIndex === index
+                            Keys.onLeftPressed: (event) => { if (index > 0) { chapterList.currentIndex = index - 1; event.accepted = true } else event.accepted = false }
+                            Keys.onRightPressed: (event) => { if (index + 1 < chapterList.count) { chapterList.currentIndex = index + 1; event.accepted = true } else event.accepted = false }
+                            Keys.onUpPressed: { playButton.forceActiveFocus() }
+                            Keys.onDownPressed: { if (castList.count > 0) castSection.focusCurrentOrFirst(); else root.focusTarget(root.nextSectionAfterCast()) }
+                            Keys.onReturnPressed: (event) => { if (!event.isAutoRepeat) root.startPlaybackWithTracksAt(modelData.startPositionTicks || 0, chapterDelegate); event.accepted = true }
+                            Keys.onEnterPressed: (event) => { if (!event.isAutoRepeat) root.startPlaybackWithTracksAt(modelData.startPositionTicks || 0, chapterDelegate); event.accepted = true }
+
+                            Rectangle {
+                                anchors.fill: parent
+                                radius: Theme.radiusMedium
+                                color: Theme.cardBackground
+                                border.width: chapterDelegate.activeFocus ? Theme.buttonFocusBorderWidth : 0
+                                border.color: Theme.accentPrimary
+                                ColumnLayout {
+                                    anchors.fill: parent
+                                    anchors.margins: Theme.spacingSmall
+                                    spacing: Theme.spacingSmall
+                                    Rectangle {
+                                        Layout.fillWidth: true
+                                        Layout.preferredHeight: Math.round(132 * Theme.layoutScale)
+                                        radius: Theme.radiusMedium
+                                        color: Theme.cardBackgroundHover
+                                        clip: true
+                                        Image {
+                                            id: movieChapterThumbnail
+                                            anchors.fill: parent
+                                            source: modelData.thumbnailUrl || ""
+                                            fillMode: Image.PreserveAspectCrop
+                                            asynchronous: true
+                                            visible: source.toString().length > 0 && status === Image.Ready
+                                        }
+                                        Text {
+                                            anchors.centerIn: parent
+                                            visible: movieChapterThumbnail.status !== Image.Ready
+                                            text: Icons.movie
+                                            font.family: Theme.fontIcon
+                                            font.pixelSize: Math.round(32 * Theme.layoutScale)
+                                            color: Theme.textSecondary
+                                        }
+                                    }
+                                    Text { Layout.fillWidth: true; text: modelData.title || qsTr("Chapter"); font.pixelSize: Theme.fontSizeBody; font.family: Theme.fontPrimary; font.bold: true; color: Theme.textPrimary; elide: Text.ElideRight }
+                                    Text { Layout.fillWidth: true; text: formatChapterTime(modelData.startSeconds || 0); font.pixelSize: Theme.fontSizeCaption; font.family: Theme.fontPrimary; color: Theme.textSecondary }
+                                }
+                            }
+                        }
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Math.round(224 * Theme.layoutScale)
+                        visible: !chaptersLoading && chapters.length === 0
+                        radius: Theme.radiusMedium
+                        color: Qt.rgba(1, 1, 1, 0.04)
+                        border.width: 1
+                        border.color: Theme.cardBorder
+                        Text { anchors.centerIn: parent; text: qsTr("No chapters available."); font.pixelSize: Theme.fontSizeBody; font.family: Theme.fontPrimary; color: Theme.textSecondary }
+                    }
+                }
+
+                WheelStepScroller { anchors.fill: parent; target: chapterList; orientation: Qt.Horizontal; stepPx: Math.round(248 * Theme.layoutScale) + Theme.spacingMedium }
+            }
+
+            FocusScope {
                 id: castSection
                 Layout.fillWidth: true
                 Layout.preferredHeight: implicitHeight
-                visible: castAndCrew.length > 0
+                visible: movieId !== ""
                 implicitHeight: castSectionContent.implicitHeight
 
                 function focusCurrentOrFirst() {
@@ -1297,6 +1492,37 @@ FocusScope {
                         font.family: Theme.fontPrimary
                         font.weight: Font.Black
                         color: Theme.textPrimary
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: root.peopleCardHeight + Math.round(16 * Theme.layoutScale)
+                        visible: isLoading && castAndCrew.length === 0
+                        radius: Theme.radiusMedium
+                        color: Qt.rgba(1, 1, 1, 0.04)
+                        border.width: 1
+                        border.color: Theme.cardBorder
+                        Row {
+                            anchors.fill: parent
+                            anchors.margins: Theme.spacingMedium
+                            spacing: Theme.spacingMedium
+                            Repeater {
+                                model: 4
+                                Rectangle {
+                                    width: root.peopleCardWidth
+                                    height: root.peopleCardHeight
+                                    radius: Theme.radiusMedium
+                                    color: Qt.rgba(1, 1, 1, 0.06)
+                                    opacity: 0.72
+                                    SequentialAnimation on opacity {
+                                        running: Theme.uiAnimationsEnabled && parent.visible
+                                        loops: Animation.Infinite
+                                        NumberAnimation { to: 0.42; duration: Theme.durationNormal }
+                                        NumberAnimation { to: 0.72; duration: Theme.durationNormal }
+                                    }
+                                }
+                            }
+                        }
                     }
 
                     ListView {
@@ -1351,7 +1577,8 @@ FocusScope {
                             }
 
                             Keys.onUpPressed: {
-                                playButton.forceActiveFocus()
+                                if (chapterList.count > 0) chapterSection.focusCurrentOrFirst()
+                                else playButton.forceActiveFocus()
                             }
 
                             Keys.onDownPressed: {
@@ -1385,6 +1612,17 @@ FocusScope {
                             orientation: Qt.Horizontal
                             stepPx: root.peopleCardWidth + Theme.spacingMedium
                         }
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: root.peopleCardHeight + Math.round(16 * Theme.layoutScale)
+                        visible: !isLoading && castAndCrew.length === 0
+                        radius: Theme.radiusMedium
+                        color: Qt.rgba(1, 1, 1, 0.04)
+                        border.width: 1
+                        border.color: Theme.cardBorder
+                        Text { anchors.centerIn: parent; text: qsTr("No cast or crew listed."); font.pixelSize: Theme.fontSizeBody; font.family: Theme.fontPrimary; color: Theme.textSecondary }
                     }
                 }
             }

--- a/src/ui/MovieDetailsView.qml
+++ b/src/ui/MovieDetailsView.qml
@@ -555,11 +555,16 @@ FocusScope {
 
         const desiredArea = state.focusArea || "hero"
         const castReady = castList.count > 0
+        const chaptersReady = chapterList.count > 0
         const recsReady = libraryRecommendationsList.count > 0
         const castPending = isLoading
+        const chaptersPending = chaptersLoading
         const recsPending = libraryRecommendationsLoading
 
         if (desiredArea === "cast" && !castReady && !recsReady && (castPending || recsPending)) {
+            return false
+        }
+        if (desiredArea === "chapters" && !chaptersReady && chaptersPending) {
             return false
         }
         if (desiredArea === "libraryRecommendations" && !recsReady && !castReady && (recsPending || castPending)) {

--- a/src/ui/MovieDetailsView.qml
+++ b/src/ui/MovieDetailsView.qml
@@ -777,6 +777,10 @@ FocusScope {
         Qt.callLater(root.tryRestorePendingReturnState)
     }
 
+    onChaptersLoadingChanged: {
+        Qt.callLater(root.tryRestorePendingReturnState)
+    }
+
     Rectangle {
         anchors.fill: parent
         color: "transparent"

--- a/src/ui/SeriesSeasonEpisodeView.qml
+++ b/src/ui/SeriesSeasonEpisodeView.qml
@@ -1907,7 +1907,7 @@ FocusScope {
                     }
 
                     Rectangle {
-                        visible: focusedEpisodeChaptersLoading && focusedEpisodeChapters.length === 0
+                        visible: (focusedEpisodeChaptersLoading || chapterPreloadTimer.running) && focusedEpisodeChapters.length === 0
                         Layout.fillWidth: true
                         Layout.preferredHeight: Math.round(224 * Theme.layoutScale)
                         radius: Theme.radiusMedium
@@ -2098,7 +2098,7 @@ FocusScope {
                     Rectangle {
                         Layout.fillWidth: true
                         Layout.preferredHeight: Math.round(224 * Theme.layoutScale)
-                        visible: !focusedEpisodeChaptersLoading && focusedEpisodeChapters.length === 0
+                        visible: !focusedEpisodeChaptersLoading && !chapterPreloadTimer.running && focusedEpisodeChapters.length === 0
                         radius: Theme.radiusMedium
                         color: Qt.rgba(1, 1, 1, 0.04)
                         border.width: 1

--- a/src/ui/SeriesSeasonEpisodeView.qml
+++ b/src/ui/SeriesSeasonEpisodeView.qml
@@ -1460,6 +1460,7 @@ FocusScope {
                                 }
 
                                 contentItem: Text {
+                                    visible: playbackInfoLoadingItemId !== selectedEpisodeId
                                     anchors.centerIn: parent
                                     text: selectedEpisodePlaybackPosition > 0 ? Icons.fastForward : Icons.playArrow
                                     font.family: Theme.fontIcon
@@ -1467,6 +1468,14 @@ FocusScope {
                                     color: Theme.textPrimary
                                     horizontalAlignment: Text.AlignHCenter
                                     verticalAlignment: Text.AlignVCenter
+                                }
+
+                                BusyIndicator {
+                                    anchors.centerIn: parent
+                                    width: Math.round(28 * Theme.layoutScale)
+                                    height: Math.round(28 * Theme.layoutScale)
+                                    running: visible
+                                    visible: playbackInfoLoadingItemId === selectedEpisodeId
                                 }
                             }
 
@@ -1862,7 +1871,7 @@ FocusScope {
                 id: chapterSection
                 Layout.fillWidth: true
                 Layout.preferredHeight: implicitHeight
-                visible: focusedEpisodeChaptersLoading || focusedEpisodeChapters.length > 0
+                visible: selectedEpisodeId !== ""
                 implicitHeight: chapterSectionContent.implicitHeight
 
                 function focusCurrentOrFirst() {
@@ -1897,21 +1906,35 @@ FocusScope {
                         color: Theme.textPrimary
                     }
 
-                    RowLayout {
+                    Rectangle {
                         visible: focusedEpisodeChaptersLoading && focusedEpisodeChapters.length === 0
-                        spacing: Theme.spacingSmall
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Math.round(224 * Theme.layoutScale)
+                        radius: Theme.radiusMedium
+                        color: Qt.rgba(1, 1, 1, 0.04)
+                        border.width: 1
+                        border.color: Theme.cardBorder
 
-                        BusyIndicator {
-                            Layout.preferredWidth: Math.round(32 * Theme.layoutScale)
-                            Layout.preferredHeight: Math.round(32 * Theme.layoutScale)
-                            running: parent.visible
-                        }
-
-                        Text {
-                            text: qsTr("Loading chapters…")
-                            font.pixelSize: Theme.fontSizeBody
-                            font.family: Theme.fontPrimary
-                            color: Theme.textSecondary
+                        Row {
+                            anchors.fill: parent
+                            anchors.margins: Theme.spacingMedium
+                            spacing: Theme.spacingMedium
+                            Repeater {
+                                model: 3
+                                Rectangle {
+                                    width: Math.round(248 * Theme.layoutScale)
+                                    height: parent.height
+                                    radius: Theme.radiusMedium
+                                    color: Qt.rgba(1, 1, 1, 0.06)
+                                    opacity: 0.72
+                                    SequentialAnimation on opacity {
+                                        running: Theme.uiAnimationsEnabled && parent.visible
+                                        loops: Animation.Infinite
+                                        NumberAnimation { to: 0.42; duration: Theme.durationNormal }
+                                        NumberAnimation { to: 0.72; duration: Theme.durationNormal }
+                                    }
+                                }
+                            }
                         }
                     }
 
@@ -2071,6 +2094,23 @@ FocusScope {
                             }
                         }
                     }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Math.round(224 * Theme.layoutScale)
+                        visible: !focusedEpisodeChaptersLoading && focusedEpisodeChapters.length === 0
+                        radius: Theme.radiusMedium
+                        color: Qt.rgba(1, 1, 1, 0.04)
+                        border.width: 1
+                        border.color: Theme.cardBorder
+                        Text {
+                            anchors.centerIn: parent
+                            text: qsTr("No chapters available.")
+                            font.pixelSize: Theme.fontSizeBody
+                            font.family: Theme.fontPrimary
+                            color: Theme.textSecondary
+                        }
+                    }
                 }
 
                 WheelStepScroller {
@@ -2085,7 +2125,7 @@ FocusScope {
                 id: castSection
                 Layout.fillWidth: true
                 Layout.preferredHeight: implicitHeight
-                visible: focusedEpisodeDetailsLoading || focusedEpisodePeople.length > 0
+                visible: selectedEpisodeId !== ""
                 implicitHeight: castSectionContent.implicitHeight
 
                 function focusCurrentOrFirst() {
@@ -2111,21 +2151,34 @@ FocusScope {
                         color: Theme.textPrimary
                     }
 
-                    RowLayout {
+                    Rectangle {
                         visible: focusedEpisodeDetailsLoading && focusedEpisodePeople.length === 0
-                        spacing: Theme.spacingSmall
-
-                        BusyIndicator {
-                            Layout.preferredWidth: Math.round(32 * Theme.layoutScale)
-                            Layout.preferredHeight: Math.round(32 * Theme.layoutScale)
-                            running: parent.visible
-                        }
-
-                        Text {
-                            text: qsTr("Loading cast and crew…")
-                            font.pixelSize: Theme.fontSizeBody
-                            font.family: Theme.fontPrimary
-                            color: Theme.textSecondary
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: root.peopleCardHeight + Math.round(16 * Theme.layoutScale)
+                        radius: Theme.radiusMedium
+                        color: Qt.rgba(1, 1, 1, 0.04)
+                        border.width: 1
+                        border.color: Theme.cardBorder
+                        Row {
+                            anchors.fill: parent
+                            anchors.margins: Theme.spacingMedium
+                            spacing: Theme.spacingMedium
+                            Repeater {
+                                model: 4
+                                Rectangle {
+                                    width: root.peopleCardWidth
+                                    height: root.peopleCardHeight
+                                    radius: Theme.radiusMedium
+                                    color: Qt.rgba(1, 1, 1, 0.06)
+                                    opacity: 0.72
+                                    SequentialAnimation on opacity {
+                                        running: Theme.uiAnimationsEnabled && parent.visible
+                                        loops: Animation.Infinite
+                                        NumberAnimation { to: 0.42; duration: Theme.durationNormal }
+                                        NumberAnimation { to: 0.72; duration: Theme.durationNormal }
+                                    }
+                                }
+                            }
                         }
                     }
 
@@ -2213,6 +2266,23 @@ FocusScope {
                             target: castList
                             orientation: Qt.Horizontal
                             stepPx: root.peopleCardWidth + Theme.spacingMedium
+                        }
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: root.peopleCardHeight + Math.round(16 * Theme.layoutScale)
+                        visible: !focusedEpisodeDetailsLoading && focusedEpisodePeople.length === 0
+                        radius: Theme.radiusMedium
+                        color: Qt.rgba(1, 1, 1, 0.04)
+                        border.width: 1
+                        border.color: Theme.cardBorder
+                        Text {
+                            anchors.centerIn: parent
+                            text: qsTr("No cast or crew listed.")
+                            font.pixelSize: Theme.fontSizeBody
+                            font.family: Theme.fontPrimary
+                            color: Theme.textSecondary
                         }
                     }
                 }

--- a/src/viewmodels/MovieDetailsViewModel.cpp
+++ b/src/viewmodels/MovieDetailsViewModel.cpp
@@ -47,6 +47,10 @@ MovieDetailsViewModel::MovieDetailsViewModel(QObject *parent)
                 this, &MovieDetailsViewModel::onSimilarItemsLoaded);
         connect(m_libraryService, &LibraryService::similarItemsFailed,
                 this, &MovieDetailsViewModel::onSimilarItemsFailed);
+        connect(m_libraryService, &LibraryService::chaptersLoaded,
+                this, &MovieDetailsViewModel::onMovieChaptersLoaded);
+        connect(m_libraryService, &LibraryService::chaptersFailed,
+                this, &MovieDetailsViewModel::onMovieChaptersFailed);
         connect(m_libraryService, &LibraryService::errorOccurred,
                 this, &MovieDetailsViewModel::onErrorOccurred);
         // Map generic itemPlayedStatusChanged to internal logic if needed,
@@ -206,6 +210,7 @@ void MovieDetailsViewModel::loadMovieDetails(const QString &movieId)
     // Fetch from server
     // Request typical fields for details view
     m_libraryService->getItem(movieId);
+    loadMovieChapters(movieId);
 }
 
 void MovieDetailsViewModel::reload()
@@ -244,6 +249,10 @@ void MovieDetailsViewModel::clear(bool preserveArtwork)
     m_runtimeTicks = 0;
     m_communityRating = 0.0;
     m_people.clear();
+    m_chapters.clear();
+    m_movieChapterId.clear();
+    m_pendingMovieChapterIds.clear();
+    m_chaptersLoading = false;
     m_genres.clear();
     m_similarItems.clear();
     m_similarItemsAttempted = false;
@@ -281,6 +290,8 @@ void MovieDetailsViewModel::clear(bool preserveArtwork)
     emit runtimeTicksChanged();
     emit communityRatingChanged();
     emit peopleChanged();
+    emit chaptersChanged();
+    emit chaptersLoadingChanged();
     emit genresChanged();
     emit similarItemsChanged();
     emit similarItemsLoadingChanged();
@@ -288,6 +299,43 @@ void MovieDetailsViewModel::clear(bool preserveArtwork)
     emit playbackPositionTicksChanged();
     if (!preserveArtwork) {
         emit mdbListRatingsChanged();
+    }
+}
+
+void MovieDetailsViewModel::loadMovieChapters(const QString &movieId)
+{
+    if (!m_libraryService || movieId.isEmpty()) {
+        clearMovieChapters();
+        return;
+    }
+
+    m_movieChapterId = movieId;
+    if (m_movieChapterCache.contains(movieId)) {
+        applyMovieChapters(movieId, m_movieChapterCache.value(movieId));
+        return;
+    }
+
+    m_chapters.clear();
+    emit chaptersChanged();
+    setMovieChaptersLoading(true);
+
+    if (m_pendingMovieChapterIds.contains(movieId)) {
+        return;
+    }
+
+    m_pendingMovieChapterIds.insert(movieId);
+    m_libraryService->getChapters(movieId);
+}
+
+void MovieDetailsViewModel::clearMovieChapters()
+{
+    const bool hadState = !m_movieChapterId.isEmpty() || !m_chapters.isEmpty() || m_chaptersLoading;
+    m_movieChapterId.clear();
+    m_chapters.clear();
+    m_pendingMovieChapterIds.clear();
+    setMovieChaptersLoading(false);
+    if (hadState) {
+        emit chaptersChanged();
     }
 }
 
@@ -360,6 +408,47 @@ void MovieDetailsViewModel::onSimilarItemsFailed(const QString &itemId, const QS
     }
 
     qWarning() << "MovieDetailsViewModel similar items error:" << error;
+}
+
+void MovieDetailsViewModel::onMovieChaptersLoaded(const QString &itemId,
+                                                  const QList<ChapterInfo> &chapters)
+{
+    if (!m_pendingMovieChapterIds.contains(itemId)) {
+        return;
+    }
+
+    m_pendingMovieChapterIds.remove(itemId);
+    QVariantList normalized;
+    normalized.reserve(chapters.size());
+    for (const ChapterInfo &chapter : chapters) {
+        const QString thumbnailUrl = m_libraryService
+            ? m_libraryService->getCachedChapterThumbnailUrl(
+                  itemId, chapter.index, chapter.imageTag, chapter.imagePath)
+            : QString();
+        normalized.append(chapter.toVariantMap(thumbnailUrl));
+    }
+    m_movieChapterCache.insert(itemId, normalized);
+
+    if (itemId == m_movieChapterId) {
+        applyMovieChapters(itemId, normalized);
+    }
+}
+
+void MovieDetailsViewModel::onMovieChaptersFailed(const QString &itemId, const QString &error)
+{
+    if (!m_pendingMovieChapterIds.contains(itemId)) {
+        return;
+    }
+
+    m_pendingMovieChapterIds.remove(itemId);
+    qWarning() << "MovieDetailsViewModel movie chapters error for" << itemId << ":" << error;
+    m_movieChapterCache.insert(itemId, {});
+
+    if (itemId == m_movieChapterId) {
+        m_chapters.clear();
+        setMovieChaptersLoading(false);
+        emit chaptersChanged();
+    }
 }
 
 void MovieDetailsViewModel::onErrorOccurred(const QString &endpoint, const QString &error)
@@ -524,4 +613,25 @@ void MovieDetailsViewModel::compileRatings()
         m_mdbListRatings = combined;
         emit mdbListRatingsChanged();
     }
+}
+
+void MovieDetailsViewModel::applyMovieChapters(const QString &movieId,
+                                               const QVariantList &chapters)
+{
+    if (movieId != m_movieChapterId) {
+        return;
+    }
+
+    m_chapters = chapters;
+    setMovieChaptersLoading(false);
+    emit chaptersChanged();
+}
+
+void MovieDetailsViewModel::setMovieChaptersLoading(bool loading)
+{
+    if (m_chaptersLoading == loading) {
+        return;
+    }
+    m_chaptersLoading = loading;
+    emit chaptersLoadingChanged();
 }

--- a/src/viewmodels/MovieDetailsViewModel.cpp
+++ b/src/viewmodels/MovieDetailsViewModel.cpp
@@ -316,8 +316,8 @@ void MovieDetailsViewModel::loadMovieChapters(const QString &movieId)
     }
 
     m_chapters.clear();
-    emit chaptersChanged();
     setMovieChaptersLoading(true);
+    emit chaptersChanged();
 
     if (m_pendingMovieChapterIds.contains(movieId)) {
         return;
@@ -442,7 +442,6 @@ void MovieDetailsViewModel::onMovieChaptersFailed(const QString &itemId, const Q
 
     m_pendingMovieChapterIds.remove(itemId);
     qWarning() << "MovieDetailsViewModel movie chapters error for" << itemId << ":" << error;
-    m_movieChapterCache.insert(itemId, {});
 
     if (itemId == m_movieChapterId) {
         m_chapters.clear();

--- a/src/viewmodels/MovieDetailsViewModel.h
+++ b/src/viewmodels/MovieDetailsViewModel.h
@@ -5,10 +5,13 @@
 #include <QJsonObject>
 #include <QString>
 #include <QList>
+#include <QSet>
+#include <QHash>
 #include <QNetworkAccessManager>
 #include <functional>
 
 class LibraryService;
+struct ChapterInfo;
 
 /**
  * @brief ViewModel for movie details display in MovieDetailsView.
@@ -36,6 +39,8 @@ class MovieDetailsViewModel : public BaseViewModel
     Q_PROPERTY(qint64 runtimeTicks READ runtimeTicks NOTIFY runtimeTicksChanged)
     Q_PROPERTY(double communityRating READ communityRating NOTIFY communityRatingChanged)
     Q_PROPERTY(QVariantList people READ people NOTIFY peopleChanged)
+    Q_PROPERTY(QVariantList chapters READ chapters NOTIFY chaptersChanged)
+    Q_PROPERTY(bool chaptersLoading READ chaptersLoading NOTIFY chaptersLoadingChanged)
     Q_PROPERTY(QStringList genres READ genres NOTIFY genresChanged)
     Q_PROPERTY(QVariantList similarItems READ similarItems NOTIFY similarItemsChanged)
     Q_PROPERTY(bool similarItemsLoading READ similarItemsLoading NOTIFY similarItemsLoadingChanged)
@@ -63,6 +68,8 @@ public:
     qint64 runtimeTicks() const { return m_runtimeTicks; }
     double communityRating() const { return m_communityRating; }
     QVariantList people() const { return m_people; }
+    QVariantList chapters() const { return m_chapters; }
+    bool chaptersLoading() const { return m_chaptersLoading; }
     QStringList genres() const { return m_genres; }
     QVariantList similarItems() const { return m_similarItems; }
     bool similarItemsLoading() const { return m_similarItemsLoading; }
@@ -98,6 +105,8 @@ public:
      * @param preserveArtwork If true, keep existing logo/poster/backdrop URLs until new data arrives.
      */
     Q_INVOKABLE void clear(bool preserveArtwork = false);
+    Q_INVOKABLE void loadMovieChapters(const QString &movieId);
+    Q_INVOKABLE void clearMovieChapters();
 
     /**
      * @brief Get full movie data as a QVariantMap.
@@ -135,6 +144,8 @@ signals:
     void runtimeTicksChanged();
     void communityRatingChanged();
     void peopleChanged();
+    void chaptersChanged();
+    void chaptersLoadingChanged();
     void genresChanged();
     void similarItemsChanged();
     void similarItemsLoadingChanged();
@@ -150,11 +161,15 @@ private slots:
     void onMovieDetailsNotModified(const QString &itemId);
     void onSimilarItemsLoaded(const QString &itemId, const QJsonArray &items);
     void onSimilarItemsFailed(const QString &itemId, const QString &error);
+    void onMovieChaptersLoaded(const QString &itemId, const QList<ChapterInfo> &chapters);
+    void onMovieChaptersFailed(const QString &itemId, const QString &error);
     void onErrorOccurred(const QString &endpoint, const QString &error);
 
 private:
     void updateMovieMetadata(const QJsonObject &data);
     void compileRatings();
+    void applyMovieChapters(const QString &movieId, const QVariantList &chapters);
+    void setMovieChaptersLoading(bool loading);
 
     LibraryService *m_libraryService = nullptr;
     QNetworkAccessManager *m_networkManager = nullptr;
@@ -173,6 +188,8 @@ private:
     qint64 m_runtimeTicks = 0;
     double m_communityRating = 0.0;
     QVariantList m_people;
+    QVariantList m_chapters;
+    bool m_chaptersLoading = false;
     QStringList m_genres;
     QVariantList m_similarItems;
     bool m_similarItemsAttempted = false;
@@ -190,4 +207,7 @@ private:
     
     // State
     bool m_loadingMovie = false;
+    QString m_movieChapterId;
+    QHash<QString, QVariantList> m_movieChapterCache;
+    QSet<QString> m_pendingMovieChapterIds;
 };

--- a/tests/SimilarItemsRetryTest.cpp
+++ b/tests/SimilarItemsRetryTest.cpp
@@ -232,7 +232,7 @@ void SimilarItemsRetryTest::movieChaptersFailureClearsVisibleState()
     QVERIFY(vm.chapters().isEmpty());
 
     vm.loadMovieChapters(QStringLiteral("movie-1"));
-    QCOMPARE(service->requests.size(), 1);
+    QCOMPARE(service->requests.size(), 2);
 }
 
 void SimilarItemsRetryTest::seriesEpisodeDetailsFailureIsTargeted()

--- a/tests/SimilarItemsRetryTest.cpp
+++ b/tests/SimilarItemsRetryTest.cpp
@@ -120,6 +120,8 @@ private slots:
     void seriesEpisodeDetailsIgnoreForeignTokens();
     void seriesEpisodeChaptersLoadNormalizeCacheAndIgnoreStale();
     void seriesEpisodeChaptersFailureClearsVisibleState();
+    void movieChaptersLoadNormalizeCacheAndIgnoreStale();
+    void movieChaptersFailureClearsVisibleState();
     void mockLibraryServiceTracksItemCacheInvalidation();
 
 private:
@@ -172,6 +174,65 @@ void SimilarItemsRetryTest::seriesSimilarItemsFailureAllowsRetry()
     vm.onSeriesDetailsLoaded(QStringLiteral("series-1"), QJsonObject{{"Id", "series-1"}, {"UserData", QJsonObject{}}});
     QCOMPARE(m_libraryService->requestedIds.size(), 1);
     QCOMPARE(m_libraryService->requestedIds.first(), QStringLiteral("series-1"));
+}
+
+void SimilarItemsRetryTest::movieChaptersLoadNormalizeCacheAndIgnoreStale()
+{
+    ServiceLocator::clear();
+    auto *service = new EpisodeChaptersLibraryService(this);
+    ServiceLocator::registerService<LibraryService>(service);
+
+    MovieDetailsViewModel vm;
+    QSignalSpy loadingSpy(&vm, &MovieDetailsViewModel::chaptersLoadingChanged);
+
+    vm.loadMovieChapters(QStringLiteral("movie-1"));
+    QCOMPARE(service->requests, QStringList{QStringLiteral("movie-1")});
+    QVERIFY(vm.chaptersLoading());
+
+    vm.loadMovieChapters(QStringLiteral("movie-2"));
+    QCOMPARE(service->requests, (QStringList{QStringLiteral("movie-1"), QStringLiteral("movie-2")}));
+
+    ChapterInfo first;
+    first.index = 0;
+    first.title = QStringLiteral("Cold Open");
+    first.startPositionTicks = 120000000;
+    first.imageTag = QStringLiteral("tag");
+    emit service->chaptersLoaded(QStringLiteral("movie-1"), QList<ChapterInfo>{first});
+    QVERIFY(vm.chapters().isEmpty());
+
+    ChapterInfo second = first;
+    second.title = QStringLiteral("Main Feature");
+    second.index = 1;
+    emit service->chaptersLoaded(QStringLiteral("movie-2"), QList<ChapterInfo>{second});
+
+    QCOMPARE(vm.chaptersLoading(), false);
+    QCOMPARE(vm.chapters().size(), 1);
+    const QVariantMap chapter = vm.chapters().first().toMap();
+    QCOMPARE(chapter.value(QStringLiteral("title")).toString(), QStringLiteral("Main Feature"));
+    QCOMPARE(chapter.value(QStringLiteral("thumbnailUrl")).toString(), QStringLiteral("chapter://movie-2/1/480"));
+    QVERIFY(loadingSpy.count() >= 2);
+
+    vm.loadMovieChapters(QStringLiteral("movie-2"));
+    QCOMPARE(service->requests.size(), 2);
+    QCOMPARE(vm.chapters().size(), 1);
+}
+
+void SimilarItemsRetryTest::movieChaptersFailureClearsVisibleState()
+{
+    ServiceLocator::clear();
+    auto *service = new EpisodeChaptersLibraryService(this);
+    ServiceLocator::registerService<LibraryService>(service);
+
+    MovieDetailsViewModel vm;
+    vm.loadMovieChapters(QStringLiteral("movie-1"));
+    QVERIFY(vm.chaptersLoading());
+
+    emit service->chaptersFailed(QStringLiteral("movie-1"), QStringLiteral("network"));
+    QCOMPARE(vm.chaptersLoading(), false);
+    QVERIFY(vm.chapters().isEmpty());
+
+    vm.loadMovieChapters(QStringLiteral("movie-1"));
+    QCOMPARE(service->requests.size(), 1);
 }
 
 void SimilarItemsRetryTest::seriesEpisodeDetailsFailureIsTargeted()


### PR DESCRIPTION
## Summary
- keep episode and movie Chapters / Cast & Crew shelves structurally stable with reserved loading and empty states
- add movie chapter loading/caching plus playable chapter cards that mirror the episode interaction model
- show playback-readiness spinners on primary Play / Resume buttons while preserving the existing preparation toast flow
- document the new movie chapter rail and ViewModel surface

## Why
Detail-page metadata shelves previously collapsed when passive data was missing or still loading, which caused layout shifts and weak loading feedback. Movies also lacked the chapter browsing behavior already present for episodes. This change keeps the detail layout steady, makes playback readiness legible before launch, and aligns movie chapter navigation with episode behavior.

## Validation
- `./scripts/build-docker.sh --clean`
- `./scripts/build-docker.sh`
- `QT_QPA_PLATFORM=offscreen ./tests/SimilarItemsRetryTest` inside the Bloom build container
- Manual testing completed for the updated detail-page shelf and playback-readiness flows

## Notes
- Focus navigation continues to skip non-focusable empty placeholders while reaching real chapter/cast cards when present.
- Chapter load failures intentionally resolve to the same quiet empty-state presentation as absent chapter data.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add chapters rail and playback readiness spinner to movie and episode detail views
> - `MovieDetailsViewModel` gains chapter loading with an in-memory per-movie cache, deduplication of in-flight requests, and failure handling; chapters are fetched automatically when movie details load.
> - `MovieDetailsView` renders a horizontal chapters rail with skeleton/empty states, keyboard navigation, and chapter-specific playback via `startPlaybackWithTracksAt` which accepts a `startPositionTicks` override.
> - `SeriesSeasonEpisodeView` chapters and cast rails now persist in layout with skeleton and empty states instead of being hidden when empty.
> - The Play/Resume button in both views shows a `BusyIndicator` and stays pressable while playback info is loading, preserving the existing 'still preparing' toast.
> - Focus restoration logic in `MovieDetailsView` is extended to include the new `'chapters'` area.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf8a0d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chapters are now available in movie details, mirroring TV episode functionality. Users can select a chapter to start playback at that point.
  * Chapter data preloads intelligently with clear empty state messaging when unavailable.

* **Bug Fixes**
  * Play/Resume buttons remain interactive while playback info loads; a spinner now indicates loading instead of hiding controls.
  * Improved empty-state placeholders for missing chapters and cast information.

* **Documentation**
  * Updated playback and viewmodel documentation to reflect chapter functionality.

* **Tests**
  * Added tests for chapter loading, caching, and failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crowquillx/Bloom/pull/55)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->