### PR TITLE
fix: better handling for the up-next screen

### DIFF
--- a/docs/playback.md
+++ b/docs/playback.md
@@ -39,7 +39,7 @@ Windows embedded overlay layering model
 - UX contract: showing/hiding controls must not resize, shift, or clip the video viewport.
 - Credits/next-up shrink mode remains a separate feature path and must continue to work independently of normal full-frame overlay behavior.
 - Terminal playback transitions are backend-first: Bloom waits for direct libmpv teardown before changing `PlayerController` into `Idle`/`Error`, and `WindowsMpvBackend` defers embedded host-window destruction while libmpv still owns the `--wid` target.
-- Windows display restoration after playback stop is deferred and non-blocking. HDR-off settle and refresh-rate restore are scheduled after the UI returns to `Idle`, allowing the main scene and detached playback overlay window to repaint/hide promptly.
+- Windows display restoration after playback stop is deferred and non-blocking. HDR-off settle and refresh-rate restore are scheduled after the UI returns to `Idle`, allowing the main scene and detached playback overlay window to repaint/hide promptly. When post-playback Up Next is shown, Bloom parks that restore until the user either leaves Up Next or starts another episode, avoiding a restore-then-switch cycle between consecutive episodes.
 - Natural playback end, explicit stop, and error-triggered shutdown now share one coordinated terminal-transition path so reporting/autoplay work runs once per playback attempt.
 - Windows direct-libmpv event handling now suppresses playback reactivation events (`START_FILE`/`FILE_LOADED`/`PLAYBACK_RESTART`/`SEEK`) while a stop command is pending, preventing stale wakeup events from re-showing the embedded host window as a black frame during teardown.
 - Refresh-rate matching starts mpv with explicit display-sync options for exact matches (`--video-sync=display-resample` plus `--display-fps=<content fps>`), except when the user has chosen to keep an already compatible higher multiple such as 120Hz for 23.976fps content. This avoids pacing fractional Windows modes as integer 23/29/59Hz after Bloom switches the display.
@@ -191,7 +191,7 @@ Track Preference Persistence
 - `excludeItemId` is used by autoplay/prefetch so the player can advance from the current item even before Jellyfin has updated watch state on the server.
 - If no next episode is available, post-playback navigation still opens `UpNextScreen.qml` in an empty state. The screen must keep keyboard focus and offer actions back to Home or the series.
 - The no-next empty state may show up to six TV-series recommendations via `UpNextRecommendationsViewModel`. Jellyfin similar series are listed first; Seerr TV recommendations are appended when the source series has a TMDB id and Seerr is configured. Recommendation provider failures are silent on this screen.
-- Leaving the Up Next interstitial keeps the exact resolved episode context, including season-0 specials, by carrying the resolved episode id plus its `ParentId`/`SeasonId` back into `SeriesSeasonEpisodeView`.
+- Leaving the Up Next interstitial keeps the exact resolved episode context, including season-0 specials, by carrying the resolved episode id plus its `ParentId`/`SeasonId` directly into `SeriesSeasonEpisodeView`. Exiting Up Next without starting playback releases any parked display restore.
 
 UI Components for Track Selection
 - `TrackSelector.qml`: Reusable dropdown component for selecting audio/subtitle tracks with keyboard navigation.

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -1432,10 +1432,6 @@ void PlayerController::startDeferredDisplayRestore(bool needsHdrRestore, bool ne
         return;
     }
 
-    m_deferredPostPlaybackDisplayRestorePending = false;
-    m_deferredPostPlaybackNeedsHdrRestore = false;
-    m_deferredPostPlaybackNeedsRefreshRestore = false;
-
     const quint64 generation = m_displayRestoreGeneration;
     qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                             << "] deferred-display-restore queued"
@@ -2579,6 +2575,7 @@ void PlayerController::playNextEpisode(const QJsonObject &episodeData, const QSt
     
     if (episodeId.isEmpty()) {
         qWarning() << "PlayerController::playNextEpisode: Empty episode ID";
+        cancelPendingDisplayRestore();
         clearPendingAutoplayContext();
         return;
     }

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -690,6 +690,17 @@ void PlayerController::onEnterIdleState()
                             << "contentFramerate=" << m_contentFramerate;
 
     enterIdleStateImmediate();
+    if (m_awaitingNextEpisodeResolution) {
+        m_deferredPostPlaybackDisplayRestorePending = needsHdrRestore || needsRefreshRestore;
+        m_deferredPostPlaybackNeedsHdrRestore = needsHdrRestore;
+        m_deferredPostPlaybackNeedsRefreshRestore = needsRefreshRestore;
+        qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                << "] deferred-display-restore parked for up-next"
+                                << "needsHdrRestore=" << needsHdrRestore
+                                << "needsRefreshRestore=" << needsRefreshRestore;
+        return;
+    }
+
     startDeferredDisplayRestore(needsHdrRestore, needsRefreshRestore);
 }
 
@@ -1421,6 +1432,10 @@ void PlayerController::startDeferredDisplayRestore(bool needsHdrRestore, bool ne
         return;
     }
 
+    m_deferredPostPlaybackDisplayRestorePending = false;
+    m_deferredPostPlaybackNeedsHdrRestore = false;
+    m_deferredPostPlaybackNeedsRefreshRestore = false;
+
     const quint64 generation = m_displayRestoreGeneration;
     qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                             << "] deferred-display-restore queued"
@@ -1480,6 +1495,20 @@ void PlayerController::startDeferredDisplayRestore(bool needsHdrRestore, bool ne
                               Qt::QueuedConnection);
 }
 
+void PlayerController::maybeStartDeferredPostPlaybackDisplayRestore()
+{
+    if (!m_deferredPostPlaybackDisplayRestorePending) {
+        return;
+    }
+
+    const bool needsHdrRestore = m_deferredPostPlaybackNeedsHdrRestore;
+    const bool needsRefreshRestore = m_deferredPostPlaybackNeedsRefreshRestore;
+    m_deferredPostPlaybackDisplayRestorePending = false;
+    m_deferredPostPlaybackNeedsHdrRestore = false;
+    m_deferredPostPlaybackNeedsRefreshRestore = false;
+    startDeferredDisplayRestore(needsHdrRestore, needsRefreshRestore);
+}
+
 void PlayerController::scheduleDeferredRefreshRestore(quint64 generation, int delayMs)
 {
     if (m_displayManager == nullptr) {
@@ -1516,6 +1545,9 @@ void PlayerController::cancelPendingDisplayRestore(bool applyCurrentPlaybackDisp
         disconnect(m_hdrRestoreFinishedConnection);
         m_hdrRestoreFinishedConnection = QMetaObject::Connection();
     }
+    m_deferredPostPlaybackDisplayRestorePending = false;
+    m_deferredPostPlaybackNeedsHdrRestore = false;
+    m_deferredPostPlaybackNeedsRefreshRestore = false;
     if (m_displayManager != nullptr) {
         m_displayManager->cancelPendingHdrAsync();
         if (applyCurrentPlaybackDisplayState) {
@@ -1661,13 +1693,11 @@ void PlayerController::onNextEpisodeLoaded(const QString &seriesId,
         noNextEpisodeData.insert(QStringLiteral("SeriesId"), seriesId);
         noNextEpisodeData.insert(QStringLiteral("SeasonId"), m_pendingAutoplaySeasonId);
         noNextEpisodeData.insert(QStringLiteral("NoNextEpisode"), true);
-        setAwaitingNextEpisodeResolution(false);
         emitNavigateToNextEpisodeQueued(noNextEpisodeData,
                                         seriesId,
                                         lastAudioIndex,
                                         lastSubtitleIndex,
                                         false);
-        clearPendingAutoplayContext();
         clearNextEpisodePrefetchState();
         return;
     }
@@ -1697,7 +1727,6 @@ void PlayerController::onNextEpisodeLoaded(const QString &seriesId,
     qDebug() << "PlayerController: Emitting navigateToNextEpisode signal with autoplay:" 
              << autoplay << "audio:" << lastAudioIndex << "subtitle:" << lastSubtitleIndex;
 
-    setAwaitingNextEpisodeResolution(false);
     emitNavigateToNextEpisodeQueued(episodeData, seriesId, lastAudioIndex, lastSubtitleIndex, autoplay);
     
     // Note: Don't clear pending autoplay context here - playNextEpisode() needs it
@@ -2553,6 +2582,8 @@ void PlayerController::playNextEpisode(const QJsonObject &episodeData, const QSt
         clearPendingAutoplayContext();
         return;
     }
+
+    cancelPendingDisplayRestore();
     
     qDebug() << "PlayerController: Playing next episode from Up Next screen:" << seriesName
              << "S" << seasonNumber << "E" << episodeNumber << "-" << episodeName;
@@ -4464,7 +4495,6 @@ void PlayerController::consumePrefetchedNextEpisodeAndNavigate()
 
     m_shouldAutoplay = false;
     m_waitingForNextEpisodeAtPlaybackEnd = false;
-    setAwaitingNextEpisodeResolution(false);
 
     qCDebug(lcPlayback) << "Using prefetched next episode for Up Next"
                         << "itemId=" << m_pendingAutoplayItemId
@@ -4491,6 +4521,7 @@ void PlayerController::emitNavigateToNextEpisodeQueued(const QJsonObject &episod
                                                              lastAudioIndex,
                                                              lastSubtitleIndex,
                                                              autoplay);
+                                  setAwaitingNextEpisodeResolution(false);
                               },
                               Qt::QueuedConnection);
 }
@@ -4559,6 +4590,11 @@ void PlayerController::clearPendingAutoplayContext()
     m_pendingAutoplayIsHDR = false;
     m_pendingAutoplayEpisodeData = QJsonObject();
     setAwaitingNextEpisodeResolution(false);
+}
+
+void PlayerController::releaseDeferredPostPlaybackDisplayRestore()
+{
+    maybeStartDeferredPostPlaybackDisplayRestore();
 }
 
 int PlayerController::pendingAutoplaySubtitleOverrideIndex() const

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -229,6 +229,7 @@ public:
      * or playback context is intentionally replaced.
      */
     Q_INVOKABLE void clearPendingAutoplayContext();
+    Q_INVOKABLE void releaseDeferredPostPlaybackDisplayRestore();
 
     /**
      * @brief Resolves the effective startup audio/subtitle selection for a media source.
@@ -567,6 +568,7 @@ private:
     void connectBackendSignals(IPlayerBackend *backend);
     void enterIdleStateImmediate();
     void startDeferredDisplayRestore(bool needsHdrRestore, bool needsRefreshRestore);
+    void maybeStartDeferredPostPlaybackDisplayRestore();
     void scheduleDeferredRefreshRestore(quint64 generation, int delayMs);
     void cancelPendingDisplayRestore(bool applyCurrentPlaybackDisplayState = false);
     void cancelPendingTerminalTransition();
@@ -843,6 +845,9 @@ private:
     std::function<void()> m_pendingReplacementPlaybackAction;
     quint64 m_displayRestoreGeneration = 0;
     QMetaObject::Connection m_hdrRestoreFinishedConnection;
+    bool m_deferredPostPlaybackDisplayRestorePending = false;
+    bool m_deferredPostPlaybackNeedsHdrRestore = false;
+    bool m_deferredPostPlaybackNeedsRefreshRestore = false;
     
     // Buffering detection
     QElapsedTimer m_lastPositionUpdateTime;

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -305,10 +305,16 @@ Window {
         Keys.onPressed: function(event) {
             if (event.key === Qt.Key_Return
                     || event.key === Qt.Key_Enter
-                    || event.key === Qt.Key_Space
-                    || event.key === Qt.Key_Escape
-                    || event.key === Qt.Key_Back) {
+                    || event.key === Qt.Key_Space) {
                 event.accepted = true
+            } else if (event.key === Qt.Key_Escape
+                       || event.key === Qt.Key_Back) {
+                event.accepted = true
+                PlayerController.releaseDeferredPostPlaybackDisplayRestore()
+                PlayerController.clearPendingAutoplayContext()
+                while (stackView.depth > 1) {
+                    stackView.pop(null, StackView.Immediate)
+                }
             }
         }
 
@@ -1102,34 +1108,50 @@ Window {
                     PlayerController.releaseDeferredPostPlaybackDisplayRestore()
                     PlayerController.clearPendingAutoplayContext()
 
-                    var targetEpisodeData = Object.assign({}, episodeData || {})
-                    if (!targetEpisodeData.itemId && targetEpisodeData.Id) {
-                        targetEpisodeData.itemId = targetEpisodeData.Id
-                    }
-                    if (!targetEpisodeData.SeasonId && targetEpisodeData.ParentId) {
-                        targetEpisodeData.SeasonId = targetEpisodeData.ParentId
-                    }
-                    
-                    var targetSeasonId = targetEpisodeData.SeasonId || ""
-                    var targetEpisodeId = hasNextEpisode ? (targetEpisodeData.itemId || targetEpisodeData.Id || "") : ""
+                    var libraryScreen
+                    if (hasNextEpisode) {
+                        var targetEpisodeData = Object.assign({}, episodeData || {})
+                        if (!targetEpisodeData.itemId && targetEpisodeData.Id) {
+                            targetEpisodeData.itemId = targetEpisodeData.Id
+                        }
+                        if (!targetEpisodeData.SeasonId && targetEpisodeData.ParentId) {
+                            targetEpisodeData.SeasonId = targetEpisodeData.ParentId
+                        }
 
-                    var libraryScreen = stackView.push("LibraryScreen.qml", {
-                        currentParentId: "",
-                        currentLibraryId: "",
-                        currentLibraryName: "",
-                        currentSeriesId: normalizedSeriesId,
-                        currentSeasonId: targetSeasonId,
-                        initialEpisodeId: targetEpisodeId,
-                        showSeasonView: true,
-                        directNavigationMode: true,
-                        returnToHomeOnDirectBack: true,
-                        pendingAudioTrackIndex: lastAudioIndex,
-                        pendingSubtitleTrackIndex: lastSubtitleIndex
-                    }, StackView.Immediate)
+                        var targetSeasonId = targetEpisodeData.SeasonId || ""
+                        var targetEpisodeId = targetEpisodeData.itemId || targetEpisodeData.Id || ""
 
-                    LibraryService.getSeriesDetails(normalizedSeriesId)
-                    if (targetSeasonId) {
-                        SeriesDetailsViewModel.loadSeasonEpisodes(targetSeasonId)
+                        libraryScreen = stackView.push("LibraryScreen.qml", {
+                            currentParentId: "",
+                            currentLibraryId: "",
+                            currentLibraryName: "",
+                            currentSeriesId: normalizedSeriesId,
+                            currentSeasonId: targetSeasonId,
+                            initialEpisodeId: targetEpisodeId,
+                            showSeasonView: true,
+                            directNavigationMode: true,
+                            returnToHomeOnDirectBack: true,
+                            pendingAudioTrackIndex: lastAudioIndex,
+                            pendingSubtitleTrackIndex: lastSubtitleIndex
+                        }, StackView.Immediate)
+
+                        LibraryService.getSeriesDetails(normalizedSeriesId)
+                        if (targetSeasonId) {
+                            SeriesDetailsViewModel.loadSeasonEpisodes(targetSeasonId)
+                        }
+                    } else {
+                        libraryScreen = stackView.push("LibraryScreen.qml", {
+                            currentParentId: "",
+                            currentLibraryId: "",
+                            currentLibraryName: "",
+                            currentSeriesId: normalizedSeriesId,
+                            showSeriesDetails: true,
+                            directNavigationMode: true,
+                            returnToHomeOnDirectBack: true
+                        }, StackView.Immediate)
+
+                        LibraryService.getSeriesDetails(normalizedSeriesId)
+                        LibraryService.getItems(normalizedSeriesId, 0, 0)
                     }
                     if (libraryScreen && libraryScreen.forceActiveFocus) {
                         Qt.callLater(function() {

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -293,7 +293,24 @@ Window {
         anchors.fill: parent
         z: 850
         visible: awaitingUpNextTransition
+        focus: visible
         color: Qt.rgba(0, 0, 0, 0.88)
+
+        onVisibleChanged: {
+            if (visible) {
+                forceActiveFocus()
+            }
+        }
+
+        Keys.onPressed: function(event) {
+            if (event.key === Qt.Key_Return
+                    || event.key === Qt.Key_Enter
+                    || event.key === Qt.Key_Space
+                    || event.key === Qt.Key_Escape
+                    || event.key === Qt.Key_Back) {
+                event.accepted = true
+            }
+        }
 
         MouseArea {
             anchors.fill: parent
@@ -1082,32 +1099,8 @@ Window {
                 upNextScreen.moreEpisodesRequested.connect(function() {
                     console.log("[Main] Up Next: More episodes requested")
                     stackView.pop(null, StackView.Immediate)
+                    PlayerController.releaseDeferredPostPlaybackDisplayRestore()
                     PlayerController.clearPendingAutoplayContext()
-
-                    if (!hasNextEpisode) {
-                        var seasonId = episodeData ? (episodeData.SeasonId || episodeData.ParentId || "") : ""
-                        var seriesScreen = stackView.push("LibraryScreen.qml", {
-                            currentParentId: "",
-                            currentLibraryId: "",
-                            currentLibraryName: "",
-                            currentSeriesId: normalizedSeriesId,
-                            currentSeasonId: seasonId,
-                            showSeriesDetails: true,
-                            directNavigationMode: true,
-                            preferStackPopOnDirectBack: true
-                        }, StackView.Immediate)
-                        LibraryService.getSeriesDetails(normalizedSeriesId)
-                        LibraryService.getItems(normalizedSeriesId, 0, 0)
-                        LibraryService.getNextUnplayedEpisode(normalizedSeriesId)
-                        if (seriesScreen) {
-                            Qt.callLater(function() {
-                                if (seriesScreen && seriesScreen.forceActiveFocus) {
-                                    seriesScreen.forceActiveFocus()
-                                }
-                            })
-                        }
-                        return
-                    }
 
                     var targetEpisodeData = Object.assign({}, episodeData || {})
                     if (!targetEpisodeData.itemId && targetEpisodeData.Id) {
@@ -1117,28 +1110,8 @@ Window {
                         targetEpisodeData.SeasonId = targetEpisodeData.ParentId
                     }
                     
-                    var destinationScreen = stackView.currentItem
                     var targetSeasonId = targetEpisodeData.SeasonId || ""
-
-                    if (destinationScreen
-                            && destinationScreen.handlesOwnBackNavigation === true
-                            && typeof destinationScreen.showEpisodeDetails === "function") {
-                        console.log("[Main] Up Next: Reusing existing LibraryScreen for episode navigation")
-                        destinationScreen.pendingAudioTrackIndex = lastAudioIndex
-                        destinationScreen.pendingSubtitleTrackIndex = lastSubtitleIndex
-                        if (normalizedSeriesId) {
-                            destinationScreen.currentSeriesId = normalizedSeriesId
-                        }
-                        if (targetSeasonId) {
-                            destinationScreen.currentSeasonId = targetSeasonId
-                        }
-                        Qt.callLater(function() {
-                            if (destinationScreen && typeof destinationScreen.showEpisodeDetails === "function") {
-                                destinationScreen.showEpisodeDetails(targetEpisodeData, true)
-                            }
-                        })
-                        return
-                    }
+                    var targetEpisodeId = hasNextEpisode ? (targetEpisodeData.itemId || targetEpisodeData.Id || "") : ""
 
                     var libraryScreen = stackView.push("LibraryScreen.qml", {
                         currentParentId: "",
@@ -1146,24 +1119,31 @@ Window {
                         currentLibraryName: "",
                         currentSeriesId: normalizedSeriesId,
                         currentSeasonId: targetSeasonId,
+                        initialEpisodeId: targetEpisodeId,
                         showSeasonView: true,
                         directNavigationMode: true,
-                        preferStackPopOnDirectBack: true,
+                        returnToHomeOnDirectBack: true,
                         pendingAudioTrackIndex: lastAudioIndex,
                         pendingSubtitleTrackIndex: lastSubtitleIndex
-                    })
+                    }, StackView.Immediate)
 
                     LibraryService.getSeriesDetails(normalizedSeriesId)
-                    if (libraryScreen) {
-                        libraryScreen.pendingEpisodeData = targetEpisodeData
-                    } else {
-                        console.warn("[Main] Up Next: LibraryScreen push failed, could not set pendingEpisodeData")
+                    if (targetSeasonId) {
+                        SeriesDetailsViewModel.loadSeasonEpisodes(targetSeasonId)
+                    }
+                    if (libraryScreen && libraryScreen.forceActiveFocus) {
+                        Qt.callLater(function() {
+                            if (libraryScreen && libraryScreen.forceActiveFocus) {
+                                libraryScreen.forceActiveFocus()
+                            }
+                        })
                     }
                 })
                 
                 // Go back to home
                 upNextScreen.backToHomeRequested.connect(function() {
                     console.log("[Main] Up Next: Back to home requested")
+                    PlayerController.releaseDeferredPostPlaybackDisplayRestore()
                     PlayerController.clearPendingAutoplayContext()
                     stackView.pop(null, StackView.Immediate)
                 })
@@ -1180,6 +1160,7 @@ Window {
                     }
 
                     console.log("[Main] Up Next: Recommendation selected", recommendedSeriesId)
+                    PlayerController.releaseDeferredPostPlaybackDisplayRestore()
                     PlayerController.clearPendingAutoplayContext()
                     stackView.pop(null, StackView.Immediate)
                     stackView.push("LibraryScreen.qml", {
@@ -1198,6 +1179,7 @@ Window {
                 })
             } else {
                 console.warn("[Main] Failed to create Up Next screen, clearing pending autoplay context")
+                PlayerController.releaseDeferredPostPlaybackDisplayRestore()
                 PlayerController.clearPendingAutoplayContext()
             }
         }

--- a/src/ui/SeriesSeasonEpisodeView.qml
+++ b/src/ui/SeriesSeasonEpisodeView.qml
@@ -23,6 +23,7 @@ FocusScope {
     property bool appliedPendingTrackOverride: false
     property bool userMadeAudioSelection: false
     property bool userMadeSubtitleSelection: false
+    readonly property bool activeVisibleDetailView: root.visible && StackView.status === StackView.Active
     readonly property int heroPosterWidth: Math.round(320 * Theme.layoutScale)
     readonly property int heroPosterHeight: Math.round(heroPosterWidth * 1.5)
     readonly property int heroPanelPadding: Theme.spacingXLarge
@@ -529,6 +530,9 @@ FocusScope {
         interval: 200  // Minimal delay to ensure playback stop event is processed before refresh
         repeat: false
         onTriggered: {
+            if (!root.activeVisibleDetailView || PlayerController.awaitingNextEpisodeResolution) {
+                return
+            }
             console.log("[SeriesSeasonEpisodeView] Refreshing episodes immediately after playback stop")
             if (SeriesDetailsViewModel.selectedSeasonId) {
                 SeriesDetailsViewModel.refreshSeasonEpisodes(SeriesDetailsViewModel.selectedSeasonId)
@@ -618,7 +622,9 @@ FocusScope {
         interval: 300
         repeat: false
         onTriggered: {
-            if (selectedEpisodeId
+            if (root.activeVisibleDetailView
+                    && !PlayerController.awaitingNextEpisodeResolution
+                    && selectedEpisodeId
                     && playbackInfoOwnerId !== selectedEpisodeId
                     && playbackInfoLoadingItemId !== selectedEpisodeId) {
                 playbackInfoLoadingItemId = selectedEpisodeId
@@ -630,7 +636,12 @@ FocusScope {
     
     // Playback info request
     function requestPlaybackInfo() {
-        if (!selectedEpisodeId || playbackInfoLoadingItemId === selectedEpisodeId) return
+        if (!selectedEpisodeId
+                || playbackInfoLoadingItemId === selectedEpisodeId
+                || !root.activeVisibleDetailView
+                || PlayerController.awaitingNextEpisodeResolution) {
+            return
+        }
         
         playbackInfoLoadingItemId = selectedEpisodeId
         console.log("[SeriesSeasonEpisodeView] Requesting playback info for episode:", selectedEpisodeId)
@@ -639,6 +650,9 @@ FocusScope {
     
     // Trigger debounced playback info preload when episode is selected
     function schedulePlaybackInfoPreload() {
+        if (!root.activeVisibleDetailView || PlayerController.awaitingNextEpisodeResolution) {
+            return
+        }
         playbackInfoPreloadTimer.restart()
     }
     
@@ -695,7 +709,9 @@ FocusScope {
                     console.log("[SeriesSeasonEpisodeView] Executing pending playback, fromBeginning:", fromBeginning, "playbackInfo available:", playbackInfo !== null)
                     // Use callLater to ensure property bindings have updated
                     Qt.callLater(function() {
-                        if (selectedEpisodeId === requestEpisodeId) {
+                        if (selectedEpisodeId === requestEpisodeId
+                                && root.activeVisibleDetailView
+                                && !PlayerController.awaitingNextEpisodeResolution) {
                             performPlayback(fromBeginning, restoreFocusTarget)
                         }
                     })
@@ -799,6 +815,7 @@ FocusScope {
 
     function restoreFocusAfterPlaybackExit() {
         if (!root.visible
+                || !root.activeVisibleDetailView
                 || !root.playbackReturnFocusPending
                 || !root.playbackReturnFocusActivated
                 || PlayerController.awaitingNextEpisodeResolution) {
@@ -825,7 +842,11 @@ FocusScope {
     
     // Playback actions
     function startPlayback(fromBeginning, restoreFocusTarget, chapterStartTicks) {
-        if (!selectedEpisodeId) return
+        if (!selectedEpisodeId
+                || !root.activeVisibleDetailView
+                || PlayerController.awaitingNextEpisodeResolution) {
+            return
+        }
         
         console.log("[SeriesSeasonEpisodeView] startPlayback - Episode:", selectedEpisodeName,
                     "ID:", selectedEpisodeId,
@@ -845,7 +866,11 @@ FocusScope {
     }
     
     function performPlayback(fromBeginning, restoreFocusTarget, chapterStartTicks) {
-        if (!selectedEpisodeId) return
+        if (!selectedEpisodeId
+                || !root.activeVisibleDetailView
+                || PlayerController.awaitingNextEpisodeResolution) {
+            return
+        }
         
         var hasChapterStart = chapterStartTicks !== undefined && chapterStartTicks !== null
         var startPos = hasChapterStart ? chapterStartTicks : (fromBeginning ? 0 : selectedEpisodePlaybackPosition)

--- a/tests/PlayerControllerAutoplayContextTest.cpp
+++ b/tests/PlayerControllerAutoplayContextTest.cpp
@@ -326,6 +326,8 @@ private slots:
     void explicitPausedStopReportsPausedState();
     void explicitMultipartStopReportsActiveSegmentContext();
     void playbackEndedUpgradesQueuedStopFinalization();
+    void nextEpisodeNavigationKeepsAwaitingUntilQueuedDelivery();
+    void deferredPostPlaybackDisplayRestoreCanBeReleased();
     void nextEpisodeNavigationUsesPendingTrackContext();
     void nextEpisodeIgnoresMismatchedSeries();
     void playbackPrefetchIgnoresGenericNextEpisodeResponses();
@@ -739,6 +741,90 @@ void PlayerControllerAutoplayContextTest::playbackEndedUpgradesQueuedStopFinaliz
     QCOMPARE(libraryService.requestedSeriesIds.size(), 1);
     QCOMPARE(libraryService.requestedContexts.first(),
              QStringLiteral("player:resolve:series-1:item-1"));
+}
+
+void PlayerControllerAutoplayContextTest::nextEpisodeNavigationKeepsAwaitingUntilQueuedDelivery()
+{
+    ConfigManager config;
+    config.setAutoplayNextEpisode(false);
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+
+    controller.m_shouldAutoplay = true;
+    controller.m_waitingForNextEpisodeAtPlaybackEnd = true;
+    controller.m_pendingAutoplayItemId = QStringLiteral("item-1");
+    controller.m_pendingAutoplaySeriesId = QStringLiteral("series-1");
+    controller.setAwaitingNextEpisodeResolution(true);
+
+    QSignalSpy navigationSpy(&controller, &PlayerController::navigateToNextEpisode);
+    QSignalSpy awaitingSpy(&controller, &PlayerController::awaitingNextEpisodeResolutionChanged);
+
+    const QJsonObject episodeData{
+        {QStringLiteral("Id"), QStringLiteral("episode-2")},
+        {QStringLiteral("Name"), QStringLiteral("Episode 2")},
+        {QStringLiteral("SeriesName"), QStringLiteral("Series A")},
+        {QStringLiteral("ParentIndexNumber"), 1},
+        {QStringLiteral("IndexNumber"), 2}
+    };
+
+    QVERIFY(QMetaObject::invokeMethod(&controller,
+                                      "onNextEpisodeLoaded",
+                                      Qt::DirectConnection,
+                                      Q_ARG(QString, QStringLiteral("series-1")),
+                                      Q_ARG(QJsonObject, episodeData),
+                                      Q_ARG(QString, QStringLiteral("player:resolve:series-1:item-1"))));
+
+    QVERIFY(controller.awaitingNextEpisodeResolution());
+    QCOMPARE(navigationSpy.count(), 0);
+
+    QCoreApplication::processEvents();
+
+    QCOMPARE(navigationSpy.count(), 1);
+    QVERIFY(!controller.awaitingNextEpisodeResolution());
+    QCOMPARE(awaitingSpy.count(), 1);
+}
+
+void PlayerControllerAutoplayContextTest::deferredPostPlaybackDisplayRestoreCanBeReleased()
+{
+    ConfigManager config;
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+
+    controller.m_deferredPostPlaybackDisplayRestorePending = true;
+    controller.m_deferredPostPlaybackNeedsHdrRestore = true;
+    controller.m_deferredPostPlaybackNeedsRefreshRestore = true;
+    const quint64 generationBeforeRelease = controller.m_displayRestoreGeneration;
+
+    controller.releaseDeferredPostPlaybackDisplayRestore();
+
+    QVERIFY(!controller.m_deferredPostPlaybackDisplayRestorePending);
+    QVERIFY(!controller.m_deferredPostPlaybackNeedsHdrRestore);
+    QVERIFY(!controller.m_deferredPostPlaybackNeedsRefreshRestore);
+    QVERIFY(controller.m_displayRestoreGeneration > generationBeforeRelease);
 }
 
 void PlayerControllerAutoplayContextTest::nextEpisodeNavigationUsesPendingTrackContext()


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix display restoration and state handling for the Up Next screen
> - Parks HDR/refresh-rate display restoration when playback ends and Up Next is pending, instead of restoring immediately. Restoration is released when the user leaves Up Next or starts another episode.
> - Adds `releaseDeferredPostPlaybackDisplayRestore()` as a QML-invokable on `PlayerController`, and a `maybeStartDeferredPostPlaybackDisplayRestore()` private helper to trigger the parked restore.
> - Fixes `awaitingNextEpisodeResolution` flag lifetime so it stays true until the queued `navigateToNextEpisode` signal is delivered, preventing premature state resets.
> - Suppresses episode list refresh and playback-info preloads in `SeriesSeasonEpisodeView` while Up Next is pending or the view is inactive, and blocks playback from starting in that state.
> - Up Next overlay in [Main.qml](https://github.com/crowquillx/Bloom/pull/56/files#diff-f4773d055809f8f8ae1877220a16747bc781215089a7b6b7eb33e5b444a27be5) now handles Back/Escape to dismiss and triggers display restore cleanup; all exit paths (back to home, more episodes, recommendation) call `releaseDeferredPostPlaybackDisplayRestore()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d000dbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved Up Next navigation to better preserve episode context when switching between episodes.
  * Enhanced keyboard focus handling in the Up Next overlay.

* **Bug Fixes**
  * Fixed display restoration timing after playback stops to prevent unwanted screen state transitions when "Up Next" is displayed.

* **Documentation**
  * Updated playback documentation to reflect refined Up Next behavior and display restoration handling.

* **Tests**
  * Added new test coverage for autoplay context and display restoration workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crowquillx/Bloom/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->