### PR TITLE
docs(migration): add Flutter and CEF kickoff plans with shared Bloom Core contract

### DIFF
--- a/docs/migration/cef-track.md
+++ b/docs/migration/cef-track.md
@@ -1,0 +1,218 @@
+# CEF Track Migration Plan (Worker B)
+
+_Last updated: 2026-05-25 (UTC)_
+
+## Scope and ownership
+
+This document is **CEF-track only** scaffolding for the migration kickoff. It is additive and interface-first, and assumes another worker is concurrently drafting Flutter-track specifics.
+
+## 1) Architecture note (short + concrete)
+
+### Target shape
+
+Bloom migration uses a **shared native backend layer** (`Bloom Core`) implemented in C++ and reused by all frontends (current QML, CEF shell, Flutter shell). CEF is a UI host, not a second backend.
+
+- **C++ owns**: auth/session, Jellyfin API access, models/viewmodels, playback state machine, reporting lifecycle, settings/config, track selection persistence hooks.
+- **JS owns**: rendering, navigation state, focus visuals, command dispatch, view composition.
+- **Command/event bridge** is typed and versioned so frontend code cannot bypass backend policy or duplicate Jellyfin logic.
+
+### Process boundaries
+
+- CEF Browser Process: window lifecycle, app-level menus/input routing, bridge registration.
+- CEF Renderer Process: JS app execution and typed bridge client.
+- Bloom Core host (C++): service locator + adapters around existing network/player/config services.
+
+### Lifecycle model
+
+1. App boot: initialize `ServiceLocator` + `BloomCoreFacade`.
+2. Frontend handshake: JS requests bridge schema version and capabilities.
+3. Session restore: C++ attempts persisted token/session restore; emits session status.
+4. Library browse: JS requests library query; C++ returns paged results.
+5. Playback: JS issues `play/start`, `play/pause`, `play/stop`; C++ controls player + emits state updates.
+6. Reporting: C++ emits/handles start/progress/pause/stop lifecycle independent of UI details.
+
+## 2) File-level implementation plan (ownership + milestones)
+
+> Milestones are organized so CEF can deliver value quickly while preserving one shared backend contract.
+
+### Milestone 0 — Contract freeze (Week 1)
+
+**Owner: Shared Core + CEF (joint review)**
+
+Planned files:
+- `docs/migration/shared-core-contract.md` (shared contract spec; owned by cross-track group)
+- `docs/migration/cef-track.md` (this file; CEF responsibilities and sequencing)
+
+Deliverables:
+- Finalize `Bloom Core` command/event surface and naming.
+- Freeze MVP command set for vertical slice.
+- Record versioning policy (`bridgeVersion`, backward compatibility window).
+
+### Milestone 1 — Native bridge scaffolding (Week 1-2)
+
+**Owner: CEF track**
+
+Planned C++ scaffolding:
+- `src/platform/cef/CefAppBootstrap.*`
+- `src/platform/cef/CefBridgeRouter.*`
+- `src/platform/cef/CefMessageCodec.*` (JSON envelope + typed payload mapping)
+- `src/core/BloomCoreFacade.*` (thin orchestration over existing services)
+
+Deliverables:
+- Browser/renderer bridge registration.
+- Envelope format:
+  - Command: `{id, domain, action, payload, schemaVersion}`
+  - Event: `{event, domain, payload, ts, schemaVersion}`
+- Unified error shape `{code, message, retriable, details}`.
+
+### Milestone 2 — Vertical slice MVP (Week 2-3)
+
+**Owner: CEF track with Shared Core support**
+
+Commands implemented:
+- `session.restore`
+- `auth.login` / `auth.logout`
+- `library.list`
+- `playback.start`
+- `playback.pause`
+- `playback.stop`
+
+Events implemented:
+- `session.stateChanged`
+- `library.page`
+- `playback.stateChanged`
+- `reporting.lifecycle` (`start/progress/pause/stop`)
+
+### Milestone 3 — HTPC interaction hardening (Week 3-5)
+
+**Owner: CEF track**
+
+Planned files:
+- `src/platform/cef/CefInputModeAdapter.*`
+- `src/platform/cef/CefFocusNavigator.*`
+- `src/platform/cef/CefWindowOverlayCoordinator.*`
+
+Deliverables:
+- Keyboard/gamepad-first focus traversal model.
+- Pointer-vs-keyboard mode detection parity with existing `InputModeManager` behavior.
+- Overlay and window geometry synchronization policy for playback controls.
+
+### Milestone 4 — Extended parity work (Week 5+)
+
+**Owner: Shared Core + CEF + Flutter**
+
+Deliverables:
+- Search/filter/sort parity.
+- Track selection mapping + persistence hooks.
+- Settings/config full bridge coverage.
+- Offline/cache semantics and richer error UX.
+
+## 3) Minimal vertical slice status
+
+## What runs now (kickoff baseline)
+
+- No committed CEF runtime vertical slice in repo yet.
+- Existing native services already exist in C++ (network/playback/config), which are the intended backend source for CEF via `Bloom Core` façade.
+
+## What is stubbed for kickoff
+
+- Stub bridge transport (`invoke(command)` / `subscribe(event)`) with static responses.
+- Stub flow target:
+  1. `session.restore` returns authenticated or signed-out state.
+  2. `library.list` returns first page of media cards.
+  3. `playback.start/pause/stop` mutates mock playback state and emits events.
+- Reporting lifecycle events are emitted from one C++ playback adapter path (not JS timers/business logic).
+
+## Exit criteria for "slice complete"
+
+- Login/session restore displayed in CEF UI.
+- Library list navigable by keyboard/gamepad.
+- Start/pause/stop commands round-trip through typed bridge.
+- State and reporting events observable in both C++ logs and JS dev console.
+
+## 4) Risks and mitigations
+
+1. **Risk: Backend logic leaks into JS over time.**
+   - Mitigation: enforce command whitelist and prohibit direct Jellyfin HTTP in frontend packages; code review checklist item.
+
+2. **Risk: Bridge contract churn blocks parallel tracks.**
+   - Mitigation: schema versioning + additive fields only during MVP window; weekly contract review cadence.
+
+3. **Risk: Focus/navigation regressions for HTPC remote workflows.**
+   - Mitigation: explicit focus graph model, deterministic initial focus per route, CI smoke tests for D-pad navigation flows.
+
+4. **Risk: Overlay/window layering issues during embedded playback.**
+   - Mitigation: keep overlay coordination in native host; define geometry sync events for resize/maximize/fullscreen/minimize/restore transitions.
+
+5. **Risk: Reporting lifecycle drift (start/progress/pause/stop) across frontends.**
+   - Mitigation: lifecycle emitted by shared C++ playback/reporting service only, with frontend as passive observer.
+
+## 5) Time estimates
+
+Assumptions: 1-2 engineers CEF-focused, shared-core support available, no major mpv/CEF embedding blocker.
+
+- **Feasibility prototype (typed bridge + vertical slice):** ~2-3 weeks.
+- **First usable HTPC CEF build (keyboard/gamepad usable, basic library + playback controls):** ~5-7 weeks.
+- **Feature parity with current QML client (core browse/playback/reporting/settings/search/track prefs):** ~12-16 weeks.
+
+## Keyboard/remote focus model
+
+CEF UI must remain fully keyboard/gamepad navigable:
+
+- Frontend defines route-level **focus scopes** and directional neighbors (up/down/left/right).
+- Native input adapter detects last input mode (pointer vs keyboard/gamepad) and emits `input.modeChanged`.
+- Cursor is hidden in keyboard/gamepad mode and restored in pointer mode.
+- On async data reload, frontend restores last stable focus target (equivalent behavior to `Qt.callLater` focus restoration pattern).
+
+## Windowing and overlay implications
+
+- Playback UI overlays (transport controls, OSD, progress) should be hosted in a layer that remains visible above embedded video surfaces.
+- Geometry sync API between native window host and frontend overlay should include:
+  - `window.boundsChanged`
+  - `window.stateChanged` (normal/maximized/fullscreen/minimized/restored)
+- Transition handling must avoid visible video jump/clip when toggling overlay visibility and window states.
+
+## Concrete C++ <-> JS binding boundary
+
+## Bridge API design
+
+Single entrypoint in JS:
+
+- `bridge.invoke<TResponse>(command: BridgeCommand): Promise<BridgeResult<TResponse>>`
+- `bridge.subscribe<TEvent>(eventName: string, handler: (evt: TEventEnvelope<TEvent>) => void): Unsubscribe`
+
+C++ dispatcher routes by `domain/action` to `BloomCoreFacade` methods.
+
+### Command domains (MVP)
+
+- `session`: restore, status
+- `auth`: login, logout
+- `library`: list, search (search can be stubbed in MVP)
+- `playback`: start, pause, stop, state
+- `reporting`: lifecycle query/debug (optional for tooling)
+- `settings`: get/set (partial MVP)
+
+### Typed payload principles
+
+- Every command/event has explicit schema with required/optional fields.
+- Unknown fields ignored (forward compatibility).
+- Unknown command/action returns deterministic `UNSUPPORTED_COMMAND`.
+- Correlation ID (`id`) echoed in success/error responses.
+
+### Lifecycle hooks required by shared backend mandate
+
+- `onPlaybackStarted(itemId, positionTicks)` -> reporting start.
+- `onPlaybackProgress(itemId, positionTicks)` -> reporting progress.
+- `onPlaybackPaused(itemId, positionTicks)` -> reporting pause.
+- `onPlaybackStopped(itemId, positionTicks)` -> reporting stop + watched-threshold resolution.
+- Track selection hooks:
+  - `getPreferredTracks(profile, itemId)`
+  - `persistTrackSelection(itemId, audioTrackId, subtitleTrackId)`
+
+These hooks are implemented in C++ and surfaced to UI as state/events only.
+
+## Open decisions to resolve in shared contract review
+
+- Final event naming convention (`dot.case` vs `snake_case`) — recommend `dot.case` for domain grouping.
+- Transport encoding choice (JSON-only MVP vs optional binary fast-path later).
+- Capability negotiation format for incremental rollout across CEF/Flutter.

--- a/docs/migration/flutter-track.md
+++ b/docs/migration/flutter-track.md
@@ -1,0 +1,170 @@
+# Flutter Track Migration Plan (Worker A)
+
+Last updated: 2026-05-25
+Owner: Worker A (Flutter track)
+Scope: Flutter-track docs/scaffolding only
+
+## 1) Architecture note (short + concrete)
+
+Flutter should be a **thin UI shell** on Linux desktop/HTPC while all media/business logic stays in a shared native layer named **Bloom Core**.
+
+- **UI layer (Flutter):** routes, widgets, focus graph, keyboard/gamepad mapping, visual theming, and user intent dispatch.
+- **Bridge layer (Flutter plugin):** typed FFI/API wrapper exposing Bloom Core commands + event streams.
+- **Core layer (native C++):** auth/session, Jellyfin API access, browse/search models, playback and mpv orchestration, playback reporting, config persistence, track-selection mapping persistence.
+
+Principle: no backend duplication in Dart; Dart only sends commands and renders state snapshots/streams.
+
+## 2) File-level implementation plan, ownership, milestones
+
+### Proposed files (Flutter track ownership)
+
+- `docs/migration/flutter-track.md` (this file)
+  - migration plan, milestones, status, risks, estimates.
+- `docs/migration/shared-core-contract.md` (new shared contract proposal)
+  - Bloom Core command/event/data contract draft for cross-track alignment.
+- `flutter/` (new additive scaffolding; not implemented yet)
+  - `flutter/bloom_flutter_app/` main desktop app shell.
+  - `flutter/plugins/bloom_core_bridge/` federated plugin exposing FFI boundary.
+  - `flutter/packages/bloom_core_contract/` generated or hand-authored Dart models mirroring shared contract.
+
+### Milestone breakdown
+
+- **M0: Contract alignment (1 week)**
+  - Freeze v0 Bloom Core contract for auth/session/library/playback/reporting/settings.
+  - Define compatibility/versioning policy and error envelope.
+  - Exit criteria: shared doc sign-off by Flutter + CEF + native owners.
+
+- **M1: Bridge bootstrap + smoke integration (1–1.5 weeks)**
+  - Create Flutter plugin with Linux desktop implementation.
+  - Wire command channel/FFI + event stream subscription.
+  - Implement minimal no-op mock backend for local UI iteration.
+  - Exit criteria: demo app receives fake session + library + player events.
+
+- **M2: Vertical slice on real core (2 weeks)**
+  - Real login/session restore, library listing, start/pause/stop playback.
+  - Reporting lifecycle events flow through core.
+  - Exit criteria: end-to-end flow works against a Jellyfin server.
+
+- **M3: HTPC interaction hardening (1.5–2 weeks)**
+  - 10-foot focus graph, gamepad/keyboard nav, pointer-mode suppression.
+  - Playback overlay controls + OSD state mirrored from core.
+  - Exit criteria: couch-remote navigation without mouse.
+
+- **M4: feature ramp (4–8 weeks parallelized)**
+  - Search, details pages, episodes/next up, track selection UX, settings pages.
+  - Robust error/reconnect, cache strategy, telemetry hooks.
+
+## 3) Minimal vertical slice status
+
+### Target slice
+Login/session restore -> library listing -> playback start/pause/stop
+
+### Current status (migration kickoff)
+
+- **Runs now:**
+  - Existing native Bloom app path already supports auth/library/playback/reporting in C++/QML stack (reference behavior).
+- **Flutter track currently stubbed/planned:**
+  - Flutter shell and plugin not yet created in-repo.
+  - Contract defined at doc level (this phase).
+  - Vertical slice implementation starts at M1/M2.
+
+### Slice acceptance criteria (for M2)
+
+- Login with server URL + token/credential exchange through Bloom Core API.
+- Session restore on app relaunch using persisted session state from core/config.
+- Library list renders first page of items with poster/title metadata.
+- Selecting an item sends `playback.start` command; pause/stop commands operate reliably.
+- Playback lifecycle reporting (`start/progress/pause/stop`) emitted by core and observable in Flutter logs/diagnostics.
+
+## 4) Linux desktop 10-foot focus/input strategy
+
+Flutter must mirror Bloom's keyboard/gamepad-first UX expectations:
+
+- **Primary nav mode:** directional focus traversal, enter/back/media keys.
+- **Input mode manager (Flutter side):**
+  - Track latest input source (`keyboard_gamepad` vs `pointer`).
+  - Hide cursor and highlight focus rails in keyboard/gamepad mode.
+  - Re-enable cursor affordances in pointer mode.
+- **Focus restoration:**
+  - Preserve per-route focused node ID.
+  - Restore after async list refresh/navigation pop using post-frame callbacks.
+- **Gamepad mapping:**
+  - D-pad -> directional focus.
+  - A/B (or South/East) -> select/back.
+  - Shoulder/trigger optional for page jump/seek (later milestone).
+- **Linux specifics:**
+  - Validate on Wayland and X11.
+  - Ensure global key handling does not depend on compositor-specific behavior.
+
+## 5) Plugin/FFI boundary proposal (concrete)
+
+Transport can be either direct Dart:FFI or Pigeon/platform channel facade over native shim. Preferred near-term: platform channel API with typed payloads; evolve to direct FFI where latency-sensitive.
+
+### Control API surface (command-oriented)
+
+- `core.initialize(clientInfo, paths)`
+- `auth.login(serverUrl, username, password | token)`
+- `auth.restoreSession()`
+- `auth.logout()`
+- `library.getHomeSections()`
+- `library.getItems(sectionId, page)`
+- `library.search(query, filters)`
+- `playback.prepare(itemId, startPositionTicks?)`
+- `playback.play()`
+- `playback.pause()`
+- `playback.stop(reason?)`
+- `playback.seek(positionTicks)`
+- `playback.selectTracks(audioTrackId?, subtitleTrackId?)`
+- `settings.get(key)` / `settings.set(key, value)`
+
+### Event streams (push from core)
+
+- `session.events`: logged_in, restored, expired, logged_out
+- `library.events`: cache_updated, refresh_started, refresh_done
+- `playback.state`: idle, buffering, playing, paused, stopped, ended, error
+- `playback.position`: periodic ticks/progress snapshots
+- `playback.tracks`: available tracks + selected track changes
+- `reporting.events`: start_sent, progress_sent, pause_sent, stop_sent, failed_retrying
+- `core.health`: backend_connected, backend_restarting, fatal_error
+
+### Data contracts (typed DTOs)
+
+- `SessionInfo { userId, accessToken, serverUrl, deviceId, expiresAt? }`
+- `MediaItemSummary { id, type, title, posterUrl, runtimeTicks?, year?, rating? }`
+- `PlaybackStateSnapshot { itemId?, state, positionTicks, durationTicks?, speed, isMuted, volume }`
+- `TrackInfo { id, kind(audio|subtitle), label, language, codec, channels?, isDefault, isForced }`
+- `CoreError { code, message, isRetriable, details? }`
+
+### Track mapping + persistence hooks
+
+- Core owns precedence logic and persistence store.
+- Flutter sends user intents (`preferredAudioLanguage`, `subtitleMode`, explicit track override).
+- Core emits resolved selection + reason (`user_override`, `language_match`, `default_track`, `none`).
+
+## 6) Risks and mitigations
+
+- **Risk: contract drift across Flutter/CEF/native teams**
+  - Mitigation: versioned shared contract doc + changelog + weekly compatibility review.
+- **Risk: event ordering race conditions (playback + reporting)**
+  - Mitigation: monotonic sequence numbers on events and idempotent handling in UI.
+- **Risk: Linux input fragmentation (Wayland/X11/gamepad stacks)**
+  - Mitigation: explicit input adapter layer + test matrix by compositor/session type.
+- **Risk: duplicated logic sneaks into Dart**
+  - Mitigation: code review checklist requiring backend decisions to stay in core.
+- **Risk: bridge latency or serialization overhead**
+  - Mitigation: benchmark high-frequency streams (position updates), move hot paths to FFI.
+
+## 7) Time estimates
+
+- **Feasibility prototype:** 2-3 weeks
+  - Includes M0 + M1 + partial M2 demo with one happy-path playback flow.
+- **First usable HTPC build:** 6-8 weeks
+  - Includes stable M2 + M3 input/focus hardening and basic browse/play loop.
+- **Feature parity with current client:** 14-20 weeks
+  - Depends on advanced playback controls, search/discovery depth, settings breadth, and QA across Linux configurations.
+
+## Key conclusions
+
+- Bloom Core contract-first approach is the critical enabler for parallel Flutter + CEF delivery.
+- Flutter should remain presentation-focused; all domain/media logic stays native.
+- A realistic first usable Linux HTPC milestone is ~6-8 weeks after contract lock.

--- a/docs/migration/shared-core-contract.md
+++ b/docs/migration/shared-core-contract.md
@@ -1,0 +1,99 @@
+# Shared Core Contract Proposal (Kickoff Draft)
+
+Last updated: 2026-05-25
+Contributors: Worker A (Flutter track)
+Status: Draft v0 for cross-track review
+
+## Purpose
+
+Define a single Bloom Core interface consumed by multiple frontends (Flutter, CEF, existing QML migration layers) so auth, library, playback, reporting, track persistence, and settings behavior remain consistent.
+
+## v0 Scope (must-have)
+
+- Auth/session: login, restore, logout, expiration signaling.
+- Library: browse sections, list items, basic search.
+- Playback: prepare/play/pause/stop/seek + state snapshots.
+- Reporting lifecycle: start/progress/pause/stop lifecycle visibility.
+- Track selection mapping + persistence hooks.
+- Config/settings get/set with typed values.
+
+## Contract shape
+
+Command-response APIs + asynchronous event streams.
+
+- Commands return `Result<T, CoreError>`.
+- Events are emitted with `eventId`, `timestampUtc`, and `sequence`.
+- State snapshots are authoritative; UI state is derived, not source-of-truth.
+
+## Versioning + compatibility
+
+- Semantic contract versioning: `major.minor.patch`.
+- Additive fields/events: minor bump.
+- Breaking rename/removal/semantic changes: major bump.
+- Bridge must expose negotiated contract version at startup.
+
+## Open decisions for joint review
+
+1. Transport default for desktop: Platform channels first vs direct FFI first.
+2. DTO source-of-truth: IDL/proto/schema generation vs hand-maintained typed models.
+3. Position update frequency and backpressure policy for UI streams.
+4. Unified error code taxonomy across network/playback/config domains.
+
+---
+
+## Worker B (CEF) append — 2026-05-25
+
+### Proposed CEF alignment notes (MVP-first)
+
+- Keep one shared `Bloom Core` contract for auth/session, library browse/search, playback control/state, reporting lifecycle, track mapping+persistence hooks, and settings.
+- CEF frontend must consume typed command/event bridge only; no duplication of backend business logic in JS.
+- Prefer command domains: `session`, `auth`, `library`, `playback`, `reporting`, `settings`.
+
+### Bridge envelope proposal
+
+```json
+// command
+{ "id": "uuid", "domain": "playback", "action": "start", "payload": {}, "schemaVersion": 1 }
+
+// success response
+{ "id": "uuid", "ok": true, "payload": {}, "schemaVersion": 1 }
+
+// error response
+{ "id": "uuid", "ok": false, "error": { "code": "...", "message": "...", "retriable": false }, "schemaVersion": 1 }
+
+// event
+{ "event": "playback.stateChanged", "domain": "playback", "payload": {}, "ts": "2026-05-25T00:00:00Z", "schemaVersion": 1 }
+```
+
+### Shared guardrails
+
+- No direct Jellyfin HTTP from JS/Dart frontends.
+- Reporting lifecycle (start/progress/pause/stop) must be emitted by shared C++ playback/reporting path.
+- Track preferences are resolved/persisted in shared backend and surfaced as state/events.
+
+## Worker A (Flutter) proposal append
+
+### Shared contract constraints
+- Bloom Core remains source-of-truth for auth/session, browse/search, playback state, reporting lifecycle, track preference resolution, and settings persistence.
+- Flutter consumes command APIs + event streams and must not duplicate backend business logic.
+
+### Flutter-oriented command/event/data additions
+
+```text
+Commands
+- core.initialize({ clientName, clientVersion, platform, cachePath, configPath })
+- auth.restoreSession()
+- playback.prepare({ itemId, startPositionTicks? })
+- playback.seek({ positionTicks })
+
+Event streams
+- session.events: logged_in | restored | expired | logged_out
+- playback.position: periodic position ticks snapshots
+- playback.tracks: options + selected track changes
+- reporting.events: start_sent | progress_sent | pause_sent | stop_sent | failed_retrying
+```
+
+### Event ordering + reliability
+- Every async event includes `{ sequence, ts, correlationId? }` to prevent UI race conditions.
+- Commands are idempotent where practical (`pause` when already paused is success no-op).
+- For high-rate telemetry (`playback.position`), support throttling/backpressure hints in bridge settings.


### PR DESCRIPTION
### Motivation

- Provide a decision-ready kickoff for two parallel migration tracks (Flutter and CEF) that maximize reuse of a single native backend layer (Bloom Core).
- Capture an interface-first approach so frontends remain thin presentation shells and playback/reporting/business logic stays centralized in C++.

### Description

- Add `docs/migration/flutter-track.md` with a concrete Flutter integration plan, plugin/FFI boundary, typed control APIs and event streams, Linux 10-foot focus/input strategy, milestones, risks, and timeline estimates.
- Add `docs/migration/cef-track.md` with a CEF integration plan, typed C++↔JS bridge envelope, lifecycle model, keyboard/gamepad focus model, overlay/windowing coordination, milestones, risks, and timeline estimates.
- Add `docs/migration/shared-core-contract.md` containing the v0 Bloom Core command/event/data contract draft, versioning rules, and append sections from both tracks to align on required guardrails (no direct Jellyfin HTTP in frontends, reporting lifecycle centralized, etc.).

### Testing

- Verified working-tree cleanliness and inspected the new files to confirm their presence and contents. 
- Performed content-level validation by printing and reviewing the new docs to ensure the contract, commands, events, and milestones are present and consistent across tracks. 
- No code build or unit/integration tests were run because these are docs-only, interface-first changes and do not modify runtime code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c3b6c59c832dbef2f092ff2f1811)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Flutter and CEF migration track docs with shared Bloom Core contract
> - Adds [cef-track.md](https://github.com/crowquillx/Bloom/pull/59/files#diff-a99a1acc89cabf6599f011084fe1424b5ddea7d4d61e63db9563620efffd8a4c) covering the CEF migration architecture, process/lifecycle, vertical slice milestones, and a concrete C++↔JS bridge API proposal.
> - Adds [flutter-track.md](https://github.com/crowquillx/Bloom/pull/59/files#diff-9359c384def27354f7a8950f6604a48ef2e777341371ea5d8e6111d56d97f168) covering Flutter architecture, ownership, Linux desktop focus/input strategy, plugin/FFI boundary, and command/event/data contracts.
> - Adds [shared-core-contract.md](https://github.com/crowquillx/Bloom/pull/59/files#diff-a85afd23656824c31a53e25824f71455b9492873348823294b94c80b7f234c72) as a kickoff draft defining the shared Bloom Core API shape (commands + event streams), versioning policy, open decisions, and alignment notes for both tracks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5964c4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->