### PR TITLE
feat(ui): add Go to Series action from season episode view

### DIFF
--- a/docs/responsive.md
+++ b/docs/responsive.md
@@ -441,7 +441,7 @@ A `Connections` block on `ResponsiveLayoutManager.onBreakpointChanged` saves the
 
 ## SeriesSeasonEpisodeView Responsive Layout
 
-[`SeriesSeasonEpisodeView.qml`](../src/ui/SeriesSeasonEpisodeView.qml) uses the responsive layout system for the episode browsing experience with seasons tabs, episode thumbnails, the selected-episode `Chapters` shelf, cast metadata, action buttons, and audio/subtitle track selection.
+[`SeriesSeasonEpisodeView.qml`](../src/ui/SeriesSeasonEpisodeView.qml) uses the responsive layout system for the episode browsing experience with seasons tabs, episode thumbnails, the selected-episode `Chapters` shelf, cast metadata, action buttons (Play, Mark Watched, Favorite, **Go to Series**, and the audio/subtitle context menu), and audio/subtitle track selection. **Go to Series** opens the parent series details view and returns to the same season/episode context via the library navigation stack.
 
 ### Token usage
 

--- a/src/ui/LibraryScreen.qml
+++ b/src/ui/LibraryScreen.qml
@@ -1718,9 +1718,6 @@ FocusScope {
     function exitSeriesDetails() {
         // Helper to exit series details view
         showSeriesDetails = false
-        currentSeriesData = null
-        currentSeriesSeasons = []
-        currentNextEpisode = null
         navigateBack()
     }
     
@@ -1883,6 +1880,7 @@ FocusScope {
             seasonName: currentSeasonName,
             seasonNumber: currentSeasonNumber,
             seasonPosterUrl: currentSeasonPosterUrl,
+            seasonsGridIndex: SeriesDetailsViewModel.selectedSeasonIndex >= 0 ? SeriesDetailsViewModel.selectedSeasonIndex : -1,
             selectedGenres: selectedGenres.slice(),
             selectedNetworks: selectedNetworks.slice(),
             showFilterPanel: showFilterPanel,

--- a/src/ui/LibraryScreen.qml
+++ b/src/ui/LibraryScreen.qml
@@ -468,6 +468,10 @@ FocusScope {
                 }))
             }
             
+            onSeriesDetailsRequested: function(episodeId) {
+                showSeriesDetailsFromSeasonView(episodeId)
+            }
+
             onBackRequested: {
                 exitSeasonView()
             }
@@ -1788,6 +1792,64 @@ FocusScope {
         updateBackdropForItem(episodeData)
         
         // Ensure focus is transferred to the episode view after it loads
+        Qt.callLater(function() {
+            if (contentLoader.item) {
+                contentLoader.item.forceActiveFocus()
+            }
+        })
+    }
+
+    function showSeriesDetailsFromSeasonView(episodeId) {
+        if (!currentSeriesId) {
+            return
+        }
+        var episodeIndex = -1
+        var lookupEpisodeId = episodeId || initialEpisodeId
+        if (SeriesDetailsViewModel.episodesModel && lookupEpisodeId !== "") {
+            for (var i = 0; i < SeriesDetailsViewModel.episodesModel.rowCount(); i++) {
+                var ep = SeriesDetailsViewModel.episodesModel.getItem(i)
+                if (ep && (ep.Id === lookupEpisodeId || ep.itemId === lookupEpisodeId)) {
+                    episodeIndex = i
+                    break
+                }
+            }
+        }
+        var previousContext = {
+            parentId: currentParentId,
+            seriesId: currentSeriesId,
+            showSeriesDetails: showSeriesDetails,
+            showSeasonView: showSeasonView,
+            showMovieDetails: showMovieDetails,
+            seriesDetailsReturnState: _seriesDetailsReturnState,
+            movieDetailsReturnState: _movieDetailsReturnState,
+            movieData: currentMovieData,
+            seasonId: currentSeasonId || SeriesDetailsViewModel.selectedSeasonId,
+            seasonName: currentSeasonName,
+            seasonNumber: currentSeasonNumber,
+            seasonPosterUrl: currentSeasonPosterUrl,
+            selectedGenres: selectedGenres.slice(),
+            selectedNetworks: selectedNetworks.slice(),
+            showFilterPanel: showFilterPanel,
+            activeFilterCategory: activeFilterCategory,
+            episodeIndex: episodeIndex
+        }
+        navigationStack.push(previousContext)
+        console.log("[Library] push navigation context for Series from season view",
+                    "stackSize:", navigationStack.length)
+        if (SeriesDetailsViewModel.selectedSeasonIndex >= 0) {
+            _pendingSeasonsGridIndex = SeriesDetailsViewModel.selectedSeasonIndex
+        }
+        if (episodeId) {
+            initialEpisodeId = episodeId
+        }
+        showSeriesDetails = true
+        showSeasonView = false
+        currentParentId = currentSeriesId
+        if (SeriesDetailsViewModel.backdropUrl !== "") {
+            currentBackdropUrl = SeriesDetailsViewModel.backdropUrl
+        } else if (currentSeriesData) {
+            updateBackdropForItem(currentSeriesData)
+        }
         Qt.callLater(function() {
             if (contentLoader.item) {
                 contentLoader.item.forceActiveFocus()

--- a/src/ui/SeriesSeasonEpisodeView.qml
+++ b/src/ui/SeriesSeasonEpisodeView.qml
@@ -73,6 +73,7 @@ FocusScope {
     signal backRequested()
     signal playRequested(var request)
     signal autoplayOverridesConsumed()
+    signal seriesDetailsRequested(string episodeId)
     
     Connections {
         target: SeriesDetailsViewModel
@@ -1605,7 +1606,7 @@ FocusScope {
                                 Layout.preferredWidth: Theme.buttonHeightLarge
 
                                 KeyNavigation.left: watchedToggleButton
-                                KeyNavigation.right: contextMenuButton
+                                KeyNavigation.right: goToSeriesButton
                                 KeyNavigation.up: (readMoreButton.visible && readMoreButton.enabled) ? readMoreButton : seasonsTabList
 
                                 onActiveFocusChanged: {
@@ -1641,6 +1642,50 @@ FocusScope {
                             }
 
                             SecondaryActionButton {
+                                id: goToSeriesButton
+                                text: qsTr("Go to Series")
+                                iconGlyph: Icons.tvShows
+                                showLabel: true
+                                enabled: seriesId !== ""
+                                Layout.preferredHeight: Theme.buttonHeightLarge
+
+                                KeyNavigation.left: favoriteButton
+                                KeyNavigation.right: contextMenuButton
+                                KeyNavigation.up: (readMoreButton.visible && readMoreButton.enabled) ? readMoreButton : seasonsTabList
+
+                                onActiveFocusChanged: {
+                                    if (activeFocus) {
+                                        mainContentFlickable.contentY = 0
+                                    }
+                                }
+
+                                Keys.onDownPressed: (event) => {
+                                    if (episodesList.count > 0) {
+                                        episodesList.forceActiveFocus()
+                                    } else if (castSection.visible && castList.count > 0) {
+                                        castSection.focusCurrentOrFirst()
+                                    }
+                                    event.accepted = true
+                                }
+
+                                Keys.onReturnPressed: (event) => {
+                                    if (!event.isAutoRepeat && enabled) {
+                                        clicked()
+                                        event.accepted = true
+                                    }
+                                }
+
+                                Keys.onEnterPressed: (event) => {
+                                    if (!event.isAutoRepeat && enabled) {
+                                        clicked()
+                                        event.accepted = true
+                                    }
+                                }
+
+                                onClicked: root.seriesDetailsRequested(selectedEpisodeId)
+                            }
+
+                            SecondaryActionButton {
                                 id: contextMenuButton
                                 text: ""
                                 iconGlyph: Icons.moreVert
@@ -1649,7 +1694,7 @@ FocusScope {
                                 Layout.preferredHeight: Theme.buttonHeightLarge
                                 Layout.preferredWidth: Theme.buttonHeightLarge
 
-                                KeyNavigation.left: favoriteButton
+                                KeyNavigation.left: goToSeriesButton
                                 KeyNavigation.up: (readMoreButton.visible && readMoreButton.enabled) ? readMoreButton : seasonsTabList
 
                                 onActiveFocusChanged: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Go to Series** hero action button in `SeriesSeasonEpisodeView`, placed between Favorite and the audio/subtitle context menu. Selecting it opens `SeriesDetailsView` for the current series; Back restores the same season/episode browse state via the library navigation stack.

## Changes

- **`SeriesSeasonEpisodeView.qml`**: New `seriesDetailsRequested` signal and `goToSeriesButton` with keyboard navigation wired into the existing action row.
- **`LibraryScreen.qml`**: `showSeriesDetailsFromSeasonView()` pushes season/episode context onto `navigationStack` before switching to series details; `seasonViewComponent` handles the signal.
- **`docs/responsive.md`**: Documents the new action in the SeriesSeasonEpisodeView responsive layout section.

## Testing

- [ ] Manual: From season/episode view, focus **Go to Series** and activate — series details opens for the correct show.
- [ ] Manual: Back from series details returns to the same season tab and episode selection.
- [ ] Manual: Keyboard/gamepad left/right navigation across Play → Watched → Favorite → Go to Series → context menu.

## Docs

- [x] `docs/responsive.md` updated
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34224266-cd11-4134-a92c-01e7f71a2a4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34224266-cd11-4134-a92c-01e7f71a2a4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Go to Series' action button to SeriesSeasonEpisodeView
> - Adds a new `goToSeriesButton` in [SeriesSeasonEpisodeView.qml](https://github.com/crowquillx/Bloom/pull/57/files#diff-c539954ce8eec484b58ff0ae0f64bbd2af20f6099e0ca3829b876f2a2e4d5a94) that emits `seriesDetailsRequested(episodeId)` when clicked, inserted between the Favorite and context menu buttons in the action bar.
> - [LibraryScreen.qml](https://github.com/crowquillx/Bloom/pull/57/files#diff-892f3c8b0cdc7073101ac08700746894b475ae1446f2bd63b86d40cf79440a7e) handles this signal via `showSeriesDetailsFromSeasonView`, which pushes the current season/episode context onto the navigation stack before switching to the series details view.
> - `exitSeriesDetails` no longer clears `currentSeriesData`, `currentSeriesSeasons`, or `currentNextEpisode`, so prior series data persists after returning from the series detail overlay.
> - Behavioral Change: navigation state is now preserved on the stack when entering series details from the season view, allowing return to the same season/episode context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 337ed3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Go to Series" button in the season/episode view, enabling quick navigation back to the parent series details while preserving your current viewing context.

* **Documentation**
  * Updated responsive layout documentation to reflect new navigation features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->