### PR TITLE
Reduce log spam with categorized logging and image filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,9 @@ jobs:
       - name: Cache Qt SDK
         id: cache_qt_windows
         uses: actions/cache@v5
-        continue-on-error: true
         with:
           path: ${{ runner.workspace }}/Qt
-          key: windows-qt-6.10.0-win64_msvc2022_64-qtmultimedia-qtshadertools-qtimageformats-qt5compat-v2
-          restore-keys: |
-            windows-qt-6.10.0-win64_msvc2022_64-qtmultimedia-qtshadertools-qtimageformats-qt5compat-
+          key: windows-qt-6.10.0-win64_msvc2022_64-qtmultimedia-qtshadertools-qtimageformats-qt5compat-v1
 
       - name: Install aqtinstall
         shell: pwsh
@@ -295,6 +292,15 @@ jobs:
           }
           sccache --show-stats
           sccache --stop-server
+
+      - name: Stop sccache server
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          if (Get-Command sccache -ErrorAction SilentlyContinue) {
+            & sccache --stop-server 2>&1 | Out-Null
+          }
 
       - name: Package App
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,10 +295,11 @@ jobs:
 
       - name: Stop sccache server
         if: always()
+        continue-on-error: true
         shell: pwsh
         run: |
           if (Get-Command sccache -ErrorAction SilentlyContinue) {
-            sccache --stop-server 2>$null
+            & sccache --stop-server 2>&1 | Out-Null
           }
 
       - name: Package App

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,9 +242,11 @@ jobs:
 
       - name: Cache sccache
         uses: actions/cache@v5
+        continue-on-error: true
+        id: cache_sccache_windows
         with:
           path: .sccache
-          key: ${{ runner.os }}-sccache-msvc2022-qt610-v2
+          key: ${{ runner.os }}-sccache-msvc2022-qt610-v3
           restore-keys: |
             ${{ runner.os }}-sccache-msvc2022-qt610-
             ${{ runner.os }}-sccache-
@@ -292,15 +294,6 @@ jobs:
           }
           sccache --show-stats
           sccache --stop-server
-
-      - name: Stop sccache server
-        if: always()
-        continue-on-error: true
-        shell: pwsh
-        run: |
-          if (Get-Command sccache -ErrorAction SilentlyContinue) {
-            & sccache --stop-server 2>&1 | Out-Null
-          }
 
       - name: Package App
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,12 @@ jobs:
       - name: Cache Qt SDK
         id: cache_qt_windows
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: ${{ runner.workspace }}/Qt
-          key: windows-qt-6.10.0-win64_msvc2022_64-qtmultimedia-qtshadertools-qtimageformats-qt5compat-v1
+          key: windows-qt-6.10.0-win64_msvc2022_64-qtmultimedia-qtshadertools-qtimageformats-qt5compat-v2
+          restore-keys: |
+            windows-qt-6.10.0-win64_msvc2022_64-qtmultimedia-qtshadertools-qtimageformats-qt5compat-
 
       - name: Install aqtinstall
         shell: pwsh
@@ -292,15 +295,6 @@ jobs:
           }
           sccache --show-stats
           sccache --stop-server
-
-      - name: Stop sccache server
-        if: always()
-        continue-on-error: true
-        shell: pwsh
-        run: |
-          if (Get-Command sccache -ErrorAction SilentlyContinue) {
-            & sccache --stop-server 2>&1 | Out-Null
-          }
 
       - name: Package App
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,11 +242,9 @@ jobs:
 
       - name: Cache sccache
         uses: actions/cache@v5
-        continue-on-error: true
-        id: cache_sccache_windows
         with:
           path: .sccache
-          key: ${{ runner.os }}-sccache-msvc2022-qt610-v3
+          key: ${{ runner.os }}-sccache-msvc2022-qt610-v2
           restore-keys: |
             ${{ runner.os }}-sccache-msvc2022-qt610-
             ${{ runner.os }}-sccache-
@@ -294,6 +292,14 @@ jobs:
           }
           sccache --show-stats
           sccache --stop-server
+
+      - name: Stop sccache server
+        if: always()
+        shell: pwsh
+        run: |
+          if (Get-Command sccache -ErrorAction SilentlyContinue) {
+            sccache --stop-server 2>$null
+          }
 
       - name: Package App
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,9 +242,11 @@ jobs:
 
       - name: Cache sccache
         uses: actions/cache@v5
+        continue-on-error: true
+        id: cache_sccache_windows
         with:
           path: .sccache
-          key: ${{ runner.os }}-sccache-msvc2022-qt610-v2
+          key: ${{ runner.os }}-sccache-msvc2022-qt610-v3
           restore-keys: |
             ${{ runner.os }}-sccache-msvc2022-qt610-
             ${{ runner.os }}-sccache-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,12 @@ jobs:
       - name: Cache Qt SDK
         id: cache_qt_windows
         uses: actions/cache@v5
+        continue-on-error: true
         with:
           path: ${{ runner.workspace }}/Qt
-          key: windows-qt-6.10.0-win64_msvc2022_64-qtmultimedia-qtshadertools-qtimageformats-qt5compat-v1
+          key: windows-qt-6.10.0-win64_msvc2022_64-qtmultimedia-qtshadertools-qtimageformats-qt5compat-v2
+          restore-keys: |
+            windows-qt-6.10.0-win64_msvc2022_64-qtmultimedia-qtshadertools-qtimageformats-qt5compat-
 
       - name: Install aqtinstall
         shell: pwsh

--- a/docs/config.md
+++ b/docs/config.md
@@ -57,6 +57,7 @@ Logging settings
 - Default `info` level silences routine **image** (`bloom.imagecache`), **library cache** (`bloom.viewmodels`, `bloom.librarycache`, `bloom.cache`), and **playback trace** noise while keeping **all warnings and errors** (including image load failures).
 - `settings.logging.qt_rules` optional Qt logging category rules (newline-separated) appended to Bloom defaults. Use for targeted diagnostics, for example `bloom.imagecache.debug=true`. The `QT_LOGGING_RULES` environment variable is still honored by Qt before startup.
 - Pass `--verbose` / `-v` on the command line to force full debug logging for one session (overrides `settings.logging.level`).
+- **Settings UI:** Settings → About & Account → **Log Level** (same section as updates). Changes apply immediately without restart.
 
 
 ### Logging categories (for `qt_rules`)

--- a/docs/config.md
+++ b/docs/config.md
@@ -52,6 +52,11 @@ When adding settings
 - Implement getters/setters in `ConfigManager.cpp` that persist to `app.json` and emit signals on change.
 - Update docs (this file) and add UI controls in `SettingsScreen.qml` where appropriate.
 
+Logging settings
+- `settings.logging.level` controls file/console verbosity. Valid values: `info` (default), `debug`, `quiet`. Default `info` suppresses uncategorized `qDebug()` spam (for example view-model cache traces) and disables debug output for noisy Qt categories such as `bloom.imagecache` and `bloom.library`.
+- `settings.logging.qt_rules` optional Qt logging category rules (newline-separated) appended to Bloom defaults. Use for targeted diagnostics, for example `bloom.imagecache.debug=true`. The `QT_LOGGING_RULES` environment variable is still honored by Qt before startup.
+- Pass `--verbose` / `-v` on the command line to force full debug logging for one session (overrides `settings.logging.level`).
+
 Cache settings
 - `settings.cache.image_cache_size_mb` controls the disk image cache size in megabytes. Default 500; minimum enforced at 50MB; config-only (no UI).
 - `settings.cache.rounded_image_mode` controls how rounded thumbnails are generated and cached. Defaults to `auto` (platform decides); you can force `always` (preprocess every image) or `never`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -54,8 +54,29 @@ When adding settings
 
 Logging settings
 - `settings.logging.level` controls file/console verbosity. Valid values: `info` (default), `debug`, `quiet`. Default `info` suppresses uncategorized `qDebug()` spam (for example view-model cache traces) and disables debug output for noisy Qt categories such as `bloom.imagecache` and `bloom.library`.
+- Default `info` level silences routine **image** (`bloom.imagecache`), **library cache** (`bloom.viewmodels`, `bloom.librarycache`, `bloom.cache`), and **playback trace** noise while keeping **all warnings and errors** (including image load failures).
 - `settings.logging.qt_rules` optional Qt logging category rules (newline-separated) appended to Bloom defaults. Use for targeted diagnostics, for example `bloom.imagecache.debug=true`. The `QT_LOGGING_RULES` environment variable is still honored by Qt before startup.
 - Pass `--verbose` / `-v` on the command line to force full debug logging for one session (overrides `settings.logging.level`).
+
+
+### Logging categories (for `qt_rules`)
+
+| Category | Purpose |
+|----------|---------|
+| `bloom.imagecache` | Poster/backdrop disk + memory image cache |
+| `bloom.viewmodels` | Library/series/movie view-model cache & SWR |
+| `bloom.librarycache` | SQLite library list cache |
+| `bloom.cache` | Detail-view JSON cache files |
+| `bloom.library` | Jellyfin library API requests |
+| `bloom.playback` | Playback controller (info suppressed by default) |
+| `bloom.playback.ipc` | mpv IPC traffic |
+| `bloom.auth` | Login, session, keychain |
+
+Example — debug image cache only:
+
+```json
+"qt_rules": "bloom.imagecache.debug=true\nbloom.imagecache.info=true"
+```
 
 Cache settings
 - `settings.cache.image_cache_size_mb` controls the disk image cache size in megabytes. Default 500; minimum enforced at 50MB; config-only (no UI).

--- a/docs/config.md
+++ b/docs/config.md
@@ -61,16 +61,33 @@ Logging settings
 
 ### Logging categories (for `qt_rules`)
 
-| Category | Purpose |
-|----------|---------|
-| `bloom.imagecache` | Poster/backdrop disk + memory image cache |
-| `bloom.viewmodels` | Library/series/movie view-model cache & SWR |
-| `bloom.librarycache` | SQLite library list cache |
-| `bloom.cache` | Detail-view JSON cache files |
-| `bloom.library` | Jellyfin library API requests |
-| `bloom.playback` | Playback controller (info suppressed by default) |
-| `bloom.playback.ipc` | mpv IPC traffic |
-| `bloom.auth` | Login, session, keychain |
+At the default `info` level, Bloom applies filter rules in `src/utils/LoggingConfig.cpp` (`LoggingConfig::defaultQtRules()`). The table below lists every category used in the codebase. **Warnings and errors are never filtered** for any category.
+
+| Category | Purpose | Routine output hidden at `info` |
+|----------|---------|----------------------------------|
+| `bloom.imagecache` | Poster/backdrop disk + memory image cache | debug, info |
+| `bloom.viewmodels` | Library/series/movie view-model cache & SWR | debug, info |
+| `bloom.librarycache` | SQLite library list cache | debug, info |
+| `bloom.cache` | Detail-view JSON cache files | debug, info |
+| `bloom.library` | Jellyfin library API requests | debug, info |
+| `bloom.auth` | Login, session, keychain | debug |
+| `bloom.config` | Config load/save | debug |
+| `bloom.app` | Application startup / service wiring | debug |
+| `bloom.ui` | Fonts, responsive layout | debug |
+| `bloom.ui.scenegraph` | Qt Quick scene graph diagnostics | debug |
+| `bloom.playback` | Playback controller | debug |
+| `bloom.playback.ipc` | mpv JSON IPC traffic | debug |
+| `bloom.playback.trickplay` | Trickplay tile processing | debug |
+| `bloom.playback.trace` | Playback state-machine trace | debug, info |
+| `bloom.playback.displaytrace` | Display refresh rate / HDR switching | debug |
+| `bloom.playback.backend.linux.libmpv` | Embedded libmpv on Linux | debug |
+| `bloom.playback.backend.windows.libmpv` | Embedded libmpv on Windows | debug |
+| `bloom.playback.backend.factory` | Player backend selection | debug |
+| `bloom.playback.backend.*` | Wildcard for all backend categories | debug |
+| `bloom.gpu.trim` | GPU memory trimming | debug |
+| `bloom.mediaSegments` | Intro/credits segment providers | debug |
+| `jellyfin.network` | Shared Jellyfin network types/helpers | debug |
+| `bloom.test` | Test mode / mock services | debug |
 
 Example — debug image cache only:
 

--- a/docs/developer_notes.md
+++ b/docs/developer_notes.md
@@ -39,6 +39,7 @@ Useful utilities
 
 Logging
 - Bloom routes Qt diagnostics through `Logger` with a default `info` level. Chatty areas use `Q_LOGGING_CATEGORY` (for example `bloom.imagecache`, `bloom.library`); debug for those categories is off unless you set `settings.logging.level` to `debug`, pass `--verbose`, or add rules under `settings.logging.qt_rules`.
+- Include `utils/BloomLogging.h` and use the declared categories (`lcImageCache`, `lcViewModels`, etc.) — never bare `qDebug()` in new code.
 - Prefer `qCDebug(category)` over bare `qDebug()` for high-volume paths so logs can be filtered without silencing the whole app.
 
 Where to add new docs

--- a/docs/developer_notes.md
+++ b/docs/developer_notes.md
@@ -37,6 +37,10 @@ Useful utilities
 - `JellyfinClient` for network operations and request retriers.
 - `ConfigManager` for settings and QML exposures.
 
+Logging
+- Bloom routes Qt diagnostics through `Logger` with a default `info` level. Chatty areas use `Q_LOGGING_CATEGORY` (for example `bloom.imagecache`, `bloom.library`); debug for those categories is off unless you set `settings.logging.level` to `debug`, pass `--verbose`, or add rules under `settings.logging.qt_rules`.
+- Prefer `qCDebug(category)` over bare `qDebug()` for high-volume paths so logs can be filtered without silencing the whole app.
+
 Where to add new docs
 - For new architectural changes, add a targeted doc under `/docs` and link it from `AGENTS.md`.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,8 @@ qt_add_executable(Bloom
     utils/GpuMemoryTrimmer.cpp
     utils/Logger.h
     utils/Logger.cpp
+    utils/LoggingConfig.h
+    utils/LoggingConfig.cpp
     viewmodels/BaseViewModel.h
     viewmodels/BaseViewModel.cpp
     viewmodels/LibraryViewModel.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,8 @@ qt_add_executable(Bloom
     utils/Logger.cpp
     utils/LoggingConfig.h
     utils/LoggingConfig.cpp
+    utils/BloomLogging.h
+    utils/BloomLogging.cpp
     viewmodels/BaseViewModel.h
     viewmodels/BaseViewModel.cpp
     viewmodels/LibraryViewModel.h

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -95,10 +95,12 @@ static void qtMessageHandler(QtMsgType type, const QMessageLogContext &context, 
 
 ApplicationInitializer::ApplicationInitializer(QGuiApplication *app,
                                                bool consoleOutputEnabled,
+                                               bool verboseLogging,
                                                QObject *parent)
     : QObject(parent)
     , m_app(app)
     , m_consoleOutputEnabled(consoleOutputEnabled)
+    , m_verboseLogging(verboseLogging)
 {
 }
 

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -35,6 +35,7 @@
 #include <QGuiApplication>
 #include <QDebug>
 #include <cstdio>
+#include "../utils/BloomLogging.h"
 
 /**
  * @brief Qt message handler that forwards all Qt diagnostic output to the custom Logger.
@@ -111,7 +112,7 @@ void ApplicationInitializer::registerServices()
 {
     // 0. Logger - Initialize logging system first (before any services)
     if (!Logger::instance().initialize()) {
-        qWarning() << "Failed to initialize Logger, falling back to console output";
+        qCWarning(lcApp) << "Failed to initialize Logger, falling back to console output";
     }
     // Enable debug-level logging and console output
     Logger::instance().setMinLogLevel(Logger::LogLevel::Debug);
@@ -143,13 +144,13 @@ void ApplicationInitializer::registerServices()
     // 2. Player backend - No dependencies
     m_playerBackend = PlayerBackendFactory::create(m_configManager->getPlayerBackend());
     ServiceLocator::registerService<IPlayerBackend>(m_playerBackend.get());
-    qInfo() << "ApplicationInitializer: Active player backend:" << m_playerBackend->backendName();
+    qCInfo(lcApp) << "ApplicationInitializer: Active player backend:" << m_playerBackend->backendName();
     
     // Check if we're in test mode
     bool isTestMode = TestModeController::instance()->isTestMode();
     
     if (isTestMode) {
-        qDebug() << "ApplicationInitializer: Running in test mode - registering mock services";
+        qCDebug(lcApp) << "ApplicationInitializer: Running in test mode - registering mock services";
         
         // 2.5 SecretStore - Create platform-specific secure storage (still needed for mock services)
         m_secretStore = SecretStoreFactory::create();
@@ -322,20 +323,20 @@ void ApplicationInitializer::initializeServices()
     
     connect(auth, &AuthenticationService::sessionExpired,
         [auth]() {
-            qWarning() << "Session expired, triggering logout";
+            qCWarning(lcApp) << "Session expired, triggering logout";
             auth->logout();
     });
     
     connect(auth, &AuthenticationService::sessionExpiredAfterPlayback,
         [auth]() {
-            qWarning() << "Session expired (detected during playback), triggering logout";
+            qCWarning(lcApp) << "Session expired (detected during playback), triggering logout";
             auth->logout();
     });
     
     // Connect playback stopped to check for pending session expiry
     connect(m_playerController.get(), &PlayerController::playbackStopped,
         [auth]() {
-            qDebug() << "Playback stopped, checking for pending session expiry";
+            qCDebug(lcApp) << "Playback stopped, checking for pending session expiry";
             auth->checkPendingSessionExpiry();
     });
     

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -25,6 +25,7 @@
 #include "utils/GpuMemoryTrimmer.h"
 #include "utils/Logger.h"
 #include "utils/LoggingConfig.h"
+#include "utils/BloomLogging.h"
 #include "network/SessionManager.h"
 #include "network/SessionService.h"
 #include "updates/UpdateService.h"
@@ -35,7 +36,6 @@
 #include <QGuiApplication>
 #include <QDebug>
 #include <cstdio>
-#include "../utils/BloomLogging.h"
 
 /**
  * @brief Qt message handler that forwards all Qt diagnostic output to the custom Logger.
@@ -114,21 +114,23 @@ void ApplicationInitializer::registerServices()
     if (!Logger::instance().initialize()) {
         qCWarning(lcApp) << "Failed to initialize Logger, falling back to console output";
     }
-    // Enable debug-level logging and console output
-    Logger::instance().setMinLogLevel(Logger::LogLevel::Debug);
-    Logger::instance().setConsoleOutputEnabled(m_consoleOutputEnabled);
-    // Install Qt message handler to route all qDebug/qWarning/etc through our Logger
-    qInstallMessageHandler(qtMessageHandler);
-    
 
     // 1. ConfigManager - No dependencies, must be first to load settings
     m_configManager = std::make_unique<ConfigManager>();
     ServiceLocator::registerService<ConfigManager>(m_configManager.get());
 
-
-    // Load configuration early so downstream services can read settings (e.g., cache size)
+    // Load configuration early so logging and downstream services can read settings
     m_configManager->load();
-    
+
+    LoggingConfig::apply(
+        LoggingConfig::levelFromString(m_configManager->getLogLevel()),
+        m_configManager->getQtLoggingRules(),
+        m_verboseLogging);
+
+    Logger::instance().setConsoleOutputEnabled(m_consoleOutputEnabled);
+    // Install Qt message handler to route all qDebug/qWarning/etc through our Logger
+    qInstallMessageHandler(qtMessageHandler);
+
     // 1.5 DisplayManager - Depends on ConfigManager
     m_displayManager = std::make_unique<DisplayManager>(m_configManager.get());
     ServiceLocator::registerService<DisplayManager>(m_displayManager.get());
@@ -144,13 +146,13 @@ void ApplicationInitializer::registerServices()
     // 2. Player backend - No dependencies
     m_playerBackend = PlayerBackendFactory::create(m_configManager->getPlayerBackend());
     ServiceLocator::registerService<IPlayerBackend>(m_playerBackend.get());
-    qCInfo(lcApp) << "ApplicationInitializer: Active player backend:" << m_playerBackend->backendName();
+    qInfo() << "ApplicationInitializer: Active player backend:" << m_playerBackend->backendName();
     
     // Check if we're in test mode
     bool isTestMode = TestModeController::instance()->isTestMode();
     
     if (isTestMode) {
-        qCDebug(lcApp) << "ApplicationInitializer: Running in test mode - registering mock services";
+        qDebug() << "ApplicationInitializer: Running in test mode - registering mock services";
         
         // 2.5 SecretStore - Create platform-specific secure storage (still needed for mock services)
         m_secretStore = SecretStoreFactory::create();
@@ -323,20 +325,20 @@ void ApplicationInitializer::initializeServices()
     
     connect(auth, &AuthenticationService::sessionExpired,
         [auth]() {
-            qCWarning(lcApp) << "Session expired, triggering logout";
+            qWarning() << "Session expired, triggering logout";
             auth->logout();
     });
     
     connect(auth, &AuthenticationService::sessionExpiredAfterPlayback,
         [auth]() {
-            qCWarning(lcApp) << "Session expired (detected during playback), triggering logout";
+            qWarning() << "Session expired (detected during playback), triggering logout";
             auth->logout();
     });
     
     // Connect playback stopped to check for pending session expiry
     connect(m_playerController.get(), &PlayerController::playbackStopped,
         [auth]() {
-            qCDebug(lcApp) << "Playback stopped, checking for pending session expiry";
+            qDebug() << "Playback stopped, checking for pending session expiry";
             auth->checkPendingSessionExpiry();
     });
     

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -24,6 +24,7 @@
 #include "ui/UiSoundController.h"
 #include "utils/GpuMemoryTrimmer.h"
 #include "utils/Logger.h"
+#include "utils/LoggingConfig.h"
 #include "network/SessionManager.h"
 #include "network/SessionService.h"
 #include "updates/UpdateService.h"

--- a/src/core/ApplicationInitializer.h
+++ b/src/core/ApplicationInitializer.h
@@ -90,6 +90,7 @@ public:
 private:
     QGuiApplication *m_app;
     bool m_consoleOutputEnabled = false;
+    bool m_verboseLogging = false;
     
     // Service ownership
     std::unique_ptr<ConfigManager> m_configManager;

--- a/src/core/ApplicationInitializer.h
+++ b/src/core/ApplicationInitializer.h
@@ -55,6 +55,7 @@ public:
     /** @brief Constructs the initializer; does not create any services yet. */
     explicit ApplicationInitializer(QGuiApplication *app,
                                     bool consoleOutputEnabled = false,
+                                    bool verboseLogging = false,
                                     QObject *parent = nullptr);
 
     /** @brief Destroys all owned services and clears the ServiceLocator. */
@@ -90,7 +91,6 @@ public:
 private:
     QGuiApplication *m_app;
     bool m_consoleOutputEnabled = false;
-    bool m_verboseLogging = false;
     
     // Service ownership
     std::unique_ptr<ConfigManager> m_configManager;

--- a/src/core/ApplicationInitializer.h
+++ b/src/core/ApplicationInitializer.h
@@ -91,6 +91,7 @@ public:
 private:
     QGuiApplication *m_app;
     bool m_consoleOutputEnabled = false;
+    bool m_verboseLogging = false;
     
     // Service ownership
     std::unique_ptr<ConfigManager> m_configManager;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,10 +157,15 @@ int main(int argc, char *argv[])
         "resolution",
         "1920x1080"
     );
+    QCommandLineOption verboseOption(
+        QStringList() << "verbose" << "v",
+        "Enable full debug logging (overrides settings.logging.level for this session)."
+    );
     
     parser.addOption(testModeOption);
     parser.addOption(fixtureOption);
     parser.addOption(resolutionOption);
+    parser.addOption(verboseOption);
     parser.process(app);
     
     // Initialize test mode if requested

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,15 +157,10 @@ int main(int argc, char *argv[])
         "resolution",
         "1920x1080"
     );
-    QCommandLineOption verboseOption(
-        QStringList() << "verbose" << "v",
-        "Enable full debug logging (overrides settings.logging.level for this session)."
-    );
     
     parser.addOption(testModeOption);
     parser.addOption(fixtureOption);
     parser.addOption(resolutionOption);
-    parser.addOption(verboseOption);
     parser.process(app);
     
     // Initialize test mode if requested
@@ -205,7 +200,8 @@ int main(int argc, char *argv[])
     fontLoader.load();
     
     // Initialize Application Services
-    ApplicationInitializer appInitializer(&app, consoleOutputEnabled);
+    const bool verboseLogging = parser.isSet(verboseOption);
+    ApplicationInitializer appInitializer(&app, consoleOutputEnabled, verboseLogging);
     appInitializer.registerServices();
     appInitializer.initializeServices();
     

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -14,20 +14,6 @@ AuthenticationService::AuthenticationService(ISecretStore *secretStore, QObject 
     , m_nam(new QNetworkAccessManager(this))
     , m_secretStore(secretStore)
 {
-    // Handle async session restoration result
-    connect(&m_restorationWatcher, &QFutureWatcher<RestorationResult>::finished, this, [this, configManager = static_cast<ConfigManager*>(nullptr)]() mutable { // capture logic handled in initialize
-        // Note: We can't capture configManager easily in the constructor unless we store it
-        // But we passed it to initialize. We'll handle the completion logic there or rely on member variables?
-        // Actually, initialize passes configManager. We can't access it here easily.
-        // Let's rely on the lambda inside initialize connecting to the watcher, OR
-        // Use a pointer stored in the service? No, dependency injection via initialize is fine but the watcher needs context.
-        // Better: Connect in initialize, or just handle generic result here?
-        // We need to update configManager if migration happened.
-        
-        // Let's handle it in initialize's lambda to keep context.
-        m_isRestoringSession = false;
-        emit isRestoringSessionChanged();
-    });
 }
 
 void AuthenticationService::initialize(ConfigManager *configManager)
@@ -222,7 +208,7 @@ void AuthenticationService::onAuthenticateFinished(QNetworkReply *reply)
     emit serverUrlChanged();
     emit userIdChanged();
     emit authenticatedChanged();
-    qCritical() << "=== AuthenticationService: EMITTING loginSuccess signal ===" << m_userId << m_username;
+    qCCritical(lcAuth) << "=== AuthenticationService: EMITTING loginSuccess signal ===" << m_userId << m_username;
     emit loginSuccess(m_userId, m_accessToken, m_username);
 }
 
@@ -244,7 +230,7 @@ void AuthenticationService::restoreSession(const QString &serverUrl, const QStri
             emit serverUrlChanged();
             emit userIdChanged();
             emit authenticatedChanged();
-            qCritical() << "=== AuthenticationService: EMITTING loginSuccess from restoreSession ===" << m_userId;
+            qCCritical(lcAuth) << "=== AuthenticationService: EMITTING loginSuccess from restoreSession ===" << m_userId;
             emit loginSuccess(m_userId, m_accessToken, m_username);
         } else {
             qCWarning(lcAuth) << "Stored session is invalid or expired";

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -7,6 +7,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QDebug>
+#include "../utils/BloomLogging.h"
 
 AuthenticationService::AuthenticationService(ISecretStore *secretStore, QObject *parent)
     : QObject(parent)
@@ -32,7 +33,7 @@ AuthenticationService::AuthenticationService(ISecretStore *secretStore, QObject 
 void AuthenticationService::initialize(ConfigManager *configManager)
 {
     if (!configManager) {
-        qWarning() << "AuthenticationService::initialize called with null ConfigManager";
+        qCWarning(lcAuth) << "AuthenticationService::initialize called with null ConfigManager";
         return;
     }
 
@@ -58,39 +59,39 @@ void AuthenticationService::initialize(ConfigManager *configManager)
 
         if (!session.accessToken.isEmpty()) {
             // Legacy token found in config -> migrate to SecretStore
-            qInfo() << "Migrating legacy token to secure storage...";
+            qCInfo(lcAuth) << "Migrating legacy token to secure storage...";
             
             if (hasSecretStore && !session.username.isEmpty()) {
                 // Use device-specific account key: serverUrl|username|deviceId
                 QString account = QString("%1|%2|%3").arg(session.serverUrl, session.username, deviceId);
-                qDebug() << "Migrating token with account key:" << account;
+                qCDebug(lcAuth) << "Migrating token with account key:" << account;
                 // Synchronous call on background thread
                 if (store->setSecret("Bloom/Jellyfin", account, session.accessToken)) {
-                    qInfo() << "Token migrated successfully";
+                    qCInfo(lcAuth) << "Token migrated successfully";
                     result.migrated = true;
                     result.accessToken = session.accessToken;
                     result.success = true;
                 } else {
                     result.error = store->lastError();
-                    qWarning() << "Failed to migrate token:" << result.error;
+                    qCWarning(lcAuth) << "Failed to migrate token:" << result.error;
                 }
             } else {
-                qWarning() << "Cannot migrate token: missing username or SecretStore unavailable";
+                qCWarning(lcAuth) << "Cannot migrate token: missing username or SecretStore unavailable";
             }
         } else if (session.isValid()) {
             // No token in config, but we have userId/serverUrl/username -> try SecretStore
             if (hasSecretStore && !session.username.isEmpty()) {
                 // Use device-specific account key: serverUrl|username|deviceId
                 QString account = QString("%1|%2|%3").arg(session.serverUrl, session.username, deviceId);
-                qDebug() << "Attempting to restore session with account key:" << account;
+                qCDebug(lcAuth) << "Attempting to restore session with account key:" << account;
                 // Synchronous call on background thread
                 QString token = store->getSecret("Bloom/Jellyfin", account);
                 if (!token.isEmpty()) {
-                    qInfo() << "Restored session from secure storage";
+                    qCInfo(lcAuth) << "Restored session from secure storage";
                     result.accessToken = token;
                     result.success = true;
                 } else {
-                    qDebug() << "No token found in secure storage for account:" << account;
+                    qCDebug(lcAuth) << "No token found in secure storage for account:" << account;
                 }
             }
         }
@@ -121,7 +122,7 @@ void AuthenticationService::initialize(ConfigManager *configManager)
             restoreSession(result.serverUrl, result.userId, result.accessToken);
         } else {
              if (!result.error.isEmpty()) {
-                 qWarning() << "Session restoration failed:" << result.error;
+                 qCWarning(lcAuth) << "Session restoration failed:" << result.error;
              }
              // If failed, we remain logged out (default state)
         }
@@ -200,7 +201,7 @@ void AuthenticationService::onAuthenticateFinished(QNetworkReply *reply)
     m_userId = obj["User"].toObject()["Id"].toString();
     m_username = obj["User"].toObject()["Name"].toString();
     
-    qDebug() << "Authentication successful. User ID:" << m_userId << "Username:" << m_username;
+    qCDebug(lcAuth) << "Authentication successful. User ID:" << m_userId << "Username:" << m_username;
     
     // Store token in SecretStore asynchronously
     if (m_secretStore && m_configManager) {
@@ -211,9 +212,9 @@ void AuthenticationService::onAuthenticateFinished(QNetworkReply *reply)
         
         QtConcurrent::run([store, account, token]() {
             if (!store->setSecret("Bloom/Jellyfin", account, token)) {
-                qWarning() << "Failed to store token in keychain:" << store->lastError();
+                qCWarning(lcAuth) << "Failed to store token in keychain:" << store->lastError();
             } else {
-                qDebug() << "Token stored in keychain (async)";
+                qCDebug(lcAuth) << "Token stored in keychain (async)";
             }
         });
     }
@@ -234,19 +235,19 @@ void AuthenticationService::restoreSession(const QString &serverUrl, const QStri
     m_sessionExpiredPending = false;
     m_sessionExpiredEmitted = false;
     
-    qDebug() << "Restoring session for user:" << userId << "on server:" << serverUrl;
+    qCDebug(lcAuth) << "Restoring session for user:" << userId << "on server:" << serverUrl;
     
     // Validate the restored session
     validateAccessToken([this](bool valid) {
         if (valid) {
-            qDebug() << "Session restored successfully";
+            qCDebug(lcAuth) << "Session restored successfully";
             emit serverUrlChanged();
             emit userIdChanged();
             emit authenticatedChanged();
             qCritical() << "=== AuthenticationService: EMITTING loginSuccess from restoreSession ===" << m_userId;
             emit loginSuccess(m_userId, m_accessToken, m_username);
         } else {
-            qWarning() << "Stored session is invalid or expired";
+            qCWarning(lcAuth) << "Stored session is invalid or expired";
             logout();
         }
     });
@@ -254,7 +255,7 @@ void AuthenticationService::restoreSession(const QString &serverUrl, const QStri
 
 void AuthenticationService::logout()
 {
-    qDebug() << "Logging out user:" << m_userId;
+    qCDebug(lcAuth) << "Logging out user:" << m_userId;
     
     // Delete token from SecretStore asynchronously BEFORE clearing member vars (so we have username/url)
     if (m_secretStore && !m_username.isEmpty() && m_configManager) {
@@ -264,7 +265,7 @@ void AuthenticationService::logout()
         
         QtConcurrent::run([store, account]() {
             store->deleteSecret("Bloom/Jellyfin", account);
-            qDebug() << "Token deleted from keychain (async)";
+            qCDebug(lcAuth) << "Token deleted from keychain (async)";
         });
     }
 
@@ -294,7 +295,7 @@ bool AuthenticationService::checkForSessionExpiry(QNetworkReply *reply, bool def
     int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     
     if (statusCode == 401) {
-        qWarning() << "Received 401 Unauthorized - session expired";
+        qCWarning(lcAuth) << "Received 401 Unauthorized - session expired";
         
         if (deferLogout) {
             // During playback, defer the logout until playback ends
@@ -326,7 +327,7 @@ void AuthenticationService::validateAccessToken(std::function<void(bool)> callba
         bool valid = (reply->error() == QNetworkReply::NoError && statusCode == 200);
         
         if (!valid) {
-            qDebug() << "Token validation failed. Status:" << statusCode 
+            qCDebug(lcAuth) << "Token validation failed. Status:" << statusCode 
                      << "Error:" << reply->errorString();
         }
         

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -7,8 +7,7 @@
 #include <QUrl>
 #include <QLoggingCategory>
 #include <memory>
-
-Q_LOGGING_CATEGORY(libraryService, "bloom.library")
+#include "../utils/BloomLogging.h"
 
 namespace {
 
@@ -50,7 +49,7 @@ void LibraryService::sendRequestWithRetry(const QString &endpoint,
                                            FailureHandler failureHandler,
                                            int attemptNumber)
 {
-    qCDebug(libraryService) << "Sending request to:" << endpoint 
+    qCDebug(lcLibrary) << "Sending request to:" << endpoint 
                             << "attempt:" << (attemptNumber + 1) << "/" << m_retryPolicy.maxRetries;
     
     QNetworkReply *reply = requestFactory();
@@ -70,7 +69,7 @@ void LibraryService::handleReplyWithRetry(QNetworkReply *reply,
     reply->deleteLater();
     
     if (reply->error() == QNetworkReply::NoError) {
-        qCDebug(libraryService) << "Request succeeded:" << endpoint;
+        qCDebug(lcLibrary) << "Request succeeded:" << endpoint;
         responseHandler(reply);
         return;
     }
@@ -82,7 +81,7 @@ void LibraryService::handleReplyWithRetry(QNetworkReply *reply,
 
     // Check for 401 Unauthorized - session expired
     if (httpStatus == 401) {
-        qCWarning(libraryService) << "Session expired (401) for endpoint:" << endpoint
+        qCWarning(lcLibrary) << "Session expired (401) for endpoint:" << endpoint
                                   << "userMessage:" << netError.userMessage;
         if (failureHandler) {
             failureHandler(netError);
@@ -92,7 +91,7 @@ void LibraryService::handleReplyWithRetry(QNetworkReply *reply,
         return;
     }
     
-    qCWarning(libraryService) << "Request failed:" << endpoint
+    qCWarning(lcLibrary) << "Request failed:" << endpoint
                               << "Error:" << reply->error()
                               << "HTTP Status:" << httpStatus
                               << "Attempt:" << (attemptNumber + 1);
@@ -105,7 +104,7 @@ void LibraryService::handleReplyWithRetry(QNetworkReply *reply,
     
     if (shouldRetry) {
         int delayMs = ErrorHandler::calculateBackoffDelay(attemptNumber, m_retryPolicy);
-        qCInfo(libraryService) << "Retrying request to:" << endpoint << "in" << delayMs << "ms";
+        qCInfo(lcLibrary) << "Retrying request to:" << endpoint << "in" << delayMs << "ms";
         
         QTimer::singleShot(delayMs, this, [this, endpoint, requestFactory, responseHandler, failureHandler, attemptNumber]() {
             sendRequestWithRetry(endpoint, requestFactory, responseHandler, failureHandler, attemptNumber + 1);
@@ -121,7 +120,7 @@ void LibraryService::handleReplyWithRetry(QNetworkReply *reply,
 
 void LibraryService::emitError(const NetworkError &error)
 {
-    qCWarning(libraryService) << "Emitting error for endpoint:" << error.endpoint
+    qCWarning(lcLibrary) << "Emitting error for endpoint:" << error.endpoint
                               << "User message:" << error.userMessage;
     emit errorOccurred(error.endpoint, error.userMessage);
     emit networkError(error);
@@ -455,7 +454,7 @@ void LibraryService::getHomeBackdropItems(int limit)
                     return;
                 }
                 QJsonArray items = doc.object()["Items"].toArray();
-                qCDebug(libraryService) << "getHomeBackdropItems starter sample size:" << items.size()
+                qCDebug(lcLibrary) << "getHomeBackdropItems starter sample size:" << items.size()
                                         << "requestedLimit:" << requestedLimit;
                 emit homeBackdropItemsLoaded(items);
             });
@@ -493,7 +492,7 @@ void LibraryService::getHomeBackdropItems(int limit)
 
                 QJsonObject obj = doc.object();
                 QJsonArray pageItems = obj["Items"].toArray();
-                qCDebug(libraryService) << "getHomeBackdropItems page startIndex:" << startIndex
+                qCDebug(lcLibrary) << "getHomeBackdropItems page startIndex:" << startIndex
                                         << "pageItems:" << pageItems.size()
                                         << "requestedLimit:" << requestedLimit;
 
@@ -510,7 +509,7 @@ void LibraryService::getHomeBackdropItems(int limit)
                 const bool reachedServerEndByPage = pageItems.size() < pageSize;
 
                 if (reachedRequestedLimit || reachedServerEndByPage) {
-                    qCDebug(libraryService) << "getHomeBackdropItems completed aggregate size:" << aggregate->size()
+                    qCDebug(lcLibrary) << "getHomeBackdropItems completed aggregate size:" << aggregate->size()
                                             << "requestedLimit:" << requestedLimit;
                     return;
                 }
@@ -619,7 +618,7 @@ void LibraryService::getChapters(const QString &itemId)
     }
 
     if (m_inFlightChapterRequests.contains(itemId)) {
-        qDebug() << "LibraryService: Skipping duplicate chapter request for item" << itemId;
+        qCDebug(lcLibrary) << "LibraryService: Skipping duplicate chapter request for item" << itemId;
         return;
     }
     m_inFlightChapterRequests.insert(itemId);
@@ -634,14 +633,14 @@ void LibraryService::getChapters(const QString &itemId)
             m_inFlightChapterRequests.remove(itemId);
             const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
             if (!doc.isObject()) {
-                qWarning() << "LibraryService: Invalid chapter response for item" << itemId;
+                qCWarning(lcLibrary) << "LibraryService: Invalid chapter response for item" << itemId;
                 emit chaptersFailed(itemId, tr("Invalid chapter response"));
                 return;
             }
 
             QList<ChapterInfo> chapters;
             const QJsonArray array = doc.object().value(QStringLiteral("Chapters")).toArray();
-            qInfo() << "LibraryService: Loaded raw chapter array for item" << itemId
+            qCInfo(lcLibrary) << "LibraryService: Loaded raw chapter array for item" << itemId
                     << "count" << array.size();
             chapters.reserve(array.size());
             for (qsizetype i = 0; i < array.size(); ++i) {
@@ -653,7 +652,7 @@ void LibraryService::getChapters(const QString &itemId)
                 if (chapter.startPositionTicks < 0) {
                     chapter.startPositionTicks = 0;
                 }
-                qInfo() << "LibraryService: Chapter metadata"
+                qCInfo(lcLibrary) << "LibraryService: Chapter metadata"
                         << "item" << itemId
                         << "index" << chapter.index
                         << "title" << chapter.title
@@ -1239,7 +1238,7 @@ QString LibraryService::getCachedImageUrlWithWidth(const QString &itemId, const 
 QString LibraryService::getCachedChapterThumbnailUrl(const QString &itemId, int chapterIndex, const QString &imageTag, const QString &imagePath, int width)
 {
     if (itemId.isEmpty() || chapterIndex < 0) {
-        qWarning() << "LibraryService: Refusing chapter thumbnail URL"
+        qCWarning(lcLibrary) << "LibraryService: Refusing chapter thumbnail URL"
                    << "item" << itemId
                    << "index" << chapterIndex;
         return QString();
@@ -1262,7 +1261,7 @@ QString LibraryService::getCachedChapterThumbnailUrl(const QString &itemId, int 
         originalUrl += QString("&tag=%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(imageTag)));
     }
     const QString cachedUrl = QString("image://cached/%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(originalUrl)));
-    qInfo() << "LibraryService: Chapter thumbnail request"
+    qCInfo(lcLibrary) << "LibraryService: Chapter thumbnail request"
             << "item" << itemId
             << "index" << chapterIndex
             << "imageTagEmpty" << imageTag.trimmed().isEmpty()

--- a/src/network/MediaSegmentProviderService.cpp
+++ b/src/network/MediaSegmentProviderService.cpp
@@ -13,8 +13,7 @@
 #include <QSet>
 #include <QUrl>
 #include <QUrlQuery>
-
-Q_LOGGING_CATEGORY(mediaSegmentProviders, "bloom.mediaSegments")
+#include "../utils/BloomLogging.h"
 
 namespace {
 constexpr double kTicksPerSecond = 10000000.0;
@@ -155,7 +154,7 @@ void MediaSegmentProviderService::fetchProviderAtIndex(const MediaSegmentLookupC
     } else if (providerId == QStringLiteral("introdb")) {
         fetchIntroDbSegments(context, continueWith);
     } else {
-        qCDebug(mediaSegmentProviders) << "Skipping unknown media segment provider" << providerOrder.at(providerIndex);
+        qCDebug(lcMediaSegments) << "Skipping unknown media segment provider" << providerOrder.at(providerIndex);
         continueWith(MediaSegmentProviderResult{providerId, {}, false, false});
     }
 }

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -11,8 +11,7 @@
 #include <QUrlQuery>
 #include <QLoggingCategory>
 #include <cmath>
-
-Q_LOGGING_CATEGORY(playbackService, "bloom.playback")
+#include "../utils/BloomLogging.h"
 
 namespace {
 QJsonObject buildPlaybackPayload(const QString &itemId, qint64 positionTicks,
@@ -67,7 +66,7 @@ void PlaybackService::sendRequestWithRetry(const QString &endpoint,
                                             FailureHandler failureHandler,
                                             int attemptNumber)
 {
-    qCDebug(playbackService) << "Sending request to:" << endpoint 
+    qCDebug(lcPlayback) << "Sending request to:" << endpoint 
                              << "attempt:" << (attemptNumber + 1) << "/" << m_retryPolicy.maxRetries;
     
     QNetworkReply *reply = requestFactory();
@@ -87,7 +86,7 @@ void PlaybackService::handleReplyWithRetry(QNetworkReply *reply,
     reply->deleteLater();
     
     if (reply->error() == QNetworkReply::NoError) {
-        qCDebug(playbackService) << "Request succeeded:" << endpoint;
+        qCDebug(lcPlayback) << "Request succeeded:" << endpoint;
         responseHandler(reply);
         return;
     }
@@ -95,7 +94,7 @@ void PlaybackService::handleReplyWithRetry(QNetworkReply *reply,
     int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 
     if (httpStatus == 401) {
-        qCWarning(playbackService) << "Session expired (401) for endpoint:" << endpoint;
+        qCWarning(lcPlayback) << "Session expired (401) for endpoint:" << endpoint;
         m_authService->checkForSessionExpiry(reply, true);
         NetworkError error;
         error.endpoint = endpoint;
@@ -107,7 +106,7 @@ void PlaybackService::handleReplyWithRetry(QNetworkReply *reply,
     
     NetworkError netError = ErrorHandler::createError(reply, endpoint);
     
-    qCWarning(playbackService) << "Request failed:" << endpoint
+    qCWarning(lcPlayback) << "Request failed:" << endpoint
                                << "Error:" << reply->error()
                                << "HTTP Status:" << httpStatus
                                << "Attempt:" << (attemptNumber + 1);
@@ -119,7 +118,7 @@ void PlaybackService::handleReplyWithRetry(QNetworkReply *reply,
     
     if (shouldRetry) {
         int delayMs = ErrorHandler::calculateBackoffDelay(attemptNumber, m_retryPolicy);
-        qCInfo(playbackService) << "Retrying request to:" << endpoint << "in" << delayMs << "ms";
+        qCInfo(lcPlayback) << "Retrying request to:" << endpoint << "in" << delayMs << "ms";
         
         QTimer::singleShot(delayMs, this, [this, endpoint, requestFactory, responseHandler, failureHandler, attemptNumber]() {
             sendRequestWithRetry(endpoint, requestFactory, responseHandler, failureHandler, attemptNumber + 1);
@@ -132,7 +131,7 @@ void PlaybackService::handleReplyWithRetry(QNetworkReply *reply,
 
 void PlaybackService::emitError(const NetworkError &error)
 {
-    qCWarning(playbackService) << "Emitting error for endpoint:" << error.endpoint
+    qCWarning(lcPlayback) << "Emitting error for endpoint:" << error.endpoint
                                << "User message:" << error.userMessage;
     emit errorOccurred(error.endpoint, error.userMessage);
     emit networkError(error);
@@ -235,12 +234,12 @@ void PlaybackService::getAdditionalParts(const QString &itemId, const QString &r
 void PlaybackService::getMediaSegments(const QString &itemId)
 {
     if (!m_authService->isAuthenticated()) {
-        qCDebug(playbackService) << "getMediaSegments: Not authenticated, skipping";
+        qCDebug(lcPlayback) << "getMediaSegments: Not authenticated, skipping";
         emit mediaSegmentsLoaded(itemId, QList<MediaSegmentInfo>());
         return;
     }
     
-    qCDebug(playbackService) << "Getting media segments for item:" << itemId;
+    qCDebug(lcPlayback) << "Getting media segments for item:" << itemId;
     
     // GET /Episode/{id}/IntroSkipperSegments
     // This endpoint is provided by the "Intro Skipper" plugin on the Jellyfin server
@@ -257,7 +256,7 @@ void PlaybackService::getMediaSegments(const QString &itemId)
         
         // Check for session expiry (defer during playback)
         if (httpStatus == 401) {
-            qCWarning(playbackService) << "Session expired while fetching media segments for" << itemId;
+            qCWarning(lcPlayback) << "Session expired while fetching media segments for" << itemId;
             m_authService->checkForSessionExpiry(reply, true);
             finishMediaSegments(itemId, QList<MediaSegmentInfo>());
             return;
@@ -266,13 +265,13 @@ void PlaybackService::getMediaSegments(const QString &itemId)
         // 404 is expected if Intro Skipper plugin is not installed
         // Just emit empty segments silently
         if (httpStatus == 404) {
-            qCDebug(playbackService) << "Intro Skipper plugin not available for" << itemId;
+            qCDebug(lcPlayback) << "Intro Skipper plugin not available for" << itemId;
             maybeLoadExternalMediaSegments(itemId, QList<MediaSegmentInfo>());
             return;
         }
         
         if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(playbackService) << "Failed to get media segments for" << itemId
+            qCWarning(lcPlayback) << "Failed to get media segments for" << itemId
                                        << "Error:" << reply->errorString();
             maybeLoadExternalMediaSegments(itemId, QList<MediaSegmentInfo>());
             return;
@@ -412,7 +411,7 @@ void PlaybackService::loadMediaSegmentLookupContext(const QString &itemId, const
                 },
                 [this, context, serverSegments, itemId](const NetworkError &error) mutable {
                     Q_UNUSED(error);
-                    qCDebug(playbackService) << "Failed to fetch series provider IDs for" << context.seriesId
+                    qCDebug(lcPlayback) << "Failed to fetch series provider IDs for" << context.seriesId
                                              << "- external segment lookup may be incomplete";
                     QPointer<PlaybackService> self(this);
                     m_mediaSegmentProviderService->fetchExternalSegments(context, serverSegments,
@@ -441,11 +440,11 @@ void PlaybackService::finishExternalMediaSegments(const QString &itemId,
 
 void PlaybackService::finishMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &segments)
 {
-    qCDebug(playbackService) << "Media segments loaded for" << itemId
+    qCDebug(lcPlayback) << "Media segments loaded for" << itemId
                              << "- Count:" << segments.size();
 
     for (const auto &segment : segments) {
-        qCDebug(playbackService) << "  Segment:" << segment.typeString
+        qCDebug(lcPlayback) << "  Segment:" << segment.typeString
                                  << "Source:" << segment.source
                                  << "Start:" << segment.startSeconds() << "s"
                                  << "End:" << segment.endSeconds() << "s";
@@ -457,12 +456,12 @@ void PlaybackService::finishMediaSegments(const QString &itemId, const QList<Med
 void PlaybackService::getTrickplayInfo(const QString &itemId)
 {
     if (!m_authService->isAuthenticated()) {
-        qCDebug(playbackService) << "getTrickplayInfo: Not authenticated, skipping";
+        qCDebug(lcPlayback) << "getTrickplayInfo: Not authenticated, skipping";
         emit trickplayInfoLoaded(itemId, QMap<int, TrickplayTileInfo>());
         return;
     }
     
-    qCDebug(playbackService) << "Getting trickplay info for item:" << itemId;
+    qCDebug(lcPlayback) << "Getting trickplay info for item:" << itemId;
     
     // GET /Items/{itemId}?Fields=Trickplay
     // The dedicated /Videos/{itemId}/Trickplay endpoint may not exist on all Jellyfin versions,
@@ -485,7 +484,7 @@ void PlaybackService::getTrickplayInfo(const QString &itemId)
             
             // Debug: Log the raw Trickplay JSON response
             QJsonObject trickplayRaw = obj["Trickplay"].toObject();
-            qCDebug(playbackService) << "Trickplay raw JSON for" << itemId << ":"
+            qCDebug(lcPlayback) << "Trickplay raw JSON for" << itemId << ":"
                                       << QJsonDocument(trickplayRaw).toJson(QJsonDocument::Compact)
                                       << "Duration:" << durationSeconds << "s";
             
@@ -509,7 +508,7 @@ void PlaybackService::getTrickplayInfo(const QString &itemId)
                         if (info.interval > 0 && durationSeconds > 0) {
                             int calculatedCount = static_cast<int>(std::ceil(durationSeconds * 1000.0 / info.interval));
                             if (calculatedCount > info.thumbnailCount) {
-                                qCDebug(playbackService) << "Overriding ThumbnailCount from" << info.thumbnailCount
+                                qCDebug(lcPlayback) << "Overriding ThumbnailCount from" << info.thumbnailCount
                                                           << "to calculated" << calculatedCount
                                                           << "(duration:" << durationSeconds << "s, interval:" << info.interval << "ms)";
                                 info.thumbnailCount = calculatedCount;
@@ -527,9 +526,9 @@ void PlaybackService::getTrickplayInfo(const QString &itemId)
             }
             
             if (trickplayInfo.isEmpty()) {
-                qCDebug(playbackService) << "No trickplay info available for" << itemId;
+                qCDebug(lcPlayback) << "No trickplay info available for" << itemId;
             } else {
-                qCDebug(playbackService) << "Trickplay info loaded for" << itemId 
+                qCDebug(lcPlayback) << "Trickplay info loaded for" << itemId 
                                           << "- Resolutions:" << trickplayInfo.keys();
             }
             
@@ -561,7 +560,7 @@ void PlaybackService::reportPlaybackStart(const QString &itemId, const QString &
 {
     if (!m_authService->isAuthenticated()) return;
 
-    qCDebug(playbackService) << "Reporting playback start for item:" << itemId
+    qCDebug(lcPlayback) << "Reporting playback start for item:" << itemId
                              << "mediaSourceId:" << mediaSourceId
                              << "audioIndex:" << audioStreamIndex
                              << "subtitleIndex:" << subtitleStreamIndex;
@@ -580,7 +579,7 @@ void PlaybackService::reportPlaybackStart(const QString &itemId, const QString &
         reply->deleteLater();
         if (m_authService->checkForSessionExpiry(reply, true)) return;
         if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(playbackService) << "Failed to report playback start for" << itemId 
+            qCWarning(lcPlayback) << "Failed to report playback start for" << itemId 
                                        << ":" << reply->errorString();
         }
     });
@@ -597,7 +596,7 @@ void PlaybackService::reportPlaybackProgress(const QString &itemId, qint64 posit
 {
     if (!m_authService->isAuthenticated()) return;
 
-    qCDebug(playbackService) << "Reporting playback progress for item:" << itemId 
+    qCDebug(lcPlayback) << "Reporting playback progress for item:" << itemId 
                              << "position:" << positionTicks;
 
     QJsonObject json = buildPlaybackPayload(itemId, positionTicks, mediaSourceId,
@@ -615,7 +614,7 @@ void PlaybackService::reportPlaybackProgress(const QString &itemId, qint64 posit
         reply->deleteLater();
         if (m_authService->checkForSessionExpiry(reply, true)) return;
         if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(playbackService) << "Failed to report playback progress for" << itemId 
+            qCWarning(lcPlayback) << "Failed to report playback progress for" << itemId 
                                        << ":" << reply->errorString();
         }
     });
@@ -632,7 +631,7 @@ void PlaybackService::reportPlaybackPaused(const QString &itemId, qint64 positio
 {
     if (!m_authService->isAuthenticated()) return;
 
-    qCDebug(playbackService) << "Reporting playback paused for item:" << itemId 
+    qCDebug(lcPlayback) << "Reporting playback paused for item:" << itemId 
                              << "position:" << positionTicks;
 
     QJsonObject json = buildPlaybackPayload(itemId, positionTicks, mediaSourceId,
@@ -650,7 +649,7 @@ void PlaybackService::reportPlaybackPaused(const QString &itemId, qint64 positio
         reply->deleteLater();
         if (m_authService->checkForSessionExpiry(reply, true)) return;
         if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(playbackService) << "Failed to report playback paused for" << itemId 
+            qCWarning(lcPlayback) << "Failed to report playback paused for" << itemId 
                                        << ":" << reply->errorString();
         }
     });
@@ -667,7 +666,7 @@ void PlaybackService::reportPlaybackResumed(const QString &itemId, qint64 positi
 {
     if (!m_authService->isAuthenticated()) return;
 
-    qCDebug(playbackService) << "Reporting playback resumed for item:" << itemId 
+    qCDebug(lcPlayback) << "Reporting playback resumed for item:" << itemId 
                              << "position:" << positionTicks;
 
     QJsonObject json = buildPlaybackPayload(itemId, positionTicks, mediaSourceId,
@@ -685,7 +684,7 @@ void PlaybackService::reportPlaybackResumed(const QString &itemId, qint64 positi
         reply->deleteLater();
         if (m_authService->checkForSessionExpiry(reply, true)) return;
         if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(playbackService) << "Failed to report playback resumed for" << itemId 
+            qCWarning(lcPlayback) << "Failed to report playback resumed for" << itemId 
                                        << ":" << reply->errorString();
         }
     });
@@ -702,7 +701,7 @@ void PlaybackService::reportPlaybackStopped(const QString &itemId, qint64 positi
 {
     if (!m_authService->isAuthenticated()) return;
 
-    qCDebug(playbackService) << "Reporting playback stopped for item:" << itemId 
+    qCDebug(lcPlayback) << "Reporting playback stopped for item:" << itemId 
                              << "position:" << positionTicks;
 
     QJsonObject json = buildPlaybackPayload(itemId, positionTicks, mediaSourceId,
@@ -720,7 +719,7 @@ void PlaybackService::reportPlaybackStopped(const QString &itemId, qint64 positi
         reply->deleteLater();
         if (m_authService->checkForSessionExpiry(reply, false)) return;
         if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(playbackService) << "Failed to report playback stopped for" << itemId 
+            qCWarning(lcPlayback) << "Failed to report playback stopped for" << itemId 
                                        << ":" << reply->errorString();
         }
     });
@@ -730,7 +729,7 @@ void PlaybackService::markItemPlayed(const QString &itemId)
 {
     if (!m_authService->isAuthenticated()) return;
 
-    qCDebug(playbackService) << "Marking item as played:" << itemId;
+    qCDebug(lcPlayback) << "Marking item as played:" << itemId;
 
     QString endpoint = QString("/Users/%1/PlayedItems/%2").arg(m_authService->getUserId(), itemId);
     QNetworkRequest request = m_authService->createRequest(endpoint);
@@ -741,10 +740,10 @@ void PlaybackService::markItemPlayed(const QString &itemId)
         reply->deleteLater();
         if (m_authService->checkForSessionExpiry(reply, false)) return;
         if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(playbackService) << "Failed to mark item as played:" << itemId 
+            qCWarning(lcPlayback) << "Failed to mark item as played:" << itemId 
                                        << ":" << reply->errorString();
         } else {
-            qCDebug(playbackService) << "Successfully marked item as played:" << itemId;
+            qCDebug(lcPlayback) << "Successfully marked item as played:" << itemId;
             emit itemMarkedPlayed(itemId);
         }
     });

--- a/src/network/SessionManager.cpp
+++ b/src/network/SessionManager.cpp
@@ -7,6 +7,7 @@
 #include <QDebug>
 #include <QJsonObject>
 #include <QJsonArray>
+#include "../utils/BloomLogging.h"
 
 SessionManager::SessionManager(ConfigManager *configManager, ISecretStore *secretStore, QObject *parent)
     : QObject(parent)
@@ -125,11 +126,11 @@ bool SessionManager::rotateDeviceId()
     QString oldDeviceId = m_deviceId;
     QString newDeviceId = generateDeviceId();
 
-    qInfo() << "SessionManager: Rotating device ID" << oldDeviceId << "->" << newDeviceId;
+    qCInfo(lcAuth) << "SessionManager: Rotating device ID" << oldDeviceId << "->" << newDeviceId;
 
     // Attempt to migrate token if we have credentials
     if (!migrateToken(oldDeviceId, newDeviceId)) {
-        qWarning() << "SessionManager: Token migration may have failed, continuing with rotation";
+        qCWarning(lcAuth) << "SessionManager: Token migration may have failed, continuing with rotation";
     }
 
     m_deviceId = newDeviceId;
@@ -177,7 +178,7 @@ void SessionManager::updateLastActivity()
     // The last activity is stored in the config via ConfigManager methods
     
     // For now, we track this in memory; persistence can be added if needed
-    qDebug() << "SessionManager: Last activity updated";
+    qCDebug(lcAuth) << "SessionManager: Last activity updated";
 }
 
 QDateTime SessionManager::lastActivity() const
@@ -277,19 +278,19 @@ bool SessionManager::migrateToken(const QString &oldDeviceId, const QString &new
     QString token = m_secretStore->getSecret("Bloom/Jellyfin", oldAccount);
     if (token.isEmpty()) {
         // No token in SecretStore for old device ID - nothing to migrate
-        qDebug() << "SessionManager: No token found for old device ID, nothing to migrate";
+        qCDebug(lcAuth) << "SessionManager: No token found for old device ID, nothing to migrate";
         return true;
     }
 
     // Store token under new account
     if (!m_secretStore->setSecret("Bloom/Jellyfin", newAccount, token)) {
-        qWarning() << "SessionManager: Failed to store token for new device ID:" << m_secretStore->lastError();
+        qCWarning(lcAuth) << "SessionManager: Failed to store token for new device ID:" << m_secretStore->lastError();
         return false;
     }
 
     // Delete old token
     m_secretStore->deleteSecret("Bloom/Jellyfin", oldAccount);
 
-    qInfo() << "SessionManager: Token migrated successfully";
+    qCInfo(lcAuth) << "SessionManager: Token migrated successfully";
     return true;
 }

--- a/src/network/SessionService.cpp
+++ b/src/network/SessionService.cpp
@@ -7,6 +7,7 @@
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QDebug>
+#include "../utils/BloomLogging.h"
 
 QVariantMap SessionInfo::toVariantMap() const
 {
@@ -148,7 +149,7 @@ void SessionService::setDeviceName(const QString &name)
     
     // We could potentially send a Capabilities POST to update session info
     // For now, just emit that we attempted
-    qDebug() << "SessionService: Device name set to" << name;
+    qCDebug(lcAuth) << "SessionService: Device name set to" << name;
 }
 
 bool SessionService::isCurrentSession(const QString &sessionId) const
@@ -227,7 +228,7 @@ void SessionService::onFetchSessionsFinished(QNetworkReply *reply)
     emit sessionsChanged();
     emit sessionsLoaded();
     
-    qDebug() << "SessionService: Loaded" << m_sessions.size() << "sessions, current:" << m_currentSessionId;
+    qCDebug(lcAuth) << "SessionService: Loaded" << m_sessions.size() << "sessions, current:" << m_currentSessionId;
 }
 
 void SessionService::onRevokeSessionFinished(QNetworkReply *reply, QString sessionId)
@@ -248,7 +249,7 @@ void SessionService::onRevokeSessionFinished(QNetworkReply *reply, QString sessi
 
     // Check if we revoked our own session
     if (sessionId == m_currentSessionId) {
-        qWarning() << "SessionService: Self-session was revoked";
+        qCWarning(lcAuth) << "SessionService: Self-session was revoked";
         emit selfSessionRevoked();
         return;
     }
@@ -265,7 +266,7 @@ void SessionService::onRevokeSessionFinished(QNetworkReply *reply, QString sessi
     emit sessionsChanged();
     emit sessionRevoked(sessionId);
     
-    qDebug() << "SessionService: Revoked session" << sessionId;
+    qCDebug(lcAuth) << "SessionService: Revoked session" << sessionId;
 }
 
 void SessionService::setIsLoading(bool loading)

--- a/src/network/Types.cpp
+++ b/src/network/Types.cpp
@@ -2,8 +2,7 @@
 #include <QJsonDocument>
 #include <QJsonParseError>
 #include <QtMath>
-
-Q_LOGGING_CATEGORY(jellyfinNetwork, "jellyfin.network")
+#include "../utils/BloomLogging.h"
 
 /**
  * @brief Register Qt metatypes for network data structures
@@ -398,7 +397,7 @@ TrickplayTileInfo TrickplayTileInfo::fromJson(const QJsonObject &json)
     info.interval = json["Interval"].toInt();
     info.bandwidth = json["Bandwidth"].toInt();
     
-    qDebug() << "TrickplayTileInfo::fromJson parsed:"
+    qCDebug(lcJellyfinNetwork) << "TrickplayTileInfo::fromJson parsed:"
              << "Width:" << info.width
              << "Height:" << info.height
              << "TileWidth:" << info.tileWidth

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -30,9 +30,7 @@
 #include <QThread>
 #include <atomic>
 #include <algorithm>
-
-Q_LOGGING_CATEGORY(lcPlayback, "bloom.playback")
-Q_LOGGING_CATEGORY(lcPlaybackTrace, "bloom.playback.trace")
+#include "../utils/BloomLogging.h"
 
 namespace {
 std::atomic<quint64> gPlaybackAttemptCounter{0};
@@ -566,7 +564,7 @@ void PlayerController::setupStateMachine()
     m_transitions[{Error, Event::Play}] = Loading;  // Retry
     m_transitions[{Error, Event::Stop}] = Idle;
     
-    qDebug() << "PlayerController: State machine initialized with" << m_transitions.size() << "transitions";
+    qCDebug(lcPlayback) << "PlayerController: State machine initialized with" << m_transitions.size() << "transitions";
 }
 
 bool PlayerController::processEvent(Event event)
@@ -577,7 +575,7 @@ bool PlayerController::processEvent(Event event)
                             << "state=" << stateToString(m_playbackState);
     
     if (!m_transitions.contains(transition)) {
-        qWarning() << "PlayerController: Invalid transition from" 
+        qCWarning(lcPlayback) << "PlayerController: Invalid transition from" 
                    << stateToString(m_playbackState) << "on event" << eventToString(event);
         qCWarning(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                                    << "] invalid-transition"
@@ -587,7 +585,7 @@ bool PlayerController::processEvent(Event event)
     }
     
     PlaybackState newState = m_transitions[transition];
-    qDebug() << "PlayerController: Transition" 
+    qCDebug(lcPlayback) << "PlayerController: Transition" 
              << stateToString(m_playbackState) << "->" << stateToString(newState)
              << "on event" << eventToString(event);
     
@@ -797,7 +795,7 @@ void PlayerController::enterIdleStateImmediate()
 
 void PlayerController::onEnterLoadingState()
 {
-    qDebug() << "PlayerController: Entering Loading state";
+    qCDebug(lcPlayback) << "PlayerController: Entering Loading state";
     
     // Start loading timeout
     m_loadingTimeoutTimer->start(kLoadingTimeoutMs);
@@ -819,7 +817,7 @@ void PlayerController::onEnterLoadingState()
 
 void PlayerController::onEnterBufferingState()
 {
-    qDebug() << "PlayerController: Entering Buffering state";
+    qCDebug(lcPlayback) << "PlayerController: Entering Buffering state";
     
     // Start buffering timeout
     m_bufferingTimeoutTimer->start(kBufferingTimeoutMs);
@@ -881,14 +879,14 @@ void PlayerController::onEnterBufferingState()
     if (m_seekTargetWhileBuffering >= 0) {
         double target = m_seekTargetWhileBuffering;
         m_seekTargetWhileBuffering = -1;
-        qDebug() << "PlayerController: Executing queued seek to" << target << "seconds";
+        qCDebug(lcPlayback) << "PlayerController: Executing queued seek to" << target << "seconds";
         m_playerBackend->sendVariantCommand({"seek", target, "absolute"});
     }
     
     // Apply audio delay
     double delaySeconds = static_cast<double>(m_config->getAudioDelay()) / 1000.0;
     if (delaySeconds != 0.0) {
-        qDebug() << "PlayerController: Applying audio delay:" << delaySeconds << "s";
+        qCDebug(lcPlayback) << "PlayerController: Applying audio delay:" << delaySeconds << "s";
         m_playerBackend->sendVariantCommand({"set_property", "audio-delay", delaySeconds});
     }
 
@@ -945,7 +943,7 @@ void PlayerController::onEnterPausedState()
  */
 void PlayerController::onEnterErrorState()
 {
-    qDebug() << "PlayerController: Entering Error state -" << m_errorMessage;
+    qCDebug(lcPlayback) << "PlayerController: Entering Error state -" << m_errorMessage;
     
     // Stop all timers
     m_loadingTimeoutTimer->stop();
@@ -964,7 +962,7 @@ void PlayerController::onEnterErrorState()
 
 void PlayerController::onLoadingTimeout()
 {
-    qDebug() << "PlayerController: Loading timeout";
+    qCDebug(lcPlayback) << "PlayerController: Loading timeout";
     m_lastErrorWasNetworkRecoverable = true;
     setErrorMessage(tr("Loading timed out. Please check your connection and try again."));
     requestTerminalTransition(TerminalReason::Error);
@@ -972,7 +970,7 @@ void PlayerController::onLoadingTimeout()
 
 void PlayerController::onBufferingTimeout()
 {
-    qDebug() << "PlayerController: Buffering timeout";
+    qCDebug(lcPlayback) << "PlayerController: Buffering timeout";
     m_lastErrorWasNetworkRecoverable = true;
     setErrorMessage(tr("Buffering timed out. Network may be too slow."));
     requestTerminalTransition(TerminalReason::Error);
@@ -990,7 +988,7 @@ void PlayerController::onBufferingTimeout()
 
 void PlayerController::onProcessStateChanged(bool running)
 {
-    qDebug() << "PlayerController: Process state changed, running:" << running;
+    qCDebug(lcPlayback) << "PlayerController: Process state changed, running:" << running;
     qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                             << "] process-state"
                             << "running=" << running
@@ -1028,7 +1026,7 @@ void PlayerController::onProcessStateChanged(bool running)
 
 void PlayerController::onProcessError(const QString &error)
 {
-    qDebug() << "PlayerController: Process error:" << error;
+    qCDebug(lcPlayback) << "PlayerController: Process error:" << error;
     qCWarning(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                                << "] process-error"
                                << error;
@@ -1120,15 +1118,15 @@ void PlayerController::onDurationChanged(double seconds)
 
 void PlayerController::onPausedForCacheChanged(bool pausedForCache)
 {
-    qDebug() << "PlayerController: Paused for cache:" << pausedForCache;
+    qCDebug(lcPlayback) << "PlayerController: Paused for cache:" << pausedForCache;
     
     if (pausedForCache && m_playbackState == Playing) {
         // mpv reports actual buffering - transition to Buffering state
-        qDebug() << "PlayerController: mpv started buffering";
+        qCDebug(lcPlayback) << "PlayerController: mpv started buffering";
         processEvent(Event::BufferStart);
     } else if (!pausedForCache && m_playbackState == Buffering) {
         // mpv finished buffering - transition back to Playing
-        qDebug() << "PlayerController: mpv finished buffering";
+        qCDebug(lcPlayback) << "PlayerController: mpv finished buffering";
         processEvent(Event::BufferComplete);
     }
 }
@@ -1143,7 +1141,7 @@ void PlayerController::onCacheEndChanged(double seconds)
 
 void PlayerController::onPauseChanged(bool paused)
 {
-    qDebug() << "PlayerController: Pause changed:" << paused;
+    qCDebug(lcPlayback) << "PlayerController: Pause changed:" << paused;
     
     const QVariantMap segment = activePlaybackSegment();
     const QString reportItemId = segment.isEmpty()
@@ -1181,7 +1179,7 @@ void PlayerController::onPlaybackEnded()
         return;
     }
 
-    qDebug() << "PlayerController: Playback ended";
+    qCDebug(lcPlayback) << "PlayerController: Playback ended";
     qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                             << "] playback-ended"
                             << "position=" << m_currentPosition
@@ -1241,7 +1239,7 @@ void PlayerController::prepareTerminalTransition(TerminalReason reason)
             m_waitingForNextEpisodeAtPlaybackEnd = true;
             stashPendingAutoplayContext();
             m_terminalPrefetchedReady = hasUsablePrefetchedNextEpisode();
-            qDebug() << "PlayerController: Threshold met, next episode will resolve after terminal finalization";
+            qCDebug(lcPlayback) << "PlayerController: Threshold met, next episode will resolve after terminal finalization";
         } else {
             clearPendingAutoplayContext();
             clearNextEpisodePrefetchState();
@@ -1686,7 +1684,7 @@ void PlayerController::onNextEpisodeLoaded(const QString &seriesId,
     }
 
     if (!m_pendingAutoplaySeriesId.isEmpty() && seriesId != m_pendingAutoplaySeriesId) {
-        qDebug() << "PlayerController: Ignoring next episode for unexpected series:" << seriesId;
+        qCDebug(lcPlayback) << "PlayerController: Ignoring next episode for unexpected series:" << seriesId;
         return;
     }
     
@@ -1697,7 +1695,7 @@ void PlayerController::onNextEpisodeLoaded(const QString &seriesId,
     const int lastSubtitleIndex = pendingAutoplaySubtitleOverrideIndex();
     
     if (episodeData.isEmpty()) {
-        qDebug() << "PlayerController: No next episode available";
+        qCDebug(lcPlayback) << "PlayerController: No next episode available";
         QJsonObject noNextEpisodeData;
         noNextEpisodeData.insert(QStringLiteral("SeriesId"), seriesId);
         noNextEpisodeData.insert(QStringLiteral("SeasonId"), m_pendingAutoplaySeasonId);
@@ -1726,14 +1724,14 @@ void PlayerController::onNextEpisodeLoaded(const QString &seriesId,
     int seasonNumber = episodeData["ParentIndexNumber"].toInt();
     int episodeNumber = episodeData["IndexNumber"].toInt();
     
-    qDebug() << "PlayerController: Next episode found:" << seriesName 
+    qCDebug(lcPlayback) << "PlayerController: Next episode found:" << seriesName 
              << "S" << seasonNumber << "E" << episodeNumber << "-" << episodeName;
     
     // Always emit navigateToNextEpisode to show the Up Next screen
     // The QML screen will handle autoplay countdown vs manual play
     bool autoplay = m_config->getAutoplayNextEpisode();
     
-    qDebug() << "PlayerController: Emitting navigateToNextEpisode signal with autoplay:" 
+    qCDebug(lcPlayback) << "PlayerController: Emitting navigateToNextEpisode signal with autoplay:" 
              << autoplay << "audio:" << lastAudioIndex << "subtitle:" << lastSubtitleIndex;
 
     emitNavigateToNextEpisodeQueued(episodeData, seriesId, lastAudioIndex, lastSubtitleIndex, autoplay);
@@ -2606,7 +2604,7 @@ void PlayerController::playNextEpisode(const QJsonObject &episodeData, const QSt
     const int episodeNumber = episodeData["IndexNumber"].toInt();
     
     if (episodeId.isEmpty()) {
-        qWarning() << "PlayerController::playNextEpisode: Empty episode ID";
+        qCWarning(lcPlayback) << "PlayerController::playNextEpisode: Empty episode ID";
         cancelPendingDisplayRestore();
         clearPendingAutoplayContext();
         return;
@@ -2614,7 +2612,7 @@ void PlayerController::playNextEpisode(const QJsonObject &episodeData, const QSt
 
     cancelPendingDisplayRestore();
     
-    qDebug() << "PlayerController: Playing next episode from Up Next screen:" << seriesName
+    qCDebug(lcPlayback) << "PlayerController: Playing next episode from Up Next screen:" << seriesName
              << "S" << seasonNumber << "E" << episodeNumber << "-" << episodeName;
     
     QString subtitle = QStringLiteral("S%1 E%2").arg(seasonNumber).arg(episodeNumber);
@@ -2896,7 +2894,7 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
     cancelPendingTerminalTransition();
     m_playbackAttemptId = ++gPlaybackAttemptCounter;
     m_reportProgressOnNextPositionUpdate = false;
-    qDebug() << "PlayerController: playUrl called with itemId:" << itemId 
+    qCDebug(lcPlayback) << "PlayerController: playUrl called with itemId:" << itemId 
              << "startPositionTicks:" << startPositionTicks
              << "seriesId:" << seriesId
              << "seasonId:" << seasonId
@@ -2965,7 +2963,7 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
         // Jellyfin ticks are 100ns units, so divide by 10,000,000 to get seconds
         if (startPositionTicks > 0) {
             m_seekTargetWhileBuffering = static_cast<double>(startPositionTicks) / 10000000.0;
-            qDebug() << "PlayerController: Will seek to" << m_seekTargetWhileBuffering << "seconds after buffering";
+            qCDebug(lcPlayback) << "PlayerController: Will seek to" << m_seekTargetWhileBuffering << "seconds after buffering";
         } else {
             m_seekTargetWhileBuffering = -1;
         }
@@ -2984,7 +2982,7 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
  */
 void PlayerController::stop()
 {
-    qDebug() << "PlayerController: stop requested";
+    qCDebug(lcPlayback) << "PlayerController: stop requested";
     qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                             << "] stop requested"
                             << "state=" << stateToString(m_playbackState)
@@ -3018,14 +3016,14 @@ void PlayerController::togglePause()
 
 void PlayerController::seek(double seconds)
 {
-    qDebug() << "PlayerController: seek to" << seconds;
+    qCDebug(lcPlayback) << "PlayerController: seek to" << seconds;
     
     // If loading/buffering, queue the seek for when buffering setup completes.
     // This is required for early intro auto-skip where segments can arrive before
     // we transition out of Loading.
     if (m_playbackState == Loading || m_playbackState == Buffering) {
         m_seekTargetWhileBuffering = seconds;
-        qDebug() << "PlayerController: Queued seek for after loading/buffering";
+        qCDebug(lcPlayback) << "PlayerController: Queued seek for after loading/buffering";
         return;
     }
     
@@ -3037,12 +3035,12 @@ void PlayerController::seek(double seconds)
 
 void PlayerController::seekRelative(double seconds)
 {
-    qDebug() << "PlayerController: seekRelative" << seconds;
+    qCDebug(lcPlayback) << "PlayerController: seekRelative" << seconds;
     
     // During buffering, convert relative to absolute and queue
     if (m_playbackState == Buffering) {
         m_seekTargetWhileBuffering = m_currentPosition + seconds;
-        qDebug() << "PlayerController: Queued relative seek for after buffering";
+        qCDebug(lcPlayback) << "PlayerController: Queued relative seek for after buffering";
         return;
     }
     
@@ -3073,7 +3071,7 @@ void PlayerController::skipActiveSegment()
 
 void PlayerController::retry()
 {
-    qDebug() << "PlayerController: retry requested";
+    qCDebug(lcPlayback) << "PlayerController: retry requested";
     
     if (m_playbackState == Error) {
         m_reportProgressOnNextPositionUpdate = false;
@@ -3113,7 +3111,7 @@ void PlayerController::retry()
 
 void PlayerController::clearError()
 {
-    qDebug() << "PlayerController: clearError requested";
+    qCDebug(lcPlayback) << "PlayerController: clearError requested";
     
     if (m_playbackState == Error) {
         processEvent(Event::Recover);
@@ -3156,7 +3154,7 @@ void PlayerController::onRecoveryTick()
     }
     ++m_recoveryAttemptCount;
     emit recoveryAttemptCountChanged();
-    qDebug() << "PlayerController: Recovery ping attempt" << m_recoveryAttemptCount;
+    qCDebug(lcPlayback) << "PlayerController: Recovery ping attempt" << m_recoveryAttemptCount;
 
     QNetworkReply *reply = m_libraryService->pingServer();
     if (!reply) {
@@ -3172,20 +3170,20 @@ void PlayerController::onRecoveryTick()
         reply->deleteLater();
         int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         if (reply->error() == QNetworkReply::NoError) {
-            qDebug() << "PlayerController: Recovery ping succeeded";
+            qCDebug(lcPlayback) << "PlayerController: Recovery ping succeeded";
             if (m_isRecovering && m_playbackState == Error && !m_terminalTransitionActive) {
                 cancelRecovery();
                 resumeFromRecoveryContext();
             }
         } else if (httpStatus == 401) {
-            qDebug() << "PlayerController: Recovery ping got 401, auth expired";
+            qCDebug(lcPlayback) << "PlayerController: Recovery ping got 401, auth expired";
             if (m_isRecovering) {
                 cancelRecovery();
                 setErrorMessage(tr("Session expired. Please log in again."));
                 m_recoveryContext = RecoveryContext{};
             }
         } else {
-            qDebug() << "PlayerController: Recovery ping failed:" << reply->errorString();
+            qCDebug(lcPlayback) << "PlayerController: Recovery ping failed:" << reply->errorString();
             if (m_isRecovering) {
                 m_recoveryTimer->start(kRecoveryPingIntervalMs);
             }
@@ -3370,7 +3368,7 @@ void PlayerController::addExternalSubtitleTrack(const QString &subtitleUrl,
 
 void PlayerController::cycleAudioTrack()
 {
-    qDebug() << "PlayerController: Cycling audio track";
+    qCDebug(lcPlayback) << "PlayerController: Cycling audio track";
     if (m_playbackState == Playing || m_playbackState == Paused) {
         m_pendingAudioTrackPersistenceFromBackend = true;
         m_playerBackend->sendCommand({"cycle", "audio"});
@@ -3379,7 +3377,7 @@ void PlayerController::cycleAudioTrack()
 
 void PlayerController::cycleSubtitleTrack()
 {
-    qDebug() << "PlayerController: Cycling subtitle track";
+    qCDebug(lcPlayback) << "PlayerController: Cycling subtitle track";
     if (m_playbackState == Playing || m_playbackState == Paused) {
         m_pendingSubtitleTrackPersistenceFromBackend = true;
         m_playerBackend->sendCommand({"cycle", "sub"});
@@ -3706,7 +3704,7 @@ void PlayerController::playUrlWithTracks(const QString &url, const QString &item
                                          const QVariantList &availableSubtitleTracks,
                                          double framerate, bool isHDR)
 {
-    qDebug() << "PlayerController: playUrlWithTracks called with itemId:" << itemId
+    qCDebug(lcPlayback) << "PlayerController: playUrlWithTracks called with itemId:" << itemId
              << "audioIndex:" << audioStreamIndex
              << "subtitleIndex:" << subtitleStreamIndex
              << "framerate:" << framerate
@@ -4388,7 +4386,7 @@ bool PlayerController::checkCompletionThresholdAndAutoplay()
     if (thresholdMet) {
         const double percentage = (m_currentPosition / m_duration) * 100.0;
         const int threshold = m_config->getPlaybackCompletionThreshold();
-        qDebug() << "PlayerController: Completion threshold met for item" << m_currentItemId
+        qCDebug(lcPlayback) << "PlayerController: Completion threshold met for item" << m_currentItemId
                  << "(" << percentage << "% >= " << threshold << "% threshold)";
         return true;  // Threshold met - eligible for autoplay
     }
@@ -4711,7 +4709,7 @@ void PlayerController::setAwaitingNextEpisodeResolution(bool awaiting)
  */
 void PlayerController::startPlayback(const QString &url)
 {
-    qDebug() << "PlayerController: Starting playback of" << url;
+    qCDebug(lcPlayback) << "PlayerController: Starting playback of" << url;
     qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                             << "] start-playback"
                             << "contentIsHDR=" << m_contentIsHDR
@@ -4729,14 +4727,14 @@ void PlayerController::startPlayback(const QString &url)
         // Snapshot refresh before HDR toggle. Some setups force 60Hz in HDR,
         // and we want restore to return to the pre-HDR rate.
         m_displayManager->captureOriginalRefreshRate();
-        qDebug() << "PlayerController: Enabling HDR for HDR content";
+        qCDebug(lcPlayback) << "PlayerController: Enabling HDR for HDR content";
         qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                                 << "] setHDR(true) begin";
         hdrEnabled = m_displayManager->setHDR(true);
         qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                                 << "] setHDR(true) result=" << hdrEnabled;
     } else if (m_config->getEnableHDR() && !m_contentIsHDR) {
-        qDebug() << "PlayerController: HDR toggle enabled but content is SDR, not switching display HDR";
+        qCDebug(lcPlayback) << "PlayerController: HDR toggle enabled but content is SDR, not switching display HDR";
     }
 
     applyFramerateMatchingAndStart();
@@ -4767,11 +4765,11 @@ void PlayerController::applyFramerateMatchingAndStart()
     if (m_config->getEnableFramerateMatching() && m_contentFramerate > 0) {
         // Pass the exact framerate to DisplayManager for precise matching
         // TVs like LG can match exact 23.976Hz, while others will use closest available (24Hz)
-        qDebug() << "PlayerController: Content framerate:" << m_contentFramerate
+        qCDebug(lcPlayback) << "PlayerController: Content framerate:" << m_contentFramerate
                  << "-> attempting exact refresh rate match";
         
         if (m_displayManager->setRefreshRate(m_contentFramerate)) {
-            qDebug() << "PlayerController: Successfully set display refresh rate for framerate" << m_contentFramerate;
+            qCDebug(lcPlayback) << "PlayerController: Successfully set display refresh rate for framerate" << m_contentFramerate;
             qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                                     << "] refresh-rate switch success";
 
@@ -4789,7 +4787,7 @@ void PlayerController::applyFramerateMatchingAndStart()
                 // Wait for display to stabilize after an actual refresh rate change.
                 int delaySeconds = m_config->getFramerateMatchDelay();
                 if (delaySeconds > 0) {
-                    qDebug() << "PlayerController: Scheduling mpv start in" << delaySeconds << "seconds for display to stabilize";
+                    qCDebug(lcPlayback) << "PlayerController: Scheduling mpv start in" << delaySeconds << "seconds for display to stabilize";
                     m_startDelayTimer->start(delaySeconds * 1000);
                 } else {
                     initiateMpvStart();
@@ -4800,12 +4798,12 @@ void PlayerController::applyFramerateMatchingAndStart()
             }
             return;  // Important: return early to avoid duplicate startMpv calls
         } else {
-            qWarning() << "PlayerController: Failed to set display refresh rate for framerate" << m_contentFramerate;
+            qCWarning(lcPlayback) << "PlayerController: Failed to set display refresh rate for framerate" << m_contentFramerate;
             qCWarning(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                                        << "] refresh-rate switch failed";
         }
     } else if (m_config->getEnableFramerateMatching()) {
-        qDebug() << "PlayerController: Framerate matching enabled but no framerate info available (framerate:" << m_contentFramerate << ")";
+        qCDebug(lcPlayback) << "PlayerController: Framerate matching enabled but no framerate info available (framerate:" << m_contentFramerate << ")";
         qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                                 << "] framerate-matching enabled but no content framerate";
     }
@@ -4843,7 +4841,7 @@ void PlayerController::initiateMpvStart()
     
     // Resolve the MPV profile for this item
     QString profileName = m_config->resolveProfileForItem(m_currentLibraryId, m_currentSeriesId);
-    qDebug() << "PlayerController: Using MPV profile:" << profileName
+    qCDebug(lcPlayback) << "PlayerController: Using MPV profile:" << profileName
              << "for library:" << m_currentLibraryId
              << "series:" << m_currentSeriesId;
     qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
@@ -4917,14 +4915,14 @@ void PlayerController::initiateMpvStart()
             filteredArgs << arg;
         }
 
-        qDebug() << "PlayerController: Embedded linux backend filtered mpv args:"
+        qCDebug(lcPlayback) << "PlayerController: Embedded linux backend filtered mpv args:"
                  << "before=" << finalArgs.size()
                  << "after=" << filteredArgs.size();
         finalArgs = filteredArgs;
     }
 #endif
 
-    qDebug() << "PlayerController: Final mpv args:" << finalArgs;
+    qCDebug(lcPlayback) << "PlayerController: Final mpv args:" << finalArgs;
     
     m_playerBackend->startMpv(m_mpvBin, finalArgs, m_pendingUrl);
 }
@@ -5052,7 +5050,7 @@ bool PlayerController::seekToSegmentEnd(MediaSegmentType segmentType)
         }
 
         const double endSeconds = segment.endSeconds();
-        qDebug() << "PlayerController: Skipping segment type" << static_cast<int>(segmentType)
+        qCDebug(lcPlayback) << "PlayerController: Skipping segment type" << static_cast<int>(segmentType)
                  << "seeking to" << endSeconds;
         seek(endSeconds);
         return true;
@@ -5107,10 +5105,10 @@ void PlayerController::loadConfig()
             m_testVideoUrl = obj["test_video_url"].toString();
         }
         
-        qDebug() << "PlayerController: Loaded config from" << configPath;
-        qDebug() << "PlayerController: mpv binary:" << m_mpvBin;
+        qCDebug(lcPlayback) << "PlayerController: Loaded config from" << configPath;
+        qCDebug(lcPlayback) << "PlayerController: mpv binary:" << m_mpvBin;
     } else {
-        qWarning() << "PlayerController: Could not load config from" << configPath;
+        qCWarning(lcPlayback) << "PlayerController: Could not load config from" << configPath;
         // Defaults
         m_mpvBin = "mpv";
         m_testVideoUrl = "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4";
@@ -5118,15 +5116,15 @@ void PlayerController::loadConfig()
     
     // Log mpv config directory being used
     QString mpvConfigDir = ConfigManager::getMpvConfigDir();
-    qDebug() << "PlayerController: Bloom mpv config directory:" << mpvConfigDir;
+    qCDebug(lcPlayback) << "PlayerController: Bloom mpv config directory:" << mpvConfigDir;
     if (!ConfigManager::getMpvConfPath().isEmpty()) {
-        qDebug() << "PlayerController: Using mpv.conf from:" << ConfigManager::getMpvConfPath();
+        qCDebug(lcPlayback) << "PlayerController: Using mpv.conf from:" << ConfigManager::getMpvConfPath();
     }
     if (!ConfigManager::getMpvInputConfPath().isEmpty()) {
-        qDebug() << "PlayerController: Using input.conf from:" << ConfigManager::getMpvInputConfPath();
+        qCDebug(lcPlayback) << "PlayerController: Using input.conf from:" << ConfigManager::getMpvInputConfPath();
     }
     if (!ConfigManager::getMpvScriptsDir().isEmpty()) {
-        qDebug() << "PlayerController: Detected user mpv scripts in:" << ConfigManager::getMpvScriptsDir();
+        qCDebug(lcPlayback) << "PlayerController: Detected user mpv scripts in:" << ConfigManager::getMpvScriptsDir();
     }
 }
 
@@ -5134,16 +5132,16 @@ void PlayerController::loadConfig()
 
 void PlayerController::onScriptMessage(const QString &messageName, const QStringList &args)
 {
-    qDebug() << "PlayerController: Received script message:" << messageName << "args:" << args;
+    qCDebug(lcPlayback) << "PlayerController: Received script message:" << messageName << "args:" << args;
     
     if (messageName == "bloom-skip-intro") {
         if (!seekToSegmentEnd(MediaSegmentType::Intro)) {
-            qDebug() << "PlayerController: No intro segment found to skip";
+            qCDebug(lcPlayback) << "PlayerController: No intro segment found to skip";
         }
         
     } else if (messageName == "bloom-skip-outro") {
         if (!seekToSegmentEnd(MediaSegmentType::Outro)) {
-            qDebug() << "PlayerController: No outro segment found to skip";
+            qCDebug(lcPlayback) << "PlayerController: No outro segment found to skip";
         }
     }
     // Script-driven trickplay handlers were retired with the native overlay migration.
@@ -5225,12 +5223,12 @@ void PlayerController::onChaptersLoaded(const QString &itemId, const QList<Chapt
 
     QVariantList chapterModels;
     chapterModels.reserve(chapters.size());
-    qInfo() << "PlayerController: Normalizing playback chapters for item" << itemId
+    qCInfo(lcPlayback) << "PlayerController: Normalizing playback chapters for item" << itemId
             << "count" << chapters.size();
     for (const ChapterInfo &chapter : chapters) {
         const QString thumbnailUrl = m_libraryService->getCachedChapterThumbnailUrl(
             itemId, chapter.index, chapter.imageTag, chapter.imagePath);
-        qInfo() << "PlayerController: Playback chapter thumbnail"
+        qCInfo(lcPlayback) << "PlayerController: Playback chapter thumbnail"
                 << "item" << itemId
                 << "index" << chapter.index
                 << "hasThumbnailUrl" << !thumbnailUrl.isEmpty();
@@ -5245,7 +5243,7 @@ void PlayerController::onChaptersLoaded(const QString &itemId, const QList<Chapt
 void PlayerController::onChaptersFailed(const QString &itemId, const QString &error)
 {
     if (itemId == m_currentItemId) {
-        qDebug() << "PlayerController: Chapter metadata unavailable for item" << itemId << error;
+        qCDebug(lcPlayback) << "PlayerController: Chapter metadata unavailable for item" << itemId << error;
         clearPlaybackChapters();
     }
 }
@@ -5253,11 +5251,11 @@ void PlayerController::onChaptersFailed(const QString &itemId, const QString &er
 void PlayerController::onMediaSegmentsLoaded(const QString &itemId, const QList<MediaSegmentInfo> &segments)
 {
     if (itemId != activePlaybackSegmentItemId()) {
-        qDebug() << "PlayerController: Ignoring segments for different item:" << itemId;
+        qCDebug(lcPlayback) << "PlayerController: Ignoring segments for different item:" << itemId;
         return;
     }
     
-    qDebug() << "PlayerController: Received" << segments.size() << "segments for item:" << itemId;
+    qCDebug(lcPlayback) << "PlayerController: Received" << segments.size() << "segments for item:" << itemId;
     m_currentSegments = segments;
     updateSkipSegmentState();
 
@@ -5300,9 +5298,9 @@ void PlayerController::onMediaSegmentsLoaded(const QString &itemId, const QList<
         double endSeconds = static_cast<double>(segment.endTicks) / 10000000.0;
 
         if (segment.type == MediaSegmentType::Intro) {
-            qDebug() << "PlayerController: Intro segment:" << startSeconds << "->" << endSeconds;
+            qCDebug(lcPlayback) << "PlayerController: Intro segment:" << startSeconds << "->" << endSeconds;
         } else if (segment.type == MediaSegmentType::Outro) {
-            qDebug() << "PlayerController: Outro segment:" << startSeconds << "->" << endSeconds;
+            qCDebug(lcPlayback) << "PlayerController: Outro segment:" << startSeconds << "->" << endSeconds;
         }
     }
 }
@@ -5310,14 +5308,14 @@ void PlayerController::onMediaSegmentsLoaded(const QString &itemId, const QList<
 void PlayerController::onTrickplayInfoLoaded(const QString &itemId, const QMap<int, TrickplayTileInfo> &trickplayInfo)
 {
     if (itemId != activePlaybackSegmentItemId()) {
-        qDebug() << "PlayerController: Ignoring trickplay info for different item:" << itemId;
+        qCDebug(lcPlayback) << "PlayerController: Ignoring trickplay info for different item:" << itemId;
         return;
     }
 
     const bool wasTrickplayReady = m_hasTrickplayInfo;
     
     if (trickplayInfo.isEmpty()) {
-        qDebug() << "PlayerController: No trickplay info available for item:" << itemId;
+        qCDebug(lcPlayback) << "PlayerController: No trickplay info available for item:" << itemId;
         m_hasTrickplayInfo = false;
         m_currentTrickplayInfo = TrickplayTileInfo{};
         m_trickplayBinaryPath.clear();
@@ -5350,7 +5348,7 @@ void PlayerController::onTrickplayInfoLoaded(const QString &itemId, const QMap<i
     const TrickplayTileInfo &info = trickplayInfo[selectedWidth];
 
     if (info.interval <= 0 || info.thumbnailCount <= 0 || info.width <= 0 || info.height <= 0) {
-        qWarning() << "PlayerController: Ignoring invalid trickplay info for item:" << itemId
+        qCWarning(lcPlayback) << "PlayerController: Ignoring invalid trickplay info for item:" << itemId
                    << "interval:" << info.interval
                    << "count:" << info.thumbnailCount
                    << "size:" << info.width << "x" << info.height;
@@ -5365,7 +5363,7 @@ void PlayerController::onTrickplayInfoLoaded(const QString &itemId, const QMap<i
         return;
     }
     
-    qDebug() << "PlayerController: Received trickplay info for item:" << itemId
+    qCDebug(lcPlayback) << "PlayerController: Received trickplay info for item:" << itemId
              << "selected width:" << selectedWidth
              << "height:" << info.height
              << "interval:" << info.interval << "ms"
@@ -5399,18 +5397,18 @@ void PlayerController::onTrickplayProcessingComplete(const QString &itemId, int 
                                                       int width, int height, const QString &filePath)
 {
     if (itemId != activePlaybackSegmentItemId()) {
-        qDebug() << "PlayerController: Ignoring trickplay processing result for different item:" << itemId;
+        qCDebug(lcPlayback) << "PlayerController: Ignoring trickplay processing result for different item:" << itemId;
         return;
     }
     
-    qDebug() << "PlayerController: Trickplay processing complete for item:" << itemId
+    qCDebug(lcPlayback) << "PlayerController: Trickplay processing complete for item:" << itemId
              << "count:" << count
              << "interval:" << intervalMs << "ms"
              << "size:" << width << "x" << height
              << "file:" << filePath;
 
     if (count <= 0 || intervalMs <= 0 || width <= 0 || height <= 0 || filePath.isEmpty() || !QFile::exists(filePath)) {
-        qWarning() << "PlayerController: Trickplay processing result is invalid, disabling trickplay for item:" << itemId;
+        qCWarning(lcPlayback) << "PlayerController: Trickplay processing result is invalid, disabling trickplay for item:" << itemId;
         m_hasTrickplayInfo = false;
         m_trickplayBinaryPath.clear();
         m_currentTrickplayFrameIndex = -1;
@@ -5440,7 +5438,7 @@ void PlayerController::onTrickplayProcessingFailed(const QString &itemId, const 
         return;
     }
     
-    qWarning() << "PlayerController: Trickplay processing failed for item:" << itemId << "error:" << error;
+    qCWarning(lcPlayback) << "PlayerController: Trickplay processing failed for item:" << itemId << "error:" << error;
     // Trickplay thumbnails won't be available, but playback continues normally
     m_hasTrickplayInfo = false;
     m_trickplayBinaryPath.clear();
@@ -5511,7 +5509,7 @@ void PlayerController::updateTrickplayPreviewForPosition(double seconds)
     );
 
     if (previewUrl.isEmpty()) {
-        qWarning() << "PlayerController: Failed to load trickplay frame" << frameIndex << "for item" << m_currentItemId;
+        qCWarning(lcPlayback) << "PlayerController: Failed to load trickplay frame" << frameIndex << "for item" << m_currentItemId;
         m_hasTrickplayInfo = false;
         m_trickplayBinaryPath.clear();
         m_currentTrickplayFrameIndex = -1;

--- a/src/player/PlayerProcessManager.cpp
+++ b/src/player/PlayerProcessManager.cpp
@@ -7,6 +7,7 @@
 #include <QThread>
 #include <QTimer>
 #include <QtMath>
+#include "../utils/BloomLogging.h"
 
 PlayerProcessManager::PlayerProcessManager(QObject *parent)
     : QObject(parent)
@@ -93,7 +94,7 @@ void PlayerProcessManager::startMpv(const QString &mpvBin, const QStringList &ar
     m_playlistPosition = -1;
     m_playlistCount = 0;
     
-    qInfo() << "Starting mpv:" << mpvBin;
+    qCInfo(lcPlaybackIpc) << "Starting mpv:" << mpvBin;
     m_process->start(mpvBin, finalArgs);
     
     // Try to connect IPC after a short delay or retry loop
@@ -193,10 +194,10 @@ void PlayerProcessManager::sendVariantCommand(const QVariantList &command)
     if (m_ipcSocket->state() != QLocalSocket::ConnectedState) {
         // Queue the command for later if we're starting up
         if (isRunning()) {
-            qDebug() << "IPC: Queueing command (not connected yet):" << command;
+            qCDebug(lcPlaybackIpc) << "IPC: Queueing command (not connected yet):" << command;
             m_pendingCommands.append(command);
         } else {
-            qDebug() << "IPC: Not connected, dropping command:" << command;
+            qCDebug(lcPlaybackIpc) << "IPC: Not connected, dropping command:" << command;
         }
         return;
     }
@@ -210,7 +211,7 @@ void PlayerProcessManager::sendVariantCommand(const QVariantList &command)
     jsonObj["command"] = cmdArray;
     
     QJsonDocument doc(jsonObj);
-    qDebug() << "IPC >" << doc.toJson(QJsonDocument::Compact);
+    qCDebug(lcPlaybackIpc) << "IPC >" << doc.toJson(QJsonDocument::Compact);
     m_ipcSocket->write(doc.toJson(QJsonDocument::Compact));
     m_ipcSocket->write("\n");
     m_ipcSocket->flush();
@@ -220,7 +221,7 @@ void PlayerProcessManager::flushPendingCommands()
 {
     if (m_pendingCommands.isEmpty()) return;
     
-    qDebug() << "IPC: Flushing" << m_pendingCommands.size() << "pending commands";
+    qCDebug(lcPlaybackIpc) << "IPC: Flushing" << m_pendingCommands.size() << "pending commands";
     QList<QVariantList> commands = m_pendingCommands;
     m_pendingCommands.clear();
     
@@ -232,10 +233,10 @@ void PlayerProcessManager::flushPendingCommands()
 void PlayerProcessManager::onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus)
 {
     if (exitStatus == QProcess::CrashExit || exitCode != 0) {
-        qWarning() << "mpv process exited abnormally: exitCode=" << exitCode 
+        qCWarning(lcPlaybackIpc) << "mpv process exited abnormally: exitCode=" << exitCode 
                    << "status=" << (exitStatus == QProcess::CrashExit ? "crashed" : "normal");
     } else {
-        qInfo() << "mpv process exited normally";
+        qCInfo(lcPlaybackIpc) << "mpv process exited normally";
     }
     m_ipcSocket->abort();
     m_isConnected = false;
@@ -257,13 +258,13 @@ void PlayerProcessManager::onProcessError(QProcess::ProcessError error)
     case QProcess::ReadError: errorStr = QStringLiteral("ReadError"); break;
     default: errorStr = QStringLiteral("Unknown"); break;
     }
-    qWarning() << "mpv process error:" << errorStr;
+    qCWarning(lcPlaybackIpc) << "mpv process error:" << errorStr;
     emit errorOccurred("mpv process error");
 }
 
 void PlayerProcessManager::onSocketConnected()
 {
-    qInfo() << "mpv IPC connected";
+    qCInfo(lcPlaybackIpc) << "mpv IPC connected";
     m_isConnected = true;
     m_ipcReconnectScheduled = false;
     
@@ -290,7 +291,7 @@ void PlayerProcessManager::onSocketReadyRead()
     // Handle events if needed
     while (m_ipcSocket->canReadLine()) {
         QByteArray line = m_ipcSocket->readLine();
-        qDebug() << "IPC <" << line;
+        qCDebug(lcPlaybackIpc) << "IPC <" << line;
         
         QJsonDocument doc = QJsonDocument::fromJson(line);
         QJsonObject obj = doc.object();
@@ -366,7 +367,7 @@ void PlayerProcessManager::onSocketReadyRead()
                 for (int i = 1; i < argsArray.size(); ++i) {
                     messageArgs.append(argsArray.at(i).toString());
                 }
-                qDebug() << "IPC: client-message received:" << messageName << messageArgs;
+                qCDebug(lcPlaybackIpc) << "IPC: client-message received:" << messageName << messageArgs;
                 emit scriptMessage(messageName, messageArgs);
             }
         }

--- a/src/player/TrickplayProcessor.cpp
+++ b/src/player/TrickplayProcessor.cpp
@@ -12,6 +12,7 @@
 #endif
 #include "../network/AuthenticationService.h"
 #include "../network/PlaybackService.h"
+#include "../utils/BloomLogging.h"
 
 TrickplayProcessor::TrickplayProcessor(AuthenticationService *authService,
                                        PlaybackService *playbackService,
@@ -25,7 +26,7 @@ TrickplayProcessor::TrickplayProcessor(AuthenticationService *authService,
     , m_isReady(false)
     , m_isProcessing(false)
 {
-    qDebug() << "TrickplayProcessor: Initialized";
+    qCDebug(lcPlaybackTrickplay) << "TrickplayProcessor: Initialized";
 }
 
 TrickplayProcessor::~TrickplayProcessor()
@@ -38,14 +39,14 @@ void TrickplayProcessor::startProcessing(const QString &itemId, const TrickplayT
     QMutexLocker locker(&m_mutex);
     
     if (!m_authService || !m_playbackService || !m_nam) {
-        qWarning() << "TrickplayProcessor: Missing services, cannot process trickplay";
+        qCWarning(lcPlaybackTrickplay) << "TrickplayProcessor: Missing services, cannot process trickplay";
         emit processingFailed(itemId, "Missing playback/auth services");
         return;
     }
     
     // If already processing the same item, skip
     if (m_isProcessing && m_currentItemId == itemId) {
-        qDebug() << "TrickplayProcessor: Already processing item" << itemId;
+        qCDebug(lcPlaybackTrickplay) << "TrickplayProcessor: Already processing item" << itemId;
         return;
     }
     
@@ -62,7 +63,7 @@ void TrickplayProcessor::startProcessing(const QString &itemId, const TrickplayT
     // Calculate number of tiles
     int thumbnailsPerTile = info.tileWidth * info.tileHeight;
     if (thumbnailsPerTile <= 0) {
-        qWarning() << "TrickplayProcessor: Invalid tile dimensions";
+        qCWarning(lcPlaybackTrickplay) << "TrickplayProcessor: Invalid tile dimensions";
         m_isProcessing = false;
         emit processingFailed(itemId, "Invalid tile dimensions");
         return;
@@ -72,7 +73,7 @@ void TrickplayProcessor::startProcessing(const QString &itemId, const TrickplayT
     m_tilesDownloaded = 0;
     m_downloadedTiles.clear();
     
-    qDebug() << "TrickplayProcessor: Starting processing for item" << itemId
+    qCDebug(lcPlaybackTrickplay) << "TrickplayProcessor: Starting processing for item" << itemId
              << "- thumbnails:" << info.thumbnailCount
              << "tiles:" << m_totalTiles
              << "tile size:" << info.tileWidth << "x" << info.tileHeight
@@ -119,7 +120,7 @@ void TrickplayProcessor::clear()
     // Remove the binary file if it exists
     if (!m_binaryFilePath.isEmpty() && QFile::exists(m_binaryFilePath)) {
         QFile::remove(m_binaryFilePath);
-        qDebug() << "TrickplayProcessor: Removed binary file" << m_binaryFilePath;
+        qCDebug(lcPlaybackTrickplay) << "TrickplayProcessor: Removed binary file" << m_binaryFilePath;
     }
     m_binaryFilePath.clear();
     
@@ -155,7 +156,7 @@ void TrickplayProcessor::onTileDownloaded(QNetworkReply *reply)
     QString itemId = m_currentItemId;
     
     if (reply->error() != QNetworkReply::NoError) {
-        qWarning() << "TrickplayProcessor: Failed to download tile" << tileIndex
+        qCWarning(lcPlaybackTrickplay) << "TrickplayProcessor: Failed to download tile" << tileIndex
                    << "for item" << itemId << ":" << reply->errorString();
         m_isProcessing = false;
         locker.unlock();
@@ -168,7 +169,7 @@ void TrickplayProcessor::onTileDownloaded(QNetworkReply *reply)
     m_downloadedTiles[tileIndex] = reply->readAll();
     m_tilesDownloaded++;
     
-    qDebug() << "TrickplayProcessor: Downloaded tile" << tileIndex 
+    qCDebug(lcPlaybackTrickplay) << "TrickplayProcessor: Downloaded tile" << tileIndex 
              << "(" << m_tilesDownloaded << "/" << m_totalTiles << ")";
     
     // Check if all tiles are downloaded
@@ -207,11 +208,11 @@ bool TrickplayProcessor::processAllTiles()
         totalTilesExpected = m_totalTiles;
     }
     
-    qDebug() << "TrickplayProcessor: Processing" << tiles.size() << "tiles into binary file";
+    qCDebug(lcPlaybackTrickplay) << "TrickplayProcessor: Processing" << tiles.size() << "tiles into binary file";
     
     QFile outputFile(filePath);
     if (!outputFile.open(QIODevice::WriteOnly)) {
-        qWarning() << "TrickplayProcessor: Failed to open output file" << filePath;
+        qCWarning(lcPlaybackTrickplay) << "TrickplayProcessor: Failed to open output file" << filePath;
         emit processingFailed(itemId, "Failed to create output file");
         return false;
     }
@@ -221,7 +222,7 @@ bool TrickplayProcessor::processAllTiles()
     // Process tiles in order - iterate by expected tile index to ensure sequential order
     for (int i = 0; i < totalTilesExpected; ++i) {
         if (!tiles.contains(i)) {
-            qWarning() << "TrickplayProcessor: Missing tile" << i;
+            qCWarning(lcPlaybackTrickplay) << "TrickplayProcessor: Missing tile" << i;
             outputFile.close();
             QFile::remove(filePath);
             emit processingFailed(itemId, QString("Missing tile %1").arg(i));
@@ -231,7 +232,7 @@ bool TrickplayProcessor::processAllTiles()
         // Load tile image
         QImage tileImage;
         if (!tileImage.loadFromData(tiles[i])) {
-            qWarning() << "TrickplayProcessor: Failed to decode tile" << i;
+            qCWarning(lcPlaybackTrickplay) << "TrickplayProcessor: Failed to decode tile" << i;
             outputFile.close();
             QFile::remove(filePath);
             emit processingFailed(itemId, QString("Failed to decode tile %1").arg(i));
@@ -249,7 +250,7 @@ bool TrickplayProcessor::processAllTiles()
     
     outputFile.close();
     
-    qDebug() << "TrickplayProcessor: Successfully wrote" << thumbnailsWritten 
+    qCDebug(lcPlaybackTrickplay) << "TrickplayProcessor: Successfully wrote" << thumbnailsWritten 
              << "thumbnails to" << filePath
              << "(" << QFileInfo(filePath).size() << "bytes)";
     
@@ -270,7 +271,7 @@ bool TrickplayProcessor::processTileImage(const QImage &tileImage, int tileIndex
     int expectedHeight = m_trickplayInfo.height * m_trickplayInfo.tileHeight;
     
     if (tileImage.width() != expectedWidth || tileImage.height() != expectedHeight) {
-        qWarning() << "TrickplayProcessor: Tile" << tileIndex 
+        qCWarning(lcPlaybackTrickplay) << "TrickplayProcessor: Tile" << tileIndex 
                    << "has unexpected dimensions:" << tileImage.size()
                    << "expected:" << expectedWidth << "x" << expectedHeight;
         // Continue anyway - some tiles might be smaller if they're the last one
@@ -305,7 +306,7 @@ bool TrickplayProcessor::processTileImage(const QImage &tileImage, int tileIndex
             int thumbLeft = x * thumbWidth;
             // Check if the entire thumbnail is within bounds
             if (thumbTop + thumbHeight > rgbaImage.height() || thumbLeft + thumbWidth > rgbaImage.width()) {
-                qWarning() << "TrickplayProcessor: Thumbnail" << thumbnailsWritten 
+                qCWarning(lcPlaybackTrickplay) << "TrickplayProcessor: Thumbnail" << thumbnailsWritten 
                            << "is out of bounds, writing blank thumbnail";
                 QByteArray blankThumb(thumbWidth * thumbHeight * 4, 0);
                 outputFile.write(blankThumb);

--- a/src/player/backend/LinuxMpvBackend.cpp
+++ b/src/player/backend/LinuxMpvBackend.cpp
@@ -20,10 +20,9 @@
 extern "C" {
 #include <mpv/client.h>
 #include <mpv/render_gl.h>
+#include "../../utils/BloomLogging.h"
 }
 #endif
-
-Q_LOGGING_CATEGORY(lcLinuxLibmpvBackend, "bloom.playback.backend.linux.libmpv")
 
 namespace {
 bool isTruthyEnv(const char *name)
@@ -181,7 +180,7 @@ void LinuxMpvBackend::startMpv(const QString &mpvBin, const QStringList &args, c
     if (m_renderWindow) {
         m_renderWindow->update();
     } else {
-        qWarning() << "LinuxMpvBackend: startMpv without render window; waiting for target/window attach";
+        qCWarning(lcLinuxLibmpvBackend) << "LinuxMpvBackend: startMpv without render window; waiting for target/window attach";
     }
 
     m_running = true;
@@ -413,7 +412,7 @@ bool LinuxMpvBackend::attachVideoTarget(QObject *target)
     }
 
     m_videoTarget = item;
-    qInfo() << "LinuxMpvBackend: attached video target" << item;
+    qCInfo(lcLinuxLibmpvBackend) << "LinuxMpvBackend: attached video target" << item;
 
     if (item->window()) {
         handleWindowChanged(item->window());
@@ -591,7 +590,7 @@ void LinuxMpvBackend::processMpvEvents()
             const QString prefix = QString::fromUtf8(logMessage->prefix ? logMessage->prefix : "");
             const QString text = QString::fromUtf8(logMessage->text).trimmed();
             if (!text.isEmpty()) {
-                qWarning().noquote() << QStringLiteral("[libmpv][%1] %2").arg(prefix, text);
+                qCWarning(lcLinuxLibmpvBackend).noquote() << QStringLiteral("[libmpv][%1] %2").arg(prefix, text);
             }
             break;
         }
@@ -860,7 +859,7 @@ void LinuxMpvBackend::handleWindowChanged(QQuickWindow *window)
     m_beforeRenderingConnection = connect(m_renderWindow, &QQuickWindow::beforeRendering,
                                           this, &LinuxMpvBackend::renderFrame,
                                           Qt::DirectConnection);
-    qInfo() << "LinuxMpvBackend: connected render hook to window" << m_renderWindow.data();
+    qCInfo(lcLinuxLibmpvBackend) << "LinuxMpvBackend: connected render hook to window" << m_renderWindow.data();
 
     if (m_renderWindow->isSceneGraphInitialized()) {
         initializeRenderContextIfNeeded();
@@ -1148,7 +1147,7 @@ void LinuxMpvBackend::renderFrame()
         ++m_consecutiveZeroFboFrames;
         static bool sLoggedZeroFbo = false;
         if (!sLoggedZeroFbo) {
-            qWarning() << "LinuxMpvBackend: rendering via FBO 0 fallback";
+            qCWarning(lcLinuxLibmpvBackend) << "LinuxMpvBackend: rendering via FBO 0 fallback";
             sLoggedZeroFbo = true;
         }
 
@@ -1244,7 +1243,7 @@ void LinuxMpvBackend::renderUpdateCallback(void *ctx)
     static std::atomic_int sUpdateCallbacks{0};
     const int count = sUpdateCallbacks.fetch_add(1, std::memory_order_relaxed);
     if (count < 5) {
-        qInfo() << "LinuxMpvBackend: renderUpdateCallback queued update" << (count + 1);
+        qCInfo(lcLinuxLibmpvBackend) << "LinuxMpvBackend: renderUpdateCallback queued update" << (count + 1);
     }
 
     QMetaObject::invokeMethod(self, [self]() {

--- a/src/player/backend/LinuxMpvBackend.cpp
+++ b/src/player/backend/LinuxMpvBackend.cpp
@@ -16,11 +16,12 @@
 #include <clocale>
 #include <algorithm>
 
+#include "../../utils/BloomLogging.h"
+
 #if defined(BLOOM_HAS_LIBMPV)
 extern "C" {
 #include <mpv/client.h>
 #include <mpv/render_gl.h>
-#include "../../utils/BloomLogging.h"
 }
 #endif
 

--- a/src/player/backend/PlayerBackendFactory.cpp
+++ b/src/player/backend/PlayerBackendFactory.cpp
@@ -11,8 +11,7 @@
 #include <QByteArray>
 #include <QLoggingCategory>
 #include <QtGlobal>
-
-Q_LOGGING_CATEGORY(lcPlayerBackendFactory, "bloom.playback.backend.factory")
+#include "../../utils/BloomLogging.h"
 
 static constexpr auto kExternalBackendName = "external-mpv-ipc";
 static constexpr auto kLinuxLibmpvBackendName = "linux-libmpv-opengl";

--- a/src/player/backend/WindowsMpvBackend.cpp
+++ b/src/player/backend/WindowsMpvBackend.cpp
@@ -18,14 +18,13 @@
 #if defined(Q_OS_WIN) && defined(BLOOM_HAS_LIBMPV)
 extern "C" {
 #include <mpv/client.h>
+#include "../../utils/BloomLogging.h"
 }
 #endif
 
 namespace {
 std::atomic<quint64> gWindowsMpvReplyUserdataCounter{0};
 }
-
-Q_LOGGING_CATEGORY(lcWindowsLibmpvBackend, "bloom.playback.backend.windows.libmpv")
 
 class WindowsMpvBackend::WindowsNativeGeometryFilter : public QAbstractNativeEventFilter
 {

--- a/src/player/backend/WindowsMpvBackend.cpp
+++ b/src/player/backend/WindowsMpvBackend.cpp
@@ -15,10 +15,11 @@
 
 #include <QLoggingCategory>
 
+#include "../../utils/BloomLogging.h"
+
 #if defined(Q_OS_WIN) && defined(BLOOM_HAS_LIBMPV)
 extern "C" {
 #include <mpv/client.h>
-#include "../../utils/BloomLogging.h"
 }
 #endif
 

--- a/src/security/SecretStoreFactory.cpp
+++ b/src/security/SecretStoreFactory.cpp
@@ -7,17 +7,18 @@
 #endif
 
 #include <QDebug>
+#include "../utils/BloomLogging.h"
 
 std::unique_ptr<ISecretStore> SecretStoreFactory::create()
 {
 #ifdef Q_OS_LINUX
-    qDebug() << "SecretStoreFactory: Creating Linux implementation (libsecret)";
+    qCDebug(lcAuth) << "SecretStoreFactory: Creating Linux implementation (libsecret)";
     return std::make_unique<SecretStoreLinux>();
 #elif defined(Q_OS_WIN)
-    qDebug() << "SecretStoreFactory: Creating Windows implementation (Credential Manager)";
+    qCDebug(lcAuth) << "SecretStoreFactory: Creating Windows implementation (Credential Manager)";
     return std::make_unique<SecretStoreWindows>();
 #else
-    qWarning() << "SecretStoreFactory: No secure storage available for this platform";
+    qCWarning(lcAuth) << "SecretStoreFactory: No secure storage available for this platform";
     return nullptr;
 #endif
 }

--- a/src/security/SecretStoreLinux.cpp
+++ b/src/security/SecretStoreLinux.cpp
@@ -8,6 +8,7 @@
 #define signals Q_SIGNALS
 
 #include <QDebug>
+#include "../utils/BloomLogging.h"
 
 // Define the secret schema for Bloom credentials
 static const SecretSchema bloom_schema = {
@@ -22,7 +23,7 @@ static const SecretSchema bloom_schema = {
 
 SecretStoreLinux::SecretStoreLinux()
 {
-    qDebug() << "SecretStoreLinux: Initialized (using libsecret)";
+    qCDebug(lcAuth) << "SecretStoreLinux: Initialized (using libsecret)";
 }
 
 bool SecretStoreLinux::setSecret(const QString &service, const QString &account, const QString &secret)
@@ -46,18 +47,18 @@ bool SecretStoreLinux::setSecret(const QString &service, const QString &account,
     
     if (error) {
         m_lastError = QString("Failed to store secret: %1").arg(error->message);
-        qWarning() << "SecretStoreLinux::setSecret:" << m_lastError;
+        qCWarning(lcAuth) << "SecretStoreLinux::setSecret:" << m_lastError;
         g_error_free(error);
         return false;
     }
     
     if (!result) {
         m_lastError = "Failed to store secret (unknown error)";
-        qWarning() << "SecretStoreLinux::setSecret:" << m_lastError;
+        qCWarning(lcAuth) << "SecretStoreLinux::setSecret:" << m_lastError;
         return false;
     }
     
-    qDebug() << "SecretStoreLinux: Stored secret for service=" << service << "account=" << account;
+    qCDebug(lcAuth) << "SecretStoreLinux: Stored secret for service=" << service << "account=" << account;
     return true;
 }
 
@@ -77,20 +78,20 @@ QString SecretStoreLinux::getSecret(const QString &service, const QString &accou
     
     if (error) {
         m_lastError = QString("Failed to retrieve secret: %1").arg(error->message);
-        qWarning() << "SecretStoreLinux::getSecret:" << m_lastError;
+        qCWarning(lcAuth) << "SecretStoreLinux::getSecret:" << m_lastError;
         g_error_free(error);
         return QString();
     }
     
     if (!password) {
-        qDebug() << "SecretStoreLinux: No secret found for service=" << service << "account=" << account;
+        qCDebug(lcAuth) << "SecretStoreLinux: No secret found for service=" << service << "account=" << account;
         return QString();
     }
     
     QString result = QString::fromUtf8(password);
     secret_password_free(password);
     
-    qDebug() << "SecretStoreLinux: Retrieved secret for service=" << service << "account=" << account;
+    qCDebug(lcAuth) << "SecretStoreLinux: Retrieved secret for service=" << service << "account=" << account;
     return result;
 }
 
@@ -110,15 +111,15 @@ bool SecretStoreLinux::deleteSecret(const QString &service, const QString &accou
     
     if (error) {
         m_lastError = QString("Failed to delete secret: %1").arg(error->message);
-        qWarning() << "SecretStoreLinux::deleteSecret:" << m_lastError;
+        qCWarning(lcAuth) << "SecretStoreLinux::deleteSecret:" << m_lastError;
         g_error_free(error);
         return false;
     }
     
     if (result) {
-        qDebug() << "SecretStoreLinux: Deleted secret for service=" << service << "account=" << account;
+        qCDebug(lcAuth) << "SecretStoreLinux: Deleted secret for service=" << service << "account=" << account;
     } else {
-        qDebug() << "SecretStoreLinux: No secret to delete for service=" << service << "account=" << account;
+        qCDebug(lcAuth) << "SecretStoreLinux: No secret to delete for service=" << service << "account=" << account;
     }
     
     return true;
@@ -146,7 +147,7 @@ QStringList SecretStoreLinux::listAccounts(const QString &service)
 
     if (error) {
         m_lastError = QString("Failed to list accounts: %1").arg(error->message);
-        qWarning() << "SecretStoreLinux::listAccounts:" << m_lastError;
+        qCWarning(lcAuth) << "SecretStoreLinux::listAccounts:" << m_lastError;
         g_error_free(error);
         return accounts;
     }
@@ -166,7 +167,7 @@ QStringList SecretStoreLinux::listAccounts(const QString &service)
 
     g_list_free(items);
 
-    qDebug() << "SecretStoreLinux: Listed" << accounts.size() << "accounts for service=" << service;
+    qCDebug(lcAuth) << "SecretStoreLinux: Listed" << accounts.size() << "accounts for service=" << service;
     return accounts;
 }
 

--- a/src/security/SecretStoreWindows.cpp
+++ b/src/security/SecretStoreWindows.cpp
@@ -5,10 +5,11 @@
 #include <windows.h>
 #include <wincred.h>
 #include <QDebug>
+#include "../utils/BloomLogging.h"
 
 SecretStoreWindows::SecretStoreWindows()
 {
-    qDebug() << "SecretStoreWindows: Initialized (using Windows Credential Manager)";
+    qCDebug(lcAuth) << "SecretStoreWindows: Initialized (using Windows Credential Manager)";
 }
 
 QString SecretStoreWindows::makeTargetName(const QString &service, const QString &account) const
@@ -36,11 +37,11 @@ bool SecretStoreWindows::setSecret(const QString &service, const QString &accoun
     if (!CredWriteW(&cred, 0)) {
         DWORD errorCode = GetLastError();
         m_lastError = QString("Failed to store credential (error %1)").arg(errorCode);
-        qWarning() << "SecretStoreWindows::setSecret:" << m_lastError;
+        qCWarning(lcAuth) << "SecretStoreWindows::setSecret:" << m_lastError;
         return false;
     }
     
-    qDebug() << "SecretStoreWindows: Stored secret for service=" << service << "account=" << account;
+    qCDebug(lcAuth) << "SecretStoreWindows: Stored secret for service=" << service << "account=" << account;
     return true;
 }
 
@@ -54,10 +55,10 @@ QString SecretStoreWindows::getSecret(const QString &service, const QString &acc
     if (!CredReadW((LPCWSTR)targetName.utf16(), CRED_TYPE_GENERIC, 0, &pcred)) {
         DWORD errorCode = GetLastError();
         if (errorCode == ERROR_NOT_FOUND) {
-            qDebug() << "SecretStoreWindows: No secret found for service=" << service << "account=" << account;
+            qCDebug(lcAuth) << "SecretStoreWindows: No secret found for service=" << service << "account=" << account;
         } else {
             m_lastError = QString("Failed to retrieve credential (error %1)").arg(errorCode);
-            qWarning() << "SecretStoreWindows::getSecret:" << m_lastError;
+            qCWarning(lcAuth) << "SecretStoreWindows::getSecret:" << m_lastError;
         }
         return QString();
     }
@@ -69,7 +70,7 @@ QString SecretStoreWindows::getSecret(const QString &service, const QString &acc
     
     CredFree(pcred);
     
-    qDebug() << "SecretStoreWindows: Retrieved secret for service=" << service << "account=" << account;
+    qCDebug(lcAuth) << "SecretStoreWindows: Retrieved secret for service=" << service << "account=" << account;
     return result;
 }
 
@@ -82,16 +83,16 @@ bool SecretStoreWindows::deleteSecret(const QString &service, const QString &acc
     if (!CredDeleteW((LPCWSTR)targetName.utf16(), CRED_TYPE_GENERIC, 0)) {
         DWORD errorCode = GetLastError();
         if (errorCode == ERROR_NOT_FOUND) {
-            qDebug() << "SecretStoreWindows: No secret to delete for service=" << service << "account=" << account;
+            qCDebug(lcAuth) << "SecretStoreWindows: No secret to delete for service=" << service << "account=" << account;
             return true;  // Not found is success
         }
         
         m_lastError = QString("Failed to delete credential (error %1)").arg(errorCode);
-        qWarning() << "SecretStoreWindows::deleteSecret:" << m_lastError;
+        qCWarning(lcAuth) << "SecretStoreWindows::deleteSecret:" << m_lastError;
         return false;
     }
     
-    qDebug() << "SecretStoreWindows: Deleted secret for service=" << service << "account=" << account;
+    qCDebug(lcAuth) << "SecretStoreWindows: Deleted secret for service=" << service << "account=" << account;
     return true;
 }
 
@@ -117,7 +118,7 @@ QStringList SecretStoreWindows::listAccounts(const QString &service)
             return accounts;
         }
         m_lastError = QString("Failed to enumerate credentials (error %1)").arg(errorCode);
-        qWarning() << "SecretStoreWindows::listAccounts:" << m_lastError;
+        qCWarning(lcAuth) << "SecretStoreWindows::listAccounts:" << m_lastError;
         return accounts;
     }
 
@@ -136,7 +137,7 @@ QStringList SecretStoreWindows::listAccounts(const QString &service)
 
     CredFree(pcreds);
 
-    qDebug() << "SecretStoreWindows: Listed" << accounts.size() << "accounts for service=" << service;
+    qCDebug(lcAuth) << "SecretStoreWindows: Listed" << accounts.size() << "accounts for service=" << service;
     return accounts;
 }
 

--- a/src/test/MockAuthenticationService.cpp
+++ b/src/test/MockAuthenticationService.cpp
@@ -1,5 +1,6 @@
 #include "MockAuthenticationService.h"
 #include <QDebug>
+#include "../utils/BloomLogging.h"
 
 MockAuthenticationService::MockAuthenticationService(ISecretStore *secretStore, QObject *parent)
     : AuthenticationService(secretStore, parent)
@@ -16,14 +17,14 @@ void MockAuthenticationService::initialize(ConfigManager *configManager)
     // Initialize the base class to set up config manager and secret store members
     AuthenticationService::initialize(configManager);
     
-    qDebug() << "MockAuthenticationService: Initialized with pre-authenticated session";
+    qCDebug(lcTest) << "MockAuthenticationService: Initialized with pre-authenticated session";
 }
 
 void MockAuthenticationService::authenticate(const QString &serverUrl, const QString &username, const QString &password)
 {
     Q_UNUSED(password)
     
-    qDebug() << "MockAuthenticationService::authenticate(" << serverUrl << "," << username << ")";
+    qCDebug(lcTest) << "MockAuthenticationService::authenticate(" << serverUrl << "," << username << ")";
     
     // Immediately emit success
     emit loginSuccess("test-user-001", "test-access-token-001", username);
@@ -31,7 +32,7 @@ void MockAuthenticationService::authenticate(const QString &serverUrl, const QSt
 
 void MockAuthenticationService::restoreSession(const QString &serverUrl, const QString &userId, const QString &accessToken)
 {
-    qDebug() << "MockAuthenticationService::restoreSession(" << serverUrl << "," << userId << ")";
+    qCDebug(lcTest) << "MockAuthenticationService::restoreSession(" << serverUrl << "," << userId << ")";
     
     // Immediately emit success
     emit loginSuccess(userId, accessToken, QString());
@@ -39,7 +40,7 @@ void MockAuthenticationService::restoreSession(const QString &serverUrl, const Q
 
 void MockAuthenticationService::logout()
 {
-    qDebug() << "MockAuthenticationService::logout()";
+    qCDebug(lcTest) << "MockAuthenticationService::logout()";
     
     emit loggedOut();
 }

--- a/src/test/MockLibraryService.cpp
+++ b/src/test/MockLibraryService.cpp
@@ -3,6 +3,7 @@
 #include "../network/NextEpisodeResolver.h"
 #include <QUrl>
 #include <QDebug>
+#include "../utils/BloomLogging.h"
 
 MockLibraryService::MockLibraryService(QObject *parent)
     : LibraryService(nullptr, parent)  // Pass nullptr for authService since we don't need it in mock
@@ -20,17 +21,17 @@ void MockLibraryService::loadFixture(const QJsonObject &fixture)
     m_nextUp = fixture["nextUp"].toObject();
     m_latestItems = fixture["latestItems"].toObject();
     
-    qDebug() << "MockLibraryService: Loaded fixture with";
-    qDebug() << "  Libraries:" << m_libraries["Items"].toArray().size();
-    qDebug() << "  Movies:" << m_movies["Items"].toArray().size();
-    qDebug() << "  Series:" << m_series["Items"].toArray().size();
-    qDebug() << "  Episodes:" << m_episodes["Items"].toArray().size();
+    qCDebug(lcTest) << "MockLibraryService: Loaded fixture with";
+    qCDebug(lcTest) << "  Libraries:" << m_libraries["Items"].toArray().size();
+    qCDebug(lcTest) << "  Movies:" << m_movies["Items"].toArray().size();
+    qCDebug(lcTest) << "  Series:" << m_series["Items"].toArray().size();
+    qCDebug(lcTest) << "  Episodes:" << m_episodes["Items"].toArray().size();
 }
 
 void MockLibraryService::getViews()
 {
     QJsonArray views = m_libraries["Items"].toArray();
-    qDebug() << "MockLibraryService::getViews() ->" << views.size() << "views";
+    qCDebug(lcTest) << "MockLibraryService::getViews() ->" << views.size() << "views";
     emit viewsLoaded(views);
 }
 
@@ -71,21 +72,21 @@ void MockLibraryService::getItems(const QString &parentId, int startIndex, int l
         totalCount = allItems.size();
     }
     
-    qDebug() << "MockLibraryService::getItems(" << parentId << ") ->" << items.size() << "items";
+    qCDebug(lcTest) << "MockLibraryService::getItems(" << parentId << ") ->" << items.size() << "items";
     emit itemsLoadedWithTotal(parentId, items, totalCount);
 }
 
 void MockLibraryService::getNextUp()
 {
     QJsonArray items = m_nextUp["Items"].toArray();
-    qDebug() << "MockLibraryService::getNextUp() ->" << items.size() << "items";
+    qCDebug(lcTest) << "MockLibraryService::getNextUp() ->" << items.size() << "items";
     emit nextUpLoaded(items);
 }
 
 void MockLibraryService::getLatestMedia(const QString &parentId)
 {
     QJsonArray items = m_latestItems["Items"].toArray();
-    qDebug() << "MockLibraryService::getLatestMedia(" << parentId << ") ->" << items.size() << "items";
+    qCDebug(lcTest) << "MockLibraryService::getLatestMedia(" << parentId << ") ->" << items.size() << "items";
     emit latestMediaLoaded(parentId, items);
 }
 
@@ -112,7 +113,7 @@ void MockLibraryService::getHomeBackdropItems(int limit)
         result.append(allItems[i]);
     }
 
-    qDebug() << "MockLibraryService::getHomeBackdropItems(" << limit << ") ->" << result.size() << "items";
+    qCDebug(lcTest) << "MockLibraryService::getHomeBackdropItems(" << limit << ") ->" << result.size() << "items";
     emit homeBackdropItemsLoaded(result);
 }
 
@@ -125,11 +126,11 @@ void MockLibraryService::getItem(const QString &itemId, const QString &requestCo
 {
     QJsonObject item = findItemById(itemId);
     if (!item.isEmpty()) {
-        qDebug() << "MockLibraryService::getItem(" << itemId << ") -> found";
+        qCDebug(lcTest) << "MockLibraryService::getItem(" << itemId << ") -> found";
         emit itemLoaded(itemId, item, requestContext);
         emit itemLoaded(itemId, item);
     } else {
-        qWarning() << "MockLibraryService::getItem(" << itemId << ") -> not found";
+        qCWarning(lcTest) << "MockLibraryService::getItem(" << itemId << ") -> not found";
         emit itemFailed(itemId, "Item not found: " + itemId, requestContext);
         emit errorOccurred("getItem", "Item not found: " + itemId);
     }
@@ -166,11 +167,11 @@ void MockLibraryService::getSeriesDetails(const QString &seriesId)
         seriesData["Seasons"] = seasons;
         seriesData["Episodes"] = episodes;
         
-        qDebug() << "MockLibraryService::getSeriesDetails(" << seriesId << ") -> found with" 
+        qCDebug(lcTest) << "MockLibraryService::getSeriesDetails(" << seriesId << ") -> found with" 
                  << seasons.size() << "seasons and" << episodes.size() << "episodes";
         emit seriesDetailsLoaded(seriesId, seriesData);
     } else {
-        qWarning() << "MockLibraryService::getSeriesDetails(" << seriesId << ") -> not found";
+        qCWarning(lcTest) << "MockLibraryService::getSeriesDetails(" << seriesId << ") -> not found";
         emit errorOccurred("getSeriesDetails", "Series not found: " + seriesId);
     }
 }
@@ -195,7 +196,7 @@ void MockLibraryService::getNextUnplayedEpisode(const QString &seriesId,
     const QJsonObject resolvedEpisode =
         NextEpisodeResolver::resolveBestNextEpisode(episodes, excludeItemId);
 
-    qDebug() << "MockLibraryService::getNextUnplayedEpisode(" << seriesId
+    qCDebug(lcTest) << "MockLibraryService::getNextUnplayedEpisode(" << seriesId
              << ", exclude:" << excludeItemId << ") ->"
              << (resolvedEpisode.isEmpty() ? "no eligible episodes" : "resolved");
     emit nextUnplayedEpisodeLoaded(seriesId, resolvedEpisode, requestContext);
@@ -203,49 +204,49 @@ void MockLibraryService::getNextUnplayedEpisode(const QString &seriesId,
 
 void MockLibraryService::markSeriesWatched(const QString &seriesId)
 {
-    qDebug() << "MockLibraryService::markSeriesWatched(" << seriesId << ")";
+    qCDebug(lcTest) << "MockLibraryService::markSeriesWatched(" << seriesId << ")";
     emit seriesWatchedStatusChanged(seriesId);
 }
 
 void MockLibraryService::markSeriesUnwatched(const QString &seriesId)
 {
-    qDebug() << "MockLibraryService::markSeriesUnwatched(" << seriesId << ")";
+    qCDebug(lcTest) << "MockLibraryService::markSeriesUnwatched(" << seriesId << ")";
     emit seriesWatchedStatusChanged(seriesId);
 }
 
 void MockLibraryService::markItemPlayed(const QString &itemId)
 {
-    qDebug() << "MockLibraryService::markItemPlayed(" << itemId << ")";
+    qCDebug(lcTest) << "MockLibraryService::markItemPlayed(" << itemId << ")";
     emit itemPlayedStatusChanged(itemId, true);
 }
 
 void MockLibraryService::markItemUnplayed(const QString &itemId)
 {
-    qDebug() << "MockLibraryService::markItemUnplayed(" << itemId << ")";
+    qCDebug(lcTest) << "MockLibraryService::markItemUnplayed(" << itemId << ")";
     emit itemPlayedStatusChanged(itemId, false);
 }
 
 void MockLibraryService::markItemFavorite(const QString &itemId)
 {
-    qDebug() << "MockLibraryService::markItemFavorite(" << itemId << ")";
+    qCDebug(lcTest) << "MockLibraryService::markItemFavorite(" << itemId << ")";
     emit favoriteStatusChanged(itemId, true);
 }
 
 void MockLibraryService::markItemUnfavorite(const QString &itemId)
 {
-    qDebug() << "MockLibraryService::markItemUnfavorite(" << itemId << ")";
+    qCDebug(lcTest) << "MockLibraryService::markItemUnfavorite(" << itemId << ")";
     emit favoriteStatusChanged(itemId, false);
 }
 
 void MockLibraryService::toggleFavorite(const QString &itemId, bool isFavorite)
 {
-    qDebug() << "MockLibraryService::toggleFavorite(" << itemId << "," << isFavorite << ")";
+    qCDebug(lcTest) << "MockLibraryService::toggleFavorite(" << itemId << "," << isFavorite << ")";
     emit favoriteStatusChanged(itemId, isFavorite);
 }
 
 void MockLibraryService::getThemeSongs(const QString &seriesId)
 {
-    qDebug() << "MockLibraryService::getThemeSongs(" << seriesId << ")";
+    qCDebug(lcTest) << "MockLibraryService::getThemeSongs(" << seriesId << ")";
     // Return empty list for test mode
     emit themeSongsLoaded(seriesId, QStringList());
 }
@@ -275,7 +276,7 @@ void MockLibraryService::search(const QString &searchTerm, int limit)
         }
     }
     
-    qDebug() << "MockLibraryService::search(" << searchTerm << ") ->" 
+    qCDebug(lcTest) << "MockLibraryService::search(" << searchTerm << ") ->" 
              << matchedMovies.size() << "movies," << matchedSeries.size() << "series";
     emit searchResultsLoaded(searchTerm, matchedMovies, matchedSeries);
 }
@@ -297,7 +298,7 @@ void MockLibraryService::getRandomItems(int limit)
         result.append(allItems[i]);
     }
     
-    qDebug() << "MockLibraryService::getRandomItems(" << limit << ") ->" << result.size() << "items";
+    qCDebug(lcTest) << "MockLibraryService::getRandomItems(" << limit << ") ->" << result.size() << "items";
     emit randomItemsLoaded(result);
 }
 

--- a/src/test/TestModeController.cpp
+++ b/src/test/TestModeController.cpp
@@ -3,6 +3,7 @@
 #include <QJsonDocument>
 #include <QDir>
 #include <QDebug>
+#include "../utils/BloomLogging.h"
 
 TestModeController* TestModeController::instance()
 {
@@ -21,21 +22,21 @@ void TestModeController::initialize(const QString& fixturePath, const QSize& res
     m_fixturePath = fixturePath;
     m_testResolution = resolution;
     
-    qDebug() << "Test mode enabled:";
-    qDebug() << "  Fixture path:" << m_fixturePath;
-    qDebug() << "  Resolution:" << m_testResolution.width() << "x" << m_testResolution.height();
+    qCDebug(lcTest) << "Test mode enabled:";
+    qCDebug(lcTest) << "  Fixture path:" << m_fixturePath;
+    qCDebug(lcTest) << "  Resolution:" << m_testResolution.width() << "x" << m_testResolution.height();
 }
 
 QJsonObject TestModeController::loadFixture() const
 {
     if (m_fixturePath.isEmpty()) {
-        qWarning() << "TestModeController: No fixture path set";
+        qCWarning(lcTest) << "TestModeController: No fixture path set";
         return QJsonObject();
     }
     
     QFile file(m_fixturePath);
     if (!file.open(QIODevice::ReadOnly)) {
-        qWarning() << "TestModeController: Failed to open fixture file:" << m_fixturePath;
+        qCWarning(lcTest) << "TestModeController: Failed to open fixture file:" << m_fixturePath;
         return QJsonObject();
     }
     
@@ -46,7 +47,7 @@ QJsonObject TestModeController::loadFixture() const
     QJsonDocument doc = QJsonDocument::fromJson(data, &parseError);
     
     if (parseError.error != QJsonParseError::NoError) {
-        qWarning() << "TestModeController: Failed to parse fixture JSON:" << parseError.errorString();
+        qCWarning(lcTest) << "TestModeController: Failed to parse fixture JSON:" << parseError.errorString();
         return QJsonObject();
     }
     

--- a/src/ui/FontLoader.cpp
+++ b/src/ui/FontLoader.cpp
@@ -3,6 +3,7 @@
 #include <QFont>
 #include <QFontMetrics>
 #include <QDebug>
+#include "../utils/BloomLogging.h"
 
 FontLoader::FontLoader(QObject *parent)
     : QObject(parent)
@@ -13,10 +14,10 @@ void FontLoader::load()
 {
     int fontId = QFontDatabase::addApplicationFont(":/fonts/MaterialSymbolsOutlined.ttf");
     if (fontId == -1) {
-        qWarning() << "Failed to load Material Symbols font";
+        qCWarning(lcUi) << "Failed to load Material Symbols font";
     } else {
         QStringList families = QFontDatabase::applicationFontFamilies(fontId);
-        qDebug() << "Loaded Material Symbols font families:" << families;
+        qCDebug(lcUi) << "Loaded Material Symbols font families:" << families;
         
         // Test if the font can render our icon codepoints
         if (!families.isEmpty()) {
@@ -28,7 +29,7 @@ void FontLoader::load()
             bool hasHome = fm.inFont(QChar(0xE88A));
             bool hasMenu = fm.inFont(QChar(0xE5D2));
             bool hasSettings = fm.inFont(QChar(0xE8B8));
-            qDebug() << "Font glyph check - home (U+E88A):" << hasHome 
+            qCDebug(lcUi) << "Font glyph check - home (U+E88A):" << hasHome 
                      << "menu (U+E5D2):" << hasMenu 
                      << "settings (U+E8B8):" << hasSettings;
         }

--- a/src/ui/ImageCacheProvider.cpp
+++ b/src/ui/ImageCacheProvider.cpp
@@ -17,8 +17,7 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QImageWriter>
-
-Q_LOGGING_CATEGORY(imageCache, "bloom.imagecache")
+#include "../utils/BloomLogging.h"
 
 // ============================================================================
 // CachedImageResponse Implementation
@@ -107,7 +106,7 @@ void CachedImageResponse::loadFromCache()
         QImage image = reader.read();
         
         if (!image.isNull()) {
-            qCDebug(imageCache) << "Cache hit:" << m_url;
+            qCDebug(lcImageCache) << "Cache hit:" << m_url;
             
             // Update access time in database
             m_provider->touchCacheEntry(m_url);
@@ -130,13 +129,13 @@ void CachedImageResponse::loadFromCache()
             finishWithImage(image);
             return;
         } else {
-            qCWarning(imageCache) << "Failed to read cached image:" << cachedPath 
+            qCWarning(lcImageCache) << "Failed to read cached image:" << cachedPath 
                                   << reader.errorString();
         }
     }
     
     // Not in cache, fetch from network
-    qCDebug(imageCache) << "Cache miss, fetching:" << m_url;
+    qCDebug(lcImageCache) << "Cache miss, fetching:" << m_url;
     fetchFromNetwork();
 }
 
@@ -258,7 +257,7 @@ void CachedImageResponse::finishWithImage(const QImage &image)
 void CachedImageResponse::finishWithError(const QString &error)
 {
     m_errorString = error;
-    qCWarning(imageCache) << "Image load failed:" << m_url << "-" << error;
+    qCWarning(lcImageCache) << "Image load failed:" << m_url << "-" << error;
     emit finished();
 }
 
@@ -279,7 +278,7 @@ ImageCacheProvider::ImageCacheProvider(qint64 maxCacheSizeMB)
     // Configure thread pool
     m_threadPool.setMaxThreadCount(4);  // Limit concurrent loads
     
-    qCInfo(imageCache) << "Image cache initialized at:" << m_cacheDir 
+    qCInfo(lcImageCache) << "Image cache initialized at:" << m_cacheDir 
                        << "Max size:" << maxCacheSizeMB << "MB";
     
     // Initialize database
@@ -328,7 +327,7 @@ void ImageCacheProvider::initDatabase()
     m_db.setDatabaseName(m_cacheDir + "/cache_index.db");
     
     if (!m_db.open()) {
-        qCCritical(imageCache) << "Failed to open cache database:" 
+        qCCritical(lcImageCache) << "Failed to open cache database:" 
                                << m_db.lastError().text();
         return;
     }
@@ -346,7 +345,7 @@ void ImageCacheProvider::initDatabase()
     )");
     
     if (!success) {
-        qCCritical(imageCache) << "Failed to create cache table:" 
+        qCCritical(lcImageCache) << "Failed to create cache table:" 
                                << query.lastError().text();
         return;
     }
@@ -358,7 +357,7 @@ void ImageCacheProvider::initDatabase()
     query.exec("SELECT COALESCE(SUM(size), 0) FROM cache_entries");
     if (query.next()) {
         m_currentCacheSize = query.value(0).toLongLong();
-        qCInfo(imageCache) << "Current cache size:" << m_currentCacheSize / (1024.0 * 1024.0) << "MB";
+        qCInfo(lcImageCache) << "Current cache size:" << m_currentCacheSize / (1024.0 * 1024.0) << "MB";
     }
     
     // Run eviction if needed on startup
@@ -373,7 +372,7 @@ QQuickImageResponse *ImageCacheProvider::requestImageResponse(const QString &id,
     QString url = QUrl::fromPercentEncoding(id.toUtf8());
     
     if (url.isEmpty()) {
-        qCWarning(imageCache) << "Empty image URL requested";
+        qCWarning(lcImageCache) << "Empty image URL requested";
         auto *response = new CachedImageResponse("", requestedSize, this);
         response->finishWithError("Empty URL");
         return response;
@@ -447,7 +446,7 @@ QString ImageCacheProvider::saveDataForKey(const QString &urlKey, const QByteArr
     // Write file
     QFile file(filepath);
     if (!file.open(QIODevice::WriteOnly)) {
-        qCWarning(imageCache) << "Failed to write cache file:" << filepath;
+        qCWarning(lcImageCache) << "Failed to write cache file:" << filepath;
         return QString();
     }
     
@@ -455,7 +454,7 @@ QString ImageCacheProvider::saveDataForKey(const QString &urlKey, const QByteArr
     file.close();
     
     if (written != data.size()) {
-        qCWarning(imageCache) << "Incomplete write to cache file:" << filepath;
+        qCWarning(lcImageCache) << "Incomplete write to cache file:" << filepath;
         QFile::remove(filepath);
         return QString();
     }
@@ -483,7 +482,7 @@ QString ImageCacheProvider::saveDataForKey(const QString &urlKey, const QByteArr
         query.addBindValue(now);
         
         if (!query.exec()) {
-            qCWarning(imageCache) << "Failed to update cache database:" 
+            qCWarning(lcImageCache) << "Failed to update cache database:" 
                                   << query.lastError().text();
             return QString();
         }
@@ -495,7 +494,7 @@ QString ImageCacheProvider::saveDataForKey(const QString &urlKey, const QByteArr
         m_currentCacheSize += data.size();
     }
     
-    qCDebug(imageCache) << "Cached:" << urlKey << "size:" << data.size();
+    qCDebug(lcImageCache) << "Cached:" << urlKey << "size:" << data.size();
     
     // Check if eviction is needed
     evictIfNeeded();
@@ -530,7 +529,7 @@ void ImageCacheProvider::evictIfNeeded()
     
     sizeLock.unlock();
     
-    qCInfo(imageCache) << "Cache eviction needed. Current:" 
+    qCInfo(lcImageCache) << "Cache eviction needed. Current:" 
                        << m_currentCacheSize / (1024.0 * 1024.0) << "MB"
                        << "Target:" << targetSize / (1024.0 * 1024.0) << "MB";
     
@@ -549,7 +548,7 @@ void ImageCacheProvider::evictIfNeeded()
     )");
     
     if (!query.exec()) {
-        qCWarning(imageCache) << "Failed to query cache for eviction:" 
+        qCWarning(lcImageCache) << "Failed to query cache for eviction:" 
                               << query.lastError().text();
         return;
     }
@@ -583,7 +582,7 @@ void ImageCacheProvider::evictIfNeeded()
     // Delete files
     for (const QString &filepath : filesToDelete) {
         if (QFile::remove(filepath)) {
-            qCDebug(imageCache) << "Evicted:" << filepath;
+            qCDebug(lcImageCache) << "Evicted:" << filepath;
         }
     }
     
@@ -591,7 +590,7 @@ void ImageCacheProvider::evictIfNeeded()
     sizeLock.relock();
     m_currentCacheSize -= freedBytes;
     
-    qCInfo(imageCache) << "Evicted" << urlsToDelete.size() << "entries,"
+    qCInfo(lcImageCache) << "Evicted" << urlsToDelete.size() << "entries,"
                        << freedBytes / (1024.0 * 1024.0) << "MB freed";
 }
 
@@ -615,7 +614,7 @@ bool ImageCacheProvider::renderRoundedPng(const QString &sourcePath, int radiusP
                                           const QSize &targetSize, QByteArray &outData) const
 {
     if (!QFile::exists(sourcePath)) {
-        qCWarning(imageCache) << "Rounded render failed, source missing:" << sourcePath;
+        qCWarning(lcImageCache) << "Rounded render failed, source missing:" << sourcePath;
         return false;
     }
 
@@ -625,7 +624,7 @@ bool ImageCacheProvider::renderRoundedPng(const QString &sourcePath, int radiusP
     }
     QImage src = reader.read();
     if (src.isNull()) {
-        qCWarning(imageCache) << "Rounded render failed to decode" << sourcePath << reader.errorString();
+        qCWarning(lcImageCache) << "Rounded render failed to decode" << sourcePath << reader.errorString();
         return false;
     }
 
@@ -651,7 +650,7 @@ bool ImageCacheProvider::renderRoundedPng(const QString &sourcePath, int radiusP
     buffer.close();
 
     if (!ok) {
-        qCWarning(imageCache) << "Rounded render failed to write PNG for" << sourcePath << writer.errorString();
+        qCWarning(lcImageCache) << "Rounded render failed to write PNG for" << sourcePath << writer.errorString();
     }
     return ok;
 }
@@ -806,7 +805,7 @@ void ImageCacheProvider::clearCache()
         m_currentCacheSize = 0;
     }
     
-    qCInfo(imageCache) << "Cache cleared";
+    qCInfo(lcImageCache) << "Cache cleared";
 }
 
 qint64 ImageCacheProvider::currentCacheSize() const

--- a/src/ui/ResponsiveLayoutManager.cpp
+++ b/src/ui/ResponsiveLayoutManager.cpp
@@ -4,11 +4,12 @@
 #include <QDebug>
 #include <QGuiApplication>
 #include <QScreen>
+#include "../utils/BloomLogging.h"
 
 ResponsiveLayoutManager::ResponsiveLayoutManager(QObject *parent)
     : QObject(parent)
 {
-    qDebug() << "ResponsiveLayoutManager: Initialized with defaults";
+    qCDebug(lcUi) << "ResponsiveLayoutManager: Initialized with defaults";
     
     // Connect to ConfigManager for manual DPI scale override changes
     connectToConfigManager();
@@ -26,15 +27,15 @@ void ResponsiveLayoutManager::connectToConfigManager()
     if (configManager) {
         connect(configManager, &ConfigManager::manualDpiScaleOverrideChanged,
                 this, &ResponsiveLayoutManager::onManualDpiScaleOverrideChanged);
-        qDebug() << "ResponsiveLayoutManager: Connected to ConfigManager for manualDpiScaleOverride changes";
+        qCDebug(lcUi) << "ResponsiveLayoutManager: Connected to ConfigManager for manualDpiScaleOverride changes";
     } else {
-        qWarning() << "ResponsiveLayoutManager: ConfigManager not available in ServiceLocator";
+        qCWarning(lcUi) << "ResponsiveLayoutManager: ConfigManager not available in ServiceLocator";
     }
 }
 
 void ResponsiveLayoutManager::onManualDpiScaleOverrideChanged()
 {
-    qDebug() << "ResponsiveLayoutManager: manualDpiScaleOverride changed, updating layout";
+    qCDebug(lcUi) << "ResponsiveLayoutManager: manualDpiScaleOverride changed, updating layout";
     updateLayout();
 }
 
@@ -61,7 +62,7 @@ void ResponsiveLayoutManager::setWindow(QQuickWindow* window)
         // Initial layout calculation
         updateLayout();
         
-        qDebug() << "ResponsiveLayoutManager: Window set, connected to geometry and screen change signals";
+        qCDebug(lcUi) << "ResponsiveLayoutManager: Window set, connected to geometry and screen change signals";
     }
 }
 
@@ -108,7 +109,7 @@ int ResponsiveLayoutManager::viewportHeight() const
 void ResponsiveLayoutManager::updateLayout()
 {
     if (!m_window) {
-        qWarning() << "ResponsiveLayoutManager: No window set, using defaults";
+        qCWarning(lcUi) << "ResponsiveLayoutManager: No window set, using defaults";
         return;
     }
     
@@ -124,7 +125,7 @@ void ResponsiveLayoutManager::updateLayout()
     
     // Calculate aspect ratio (guard against division by zero)
     if (newHeight == 0) {
-        qWarning() << "ResponsiveLayoutManager: newHeight is 0, skipping layout update";
+        qCWarning(lcUi) << "ResponsiveLayoutManager: newHeight is 0, skipping layout update";
         return;
     }
     qreal newAspectRatio = static_cast<qreal>(newWidth) / static_cast<qreal>(newHeight);
@@ -172,23 +173,23 @@ void ResponsiveLayoutManager::updateLayout()
         emit aspectRatioChanged();
     }
     if (bBreakpointChanged) {
-        qDebug() << "ResponsiveLayoutManager: Breakpoint changed to" << newBreakpoint;
+        qCDebug(lcUi) << "ResponsiveLayoutManager: Breakpoint changed to" << newBreakpoint;
         emit breakpointChanged();
     }
     if (bLayoutScaleChanged) {
         emit layoutScaleChanged();
     }
     if (bGridColumnsChanged) {
-        qDebug() << "ResponsiveLayoutManager: Grid columns changed to" << newGridColumns;
+        qCDebug(lcUi) << "ResponsiveLayoutManager: Grid columns changed to" << newGridColumns;
         emit gridColumnsChanged();
     }
     if (bSidebarModeChanged) {
-        qDebug() << "ResponsiveLayoutManager: Sidebar mode changed to" << newSidebarMode;
+        qCDebug(lcUi) << "ResponsiveLayoutManager: Sidebar mode changed to" << newSidebarMode;
         emit sidebarDefaultModeChanged();
     }
     
     // Debug output
-    qDebug() << "ResponsiveLayoutManager: Layout updated -"
+    qCDebug(lcUi) << "ResponsiveLayoutManager: Layout updated -"
              << "viewport:" << newWidth << "x" << newHeight
              << "effectiveHeight:" << effectiveHeight
              << "DPR:" << dpr
@@ -266,7 +267,7 @@ int ResponsiveLayoutManager::calculateGridColumns(const QString& breakpoint, qre
         qreal extraWidth = aspectRatio - ULTRAWIDE_THRESHOLD;
         int extraColumns = qMin(ULTRAWIDE_MAX_EXTRA_COLUMNS, static_cast<int>(extraWidth * 2));
         baseColumns += extraColumns;
-        qDebug() << "ResponsiveLayoutManager: Ultrawide detected (aspectRatio:" << aspectRatio 
+        qCDebug(lcUi) << "ResponsiveLayoutManager: Ultrawide detected (aspectRatio:" << aspectRatio 
                  << "), adding" << extraColumns << "columns";
     }
     
@@ -292,7 +293,7 @@ int ResponsiveLayoutManager::calculateEffectiveHeight(int logicalHeight, qreal d
     
     if (devicePixelRatio > HIGH_DPI_THRESHOLD) {
         int physicalHeight = qRound(logicalHeight * devicePixelRatio);
-        qDebug() << "ResponsiveLayoutManager: High-DPI detected (DPR:" << devicePixelRatio 
+        qCDebug(lcUi) << "ResponsiveLayoutManager: High-DPI detected (DPR:" << devicePixelRatio 
                  << "), using physical height:" << physicalHeight;
         return physicalHeight;
     }

--- a/src/ui/SettingsScreen.qml
+++ b/src/ui/SettingsScreen.qml
@@ -75,6 +75,7 @@ FocusScope {
         function onManualDpiScaleOverrideChanged() { root.scheduleSettingsSavedToast() }
         function onUpdateChannelChanged() { root.scheduleSettingsSavedToast() }
         function onAutoUpdateCheckEnabledChanged() { root.scheduleSettingsSavedToast() }
+        function onLogLevelChanged() { root.scheduleSettingsSavedToast() }
     }
 
     signal signOutRequested()

--- a/src/ui/WindowManager.cpp
+++ b/src/ui/WindowManager.cpp
@@ -25,10 +25,9 @@
 #include <QQmlContext>
 #include <QQuickStyle>
 #include <QLoggingCategory>
+#include "../utils/BloomLogging.h"
 
 using namespace Qt::StringLiterals;
-
-Q_LOGGING_CATEGORY(lcUiSceneGraph, "bloom.ui.scenegraph")
 
 WindowManager::WindowManager(QGuiApplication* app, QObject *parent)
     : QObject(parent)

--- a/src/ui/settings/AboutAccountSettings.qml
+++ b/src/ui/settings/AboutAccountSettings.qml
@@ -47,6 +47,46 @@ FocusScope {
         return rowButtons.length > 0 ? rowButtons[rowButtons.length - 1] : null
     }
 
+
+    function logLevelIndexForValue(value) {
+        if (value === "debug") return 1
+        if (value === "quiet") return 2
+        return 0
+    }
+
+    function logLevelValueForIndex(index) {
+        if (index === 1) return "debug"
+        if (index === 2) return "quiet"
+        return "info"
+    }
+
+    function focusUpdatesDownFromChannel() {
+        if (checkUpdatesBtn.enabled) {
+            checkUpdatesBtn.forceActiveFocus()
+        } else if (openDownloadPageBtn.visible) {
+            openDownloadPageBtn.forceActiveFocus()
+        } else {
+            logLevelCombo.forceActiveFocus()
+        }
+    }
+
+    function focusLastUpdatesControl() {
+        if (openDownloadPageBtn.visible) {
+            openDownloadPageBtn.forceActiveFocus()
+            return
+        }
+        var rowButtons = visibleUpdateRowButtons()
+        if (rowButtons.length > 0) {
+            rowButtons[rowButtons.length - 1].forceActiveFocus()
+            return
+        }
+        if (checkUpdatesBtn.enabled) {
+            checkUpdatesBtn.forceActiveFocus()
+            return
+        }
+        logLevelCombo.forceActiveFocus()
+    }
+
     function focusAdjacentUpdateButton(currentButton, step) {
         var buttons = [checkUpdatesBtn].concat(visibleUpdateRowButtons())
         if (openDownloadPageBtn.visible) buttons.push(openDownloadPageBtn)
@@ -228,7 +268,7 @@ FocusScope {
                             if (!popup.visible) {
                                 if (checkUpdatesBtn.enabled) checkUpdatesBtn.forceActiveFocus()
                                 else if (openDownloadPageBtn.visible) openDownloadPageBtn.forceActiveFocus()
-                                else signOutBtn.forceActiveFocus()
+                                else logLevelCombo.forceActiveFocus()
                                 event.accepted = true
                             }
                         }
@@ -327,7 +367,7 @@ FocusScope {
                             if (openDownloadPageBtn.visible) {
                                 openDownloadPageBtn.forceActiveFocus()
                             } else {
-                                signOutBtn.forceActiveFocus()
+                                logLevelCombo.forceActiveFocus()
                             }
                             event.accepted = true
                         }
@@ -362,7 +402,7 @@ FocusScope {
                             if (openDownloadPageBtn.visible) {
                                 openDownloadPageBtn.forceActiveFocus()
                             } else {
-                                signOutBtn.forceActiveFocus()
+                                logLevelCombo.forceActiveFocus()
                             }
                             event.accepted = true
                         }
@@ -398,7 +438,7 @@ FocusScope {
                             if (openDownloadPageBtn.visible) {
                                 openDownloadPageBtn.forceActiveFocus()
                             } else {
-                                signOutBtn.forceActiveFocus()
+                                logLevelCombo.forceActiveFocus()
                             }
                             event.accepted = true
                         }
@@ -434,7 +474,7 @@ FocusScope {
                             if (openDownloadPageBtn.visible) {
                                 openDownloadPageBtn.forceActiveFocus()
                             } else {
-                                signOutBtn.forceActiveFocus()
+                                logLevelCombo.forceActiveFocus()
                             }
                             event.accepted = true
                         }
@@ -522,7 +562,7 @@ FocusScope {
                         event.accepted = true
                     }
                     Keys.onDownPressed: function(event) {
-                        signOutBtn.forceActiveFocus()
+                        logLevelCombo.forceActiveFocus()
                         event.accepted = true
                     }
                     Keys.onLeftPressed: function(event) {
@@ -540,6 +580,149 @@ FocusScope {
                     contentItem: Text { text: openDownloadPageBtn.text; font.pixelSize: Theme.fontSizeBody; font.family: Theme.fontPrimary; color: openDownloadPageBtn.enabled ? Theme.textPrimary : Theme.textDisabled; horizontalAlignment: Text.AlignHCenter; verticalAlignment: Text.AlignVCenter }
                     background: Rectangle { implicitHeight: Theme.buttonHeightSmall; radius: Theme.radiusSmall; color: openDownloadPageBtn.activeFocus || openDownloadPageBtn.hovered ? Theme.buttonSecondaryBackgroundHover : Theme.buttonSecondaryBackground; border.color: openDownloadPageBtn.activeFocus ? Theme.focusBorder : Theme.buttonSecondaryBorder; border.width: openDownloadPageBtn.activeFocus ? 2 : Theme.buttonBorderWidth; opacity: openDownloadPageBtn.enabled ? 1.0 : 0.5 }
                 }
+
+
+                // Log verbosity
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: Math.round(4 * Theme.layoutScale)
+
+                    Text {
+                        text: qsTr("Log Level")
+                        font.pixelSize: Theme.fontSizeBody
+                        font.family: Theme.fontPrimary
+                        color: Theme.textPrimary
+                    }
+
+                    Text {
+                        text: qsTr("Controls how much detail is written to the log file. Warnings and errors are always kept.")
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.family: Theme.fontPrimary
+                        color: Theme.textSecondary
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+
+                    ComboBox {
+                        id: logLevelCombo
+                        focusPolicy: Qt.StrongFocus
+                        model: [qsTr("Normal"), qsTr("Verbose"), qsTr("Quiet (warnings only)")]
+                        Layout.preferredWidth: Math.round(280 * Theme.layoutScale)
+
+                        property bool initialized: false
+                        property bool updatingSelection: false
+
+                        Component.onCompleted: {
+                            currentIndex = root.logLevelIndexForValue(ConfigManager.logLevel)
+                            initialized = true
+                        }
+
+                        onActiveFocusChanged: {
+                            if (activeFocus) {
+                                root._lastFocusedItem = this
+                                flickable.ensureFocusVisible(this)
+                            }
+                        }
+
+                        onCurrentIndexChanged: {
+                            if (!initialized || updatingSelection) return
+                            var level = root.logLevelValueForIndex(currentIndex)
+                            if (level !== ConfigManager.logLevel) {
+                                ConfigManager.logLevel = level
+                            }
+                        }
+
+                        Connections {
+                            target: ConfigManager
+                            function onLogLevelChanged() {
+                                logLevelCombo.updatingSelection = true
+                                logLevelCombo.currentIndex = root.logLevelIndexForValue(ConfigManager.logLevel)
+                                logLevelCombo.updatingSelection = false
+                            }
+                        }
+
+                        Keys.onUpPressed: function(event) {
+                            if (!popup.visible) {
+                                root.focusLastUpdatesControl()
+                                event.accepted = true
+                            }
+                        }
+                        Keys.onDownPressed: function(event) {
+                            if (!popup.visible) {
+                                signOutBtn.forceActiveFocus()
+                                event.accepted = true
+                            }
+                        }
+                        Keys.onReturnPressed: popup.open()
+                        Keys.onEnterPressed: popup.open()
+
+                        background: Rectangle {
+                            implicitHeight: Theme.buttonHeightSmall
+                            radius: Theme.radiusSmall
+                            color: Theme.inputBackground
+                            border.color: logLevelCombo.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                            border.width: logLevelCombo.activeFocus ? 2 : 1
+                        }
+
+                        contentItem: Text {
+                            text: logLevelCombo.displayText
+                            font.pixelSize: Theme.fontSizeBody
+                            font.family: Theme.fontPrimary
+                            color: Theme.textPrimary
+                            verticalAlignment: Text.AlignVCenter
+                            leftPadding: Theme.spacingSmall
+                        }
+
+                        delegate: ItemDelegate {
+                            width: logLevelCombo.width
+                            contentItem: Text {
+                                text: modelData
+                                color: highlighted ? Theme.textPrimary : Theme.textSecondary
+                                font.pixelSize: Theme.fontSizeBody
+                                font.family: Theme.fontPrimary
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                            background: Rectangle {
+                                color: highlighted ? Theme.buttonPrimaryBackground : "transparent"
+                                radius: Theme.radiusSmall
+                            }
+                            highlighted: ListView.isCurrentItem || logLevelCombo.highlightedIndex === index
+                        }
+
+                        popup: Popup {
+                            y: logLevelCombo.height + 5
+                            width: logLevelCombo.width
+                            implicitHeight: contentItem.implicitHeight
+                            padding: 1
+
+                            onOpened: {
+                                logLevelPopupList.currentIndex = logLevelCombo.highlightedIndex >= 0 ? logLevelCombo.highlightedIndex : logLevelCombo.currentIndex
+                                logLevelPopupList.forceActiveFocus()
+                            }
+                            onClosed: logLevelCombo.forceActiveFocus()
+
+                            contentItem: ListView {
+                                id: logLevelPopupList
+                                clip: true
+                                implicitHeight: contentHeight
+                                model: logLevelCombo.popup.visible ? logLevelCombo.delegateModel : null
+                                currentIndex: logLevelCombo.highlightedIndex >= 0 ? logLevelCombo.highlightedIndex : logLevelCombo.currentIndex
+                                ScrollIndicator.vertical: ScrollIndicator { }
+                                Keys.onReturnPressed: { logLevelCombo.currentIndex = currentIndex; logLevelCombo.popup.close() }
+                                Keys.onEnterPressed: { logLevelCombo.currentIndex = currentIndex; logLevelCombo.popup.close() }
+                                Keys.onEscapePressed: logLevelCombo.popup.close()
+                            }
+
+                            background: Rectangle {
+                                color: Theme.cardBackground
+                                border.color: Theme.focusBorder
+                                border.width: 1
+                                radius: Theme.radiusSmall
+                            }
+                        }
+                    }
+                }
+
 
                 SettingsGroupDivider { Layout.fillWidth: true }
 
@@ -569,14 +752,7 @@ FocusScope {
                         }
                     }
                     Keys.onUpPressed: function(event) {
-                        var target = root.lastVisibleUpdateTarget()
-                        if (target) {
-                            target.forceActiveFocus()
-                        } else if (checkUpdatesBtn.enabled) {
-                            checkUpdatesBtn.forceActiveFocus()
-                        } else {
-                            updateChannelCombo.forceActiveFocus()
-                        }
+                        logLevelCombo.forceActiveFocus()
                         event.accepted = true
                     }
                     Keys.onReturnPressed: root.signOutRequested()

--- a/src/utils/BloomLogging.cpp
+++ b/src/utils/BloomLogging.cpp
@@ -1,0 +1,27 @@
+#include "BloomLogging.h"
+
+Q_LOGGING_CATEGORY(lcImageCache, "bloom.imagecache")
+Q_LOGGING_CATEGORY(lcLibraryCache, "bloom.librarycache")
+Q_LOGGING_CATEGORY(lcCache, "bloom.cache")
+
+Q_LOGGING_CATEGORY(lcLibrary, "bloom.library")
+Q_LOGGING_CATEGORY(lcViewModels, "bloom.viewmodels")
+Q_LOGGING_CATEGORY(lcJellyfinNetwork, "jellyfin.network")
+
+Q_LOGGING_CATEGORY(lcPlayback, "bloom.playback")
+Q_LOGGING_CATEGORY(lcPlaybackTrace, "bloom.playback.trace")
+Q_LOGGING_CATEGORY(lcPlaybackIpc, "bloom.playback.ipc")
+Q_LOGGING_CATEGORY(lcPlaybackTrickplay, "bloom.playback.trickplay")
+Q_LOGGING_CATEGORY(lcMediaSegments, "bloom.mediaSegments")
+Q_LOGGING_CATEGORY(lcLinuxLibmpvBackend, "bloom.playback.backend.linux.libmpv")
+Q_LOGGING_CATEGORY(lcWindowsLibmpvBackend, "bloom.playback.backend.windows.libmpv")
+Q_LOGGING_CATEGORY(lcPlayerBackendFactory, "bloom.playback.backend.factory")
+Q_LOGGING_CATEGORY(lcDisplayTrace, "bloom.playback.displaytrace")
+Q_LOGGING_CATEGORY(lcGpuTrim, "bloom.gpu.trim")
+
+Q_LOGGING_CATEGORY(lcAuth, "bloom.auth")
+Q_LOGGING_CATEGORY(lcConfig, "bloom.config")
+Q_LOGGING_CATEGORY(lcApp, "bloom.app")
+Q_LOGGING_CATEGORY(lcUi, "bloom.ui")
+Q_LOGGING_CATEGORY(lcUiSceneGraph, "bloom.ui.scenegraph")
+Q_LOGGING_CATEGORY(lcTest, "bloom.test")

--- a/src/utils/BloomLogging.h
+++ b/src/utils/BloomLogging.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <QLoggingCategory>
+
+// Image & disk cache (suppress info/debug by default; warnings/errors always show)
+Q_DECLARE_LOGGING_CATEGORY(lcImageCache)       // bloom.imagecache
+Q_DECLARE_LOGGING_CATEGORY(lcLibraryCache)     // bloom.librarycache
+Q_DECLARE_LOGGING_CATEGORY(lcCache)            // bloom.cache — detail-view JSON cache
+
+// Library / API
+Q_DECLARE_LOGGING_CATEGORY(lcLibrary)          // bloom.library
+Q_DECLARE_LOGGING_CATEGORY(lcViewModels)       // bloom.viewmodels
+Q_DECLARE_LOGGING_CATEGORY(lcJellyfinNetwork)  // jellyfin.network
+
+// Playback
+Q_DECLARE_LOGGING_CATEGORY(lcPlayback)         // bloom.playback
+Q_DECLARE_LOGGING_CATEGORY(lcPlaybackTrace)    // bloom.playback.trace
+Q_DECLARE_LOGGING_CATEGORY(lcPlaybackIpc)      // bloom.playback.ipc
+Q_DECLARE_LOGGING_CATEGORY(lcPlaybackTrickplay) // bloom.playback.trickplay
+Q_DECLARE_LOGGING_CATEGORY(lcMediaSegments)    // bloom.mediaSegments
+Q_DECLARE_LOGGING_CATEGORY(lcLinuxLibmpvBackend)   // bloom.playback.backend.linux.libmpv
+Q_DECLARE_LOGGING_CATEGORY(lcWindowsLibmpvBackend) // bloom.playback.backend.windows.libmpv
+Q_DECLARE_LOGGING_CATEGORY(lcPlayerBackendFactory) // bloom.playback.backend.factory
+Q_DECLARE_LOGGING_CATEGORY(lcDisplayTrace)     // bloom.playback.displaytrace
+Q_DECLARE_LOGGING_CATEGORY(lcGpuTrim)          // bloom.gpu.trim
+
+// App / UI / auth
+Q_DECLARE_LOGGING_CATEGORY(lcAuth)             // bloom.auth
+Q_DECLARE_LOGGING_CATEGORY(lcConfig)           // bloom.config
+Q_DECLARE_LOGGING_CATEGORY(lcApp)              // bloom.app
+Q_DECLARE_LOGGING_CATEGORY(lcUi)               // bloom.ui
+Q_DECLARE_LOGGING_CATEGORY(lcUiSceneGraph)     // bloom.ui.scenegraph
+Q_DECLARE_LOGGING_CATEGORY(lcTest)             // bloom.test

--- a/src/utils/CacheMigrator.cpp
+++ b/src/utils/CacheMigrator.cpp
@@ -2,6 +2,7 @@
 #include <QStandardPaths>
 #include <QDir>
 #include <QDebug>
+#include "BloomLogging.h"
 
 CacheMigrator::CacheMigrator(QObject *parent)
     : QObject(parent)
@@ -16,11 +17,11 @@ void CacheMigrator::migrate()
     QDir newCacheDir(newCachePath);
     
     if (oldCacheDir.exists() && !newCacheDir.exists()) {
-        qInfo() << "Migrating cache from Reef to Bloom:" << oldCachePath << "->" << newCachePath;
+        qCInfo(lcCache) << "Migrating cache from Reef to Bloom:" << oldCachePath << "->" << newCachePath;
         if (oldCacheDir.rename(oldCachePath, newCachePath)) {
-            qInfo() << "Cache migration successful";
+            qCInfo(lcCache) << "Cache migration successful";
         } else {
-            qWarning() << "Cache migration failed, will use new cache location";
+            qCWarning(lcCache) << "Cache migration failed, will use new cache location";
         }
     }
 }

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -4,6 +4,7 @@
 #include <QStandardPaths>
 #include <QDir>
 #include <QDebug>
+#include "BloomLogging.h"
 #include <QDateTime>
 #include <QFileInfo>
 #include <QCoreApplication>
@@ -159,7 +160,7 @@ bool migrateLegacyWindowsConfigDirIfNeeded(const QString &targetDirPath)
 
     QDir targetDir(targetDirPath);
     if (!targetDir.exists() && !targetDir.mkpath(".")) {
-        qWarning() << "ConfigManager: Failed to create target config directory for migration:" << targetDirPath;
+        qCWarning(lcConfig) << "ConfigManager: Failed to create target config directory for migration:" << targetDirPath;
         return false;
     }
 
@@ -169,7 +170,7 @@ bool migrateLegacyWindowsConfigDirIfNeeded(const QString &targetDirPath)
         const QString dstPath = targetDir.absoluteFilePath(entry.fileName());
 
         if (QFileInfo::exists(dstPath)) {
-            qWarning() << "ConfigManager: Skipping legacy config entry because target already exists:" << dstPath;
+            qCWarning(lcConfig) << "ConfigManager: Skipping legacy config entry because target already exists:" << dstPath;
             continue;
         }
 
@@ -181,9 +182,9 @@ bool migrateLegacyWindowsConfigDirIfNeeded(const QString &targetDirPath)
         }
 
         if (!migrated) {
-            qWarning() << "ConfigManager: Failed to migrate legacy config entry:" << srcPath << "->" << dstPath;
+            qCWarning(lcConfig) << "ConfigManager: Failed to migrate legacy config entry:" << srcPath << "->" << dstPath;
         } else {
-            qDebug() << "ConfigManager: Migrated legacy config entry:" << srcPath << "->" << dstPath;
+            qCDebug(lcConfig) << "ConfigManager: Migrated legacy config entry:" << srcPath << "->" << dstPath;
         }
     }
 
@@ -303,12 +304,12 @@ QStringList ConfigManager::getMpvConfigArgs() const
             const QString cleanedCanonicalPath = normalizePath(canonicalPath);
 
             if (canonicalPath.isEmpty()) {
-                qWarning() << "ConfigManager: Skipping mpv script with unresolved path:" << scriptInfo.absoluteFilePath();
+                qCWarning(lcConfig) << "ConfigManager: Skipping mpv script with unresolved path:" << scriptInfo.absoluteFilePath();
                 continue;
             }
 
             if (!cleanedCanonicalPath.startsWith(scriptsRootPrefix)) {
-                qWarning() << "ConfigManager: Skipping mpv script outside scripts directory:" << canonicalPath;
+                qCWarning(lcConfig) << "ConfigManager: Skipping mpv script outside scripts directory:" << canonicalPath;
                 continue;
             }
 
@@ -323,7 +324,7 @@ QStringList ConfigManager::getMpvConfigArgs() const
         args << QString("--demuxer-max-bytes=%1M").arg(cacheSizeMB);
         args << QString("--demuxer-max-back-bytes=%1M").arg(qMax(1, cacheSizeMB / 4));
         args << "--stream-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_delay_max=30";
-        qDebug() << "ConfigManager: mpv cache args: demuxer-max-bytes=" << cacheSizeMB << "MB back-bytes=" << qMax(1, cacheSizeMB / 4) << "MB";
+        qCDebug(lcConfig) << "ConfigManager: mpv cache args: demuxer-max-bytes=" << cacheSizeMB << "MB back-bytes=" << qMax(1, cacheSizeMB / 4) << "MB";
     }
     
     return args;
@@ -340,10 +341,10 @@ bool ConfigManager::ensureConfigDirExists()
     QDir dir(getConfigDir());
     if (!dir.exists()) {
         if (!dir.mkpath(".")) {
-            qWarning() << "ConfigManager: Failed to create config directory:" << getConfigDir();
+            qCWarning(lcConfig) << "ConfigManager: Failed to create config directory:" << getConfigDir();
             return false;
         }
-        qDebug() << "ConfigManager: Created config directory:" << getConfigDir();
+        qCDebug(lcConfig) << "ConfigManager: Created config directory:" << getConfigDir();
     }
     
     // Also create mpv subdirectory structure
@@ -351,10 +352,10 @@ bool ConfigManager::ensureConfigDirExists()
     QDir mpv(mpvDir);
     if (!mpv.exists()) {
         if (!mpv.mkpath(".")) {
-            qWarning() << "ConfigManager: Failed to create mpv config directory:" << mpvDir;
+            qCWarning(lcConfig) << "ConfigManager: Failed to create mpv config directory:" << mpvDir;
             return false;
         }
-        qDebug() << "ConfigManager: Created mpv config directory:" << mpvDir;
+        qCDebug(lcConfig) << "ConfigManager: Created mpv config directory:" << mpvDir;
     }
     
     return true;
@@ -368,14 +369,14 @@ void ConfigManager::load()
     QString path = getConfigPath();
     QFile file(path);
     if (!file.exists()) {
-        qWarning() << "Config file not found, creating default:" << path;
+        qCWarning(lcConfig) << "Config file not found, creating default:" << path;
         m_config = defaultConfig();
         save();
         return;
     }
 
     if (!file.open(QIODevice::ReadOnly)) {
-        qWarning() << "Could not open config file for reading:" << path << ", using defaults";
+        qCWarning(lcConfig) << "Could not open config file for reading:" << path << ", using defaults";
         m_config = defaultConfig();
         return;
     }
@@ -384,16 +385,16 @@ void ConfigManager::load()
     QJsonParseError parseError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &parseError);
     if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
-        qWarning() << "Invalid config file (JSON parse error):" << parseError.errorString();
+        qCWarning(lcConfig) << "Invalid config file (JSON parse error):" << parseError.errorString();
         // Backup the bad file
         QString backup = path + ".corrupt-" + QDateTime::currentDateTime().toString(Qt::ISODate);
         if (QFile::exists(backup)) {
             QFile::remove(backup);
         }
         if (!QFile::rename(path, backup)) {
-            qWarning() << "Could not rename corrupt config file to backup:" << backup;
+            qCWarning(lcConfig) << "Could not rename corrupt config file to backup:" << backup;
         } else {
-            qWarning() << "Backed up corrupt config to" << backup;
+            qCWarning(lcConfig) << "Backed up corrupt config to" << backup;
         }
         m_config = defaultConfig();
         save();
@@ -404,7 +405,7 @@ void ConfigManager::load()
 
     // Run migrations, ensure config is at the current version
     if (!migrateConfig()) {
-        qWarning() << "Config migration failed -- resetting config to defaults";
+        qCWarning(lcConfig) << "Config migration failed -- resetting config to defaults";
         QString backup = path + ".migratefail-" + QDateTime::currentDateTime().toString(Qt::ISODate);
         if (QFile::exists(backup)) QFile::remove(backup);
         QFile::rename(path, backup);
@@ -414,7 +415,7 @@ void ConfigManager::load()
     }
 
     if (!validateConfig(m_config)) {
-        qWarning() << "Config failed schema validation -- resetting to defaults";
+        qCWarning(lcConfig) << "Config failed schema validation -- resetting to defaults";
         QString backup = path + ".badschema-" + QDateTime::currentDateTime().toString(Qt::ISODate);
         if (QFile::exists(backup)) QFile::remove(backup);
         QFile::rename(path, backup);
@@ -423,7 +424,7 @@ void ConfigManager::load()
         return;
     }
 
-    qDebug() << "Loaded config from" << path;
+    qCDebug(lcConfig) << "Loaded config from" << path;
 }
 
 void ConfigManager::save()
@@ -439,7 +440,7 @@ void ConfigManager::save()
     }
 
     if (!file.open(QIODevice::WriteOnly)) {
-        qWarning() << "Could not open config file for writing:" << path;
+        qCWarning(lcConfig) << "Could not open config file for writing:" << path;
         return;
     }
     // Ensure current version and settings exist before saving
@@ -456,7 +457,7 @@ void ConfigManager::save()
 
     QJsonDocument doc(m_config);
     file.write(doc.toJson(QJsonDocument::Indented));
-    qDebug() << "Saved config to" << path;
+    qCDebug(lcConfig) << "Saved config to" << path;
 }
 
 void ConfigManager::exitApplication()
@@ -558,7 +559,7 @@ int ConfigManager::getImageCacheSizeMB() const
 void ConfigManager::setPlaybackCacheSizeMB(int mb)
 {
     int clamped = std::clamp(mb, 50, 2048);
-    qDebug() << "ConfigManager: setPlaybackCacheSizeMB called with" << mb << "clamped to" << clamped << "current" << getPlaybackCacheSizeMB();
+    qCDebug(lcConfig) << "ConfigManager: setPlaybackCacheSizeMB called with" << mb << "clamped to" << clamped << "current" << getPlaybackCacheSizeMB();
     if (clamped == getPlaybackCacheSizeMB()) {
         return;
     }
@@ -576,7 +577,7 @@ void ConfigManager::setPlaybackCacheSizeMB(int mb)
     m_config["settings"] = settings;
     save();
     emit playbackCacheSizeMBChanged();
-    qDebug() << "ConfigManager: playbackCacheSizeMB saved as" << clamped;
+    qCDebug(lcConfig) << "ConfigManager: playbackCacheSizeMB saved as" << clamped;
 }
 
 int ConfigManager::getPlaybackCacheSizeMB() const
@@ -592,7 +593,7 @@ int ConfigManager::getPlaybackCacheSizeMB() const
         }
     }
     int result = std::clamp(value, 50, 2048);
-    qDebug() << "ConfigManager: getPlaybackCacheSizeMB returning" << result << "(raw" << value << ")";
+    qCDebug(lcConfig) << "ConfigManager: getPlaybackCacheSizeMB returning" << result << "(raw" << value << ")";
     return result;
 }
 
@@ -728,7 +729,7 @@ QString ConfigManager::normalizePlayerBackendName(const QString &backendName) co
         return normalized;
     }
 
-    qWarning() << "ConfigManager: Ignoring unknown player backend preference:" << backendName;
+    qCWarning(lcConfig) << "ConfigManager: Ignoring unknown player backend preference:" << backendName;
     return QString();
 }
 
@@ -790,7 +791,7 @@ QString ConfigManager::getDeviceId() const
     mutableThis->m_config["settings"] = settings;
     mutableThis->save();
     
-    qDebug() << "ConfigManager: Generated new device ID:" << deviceId;
+    qCDebug(lcConfig) << "ConfigManager: Generated new device ID:" << deviceId;
     return deviceId;
 }
 
@@ -813,7 +814,7 @@ void ConfigManager::clearJellyfinSession()
         m_config["settings"] = settings;
         save();
         emit sessionChanged();
-        qDebug() << "ConfigManager: Cleared Jellyfin session data";
+        qCDebug(lcConfig) << "ConfigManager: Cleared Jellyfin session data";
     }
 }
 
@@ -1550,11 +1551,11 @@ void ConfigManager::setManualDpiScaleOverride(qreal scale)
     qreal clamped = qBound(0.5, scale, 2.0);
     
     qreal current = getManualDpiScaleOverride();
-    qDebug() << "ConfigManager::setManualDpiScaleOverride called with:" << scale 
+    qCDebug(lcConfig) << "ConfigManager::setManualDpiScaleOverride called with:" << scale 
              << "clamped to:" << clamped << "current value:" << current;
     
     if (qFuzzyCompare(clamped, current)) {
-        qDebug() << "ConfigManager: Value unchanged, skipping";
+        qCDebug(lcConfig) << "ConfigManager: Value unchanged, skipping";
         return;
     }
     
@@ -1565,7 +1566,7 @@ void ConfigManager::setManualDpiScaleOverride(qreal scale)
     settings["manualDpiScaleOverride"] = clamped;
     m_config["settings"] = settings;
     save();
-    qDebug() << "ConfigManager: Emitting manualDpiScaleOverrideChanged() signal";
+    qCDebug(lcConfig) << "ConfigManager: Emitting manualDpiScaleOverrideChanged() signal";
     emit manualDpiScaleOverrideChanged();
 }
 
@@ -2558,7 +2559,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 1) {
@@ -2566,7 +2567,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 2) {
@@ -2574,7 +2575,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 3) {
@@ -2582,7 +2583,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 4) {
@@ -2590,7 +2591,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 5) {
@@ -2598,7 +2599,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 6) {
@@ -2606,7 +2607,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 7) {
@@ -2614,7 +2615,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 8) {
@@ -2622,7 +2623,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 9) {
@@ -2630,7 +2631,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 10) {
@@ -2638,7 +2639,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 11) {
@@ -2646,7 +2647,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 12) {
@@ -2654,7 +2655,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 13) {
@@ -2662,7 +2663,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 14) {
@@ -2670,7 +2671,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 15) {
@@ -2678,7 +2679,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 16) {
@@ -2686,7 +2687,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 17) {
@@ -2694,7 +2695,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 18) {
@@ -2702,11 +2703,11 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qWarning() << "Migration produced invalid config (no version)";
+                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
                 return false;
             }
         } else {
-            qWarning() << "Unknown config version during migration:" << version;
+            qCWarning(lcConfig) << "Unknown config version during migration:" << version;
             return false;
         }
     }
@@ -3072,7 +3073,7 @@ bool ConfigManager::deleteMpvProfile(const QString &name)
 {
     // Cannot delete built-in profiles
     if (name == "Default" || name == "High Quality") {
-        qWarning() << "ConfigManager: Cannot delete built-in profile:" << name;
+        qCWarning(lcConfig) << "ConfigManager: Cannot delete built-in profile:" << name;
         return false;
     }
     
@@ -3144,12 +3145,12 @@ void ConfigManager::setDefaultProfileName(const QString &name)
 {
     const QString trimmedName = name.trimmed();
     if (trimmedName.isEmpty()) {
-        qWarning() << "ConfigManager: Ignoring empty default MPV profile name";
+        qCWarning(lcConfig) << "ConfigManager: Ignoring empty default MPV profile name";
         return;
     }
 
     if (!getMpvProfileNames().contains(trimmedName)) {
-        qWarning() << "ConfigManager: Ignoring unknown default MPV profile name:" << trimmedName;
+        qCWarning(lcConfig) << "ConfigManager: Ignoring unknown default MPV profile name:" << trimmedName;
         return;
     }
 

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -2783,6 +2783,11 @@ QJsonObject ConfigManager::defaultConfig() const
     cache["rounded_preprocess_enabled"] = true;
     settings["cache"] = cache;
 
+    QJsonObject logging;
+    logging["level"] = QStringLiteral("info");
+    logging["qt_rules"] = QString();
+    settings["logging"] = logging;
+
     // UI Settings
     QJsonObject ui;
     ui["backdrop_rotation_interval"] = 30000;

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -1,10 +1,10 @@
 #include "ConfigManager.h"
+#include "LoggingConfig.h"
 #include <QFile>
 #include <QJsonDocument>
 #include <QStandardPaths>
 #include <QDir>
 #include <QDebug>
-#include "BloomLogging.h"
 #include <QDateTime>
 #include <QFileInfo>
 #include <QCoreApplication>
@@ -24,6 +24,19 @@ QString normalizeUpdateChannelValue(const QString &channel)
     return channel.trimmed().compare(QStringLiteral("dev"), Qt::CaseInsensitive) == 0
         ? QStringLiteral("dev")
         : QStringLiteral("stable");
+}
+
+QString normalizeLogLevelValue(const QString &level)
+{
+    const QString normalized = level.trimmed().toLower();
+    if (normalized == QStringLiteral("debug") || normalized == QStringLiteral("verbose")) {
+        return QStringLiteral("debug");
+    }
+    if (normalized == QStringLiteral("quiet") || normalized == QStringLiteral("warn")
+        || normalized == QStringLiteral("warning")) {
+        return QStringLiteral("quiet");
+    }
+    return QStringLiteral("info");
 }
 
 QVariantList supportedTrackLanguageOptions()
@@ -160,7 +173,7 @@ bool migrateLegacyWindowsConfigDirIfNeeded(const QString &targetDirPath)
 
     QDir targetDir(targetDirPath);
     if (!targetDir.exists() && !targetDir.mkpath(".")) {
-        qCWarning(lcConfig) << "ConfigManager: Failed to create target config directory for migration:" << targetDirPath;
+        qWarning() << "ConfigManager: Failed to create target config directory for migration:" << targetDirPath;
         return false;
     }
 
@@ -170,7 +183,7 @@ bool migrateLegacyWindowsConfigDirIfNeeded(const QString &targetDirPath)
         const QString dstPath = targetDir.absoluteFilePath(entry.fileName());
 
         if (QFileInfo::exists(dstPath)) {
-            qCWarning(lcConfig) << "ConfigManager: Skipping legacy config entry because target already exists:" << dstPath;
+            qWarning() << "ConfigManager: Skipping legacy config entry because target already exists:" << dstPath;
             continue;
         }
 
@@ -182,9 +195,9 @@ bool migrateLegacyWindowsConfigDirIfNeeded(const QString &targetDirPath)
         }
 
         if (!migrated) {
-            qCWarning(lcConfig) << "ConfigManager: Failed to migrate legacy config entry:" << srcPath << "->" << dstPath;
+            qWarning() << "ConfigManager: Failed to migrate legacy config entry:" << srcPath << "->" << dstPath;
         } else {
-            qCDebug(lcConfig) << "ConfigManager: Migrated legacy config entry:" << srcPath << "->" << dstPath;
+            qDebug() << "ConfigManager: Migrated legacy config entry:" << srcPath << "->" << dstPath;
         }
     }
 
@@ -304,12 +317,12 @@ QStringList ConfigManager::getMpvConfigArgs() const
             const QString cleanedCanonicalPath = normalizePath(canonicalPath);
 
             if (canonicalPath.isEmpty()) {
-                qCWarning(lcConfig) << "ConfigManager: Skipping mpv script with unresolved path:" << scriptInfo.absoluteFilePath();
+                qWarning() << "ConfigManager: Skipping mpv script with unresolved path:" << scriptInfo.absoluteFilePath();
                 continue;
             }
 
             if (!cleanedCanonicalPath.startsWith(scriptsRootPrefix)) {
-                qCWarning(lcConfig) << "ConfigManager: Skipping mpv script outside scripts directory:" << canonicalPath;
+                qWarning() << "ConfigManager: Skipping mpv script outside scripts directory:" << canonicalPath;
                 continue;
             }
 
@@ -324,7 +337,7 @@ QStringList ConfigManager::getMpvConfigArgs() const
         args << QString("--demuxer-max-bytes=%1M").arg(cacheSizeMB);
         args << QString("--demuxer-max-back-bytes=%1M").arg(qMax(1, cacheSizeMB / 4));
         args << "--stream-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_delay_max=30";
-        qCDebug(lcConfig) << "ConfigManager: mpv cache args: demuxer-max-bytes=" << cacheSizeMB << "MB back-bytes=" << qMax(1, cacheSizeMB / 4) << "MB";
+        qDebug() << "ConfigManager: mpv cache args: demuxer-max-bytes=" << cacheSizeMB << "MB back-bytes=" << qMax(1, cacheSizeMB / 4) << "MB";
     }
     
     return args;
@@ -341,10 +354,10 @@ bool ConfigManager::ensureConfigDirExists()
     QDir dir(getConfigDir());
     if (!dir.exists()) {
         if (!dir.mkpath(".")) {
-            qCWarning(lcConfig) << "ConfigManager: Failed to create config directory:" << getConfigDir();
+            qWarning() << "ConfigManager: Failed to create config directory:" << getConfigDir();
             return false;
         }
-        qCDebug(lcConfig) << "ConfigManager: Created config directory:" << getConfigDir();
+        qDebug() << "ConfigManager: Created config directory:" << getConfigDir();
     }
     
     // Also create mpv subdirectory structure
@@ -352,10 +365,10 @@ bool ConfigManager::ensureConfigDirExists()
     QDir mpv(mpvDir);
     if (!mpv.exists()) {
         if (!mpv.mkpath(".")) {
-            qCWarning(lcConfig) << "ConfigManager: Failed to create mpv config directory:" << mpvDir;
+            qWarning() << "ConfigManager: Failed to create mpv config directory:" << mpvDir;
             return false;
         }
-        qCDebug(lcConfig) << "ConfigManager: Created mpv config directory:" << mpvDir;
+        qDebug() << "ConfigManager: Created mpv config directory:" << mpvDir;
     }
     
     return true;
@@ -369,14 +382,14 @@ void ConfigManager::load()
     QString path = getConfigPath();
     QFile file(path);
     if (!file.exists()) {
-        qCWarning(lcConfig) << "Config file not found, creating default:" << path;
+        qWarning() << "Config file not found, creating default:" << path;
         m_config = defaultConfig();
         save();
         return;
     }
 
     if (!file.open(QIODevice::ReadOnly)) {
-        qCWarning(lcConfig) << "Could not open config file for reading:" << path << ", using defaults";
+        qWarning() << "Could not open config file for reading:" << path << ", using defaults";
         m_config = defaultConfig();
         return;
     }
@@ -385,16 +398,16 @@ void ConfigManager::load()
     QJsonParseError parseError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &parseError);
     if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
-        qCWarning(lcConfig) << "Invalid config file (JSON parse error):" << parseError.errorString();
+        qWarning() << "Invalid config file (JSON parse error):" << parseError.errorString();
         // Backup the bad file
         QString backup = path + ".corrupt-" + QDateTime::currentDateTime().toString(Qt::ISODate);
         if (QFile::exists(backup)) {
             QFile::remove(backup);
         }
         if (!QFile::rename(path, backup)) {
-            qCWarning(lcConfig) << "Could not rename corrupt config file to backup:" << backup;
+            qWarning() << "Could not rename corrupt config file to backup:" << backup;
         } else {
-            qCWarning(lcConfig) << "Backed up corrupt config to" << backup;
+            qWarning() << "Backed up corrupt config to" << backup;
         }
         m_config = defaultConfig();
         save();
@@ -405,7 +418,7 @@ void ConfigManager::load()
 
     // Run migrations, ensure config is at the current version
     if (!migrateConfig()) {
-        qCWarning(lcConfig) << "Config migration failed -- resetting config to defaults";
+        qWarning() << "Config migration failed -- resetting config to defaults";
         QString backup = path + ".migratefail-" + QDateTime::currentDateTime().toString(Qt::ISODate);
         if (QFile::exists(backup)) QFile::remove(backup);
         QFile::rename(path, backup);
@@ -415,7 +428,7 @@ void ConfigManager::load()
     }
 
     if (!validateConfig(m_config)) {
-        qCWarning(lcConfig) << "Config failed schema validation -- resetting to defaults";
+        qWarning() << "Config failed schema validation -- resetting to defaults";
         QString backup = path + ".badschema-" + QDateTime::currentDateTime().toString(Qt::ISODate);
         if (QFile::exists(backup)) QFile::remove(backup);
         QFile::rename(path, backup);
@@ -424,7 +437,7 @@ void ConfigManager::load()
         return;
     }
 
-    qCDebug(lcConfig) << "Loaded config from" << path;
+    qDebug() << "Loaded config from" << path;
 }
 
 void ConfigManager::save()
@@ -440,7 +453,7 @@ void ConfigManager::save()
     }
 
     if (!file.open(QIODevice::WriteOnly)) {
-        qCWarning(lcConfig) << "Could not open config file for writing:" << path;
+        qWarning() << "Could not open config file for writing:" << path;
         return;
     }
     // Ensure current version and settings exist before saving
@@ -457,7 +470,7 @@ void ConfigManager::save()
 
     QJsonDocument doc(m_config);
     file.write(doc.toJson(QJsonDocument::Indented));
-    qCDebug(lcConfig) << "Saved config to" << path;
+    qDebug() << "Saved config to" << path;
 }
 
 void ConfigManager::exitApplication()
@@ -555,11 +568,76 @@ int ConfigManager::getImageCacheSizeMB() const
     }
     return 500; // Default 500MB
 }
+QString ConfigManager::getLogLevel() const
+{
+    if (m_config.contains(QStringLiteral("settings")) && m_config[QStringLiteral("settings")].isObject()) {
+        const QJsonObject settings = m_config[QStringLiteral("settings")].toObject();
+        if (settings.contains(QStringLiteral("logging")) && settings[QStringLiteral("logging")].isObject()) {
+            const QJsonObject logging = settings[QStringLiteral("logging")].toObject();
+            if (logging.contains(QStringLiteral("level"))) {
+                return normalizeLogLevelValue(logging[QStringLiteral("level")].toString());
+            }
+        }
+    }
+    return QStringLiteral("info");
+}
+
+QString ConfigManager::getQtLoggingRules() const
+{
+    if (m_config.contains(QStringLiteral("settings")) && m_config[QStringLiteral("settings")].isObject()) {
+        const QJsonObject settings = m_config[QStringLiteral("settings")].toObject();
+        if (settings.contains(QStringLiteral("logging")) && settings[QStringLiteral("logging")].isObject()) {
+            const QJsonObject logging = settings[QStringLiteral("logging")].toObject();
+            if (logging.contains(QStringLiteral("qt_rules"))) {
+                return logging[QStringLiteral("qt_rules")].toString();
+            }
+        }
+    }
+    return QString();
+}
+
+void ConfigManager::setLogLevel(const QString &level)
+{
+    const QString normalized = normalizeLogLevelValue(level);
+    if (normalized == getLogLevel()) {
+        return;
+    }
+
+    QJsonObject settings;
+    if (m_config.contains(QStringLiteral("settings")) && m_config[QStringLiteral("settings")].isObject()) {
+        settings = m_config[QStringLiteral("settings")].toObject();
+    }
+    QJsonObject logging;
+    if (settings.contains(QStringLiteral("logging")) && settings[QStringLiteral("logging")].isObject()) {
+        logging = settings[QStringLiteral("logging")].toObject();
+    }
+    logging[QStringLiteral("level")] = normalized;
+    settings[QStringLiteral("logging")] = logging;
+    m_config[QStringLiteral("settings")] = settings;
+    save();
+    applyLoggingSettings();
+    emit logLevelChanged();
+}
+
+QString ConfigManager::normalizeLogLevelValue(const QString &level) const
+{
+    return ::normalizeLogLevelValue(level);
+}
+
+void ConfigManager::applyLoggingSettings()
+{
+    LoggingConfig::apply(
+        LoggingConfig::levelFromString(getLogLevel()),
+        getQtLoggingRules(),
+        false);
+}
+
+
 
 void ConfigManager::setPlaybackCacheSizeMB(int mb)
 {
     int clamped = std::clamp(mb, 50, 2048);
-    qCDebug(lcConfig) << "ConfigManager: setPlaybackCacheSizeMB called with" << mb << "clamped to" << clamped << "current" << getPlaybackCacheSizeMB();
+    qDebug() << "ConfigManager: setPlaybackCacheSizeMB called with" << mb << "clamped to" << clamped << "current" << getPlaybackCacheSizeMB();
     if (clamped == getPlaybackCacheSizeMB()) {
         return;
     }
@@ -577,7 +655,7 @@ void ConfigManager::setPlaybackCacheSizeMB(int mb)
     m_config["settings"] = settings;
     save();
     emit playbackCacheSizeMBChanged();
-    qCDebug(lcConfig) << "ConfigManager: playbackCacheSizeMB saved as" << clamped;
+    qDebug() << "ConfigManager: playbackCacheSizeMB saved as" << clamped;
 }
 
 int ConfigManager::getPlaybackCacheSizeMB() const
@@ -593,7 +671,7 @@ int ConfigManager::getPlaybackCacheSizeMB() const
         }
     }
     int result = std::clamp(value, 50, 2048);
-    qCDebug(lcConfig) << "ConfigManager: getPlaybackCacheSizeMB returning" << result << "(raw" << value << ")";
+    qDebug() << "ConfigManager: getPlaybackCacheSizeMB returning" << result << "(raw" << value << ")";
     return result;
 }
 
@@ -729,7 +807,7 @@ QString ConfigManager::normalizePlayerBackendName(const QString &backendName) co
         return normalized;
     }
 
-    qCWarning(lcConfig) << "ConfigManager: Ignoring unknown player backend preference:" << backendName;
+    qWarning() << "ConfigManager: Ignoring unknown player backend preference:" << backendName;
     return QString();
 }
 
@@ -791,7 +869,7 @@ QString ConfigManager::getDeviceId() const
     mutableThis->m_config["settings"] = settings;
     mutableThis->save();
     
-    qCDebug(lcConfig) << "ConfigManager: Generated new device ID:" << deviceId;
+    qDebug() << "ConfigManager: Generated new device ID:" << deviceId;
     return deviceId;
 }
 
@@ -814,7 +892,7 @@ void ConfigManager::clearJellyfinSession()
         m_config["settings"] = settings;
         save();
         emit sessionChanged();
-        qCDebug(lcConfig) << "ConfigManager: Cleared Jellyfin session data";
+        qDebug() << "ConfigManager: Cleared Jellyfin session data";
     }
 }
 
@@ -1551,11 +1629,11 @@ void ConfigManager::setManualDpiScaleOverride(qreal scale)
     qreal clamped = qBound(0.5, scale, 2.0);
     
     qreal current = getManualDpiScaleOverride();
-    qCDebug(lcConfig) << "ConfigManager::setManualDpiScaleOverride called with:" << scale 
+    qDebug() << "ConfigManager::setManualDpiScaleOverride called with:" << scale 
              << "clamped to:" << clamped << "current value:" << current;
     
     if (qFuzzyCompare(clamped, current)) {
-        qCDebug(lcConfig) << "ConfigManager: Value unchanged, skipping";
+        qDebug() << "ConfigManager: Value unchanged, skipping";
         return;
     }
     
@@ -1566,7 +1644,7 @@ void ConfigManager::setManualDpiScaleOverride(qreal scale)
     settings["manualDpiScaleOverride"] = clamped;
     m_config["settings"] = settings;
     save();
-    qCDebug(lcConfig) << "ConfigManager: Emitting manualDpiScaleOverrideChanged() signal";
+    qDebug() << "ConfigManager: Emitting manualDpiScaleOverrideChanged() signal";
     emit manualDpiScaleOverrideChanged();
 }
 
@@ -2559,7 +2637,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 1) {
@@ -2567,7 +2645,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 2) {
@@ -2575,7 +2653,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 3) {
@@ -2583,7 +2661,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 4) {
@@ -2591,7 +2669,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 5) {
@@ -2599,7 +2677,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 6) {
@@ -2607,7 +2685,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 7) {
@@ -2615,7 +2693,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 8) {
@@ -2623,7 +2701,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 9) {
@@ -2631,7 +2709,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 10) {
@@ -2639,7 +2717,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 11) {
@@ -2647,7 +2725,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 12) {
@@ -2655,7 +2733,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 13) {
@@ -2663,7 +2741,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 14) {
@@ -2671,7 +2749,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 15) {
@@ -2679,7 +2757,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 16) {
@@ -2687,7 +2765,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 17) {
@@ -2695,7 +2773,7 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else if (version == 18) {
@@ -2703,11 +2781,11 @@ bool ConfigManager::migrateConfig()
             if (m_config.contains("version") && m_config["version"].isDouble()) {
                 version = m_config["version"].toInt();
             } else {
-                qCWarning(lcConfig) << "Migration produced invalid config (no version)";
+                qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
         } else {
-            qCWarning(lcConfig) << "Unknown config version during migration:" << version;
+            qWarning() << "Unknown config version during migration:" << version;
             return false;
         }
     }
@@ -2783,11 +2861,6 @@ QJsonObject ConfigManager::defaultConfig() const
     cache["rounded_image_mode"] = "auto";
     cache["rounded_preprocess_enabled"] = true;
     settings["cache"] = cache;
-
-    QJsonObject logging;
-    logging["level"] = QStringLiteral("info");
-    logging["qt_rules"] = QString();
-    settings["logging"] = logging;
 
     // UI Settings
     QJsonObject ui;
@@ -3073,7 +3146,7 @@ bool ConfigManager::deleteMpvProfile(const QString &name)
 {
     // Cannot delete built-in profiles
     if (name == "Default" || name == "High Quality") {
-        qCWarning(lcConfig) << "ConfigManager: Cannot delete built-in profile:" << name;
+        qWarning() << "ConfigManager: Cannot delete built-in profile:" << name;
         return false;
     }
     
@@ -3145,12 +3218,12 @@ void ConfigManager::setDefaultProfileName(const QString &name)
 {
     const QString trimmedName = name.trimmed();
     if (trimmedName.isEmpty()) {
-        qCWarning(lcConfig) << "ConfigManager: Ignoring empty default MPV profile name";
+        qWarning() << "ConfigManager: Ignoring empty default MPV profile name";
         return;
     }
 
     if (!getMpvProfileNames().contains(trimmedName)) {
-        qCWarning(lcConfig) << "ConfigManager: Ignoring unknown default MPV profile name:" << trimmedName;
+        qWarning() << "ConfigManager: Ignoring unknown default MPV profile name:" << trimmedName;
         return;
     }
 

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -129,7 +129,6 @@ class ConfigManager : public QObject
     Q_PROPERTY(bool autoUpdateCheckEnabled READ getAutoUpdateCheckEnabled WRITE setAutoUpdateCheckEnabled NOTIFY autoUpdateCheckEnabledChanged)
     Q_PROPERTY(QString lastUpdateCheckAt READ getLastUpdateCheckAt WRITE setLastUpdateCheckAt NOTIFY lastUpdateCheckAtChanged)
     Q_PROPERTY(QString skippedUpdateVersion READ getSkippedUpdateVersion WRITE setSkippedUpdateVersion NOTIFY skippedUpdateVersionChanged)
-    Q_PROPERTY(QString logLevel READ getLogLevel WRITE setLogLevel NOTIFY logLevelChanged)
     Q_PROPERTY(QVariantList supportedTrackLanguages READ getSupportedTrackLanguages CONSTANT)
     
 public:
@@ -363,11 +362,6 @@ public:
     QString getUsername() const;
     QString getUserId() const;
 
-    // Logging
-    QString getLogLevel() const;
-    void setLogLevel(const QString &level);
-    QString getQtLoggingRules() const;
-
     // Cache Settings
     void setImageCacheSizeMB(int mb);
     int getImageCacheSizeMB() const;
@@ -465,8 +459,12 @@ signals:
     void autoUpdateCheckEnabledChanged();
     void lastUpdateCheckAtChanged();
     void skippedUpdateVersionChanged();
+    void logLevelChanged();
 
 private:
+    QString normalizeLogLevelValue(const QString &level) const;
+    void applyLoggingSettings();
+
     QString normalizePlayerBackendName(const QString &backendName) const;
     QString normalizeRoundedMode(const QString &raw) const;
     bool envOverridesRoundedPreprocess(bool current) const;

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -362,6 +362,12 @@ public:
     QString getUsername() const;
     QString getUserId() const;
 
+    // Logging (config-only; no settings UI)
+    /// @brief Log verbosity: "info" (default), "debug", or "quiet".
+    QString getLogLevel() const;
+    /// @brief Optional Qt logging category rules appended to Bloom defaults.
+    QString getQtLoggingRules() const;
+
     // Cache Settings
     void setImageCacheSizeMB(int mb);
     int getImageCacheSizeMB() const;

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -129,6 +129,7 @@ class ConfigManager : public QObject
     Q_PROPERTY(bool autoUpdateCheckEnabled READ getAutoUpdateCheckEnabled WRITE setAutoUpdateCheckEnabled NOTIFY autoUpdateCheckEnabledChanged)
     Q_PROPERTY(QString lastUpdateCheckAt READ getLastUpdateCheckAt WRITE setLastUpdateCheckAt NOTIFY lastUpdateCheckAtChanged)
     Q_PROPERTY(QString skippedUpdateVersion READ getSkippedUpdateVersion WRITE setSkippedUpdateVersion NOTIFY skippedUpdateVersionChanged)
+    Q_PROPERTY(QString logLevel READ getLogLevel WRITE setLogLevel NOTIFY logLevelChanged)
     Q_PROPERTY(QVariantList supportedTrackLanguages READ getSupportedTrackLanguages CONSTANT)
     
 public:
@@ -362,10 +363,9 @@ public:
     QString getUsername() const;
     QString getUserId() const;
 
-    // Logging (config-only; no settings UI)
-    /// @brief Log verbosity: "info" (default), "debug", or "quiet".
+    // Logging
     QString getLogLevel() const;
-    /// @brief Optional Qt logging category rules appended to Bloom defaults.
+    void setLogLevel(const QString &level);
     QString getQtLoggingRules() const;
 
     // Cache Settings

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -129,6 +129,7 @@ class ConfigManager : public QObject
     Q_PROPERTY(bool autoUpdateCheckEnabled READ getAutoUpdateCheckEnabled WRITE setAutoUpdateCheckEnabled NOTIFY autoUpdateCheckEnabledChanged)
     Q_PROPERTY(QString lastUpdateCheckAt READ getLastUpdateCheckAt WRITE setLastUpdateCheckAt NOTIFY lastUpdateCheckAtChanged)
     Q_PROPERTY(QString skippedUpdateVersion READ getSkippedUpdateVersion WRITE setSkippedUpdateVersion NOTIFY skippedUpdateVersionChanged)
+    Q_PROPERTY(QString logLevel READ getLogLevel WRITE setLogLevel NOTIFY logLevelChanged)
     Q_PROPERTY(QVariantList supportedTrackLanguages READ getSupportedTrackLanguages CONSTANT)
     
 public:
@@ -464,8 +465,12 @@ signals:
     void autoUpdateCheckEnabledChanged();
     void lastUpdateCheckAtChanged();
     void skippedUpdateVersionChanged();
+    void logLevelChanged();
 
 private:
+    QString normalizeLogLevelValue(const QString &level) const;
+    void applyLoggingSettings();
+
     QString normalizePlayerBackendName(const QString &backendName) const;
     QString normalizeRoundedMode(const QString &raw) const;
     bool envOverridesRoundedPreprocess(bool current) const;

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -362,6 +362,11 @@ public:
     QString getUsername() const;
     QString getUserId() const;
 
+    // Logging
+    QString getLogLevel() const;
+    void setLogLevel(const QString &level);
+    QString getQtLoggingRules() const;
+
     // Cache Settings
     void setImageCacheSizeMB(int mb);
     int getImageCacheSizeMB() const;
@@ -459,12 +464,8 @@ signals:
     void autoUpdateCheckEnabledChanged();
     void lastUpdateCheckAtChanged();
     void skippedUpdateVersionChanged();
-    void logLevelChanged();
 
 private:
-    QString normalizeLogLevelValue(const QString &level) const;
-    void applyLoggingSettings();
-
     QString normalizePlayerBackendName(const QString &backendName) const;
     QString normalizeRoundedMode(const QString &raw) const;
     bool envOverridesRoundedPreprocess(bool current) const;

--- a/src/utils/DetailViewCache.cpp
+++ b/src/utils/DetailViewCache.cpp
@@ -2,6 +2,7 @@
 
 #include <QDebug>
 #include <QSaveFile>
+#include "BloomLogging.h"
 
 namespace DetailViewCache {
 
@@ -119,19 +120,19 @@ void storeObjectCache(QHash<QString, ObjectCacheEntry> &memoryCache,
 
     QSaveFile file(path);
     if (!file.open(QIODevice::WriteOnly)) {
-        qWarning() << "DetailViewCache: Failed to open object cache for write:" << path;
+        qCWarning(lcCache) << "DetailViewCache: Failed to open object cache for write:" << path;
         return;
     }
 
     const QByteArray payload = QJsonDocument(root).toJson(QJsonDocument::Compact);
     if (file.write(payload) != payload.size()) {
-        qWarning() << "DetailViewCache: Failed to write object cache:" << path;
+        qCWarning(lcCache) << "DetailViewCache: Failed to write object cache:" << path;
         file.cancelWriting();
         return;
     }
 
     if (!file.commit()) {
-        qWarning() << "DetailViewCache: Failed to commit object cache:" << path;
+        qCWarning(lcCache) << "DetailViewCache: Failed to commit object cache:" << path;
     }
 }
 
@@ -235,19 +236,19 @@ void storeArrayCache(QHash<QString, ArrayCacheEntry> &memoryCache,
 
     QSaveFile file(path);
     if (!file.open(QIODevice::WriteOnly)) {
-        qWarning() << "DetailViewCache: Failed to open array cache for write:" << path;
+        qCWarning(lcCache) << "DetailViewCache: Failed to open array cache for write:" << path;
         return;
     }
 
     const QByteArray payload = QJsonDocument(root).toJson(QJsonDocument::Compact);
     if (file.write(payload) != payload.size()) {
-        qWarning() << "DetailViewCache: Failed to write array cache:" << path;
+        qCWarning(lcCache) << "DetailViewCache: Failed to write array cache:" << path;
         file.cancelWriting();
         return;
     }
 
     if (!file.commit()) {
-        qWarning() << "DetailViewCache: Failed to commit array cache:" << path;
+        qCWarning(lcCache) << "DetailViewCache: Failed to commit array cache:" << path;
     }
 }
 

--- a/src/utils/DisplayManager.cpp
+++ b/src/utils/DisplayManager.cpp
@@ -12,9 +12,10 @@
 #include <QtConcurrent/QtConcurrent>
 #include <vector>
 
+#include "BloomLogging.h"
+
 #ifdef Q_OS_WIN
 #include <windows.h>
-#include "BloomLogging.h"
 #endif
 
 // Windows 10 SDK 10.0.26100.0+ already includes the necessary definitions.

--- a/src/utils/DisplayManager.cpp
+++ b/src/utils/DisplayManager.cpp
@@ -14,6 +14,7 @@
 
 #ifdef Q_OS_WIN
 #include <windows.h>
+#include "BloomLogging.h"
 #endif
 
 // Windows 10 SDK 10.0.26100.0+ already includes the necessary definitions.
@@ -21,8 +22,6 @@
 // but since we're targeting newer SDKs, we can rely on wingdi.h providing them.
 
 namespace {
-Q_LOGGING_CATEGORY(lcDisplayTrace, "bloom.playback.displaytrace")
-
 struct HdrAsyncFallbackResult
 {
     bool success = false;
@@ -35,7 +34,7 @@ bool runCommandAndWait(const QString &cmd, int *exitCode = nullptr)
     process.startCommand(cmd);
     const bool finished = process.waitForFinished();
     if (!finished) {
-        qWarning() << "DisplayManager: Command timed out:" << cmd;
+        qCWarning(lcDisplayTrace) << "DisplayManager: Command timed out:" << cmd;
         process.kill();
         process.waitForFinished(1000);
     }
@@ -200,7 +199,7 @@ bool setHDRWindowsImpl(bool enabled)
                            << "paths=" << numPathArrayElements
                            << "modes=" << numModeInfoArrayElements;
     if (sizeRet != ERROR_SUCCESS) {
-        qWarning() << "DisplayManager: GetDisplayConfigBufferSizes failed";
+        qCWarning(lcDisplayTrace) << "DisplayManager: GetDisplayConfigBufferSizes failed";
         return false;
     }
 
@@ -219,7 +218,7 @@ bool setHDRWindowsImpl(bool enabled)
                            << "paths=" << numPathArrayElements
                            << "modes=" << numModeInfoArrayElements;
     if (queryRet != ERROR_SUCCESS) {
-        qWarning() << "DisplayManager: QueryDisplayConfig failed";
+        qCWarning(lcDisplayTrace) << "DisplayManager: QueryDisplayConfig failed";
         return false;
     }
 
@@ -256,7 +255,7 @@ bool setHDRWindowsImpl(bool enabled)
                                << "requested=" << enabled
                                << "ret=" << ret;
         if (ret == ERROR_SUCCESS) {
-            qDebug() << "DisplayManager: Successfully set HDR to" << enabled << "for path" << i;
+            qCDebug(lcDisplayTrace) << "DisplayManager: Successfully set HDR to" << enabled << "for path" << i;
             static constexpr int kHdrSettleTimeoutMs = 5000;
             static constexpr int kHdrSettlePollMs = 50;
             const bool settled = waitForAdvancedColorState(pathArray[i], enabled, kHdrSettleTimeoutMs, kHdrSettlePollMs);
@@ -275,7 +274,7 @@ bool setHDRWindowsImpl(bool enabled)
             }
             success = true;
         } else {
-            qWarning() << "DisplayManager: Failed to set HDR for path" << i << "error:" << ret;
+            qCWarning(lcDisplayTrace) << "DisplayManager: Failed to set HDR for path" << i << "error:" << ret;
         }
     }
 
@@ -290,7 +289,7 @@ HdrAsyncFallbackResult runBlockingWindowsHdrToggle(bool enabled, const QString &
     if (!customCmdTemplate.isEmpty()) {
         QString cmd = customCmdTemplate;
         cmd.replace("{STATE}", enabled ? "on" : "off");
-        qDebug() << "DisplayManager: Executing custom Windows HDR command:" << cmd;
+        qCDebug(lcDisplayTrace) << "DisplayManager: Executing custom Windows HDR command:" << cmd;
 
         int exitCode = -1;
         result.success = runCommandAndWait(cmd, &exitCode);
@@ -307,14 +306,14 @@ HdrAsyncFallbackResult runBlockingWindowsHdrToggle(bool enabled, const QString &
 bool setHDRLinuxImpl(const QString &cmdTemplate, bool enabled)
 {
     if (cmdTemplate.isEmpty()) {
-        qWarning() << "DisplayManager: No Linux HDR command configured";
+        qCWarning(lcDisplayTrace) << "DisplayManager: No Linux HDR command configured";
         return false;
     }
 
     QString cmd = cmdTemplate;
     cmd.replace("{STATE}", enabled ? "on" : "off");
 
-    qDebug() << "DisplayManager: Executing Linux HDR command:" << cmd;
+    qCDebug(lcDisplayTrace) << "DisplayManager: Executing Linux HDR command:" << cmd;
     return runCommandAndWait(cmd);
 }
 #endif
@@ -359,13 +358,13 @@ void DisplayManager::captureOriginalRefreshRate()
     }
 #endif
     if (current <= 0.0) {
-        qWarning() << "DisplayManager: Failed to capture original refresh rate (current:" << current << ")";
+        qCWarning(lcDisplayTrace) << "DisplayManager: Failed to capture original refresh rate (current:" << current << ")";
         return;
     }
 
     m_originalRefreshRate = current;
     m_hasCapturedOriginalRefreshRate = true;
-    qDebug() << "DisplayManager: Captured original refresh rate:" << m_originalRefreshRate << "Hz";
+    qCDebug(lcDisplayTrace) << "DisplayManager: Captured original refresh rate:" << m_originalRefreshRate << "Hz";
     qCInfo(lcDisplayTrace) << "captureOriginalRefreshRate"
                            << "capturedHz=" << m_originalRefreshRate
                            << "refreshOverrideActive=" << m_refreshRateChanged;
@@ -392,30 +391,30 @@ void DisplayManager::updateHdrRestoreTracking(bool requestedState, bool preState
 
 bool DisplayManager::setRefreshRate(double hz)
 {
-    qDebug() << "DisplayManager::setRefreshRate called with hz:" << hz;
+    qCDebug(lcDisplayTrace) << "DisplayManager::setRefreshRate called with hz:" << hz;
     m_lastRefreshRateSwitchChanged = false;
     m_lastRefreshRateSwitchSkippedCompatibleMultiple = false;
     m_lastRefreshRateSwitchEffectiveRate = 0.0;
     
     if (hz <= 0) {
-        qDebug() << "DisplayManager: Invalid refresh rate" << hz << ", skipping";
+        qCDebug(lcDisplayTrace) << "DisplayManager: Invalid refresh rate" << hz << ", skipping";
         return false;
     }
     
     // Don't switch if already at target. Keep the tolerance tight so fractional
     // film modes are not confused with their neighboring integer modes.
     double current = getCurrentRefreshRate();
-    qDebug() << "DisplayManager: Current refresh rate:" << current << "Hz, target:" << hz << "Hz";
+    qCDebug(lcDisplayTrace) << "DisplayManager: Current refresh rate:" << current << "Hz, target:" << hz << "Hz";
     
     if (isCurrentRefreshAlreadyTarget(current, hz)) {
-        qDebug() << "DisplayManager: Already at target refresh rate" << current << "Hz";
+        qCDebug(lcDisplayTrace) << "DisplayManager: Already at target refresh rate" << current << "Hz";
         m_lastRefreshRateSwitchEffectiveRate = hz;
         return true;
     }
 
     if (m_config->getSkipRefreshRateOnCompatibleMultiple() && isCadenceCompatible(current, hz)) {
         const double ratio = current / hz;
-        qDebug() << "DisplayManager: Current refresh rate" << current
+        qCDebug(lcDisplayTrace) << "DisplayManager: Current refresh rate" << current
                  << "Hz is cadence-compatible with target" << hz
                  << "Hz (ratio" << ratio << "), skipping mode switch";
         m_lastRefreshRateSwitchSkippedCompatibleMultiple = true;
@@ -425,12 +424,12 @@ bool DisplayManager::setRefreshRate(double hz)
 
     if (!m_refreshRateChanged) {
         if (m_hasCapturedOriginalRefreshRate && m_originalRefreshRate > 0.0) {
-            qDebug() << "DisplayManager: Using captured original refresh rate for restore target:"
+            qCDebug(lcDisplayTrace) << "DisplayManager: Using captured original refresh rate for restore target:"
                      << m_originalRefreshRate << "Hz";
         } else {
             m_originalRefreshRate = current;
             m_hasCapturedOriginalRefreshRate = true;
-            qDebug() << "DisplayManager: Stored original refresh rate:" << m_originalRefreshRate << "Hz";
+            qCDebug(lcDisplayTrace) << "DisplayManager: Stored original refresh rate:" << m_originalRefreshRate << "Hz";
         }
     }
 
@@ -591,7 +590,7 @@ double DisplayManager::getCurrentRefreshRate()
             return static_cast<double>(dm.dmDisplayFrequency);
         }
     } else {
-        qWarning() << "DisplayManager: EnumDisplaySettings failed when reading current refresh rate";
+        qCWarning(lcDisplayTrace) << "DisplayManager: EnumDisplaySettings failed when reading current refresh rate";
     }
 #endif
 
@@ -605,14 +604,14 @@ double DisplayManager::getCurrentRefreshRate()
 #ifdef Q_OS_WIN
 bool DisplayManager::setRefreshRateWindows(double hz)
 {
-    qDebug() << "DisplayManager::setRefreshRateWindows called with hz:" << hz;
+    qCDebug(lcDisplayTrace) << "DisplayManager::setRefreshRateWindows called with hz:" << hz;
     
     DEVMODE dm;
     ZeroMemory(&dm, sizeof(dm));
     dm.dmSize = sizeof(dm);
     
     if (EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &dm)) {
-        qDebug() << "DisplayManager: Current display settings - Width:" << dm.dmPelsWidth 
+        qCDebug(lcDisplayTrace) << "DisplayManager: Current display settings - Width:" << dm.dmPelsWidth 
                  << "Height:" << dm.dmPelsHeight 
                  << "BitsPerPel:" << dm.dmBitsPerPel 
                  << "Frequency:" << dm.dmDisplayFrequency;
@@ -631,15 +630,15 @@ bool DisplayManager::setRefreshRateWindows(double hz)
         if (hz > 23.0 && hz < 24.0 && hz != 24.0) {
             // This is likely 23.976 content, try 23Hz first (how Windows reports 23.976)
             tryExactFirst = true;
-            qDebug() << "DisplayManager: Detected film framerate" << hz << ", will try 23Hz mode first";
+            qCDebug(lcDisplayTrace) << "DisplayManager: Detected film framerate" << hz << ", will try 23Hz mode first";
         } else if (hz > 29.0 && hz < 30.0 && hz != 30.0) {
             // 29.97 content
             tryExactFirst = true;
-            qDebug() << "DisplayManager: Detected 29.97 framerate, will try 29Hz mode first";
+            qCDebug(lcDisplayTrace) << "DisplayManager: Detected 29.97 framerate, will try 29Hz mode first";
         } else if (hz > 59.0 && hz < 60.0 && hz != 60.0) {
             // 59.94 content
             tryExactFirst = true;
-            qDebug() << "DisplayManager: Detected 59.94 framerate, will try 59Hz mode first";
+            qCDebug(lcDisplayTrace) << "DisplayManager: Detected 59.94 framerate, will try 59Hz mode first";
         }
         
         // Try exact truncated rate first if applicable (23 for 23.976, etc.)
@@ -649,10 +648,10 @@ bool DisplayManager::setRefreshRateWindows(double hz)
             
             LONG ret = ChangeDisplaySettingsEx(NULL, &dm, NULL, CDS_FULLSCREEN, NULL);
             if (ret == DISP_CHANGE_SUCCESSFUL) {
-                qDebug() << "DisplayManager: Successfully set refresh rate to" << exactHz << "Hz (exact match for" << hz << ")";
+                qCDebug(lcDisplayTrace) << "DisplayManager: Successfully set refresh rate to" << exactHz << "Hz (exact match for" << hz << ")";
                 return true;
             }
-            qDebug() << "DisplayManager: Exact" << exactHz << "Hz mode not available, trying" << targetHz << "Hz";
+            qCDebug(lcDisplayTrace) << "DisplayManager: Exact" << exactHz << "Hz mode not available, trying" << targetHz << "Hz";
         }
         
         // Try rounded rate
@@ -662,8 +661,8 @@ bool DisplayManager::setRefreshRateWindows(double hz)
         // Use CDS_FULLSCREEN without CDS_UPDATEREGISTRY so we can restore to registry settings later
         LONG ret = ChangeDisplaySettingsEx(NULL, &dm, NULL, CDS_FULLSCREEN, NULL);
         if (ret == DISP_CHANGE_SUCCESSFUL) {
-            qDebug() << "DisplayManager: Successfully set refresh rate to" << targetHz << "Hz";
-            qDebug() << "DisplayManager: Reported refresh after switch:" << getCurrentRefreshRate() << "Hz";
+            qCDebug(lcDisplayTrace) << "DisplayManager: Successfully set refresh rate to" << targetHz << "Hz";
+            qCDebug(lcDisplayTrace) << "DisplayManager: Reported refresh after switch:" << getCurrentRefreshRate() << "Hz";
             return true;
         } else {
             QString errorMsg;
@@ -677,10 +676,10 @@ bool DisplayManager::setRefreshRateWindows(double hz)
                 case DISP_CHANGE_RESTART: errorMsg = "RESTART (reboot required)"; break;
                 default: errorMsg = QString("Unknown error %1").arg(ret); break;
             }
-            qWarning() << "DisplayManager: Failed to set refresh rate to" << targetHz << "Hz, error:" << errorMsg;
+            qCWarning(lcDisplayTrace) << "DisplayManager: Failed to set refresh rate to" << targetHz << "Hz, error:" << errorMsg;
         }
     } else {
-        qWarning() << "DisplayManager: EnumDisplaySettings failed";
+        qCWarning(lcDisplayTrace) << "DisplayManager: EnumDisplaySettings failed";
     }
     return false;
 }
@@ -689,22 +688,22 @@ bool DisplayManager::restoreRefreshRateWindows()
 {
     const double targetHz = (m_originalRefreshRate > 0.0) ? m_originalRefreshRate : m_baselineRefreshRate;
     if (targetHz > 0.0) {
-        qDebug() << "DisplayManager: Restoring display refresh to captured original rate"
+        qCDebug(lcDisplayTrace) << "DisplayManager: Restoring display refresh to captured original rate"
                  << targetHz << "Hz";
         if (setRefreshRateWindows(targetHz)) {
             return true;
         }
-        qWarning() << "DisplayManager: Failed to restore to captured rate, falling back to registry defaults";
+        qCWarning(lcDisplayTrace) << "DisplayManager: Failed to restore to captured rate, falling back to registry defaults";
     }
 
-    qDebug() << "DisplayManager: Restoring display settings to registry defaults";
+    qCDebug(lcDisplayTrace) << "DisplayManager: Restoring display settings to registry defaults";
     LONG ret = ChangeDisplaySettingsEx(NULL, NULL, NULL, 0, NULL);
     if (ret == DISP_CHANGE_SUCCESSFUL) {
-        qDebug() << "DisplayManager: Restored display settings";
+        qCDebug(lcDisplayTrace) << "DisplayManager: Restored display settings";
         return true;
     }
 
-    qWarning() << "DisplayManager: Failed to restore display settings, error:" << ret;
+    qCWarning(lcDisplayTrace) << "DisplayManager: Failed to restore display settings, error:" << ret;
     return false;
 }
 
@@ -729,7 +728,7 @@ bool DisplayManager::startHDRAsyncWindows(bool enabled)
     UINT32 numModeInfoArrayElements = 0;
     const LONG sizeRet = GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &numPathArrayElements, &numModeInfoArrayElements);
     if (sizeRet != ERROR_SUCCESS) {
-        qWarning() << "DisplayManager: GetDisplayConfigBufferSizes failed for async HDR toggle";
+        qCWarning(lcDisplayTrace) << "DisplayManager: GetDisplayConfigBufferSizes failed for async HDR toggle";
         return false;
     }
 
@@ -742,7 +741,7 @@ bool DisplayManager::startHDRAsyncWindows(bool enabled)
                                              modeInfoArray.data(),
                                              nullptr);
     if (queryRet != ERROR_SUCCESS) {
-        qWarning() << "DisplayManager: QueryDisplayConfig failed for async HDR toggle";
+        qCWarning(lcDisplayTrace) << "DisplayManager: QueryDisplayConfig failed for async HDR toggle";
         return false;
     }
 
@@ -783,7 +782,7 @@ bool DisplayManager::startHDRAsyncWindows(bool enabled)
             m_hdrAsyncPaths.push_back(pathInfo);
         } else {
             success = false;
-            qWarning() << "DisplayManager: Failed async HDR toggle for path" << i << "error:" << ret;
+            qCWarning(lcDisplayTrace) << "DisplayManager: Failed async HDR toggle for path" << i << "error:" << ret;
         }
     }
 
@@ -819,7 +818,7 @@ bool DisplayManager::setRefreshRateLinux(double hz)
     if (cmdTemplate.isEmpty()) {
         // Default to xrandr if not configured
         // This is a naive default, users likely need to configure it
-        qWarning() << "DisplayManager: No Linux refresh rate command configured";
+        qCWarning(lcDisplayTrace) << "DisplayManager: No Linux refresh rate command configured";
         return false;
     }
     
@@ -844,7 +843,7 @@ bool DisplayManager::setRefreshRateLinux(double hz)
     cmd.replace("{RATE}", rateStr);
     cmd.replace("{RATE_INT}", QString::number(qRound(hz)));
     
-    qDebug() << "DisplayManager: Executing Linux refresh rate command:" << cmd;
+    qCDebug(lcDisplayTrace) << "DisplayManager: Executing Linux refresh rate command:" << cmd;
     
     QProcess process;
     process.startCommand(cmd);
@@ -854,7 +853,7 @@ bool DisplayManager::setRefreshRateLinux(double hz)
         return true;
     }
     
-    qWarning() << "DisplayManager: Command failed:" << process.readAllStandardError();
+    qCWarning(lcDisplayTrace) << "DisplayManager: Command failed:" << process.readAllStandardError();
     return false;
 }
 

--- a/src/utils/ExternalRatingsHelper.h
+++ b/src/utils/ExternalRatingsHelper.h
@@ -95,7 +95,7 @@ inline void fetchMdbListRatings(QNetworkAccessManager *networkManager,
                 onSuccess(doc.object().toVariantMap());
             }
         } else {
-            qWarning() << "MDBList API error:" << reply->errorString();
+            qCWarning(lcViewModels) << "MDBList API error:" << reply->errorString();
         }
     });
 }
@@ -143,7 +143,7 @@ inline void fetchAniListIdFromWikidata(QNetworkAccessManager *networkManager,
                 anilistId = binding.value("anilistId").toObject().value("value").toString();
             }
         } else {
-            qWarning() << "Wikidata query failed:" << reply->errorString();
+            qCWarning(lcViewModels) << "Wikidata query failed:" << reply->errorString();
         }
 
         if (onFinished) {
@@ -182,7 +182,7 @@ inline void queryAniListById(QNetworkAccessManager *networkManager,
         }
 
         if (reply->error() != QNetworkReply::NoError) {
-            qWarning() << "AniList API error:" << reply->errorString();
+            qCWarning(lcViewModels) << "AniList API error:" << reply->errorString();
             return;
         }
 

--- a/src/utils/ExternalRatingsHelper.h
+++ b/src/utils/ExternalRatingsHelper.h
@@ -11,6 +11,7 @@
 #include <QUrlQuery>
 #include <QVariantMap>
 #include <functional>
+#include "BloomLogging.h"
 
 namespace ExternalRatingsHelper {
 
@@ -57,11 +58,11 @@ inline void fetchMdbListRatings(QNetworkAccessManager *networkManager,
     }
 
     if (imdbId.isEmpty() && tmdbId.isEmpty()) {
-        qWarning() << "No external IDs found for MDBList lookup";
+        qCWarning(lcViewModels) << "No external IDs found for MDBList lookup";
         return;
     }
 
-    qDebug() << "Fetching MDBList ratings for IMDb:" << imdbId << "TMDB:" << tmdbId;
+    qCDebug(lcViewModels) << "Fetching MDBList ratings for IMDb:" << imdbId << "TMDB:" << tmdbId;
 
     QUrl url;
     QUrlQuery query;
@@ -72,7 +73,7 @@ inline void fetchMdbListRatings(QNetworkAccessManager *networkManager,
     } else if (!imdbId.isEmpty()) {
         url = QUrl("https://api.mdblist.com/imdb/" + imdbId);
     } else {
-        qWarning() << "No IDs for MDBList request";
+        qCWarning(lcViewModels) << "No IDs for MDBList request";
         return;
     }
 

--- a/src/utils/GpuMemoryTrimmer.cpp
+++ b/src/utils/GpuMemoryTrimmer.cpp
@@ -1,20 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "GpuMemoryTrimmer.h"
 
-#include <QLoggingCategory>
 #include <QQuickWindow>
 #include <QPixmapCache>
 
+#include "BloomLogging.h"
 #include "ConfigManager.h"
 #include "ui/ImageCacheProvider.h"
-#include "BloomLogging.h"
 
 GpuMemoryTrimmer::GpuMemoryTrimmer(ConfigManager *config,
-                                   ImageCacheProvider *lcImageCache,
+                                   ImageCacheProvider *imageCache,
                                    QObject *parent)
     : QObject(parent)
     , m_config(config)
-    , m_imageCache(lcImageCache)
+    , m_imageCache(imageCache)
 {
 }
 

--- a/src/utils/GpuMemoryTrimmer.cpp
+++ b/src/utils/GpuMemoryTrimmer.cpp
@@ -7,15 +7,14 @@
 
 #include "ConfigManager.h"
 #include "ui/ImageCacheProvider.h"
-
-Q_LOGGING_CATEGORY(lcGpuTrim, "bloom.gpu.trim")
+#include "BloomLogging.h"
 
 GpuMemoryTrimmer::GpuMemoryTrimmer(ConfigManager *config,
-                                   ImageCacheProvider *imageCache,
+                                   ImageCacheProvider *lcImageCache,
                                    QObject *parent)
     : QObject(parent)
     , m_config(config)
-    , m_imageCache(imageCache)
+    , m_imageCache(lcImageCache)
 {
 }
 

--- a/src/utils/GpuMemoryTrimmer.h
+++ b/src/utils/GpuMemoryTrimmer.h
@@ -3,15 +3,12 @@
 
 #include <QObject>
 #include <QPointer>
-#include <QLoggingCategory>
 #include <QQuickWindow>
 #include <QSGRendererInterface>
 #include <optional>
 
 class ConfigManager;
 class ImageCacheProvider;
-
-Q_DECLARE_LOGGING_CATEGORY(lcGpuTrim)
 
 /**
  * @brief Trims GPU/scenegraph usage while mpv handles playback.

--- a/src/utils/LibraryCacheStore.cpp
+++ b/src/utils/LibraryCacheStore.cpp
@@ -11,8 +11,7 @@
 #include <QFileInfo>
 #include <QMutexLocker>
 #include <QStringList>
-
-Q_LOGGING_CATEGORY(libraryCacheStore, "bloom.librarycache")
+#include "BloomLogging.h"
 
 namespace {
 constexpr const char *kDefaultConnectionName = "bloom_library_cache";
@@ -54,7 +53,7 @@ bool LibraryCacheStore::open(const QString &dbPath)
             base = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
         }
         if (base.isEmpty()) {
-            qCWarning(libraryCacheStore) << "No writable cache location available";
+            qCWarning(lcLibraryCache) << "No writable cache location available";
             return false;
         }
         m_dbPath = base + "/Bloom/library_cache.db";
@@ -62,7 +61,7 @@ bool LibraryCacheStore::open(const QString &dbPath)
 
     QDir dir(QFileInfo(m_dbPath).absolutePath());
     if (!dir.exists() && !dir.mkpath(".")) {
-        qCWarning(libraryCacheStore) << "Failed to create cache directory for" << m_dbPath;
+        qCWarning(lcLibraryCache) << "Failed to create cache directory for" << m_dbPath;
         return false;
     }
 
@@ -73,12 +72,12 @@ bool LibraryCacheStore::open(const QString &dbPath)
     m_db = QSqlDatabase::addDatabase("QSQLITE", connectionName);
     m_db.setDatabaseName(m_dbPath);
     if (!m_db.open()) {
-        qCWarning(libraryCacheStore) << "Failed to open library cache DB" << m_dbPath << m_db.lastError().text();
+        qCWarning(lcLibraryCache) << "Failed to open library cache DB" << m_dbPath << m_db.lastError().text();
         return false;
     }
 
     if (!ensureSchema()) {
-        qCWarning(libraryCacheStore) << "Failed to prepare library cache schema";
+        qCWarning(lcLibraryCache) << "Failed to prepare library cache schema";
         return false;
     }
     return true;
@@ -104,7 +103,7 @@ bool LibraryCacheStore::ensureSchema()
         )
     )");
     if (!ok) {
-        qCWarning(libraryCacheStore) << "Failed to create library_cache table" << query.lastError().text();
+        qCWarning(lcLibraryCache) << "Failed to create library_cache table" << query.lastError().text();
         return false;
     }
 
@@ -116,7 +115,7 @@ bool LibraryCacheStore::ensureSchema()
         )
     )");
     if (!ok) {
-        qCWarning(libraryCacheStore) << "Failed to create library_meta table" << query.lastError().text();
+        qCWarning(lcLibraryCache) << "Failed to create library_meta table" << query.lastError().text();
         return false;
     }
 
@@ -158,7 +157,7 @@ LibraryCacheStore::CachedSlice LibraryCacheStore::read(const QString &parentId, 
     }
 
     if (!query.exec()) {
-        qCWarning(libraryCacheStore) << "Failed to read library cache" << parentId << query.lastError().text();
+        qCWarning(lcLibraryCache) << "Failed to read library cache" << parentId << query.lastError().text();
         return slice;
     }
 
@@ -216,7 +215,7 @@ bool LibraryCacheStore::replaceAll(const QString &parentId, const QJsonArray &it
         insert.addBindValue(QJsonDocument(obj).toJson(QJsonDocument::Compact));
         insert.addBindValue(now);
         if (!insert.exec()) {
-            qCWarning(libraryCacheStore) << "Failed to insert cache row" << insert.lastError().text();
+            qCWarning(lcLibraryCache) << "Failed to insert cache row" << insert.lastError().text();
             rollbackTransaction();
             return false;
         }
@@ -231,7 +230,7 @@ bool LibraryCacheStore::replaceAll(const QString &parentId, const QJsonArray &it
     meta.addBindValue(totalCount);
     meta.addBindValue(now);
     if (!meta.exec()) {
-        qCWarning(libraryCacheStore) << "Failed to update library_meta" << meta.lastError().text();
+        qCWarning(lcLibraryCache) << "Failed to update library_meta" << meta.lastError().text();
         rollbackTransaction();
         return false;
     }
@@ -278,7 +277,7 @@ bool LibraryCacheStore::upsertItems(const QString &parentId, const QJsonArray &i
         upsert.addBindValue(QJsonDocument(obj).toJson(QJsonDocument::Compact));
         upsert.addBindValue(now);
         if (!upsert.exec()) {
-            qCWarning(libraryCacheStore) << "Failed to upsert cache row" << upsert.lastError().text();
+            qCWarning(lcLibraryCache) << "Failed to upsert cache row" << upsert.lastError().text();
             rollbackTransaction();
             return false;
         }
@@ -306,7 +305,7 @@ bool LibraryCacheStore::upsertItems(const QString &parentId, const QJsonArray &i
     meta.addBindValue(totalCount);
     meta.addBindValue(now);
     if (!meta.exec()) {
-        qCWarning(libraryCacheStore) << "Failed to update library_meta" << meta.lastError().text();
+        qCWarning(lcLibraryCache) << "Failed to update library_meta" << meta.lastError().text();
         rollbackTransaction();
         return false;
     }

--- a/src/utils/LoggingConfig.cpp
+++ b/src/utils/LoggingConfig.cpp
@@ -1,0 +1,87 @@
+#include "LoggingConfig.h"
+
+#include <QLoggingCategory>
+
+namespace LoggingConfig {
+
+namespace {
+
+QString joinRules(const QStringList &parts)
+{
+    QStringList nonEmpty;
+    for (const QString &part : parts) {
+        const QString trimmed = part.trimmed();
+        if (!trimmed.isEmpty()) {
+            nonEmpty.append(trimmed);
+        }
+    }
+    return nonEmpty.join(QLatin1Char('\n'));
+}
+
+} // namespace
+
+Level levelFromString(const QString &value)
+{
+    const QString normalized = value.trimmed().toLower();
+    if (normalized == QStringLiteral("debug") || normalized == QStringLiteral("verbose")) {
+        return Level::Debug;
+    }
+    if (normalized == QStringLiteral("quiet") || normalized == QStringLiteral("warn")
+        || normalized == QStringLiteral("warning")) {
+        return Level::Quiet;
+    }
+    return Level::Info;
+}
+
+QString defaultQtRules(Level level)
+{
+    if (level == Level::Debug) {
+        return QStringLiteral("*.debug=true\n*.info=true");
+    }
+
+    if (level == Level::Quiet) {
+        return QStringLiteral("*.debug=false\n*.info=false");
+    }
+
+    // Info: allow info/warnings globally, silence chatty debug categories.
+    return QStringLiteral(
+        "*.debug=false\n"
+        "*.info=true\n"
+        "*.warning=true\n"
+        "bloom.imagecache.debug=false\n"
+        "bloom.librarycache.debug=false\n"
+        "bloom.library.debug=false\n"
+        "bloom.playback.trace.debug=false\n"
+        "bloom.ui.scenegraph.debug=false\n"
+        "bloom.gpu.trim.debug=false\n"
+        "bloom.playback.displaytrace.debug=false\n"
+        "jellyfin.network.debug=false");
+}
+
+void apply(Level level, const QString &extraQtRules, bool forceVerbose)
+{
+    const Level effectiveLevel = forceVerbose ? Level::Debug : level;
+
+    Logger::LogLevel loggerLevel = Logger::LogLevel::Info;
+    switch (effectiveLevel) {
+    case Level::Quiet:
+        loggerLevel = Logger::LogLevel::Warning;
+        break;
+    case Level::Debug:
+        loggerLevel = Logger::LogLevel::Debug;
+        break;
+    case Level::Info:
+    default:
+        loggerLevel = Logger::LogLevel::Info;
+        break;
+    }
+
+    Logger::instance().setMinLogLevel(loggerLevel);
+
+    const QString rules = joinRules({defaultQtRules(effectiveLevel), extraQtRules});
+    if (!rules.isEmpty()) {
+        QLoggingCategory::setFilterRules(rules);
+    }
+}
+
+} // namespace LoggingConfig

--- a/src/utils/LoggingConfig.cpp
+++ b/src/utils/LoggingConfig.cpp
@@ -43,19 +43,37 @@ QString defaultQtRules(Level level)
         return QStringLiteral("*.debug=false\n*.info=false");
     }
 
-    // Info: allow info/warnings globally, silence chatty debug categories.
+    // Info: warnings/errors everywhere; suppress routine image/cache/view-model noise.
     return QStringLiteral(
         "*.debug=false\n"
         "*.info=true\n"
         "*.warning=true\n"
+        "*.critical=true\n"
         "bloom.imagecache.debug=false\n"
+        "bloom.imagecache.info=false\n"
         "bloom.librarycache.debug=false\n"
+        "bloom.librarycache.info=false\n"
+        "bloom.cache.debug=false\n"
+        "bloom.cache.info=false\n"
+        "bloom.viewmodels.debug=false\n"
+        "bloom.viewmodels.info=false\n"
         "bloom.library.debug=false\n"
+        "bloom.library.info=false\n"
+        "bloom.auth.debug=false\n"
+        "bloom.config.debug=false\n"
+        "bloom.ui.debug=false\n"
+        "bloom.playback.debug=false\n"
+        "bloom.playback.ipc.debug=false\n"
+        "bloom.playback.trickplay.debug=false\n"
         "bloom.playback.trace.debug=false\n"
+        "bloom.playback.trace.info=false\n"
+        "bloom.playback.displaytrace.debug=false\n"
+        "bloom.playback.backend.*.debug=false\n"
         "bloom.ui.scenegraph.debug=false\n"
         "bloom.gpu.trim.debug=false\n"
-        "bloom.playback.displaytrace.debug=false\n"
-        "jellyfin.network.debug=false");
+        "bloom.mediaSegments.debug=false\n"
+        "jellyfin.network.debug=false\n"
+        "bloom.test.debug=false");
 }
 
 void apply(Level level, const QString &extraQtRules, bool forceVerbose)

--- a/src/utils/LoggingConfig.h
+++ b/src/utils/LoggingConfig.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Logger.h"
+#include <QString>
+
+/**
+ * @brief Applies Bloom log level and Qt logging category filter rules.
+ *
+ * Default ("info") keeps warnings/errors visible while suppressing noisy
+ * cache, image, and trace categories. Use level "debug" or --verbose for
+ * full diagnostics. Optional rules in app.json append to the defaults.
+ */
+namespace LoggingConfig {
+
+enum class Level {
+    Quiet,  ///< Warnings and errors only
+    Info,   ///< Default: info+ without noisy debug categories
+    Debug   ///< Full verbosity (all categories)
+};
+
+Level levelFromString(const QString &value);
+
+/** Qt filter rules applied for the given level (before user overrides). */
+QString defaultQtRules(Level level);
+
+/**
+ * @brief Configure Logger minimum level and QLoggingCategory filters.
+ *
+ * @param level          Resolved log level (info unless overridden).
+ * @param extraQtRules   Optional rules from settings.logging.qt_rules (appended).
+ * @param forceVerbose   When true (--verbose), enables full debug output.
+ */
+void apply(Level level, const QString &extraQtRules = QString(), bool forceVerbose = false);
+
+} // namespace LoggingConfig

--- a/src/utils/TrackPreferencesManager.cpp
+++ b/src/utils/TrackPreferencesManager.cpp
@@ -8,6 +8,7 @@
 #include <QJsonDocument>
 #include <QSaveFile>
 #include <QTimer>
+#include "BloomLogging.h"
 
 namespace {
 constexpr auto kVersionKey = "version";
@@ -163,7 +164,7 @@ void TrackPreferencesManager::load()
     QFile file(path);
     const auto discardPersistedPreferences = [&path]() {
         if (!QFile::remove(path)) {
-            qWarning() << "TrackPreferencesManager: Failed to remove invalid preferences file:" << path;
+            qCWarning(lcConfig) << "TrackPreferencesManager: Failed to remove invalid preferences file:" << path;
         }
     };
 
@@ -171,12 +172,12 @@ void TrackPreferencesManager::load()
     m_moviePreferences.clear();
 
     if (!file.exists()) {
-        qDebug() << "TrackPreferencesManager: No preferences file found at" << path;
+        qCDebug(lcConfig) << "TrackPreferencesManager: No preferences file found at" << path;
         return;
     }
 
     if (!file.open(QIODevice::ReadOnly)) {
-        qWarning() << "TrackPreferencesManager: Failed to open preferences file:" << path;
+        qCWarning(lcConfig) << "TrackPreferencesManager: Failed to open preferences file:" << path;
         return;
     }
 
@@ -185,14 +186,14 @@ void TrackPreferencesManager::load()
     file.close();
 
     if (parseError.error != QJsonParseError::NoError) {
-        qWarning() << "TrackPreferencesManager: JSON parse error:" << parseError.errorString()
+        qCWarning(lcConfig) << "TrackPreferencesManager: JSON parse error:" << parseError.errorString()
                    << "- clearing saved track preferences";
         discardPersistedPreferences();
         return;
     }
 
     if (!document.isObject()) {
-        qWarning() << "TrackPreferencesManager: Invalid preferences format - clearing saved track preferences";
+        qCWarning(lcConfig) << "TrackPreferencesManager: Invalid preferences format - clearing saved track preferences";
         discardPersistedPreferences();
         return;
     }
@@ -200,7 +201,7 @@ void TrackPreferencesManager::load()
     const QJsonObject root = document.object();
     const int version = root.value(kVersionKey).toInt(-1);
     if (version != kCurrentSchemaVersion) {
-        qWarning() << "TrackPreferencesManager: Resetting legacy track preferences schema version"
+        qCWarning(lcConfig) << "TrackPreferencesManager: Resetting legacy track preferences schema version"
                    << version << "expected" << kCurrentSchemaVersion;
         discardPersistedPreferences();
         return;
@@ -209,7 +210,7 @@ void TrackPreferencesManager::load()
     loadPreferenceSection(root.value(kEpisodesKey).toObject(), m_episodePreferences);
     loadPreferenceSection(root.value(kMoviesKey).toObject(), m_moviePreferences);
 
-    qDebug() << "TrackPreferencesManager: Loaded preferences for"
+    qCDebug(lcConfig) << "TrackPreferencesManager: Loaded preferences for"
              << m_episodePreferences.size() << "episode scopes and"
              << m_moviePreferences.size() << "movie scopes";
 }
@@ -229,21 +230,21 @@ void TrackPreferencesManager::save()
 
     QSaveFile file(path);
     if (!file.open(QIODevice::WriteOnly)) {
-        qWarning() << "TrackPreferencesManager: Failed to save preferences to" << path;
+        qCWarning(lcConfig) << "TrackPreferencesManager: Failed to save preferences to" << path;
         scheduleRetrySave();
         return;
     }
 
     file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
     if (!file.commit()) {
-        qWarning() << "TrackPreferencesManager: Failed to commit preferences to" << path;
+        qCWarning(lcConfig) << "TrackPreferencesManager: Failed to commit preferences to" << path;
         scheduleRetrySave();
         return;
     }
 
     m_dirty = false;
     m_saveRetryAttempts = 0;
-    qDebug() << "TrackPreferencesManager: Saved preferences for"
+    qCDebug(lcConfig) << "TrackPreferencesManager: Saved preferences for"
              << m_episodePreferences.size() << "episode scopes and"
              << m_moviePreferences.size() << "movie scopes";
 }
@@ -266,7 +267,7 @@ void TrackPreferencesManager::scheduleRetrySave()
     }
 
     if (m_saveRetryAttempts >= kMaxSaveRetryAttempts) {
-        qWarning() << "TrackPreferencesManager: Giving up on autosave retries until preferences change again";
+        qCWarning(lcConfig) << "TrackPreferencesManager: Giving up on autosave retries until preferences change again";
         return;
     }
 

--- a/src/viewmodels/LibraryViewModel.cpp
+++ b/src/viewmodels/LibraryViewModel.cpp
@@ -7,6 +7,7 @@
 #include <QDateTime>
 #include <QDir>
 #include <QStandardPaths>
+#include "../utils/BloomLogging.h"
 
 // Static cache initialization
 QHash<QString, LibraryCacheEntry> LibraryViewModel::s_libraryCache;
@@ -20,7 +21,7 @@ LibraryViewModel::LibraryViewModel(QObject *parent)
     QString dbPath = cacheDbPath();
     m_cacheStore = std::make_unique<LibraryCacheStore>(dbPath, kDiskCacheTtlMs);
     if (!m_cacheStore->open()) {
-        qWarning() << "LibraryViewModel: failed to open library cache store at" << dbPath;
+        qCWarning(lcViewModels) << "LibraryViewModel: failed to open library cache store at" << dbPath;
     }
 
     if (m_libraryService) {
@@ -33,7 +34,7 @@ LibraryViewModel::LibraryViewModel(QObject *parent)
         connect(m_libraryService, &LibraryService::errorOccurred,
                 this, &LibraryViewModel::onErrorOccurred);
     } else {
-        qWarning() << "LibraryViewModel: LibraryService not available in ServiceLocator";
+        qCWarning(lcViewModels) << "LibraryViewModel: LibraryService not available in ServiceLocator";
     }
 }
 
@@ -113,7 +114,7 @@ void LibraryViewModel::loadLibrary(const QString &parentId, int startIndex, int 
         LibraryCacheEntry cached = getCachedData(parentId);
         bool isStale = !cached.isValid(kCacheTtlMs);
         
-        qDebug() << "LibraryViewModel::loadLibrary SWR" << (isStale ? "STALE" : "FRESH") 
+        qCDebug(lcViewModels) << "LibraryViewModel::loadLibrary SWR" << (isStale ? "STALE" : "FRESH") 
                  << "cache for" << parentId 
                  << "items:" << cached.items.size() << "total:" << cached.totalRecordCount;
         
@@ -130,7 +131,7 @@ void LibraryViewModel::loadLibrary(const QString &parentId, int startIndex, int 
         
         // SWR: Cache is stale - trigger background refresh
         // This won't show loading spinner, data is already displayed
-        qDebug() << "LibraryViewModel: SWR background refresh for" << parentId;
+        qCDebug(lcViewModels) << "LibraryViewModel: SWR background refresh for" << parentId;
         m_isBackgroundRefresh = true;
         m_loadTimer.restart();
         clearError();
@@ -143,7 +144,7 @@ void LibraryViewModel::loadLibrary(const QString &parentId, int startIndex, int 
     m_loadTimer.restart();
     clearError();
 
-    qDebug() << "LibraryViewModel::loadLibrary" << parentId << "startIndex:" << startIndex << "limit:" << limit << "heavyFields:" << m_lastIncludeHeavyFields;
+    qCDebug(lcViewModels) << "LibraryViewModel::loadLibrary" << parentId << "startIndex:" << startIndex << "limit:" << limit << "heavyFields:" << m_lastIncludeHeavyFields;
     m_libraryService->getItems(parentId, startIndex, limit, QStringList(), QStringList(), QString(), QString(), m_lastIncludeHeavyFields);
 }
 
@@ -164,7 +165,7 @@ void LibraryViewModel::loadViews()
     setLoading(true);
     clearError();
 
-    qDebug() << "LibraryViewModel::loadViews";
+    qCDebug(lcViewModels) << "LibraryViewModel::loadViews";
     m_libraryService->getViews();
 }
 
@@ -219,7 +220,7 @@ void LibraryViewModel::loadMore(int limit)
     clearError();
     
     int startIndex = m_items.size();
-    qDebug() << "LibraryViewModel::loadMore from index" << startIndex << "limit:" << limit;
+    qCDebug(lcViewModels) << "LibraryViewModel::loadMore from index" << startIndex << "limit:" << limit;
     
     // Store the start index for the incremental load handler
     m_lastStartIndex = startIndex;
@@ -247,7 +248,7 @@ QString LibraryViewModel::buildImageUrl(const QVariantMap &item) const
 
 void LibraryViewModel::onViewsLoaded(const QJsonArray &views)
 {
-    qDebug() << "LibraryViewModel::onViewsLoaded" << views.size() << "items, loadingViews:" << m_loadingViews;
+    qCDebug(lcViewModels) << "LibraryViewModel::onViewsLoaded" << views.size() << "items, loadingViews:" << m_loadingViews;
     
     // Always store views for Settings access (library profile assignments)
     // even if we didn't initiate the request (HomeScreen might have)
@@ -258,7 +259,7 @@ void LibraryViewModel::onViewsLoaded(const QJsonArray &views)
         QString collectionType = viewObj["CollectionType"].toString();
         // Skip "boxsets" (Collections library) - items use their home library's profile
         if (collectionType == "boxsets") {
-            qDebug() << "LibraryViewModel: Filtering out Collections library from views";
+            qCDebug(lcViewModels) << "LibraryViewModel: Filtering out Collections library from views";
             continue;
         }
         viewsList.append(viewObj.toVariantMap());
@@ -292,7 +293,7 @@ void LibraryViewModel::onItemsLoadedWithTotal(const QString &parentId, const QJs
     if (parentId != m_currentParentId)
         return;
 
-    qDebug() << "LibraryViewModel::onItemsLoadedWithTotal" << parentId << items.size() 
+    qCDebug(lcViewModels) << "LibraryViewModel::onItemsLoadedWithTotal" << parentId << items.size() 
              << "items, total:" << totalRecordCount 
              << "backgroundRefresh:" << m_isBackgroundRefresh;
     
@@ -301,7 +302,7 @@ void LibraryViewModel::onItemsLoadedWithTotal(const QString &parentId, const QJs
         setIsLoadingMore(false);
         setTotalRecordCount(totalRecordCount);
         appendItems(items);
-        qDebug() << "LibraryViewModel: loadMore completed in" << m_loadMoreTimer.elapsed() << "ms";
+        qCDebug(lcViewModels) << "LibraryViewModel: loadMore completed in" << m_loadMoreTimer.elapsed() << "ms";
         
         // Cache incremental items without rewriting the whole dataset
         QJsonArray filteredItems;
@@ -322,7 +323,7 @@ void LibraryViewModel::onItemsLoadedWithTotal(const QString &parentId, const QJs
 
         if (m_cacheStore && m_cacheStore->isOpen()) {
             if (!m_cacheStore->upsertItems(parentId, filteredItems, totalRecordCount, false, m_lastStartIndex)) {
-                qWarning() << "LibraryViewModel: failed to upsert paginated cache for" << parentId;
+                qCWarning(lcViewModels) << "LibraryViewModel: failed to upsert paginated cache for" << parentId;
             }
         }
         
@@ -331,17 +332,17 @@ void LibraryViewModel::onItemsLoadedWithTotal(const QString &parentId, const QJs
     } else if (m_isBackgroundRefresh) {
         // SWR: Background refresh completed
         m_isBackgroundRefresh = false;
-        qDebug() << "LibraryViewModel: background refresh completed in" << m_loadTimer.elapsed() << "ms";
+        qCDebug(lcViewModels) << "LibraryViewModel: background refresh completed in" << m_loadTimer.elapsed() << "ms";
         
         // Check if data actually changed
         LibraryCacheEntry cached = getCachedData(parentId);
         if (hasDataChanged(items, totalRecordCount, cached)) {
-            qDebug() << "LibraryViewModel: SWR detected changes, updating model";
+            qCDebug(lcViewModels) << "LibraryViewModel: SWR detected changes, updating model";
             setTotalRecordCount(totalRecordCount);
             updateItemsFromBackground(items);
             emit canLoadMoreChanged();
         } else {
-            qDebug() << "LibraryViewModel: SWR no changes detected, updating timestamp only";
+            qCDebug(lcViewModels) << "LibraryViewModel: SWR no changes detected, updating timestamp only";
         }
         
         // Always update cache with fresh data and timestamp
@@ -350,7 +351,7 @@ void LibraryViewModel::onItemsLoadedWithTotal(const QString &parentId, const QJs
         setLoading(false);
         setTotalRecordCount(totalRecordCount);
         setItems(items);
-        qDebug() << "LibraryViewModel: initial load completed in" << m_loadTimer.elapsed() << "ms";
+        qCDebug(lcViewModels) << "LibraryViewModel: initial load completed in" << m_loadTimer.elapsed() << "ms";
         
         // Cache the data for faster back navigation (only for initial loads)
         if (m_lastStartIndex == 0) {
@@ -368,7 +369,7 @@ void LibraryViewModel::onErrorOccurred(const QString &endpoint, const QString &e
     if (endpoint != "getViews" && endpoint != "getItems")
         return;
 
-    qWarning() << "LibraryViewModel error:" << endpoint << error;
+    qCWarning(lcViewModels) << "LibraryViewModel error:" << endpoint << error;
     setLoading(false);
     setError(mapNetworkError(endpoint, error));
     emit loadError(error);
@@ -411,7 +412,7 @@ bool LibraryViewModel::isEmptyFolder(const QJsonObject &item) const
         if (item.contains("ChildCount")) {
             int childCount = item.value("ChildCount").toInt();
             if (childCount == 0) {
-                qDebug() << "Filtering out empty" << type << ":" << item.value("Name").toString();
+                qCDebug(lcViewModels) << "Filtering out empty" << type << ":" << item.value("Name").toString();
                 return true;
             }
         }
@@ -568,7 +569,7 @@ void LibraryViewModel::updateCache(const QString &parentId, const QJsonArray &it
     
     if (m_cacheStore && m_cacheStore->isOpen()) {
         if (!m_cacheStore->replaceAll(parentId, items, totalRecordCount)) {
-            qWarning() << "LibraryViewModel: failed to persist library cache for" << parentId;
+            qCWarning(lcViewModels) << "LibraryViewModel: failed to persist library cache for" << parentId;
         }
     }
 }
@@ -589,14 +590,14 @@ void LibraryViewModel::clearAllCache()
             vm->m_cacheStore->clearAll();
         }
     }
-    qDebug() << "LibraryViewModel: Cleared all cache";
+    qCDebug(lcViewModels) << "LibraryViewModel: Cleared all cache";
 }
 
 void LibraryViewModel::invalidateCache(const QString &parentId)
 {
     if (s_libraryCache.contains(parentId)) {
         s_libraryCache.remove(parentId);
-        qDebug() << "LibraryViewModel: Invalidated cache for" << parentId;
+        qCDebug(lcViewModels) << "LibraryViewModel: Invalidated cache for" << parentId;
     }
     if (m_cacheStore && m_cacheStore->isOpen()) {
         m_cacheStore->clearParent(parentId);
@@ -629,12 +630,12 @@ bool LibraryViewModel::hasDataChanged(const QJsonArray &newItems, int newTotal, 
 {
     // Quick checks first
     if (newTotal != cached.totalRecordCount) {
-        qDebug() << "LibraryViewModel: SWR total changed" << cached.totalRecordCount << "->" << newTotal;
+        qCDebug(lcViewModels) << "LibraryViewModel: SWR total changed" << cached.totalRecordCount << "->" << newTotal;
         return true;
     }
     
     if (newItems.size() != cached.items.size()) {
-        qDebug() << "LibraryViewModel: SWR item count changed" << cached.items.size() << "->" << newItems.size();
+        qCDebug(lcViewModels) << "LibraryViewModel: SWR item count changed" << cached.items.size() << "->" << newItems.size();
         return true;
     }
     
@@ -643,7 +644,7 @@ bool LibraryViewModel::hasDataChanged(const QJsonArray &newItems, int newTotal, 
         QString newId = newItems[i].toObject().value("Id").toString();
         QString cachedId = cached.items[i].toObject().value("Id").toString();
         if (newId != cachedId) {
-            qDebug() << "LibraryViewModel: SWR item ID mismatch at" << i << ":" << cachedId << "->" << newId;
+            qCDebug(lcViewModels) << "LibraryViewModel: SWR item ID mismatch at" << i << ":" << cachedId << "->" << newId;
             return true;
         }
     }
@@ -668,5 +669,5 @@ void LibraryViewModel::updateItemsFromBackground(const QJsonArray &items)
     }
     endResetModel();
     
-    qDebug() << "LibraryViewModel: SWR updated model with" << m_items.size() << "items";
+    qCDebug(lcViewModels) << "LibraryViewModel: SWR updated model with" << m_items.size() << "items";
 }

--- a/src/viewmodels/MovieDetailsViewModel.cpp
+++ b/src/viewmodels/MovieDetailsViewModel.cpp
@@ -17,6 +17,7 @@
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QPointer>
+#include "../utils/BloomLogging.h"
 
 namespace {
 constexpr qint64 kMovieMemoryTtlMs = 5 * 60 * 1000;   // 5 minutes
@@ -70,7 +71,7 @@ MovieDetailsViewModel::MovieDetailsViewModel(QObject *parent)
                     }
                 });
     } else {
-        qWarning() << "MovieDetailsViewModel: LibraryService not available in ServiceLocator";
+        qCWarning(lcViewModels) << "MovieDetailsViewModel: LibraryService not available in ServiceLocator";
     }
 }
 
@@ -175,14 +176,14 @@ void MovieDetailsViewModel::loadMovieDetails(const QString &movieId)
     bool hasAnySimilarItems = hasFreshSimilarItems || loadSimilarItemsFromCache(movieId, cachedSimilarItems, /*requireFresh*/false);
 
     if (hasAny) {
-        qDebug() << "MovieDetailsViewModel: Serving movie details from cache"
+        qCDebug(lcViewModels) << "MovieDetailsViewModel: Serving movie details from cache"
                  << (hasFresh ? "FRESH" : "STALE");
         m_movieData = cachedMovie;
         updateMovieMetadata(cachedMovie);
     }
 
     if (hasAnySimilarItems) {
-        qDebug() << "MovieDetailsViewModel: Serving similar items from cache"
+        qCDebug(lcViewModels) << "MovieDetailsViewModel: Serving similar items from cache"
                  << (hasFreshSimilarItems ? "FRESH" : "STALE")
                  << "count:" << cachedSimilarItems.size();
         QVariantList mappedItems;
@@ -205,7 +206,7 @@ void MovieDetailsViewModel::loadMovieDetails(const QString &movieId)
     setLoading(m_loadingMovie);
     clearError();
 
-    qDebug() << "MovieDetailsViewModel::loadMovieDetails" << movieId;
+    qCDebug(lcViewModels) << "MovieDetailsViewModel::loadMovieDetails" << movieId;
     
     // Fetch from server
     // Request typical fields for details view
@@ -371,7 +372,7 @@ void MovieDetailsViewModel::onMovieDetailsNotModified(const QString &itemId)
     
     m_loadingMovie = false;
     setLoading(false);
-    qDebug() << "MovieDetailsViewModel: Movie details not modified" << itemId;
+    qCDebug(lcViewModels) << "MovieDetailsViewModel: Movie details not modified" << itemId;
 
     if (!m_similarItemsAttempted && !m_similarItemsLoading && m_libraryService) {
         m_similarItemsAttempted = true;
@@ -407,7 +408,7 @@ void MovieDetailsViewModel::onSimilarItemsFailed(const QString &itemId, const QS
         emit similarItemsLoadingChanged();
     }
 
-    qWarning() << "MovieDetailsViewModel similar items error:" << error;
+    qCWarning(lcViewModels) << "MovieDetailsViewModel similar items error:" << error;
 }
 
 void MovieDetailsViewModel::onMovieChaptersLoaded(const QString &itemId,
@@ -441,7 +442,7 @@ void MovieDetailsViewModel::onMovieChaptersFailed(const QString &itemId, const Q
     }
 
     m_pendingMovieChapterIds.remove(itemId);
-    qWarning() << "MovieDetailsViewModel movie chapters error for" << itemId << ":" << error;
+    qCWarning(lcViewModels) << "MovieDetailsViewModel movie chapters error for" << itemId << ":" << error;
 
     if (itemId == m_movieChapterId) {
         m_chapters.clear();
@@ -553,7 +554,7 @@ void MovieDetailsViewModel::fetchMdbListRatings(const QString &imdbId, const QSt
         compileRatings();
 
         const QVariantList ratingsList = m_mdbListRatings.value("ratings").toList();
-        qDebug() << "MDBList ratings updated, count:" << ratingsList.size();
+        qCDebug(lcViewModels) << "MDBList ratings updated, count:" << ratingsList.size();
     });
 }
 
@@ -594,13 +595,13 @@ void MovieDetailsViewModel::fetchAniListRating(const QString &imdbId, const QStr
     // First try mapping via Wikidata
     fetchAniListIdFromWikidata(imdbId, [this, title, year](const QString &foundId) {
         if (!foundId.isEmpty()) {
-            qDebug() << "Found AniList ID via Wikidata:" << foundId;
+            qCDebug(lcViewModels) << "Found AniList ID via Wikidata:" << foundId;
             queryAniListById(foundId);
         } else {
             // Fallback: Search by title if Wikidata fails
             // NOTE: Implementing just the Wikidata path first as it's cleaner. 
             // Title search can be fuzzy.
-            qWarning() << "No AniList ID found in Wikidata for" << title;
+            qCWarning(lcViewModels) << "No AniList ID found in Wikidata for" << title;
         }
     });
 }

--- a/src/viewmodels/SeriesDetailsViewModel.cpp
+++ b/src/viewmodels/SeriesDetailsViewModel.cpp
@@ -14,6 +14,7 @@
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QUrlQuery>
+#include "../utils/BloomLogging.h"
 
 namespace {
 constexpr qint64 kSeriesMemoryTtlMs = 5 * 60 * 1000;   // 5 minutes
@@ -485,7 +486,7 @@ SeriesDetailsViewModel::SeriesDetailsViewModel(QObject *parent)
                         // Prefetch responses should be cached but not bound to UI
                         storeItemsCache(parentId, items);
                         m_prefetchSeasonIds.remove(parentId);
-                        qDebug() << "SeriesDetailsViewModel: Prefetched episodes for season" << parentId
+                        qCDebug(lcViewModels) << "SeriesDetailsViewModel: Prefetched episodes for season" << parentId
                                  << "count:" << items.size();
                     }
                 });
@@ -518,7 +519,7 @@ SeriesDetailsViewModel::SeriesDetailsViewModel(QObject *parent)
         connect(m_libraryService, &LibraryService::errorOccurred,
                 this, &SeriesDetailsViewModel::onErrorOccurred);
     } else {
-        qWarning() << "SeriesDetailsViewModel: LibraryService not available in ServiceLocator";
+        qCWarning(lcViewModels) << "SeriesDetailsViewModel: LibraryService not available in ServiceLocator";
     }
 }
 
@@ -560,14 +561,14 @@ void SeriesDetailsViewModel::loadSeriesDetails(const QString &seriesId)
     bool hasAnySimilarItems = hasFreshSimilarItems || loadSimilarItemsFromCache(seriesId, cachedSimilarItems, /*requireFresh*/false);
 
     if (hasAnySeries) {
-        qDebug() << "SeriesDetailsViewModel: Serving series details from cache"
+        qCDebug(lcViewModels) << "SeriesDetailsViewModel: Serving series details from cache"
                  << (hasFreshSeries ? "FRESH" : "STALE");
         m_seriesData = cachedSeries;
         updateSeriesMetadata(cachedSeries);
     }
 
     if (hasAnySeasons) {
-        qDebug() << "SeriesDetailsViewModel: Serving seasons from cache"
+        qCDebug(lcViewModels) << "SeriesDetailsViewModel: Serving seasons from cache"
                  << (hasFreshSeasons ? "FRESH" : "STALE")
                  << "count:" << cachedSeasons.size();
         // Block seriesLoaded() during synchronous cache hydration; the async
@@ -578,7 +579,7 @@ void SeriesDetailsViewModel::loadSeriesDetails(const QString &seriesId)
     }
 
     if (hasAnySimilarItems) {
-        qDebug() << "SeriesDetailsViewModel: Serving similar items from cache"
+        qCDebug(lcViewModels) << "SeriesDetailsViewModel: Serving similar items from cache"
                  << (hasFreshSimilarItems ? "FRESH" : "STALE")
                  << "count:" << cachedSimilarItems.size();
         m_similarItems = DetailListHelper::mapSimilarItems(cachedSimilarItems);
@@ -593,7 +594,7 @@ void SeriesDetailsViewModel::loadSeriesDetails(const QString &seriesId)
     setLoading(m_loadingSeries || m_loadingSeasons);
     clearError();
 
-    qDebug() << "SeriesDetailsViewModel::loadSeriesDetails" << seriesId;
+    qCDebug(lcViewModels) << "SeriesDetailsViewModel::loadSeriesDetails" << seriesId;
     
     // Load series details
     m_seriesTimer.restart();
@@ -636,13 +637,13 @@ void SeriesDetailsViewModel::loadSeasonEpisodes(const QString &seasonId)
 
     // If cached data is missing special placement fields, treat as stale
     if (hasAnyEpisodes && !hasSpecialPlacementFields(cachedEpisodes)) {
-        qDebug() << "SeriesDetailsViewModel: Cached episodes missing placement fields, ignoring cache for" << seasonId;
+        qCDebug(lcViewModels) << "SeriesDetailsViewModel: Cached episodes missing placement fields, ignoring cache for" << seasonId;
         hasFreshEpisodes = false;
         hasAnyEpisodes = false;
     }
 
     if (hasAnyEpisodes) {
-        qDebug() << "SeriesDetailsViewModel: Serving episodes from cache for season"
+        qCDebug(lcViewModels) << "SeriesDetailsViewModel: Serving episodes from cache for season"
                  << seasonId << (hasFreshEpisodes ? "FRESH" : "STALE")
                  << "count:" << cachedEpisodes.size();
         m_loadingEpisodes = true;
@@ -654,7 +655,7 @@ void SeriesDetailsViewModel::loadSeasonEpisodes(const QString &seasonId)
     m_loadingEpisodes = true;
     setLoading(!hasAnyEpisodes);
 
-    qDebug() << "SeriesDetailsViewModel::loadSeasonEpisodes" << seasonId;
+    qCDebug(lcViewModels) << "SeriesDetailsViewModel::loadSeasonEpisodes" << seasonId;
     m_episodesTimer.restart();
     m_libraryService->getItems(seasonId, 0, 0, QStringList(), QStringList(), QString(), QString(), /*includeHeavyFields*/false, /*useCacheValidation*/true);
 }
@@ -681,7 +682,7 @@ void SeriesDetailsViewModel::refreshSeasonEpisodes(const QString &seasonId)
     m_loadingEpisodes = true;
     setLoading(true);
 
-    qDebug() << "SeriesDetailsViewModel::refreshSeasonEpisodes" << seasonId;
+    qCDebug(lcViewModels) << "SeriesDetailsViewModel::refreshSeasonEpisodes" << seasonId;
     m_episodesTimer.restart();
     m_libraryService->getItems(seasonId, 0, 0, QStringList(), QStringList(), QString(), QString(),
                                /*includeHeavyFields*/false, /*useCacheValidation*/false);
@@ -735,7 +736,7 @@ void SeriesDetailsViewModel::prefetchSeasonsAround(int startIndex, int radius)
             continue;
         }
 
-        qDebug() << "SeriesDetailsViewModel: Prefetching season episodes for" << seasonId;
+        qCDebug(lcViewModels) << "SeriesDetailsViewModel: Prefetching season episodes for" << seasonId;
         m_prefetchSeasonIds.insert(seasonId);
         m_libraryService->getItems(seasonId, 0, 0, QStringList(), QStringList(),
                                    QString(), QString(), /*includeHeavyFields*/false, /*useCacheValidation*/true);
@@ -748,7 +749,7 @@ void SeriesDetailsViewModel::markAsWatched()
         return;
     }
 
-    qDebug() << "SeriesDetailsViewModel::markAsWatched" << m_seriesId;
+    qCDebug(lcViewModels) << "SeriesDetailsViewModel::markAsWatched" << m_seriesId;
     m_libraryService->markSeriesWatched(m_seriesId);
 }
 
@@ -758,7 +759,7 @@ void SeriesDetailsViewModel::markAsUnwatched()
         return;
     }
 
-    qDebug() << "SeriesDetailsViewModel::markAsUnwatched" << m_seriesId;
+    qCDebug(lcViewModels) << "SeriesDetailsViewModel::markAsUnwatched" << m_seriesId;
     m_libraryService->markSeriesUnwatched(m_seriesId);
 }
 
@@ -774,7 +775,7 @@ void SeriesDetailsViewModel::toggleFavorite()
 void SeriesDetailsViewModel::loadFocusedEpisodeDetails(const QString &episodeId)
 {
     if (!m_libraryService) {
-        qWarning() << "SeriesDetailsViewModel::loadFocusedEpisodeDetails without LibraryService";
+        qCWarning(lcViewModels) << "SeriesDetailsViewModel::loadFocusedEpisodeDetails without LibraryService";
         clearFocusedEpisodeDetails();
         return;
     }
@@ -985,7 +986,7 @@ void SeriesDetailsViewModel::fetchMdbListRatings(const QString &imdbId, const QS
         compileRatings();
 
         const QVariantList ratingsList = m_mdbListRatings.value("ratings").toList();
-        qDebug() << "MDBList ratings updated, count:" << ratingsList.size();
+        qCDebug(lcViewModels) << "MDBList ratings updated, count:" << ratingsList.size();
     });
 }
 
@@ -1024,7 +1025,7 @@ void SeriesDetailsViewModel::fetchAniListRating(const QString &imdbId, const QSt
         if (!anilistId.isEmpty()) {
             queryAniListById(anilistId, requestedImdbId);
         } else {
-            qDebug() << "AniList ID not found via Wikidata";
+            qCDebug(lcViewModels) << "AniList ID not found via Wikidata";
         }
     });
 }
@@ -1046,7 +1047,7 @@ void SeriesDetailsViewModel::queryAniListById(const QString &anilistId, const QS
         const int score = (avgScore > 0) ? avgScore : meanScore;
 
         if (score > 0) {
-            qDebug() << "AniList Score found:" << score;
+            qCDebug(lcViewModels) << "AniList Score found:" << score;
 
             QVariantMap anilistRating;
             anilistRating["source"] = "AniList";
@@ -1085,7 +1086,7 @@ void SeriesDetailsViewModel::onSeriesDetailsLoaded(const QString &seriesId, cons
         return;
     }
 
-    qDebug() << "SeriesDetailsViewModel::onSeriesDetailsLoaded" << seriesId
+    qCDebug(lcViewModels) << "SeriesDetailsViewModel::onSeriesDetailsLoaded" << seriesId
              << "elapsed(ms):" << m_seriesTimer.elapsed();
     m_loadingSeries = false;
     
@@ -1115,7 +1116,7 @@ void SeriesDetailsViewModel::onSeriesDetailsNotModified(const QString &seriesId)
 
     QJsonObject cached;
     if (loadSeriesFromCache(seriesId, cached, /*requireFresh*/false)) {
-        qDebug() << "SeriesDetailsViewModel::onSeriesDetailsNotModified using cached data";
+        qCDebug(lcViewModels) << "SeriesDetailsViewModel::onSeriesDetailsNotModified using cached data";
         m_loadingSeries = false;
         m_seriesData = cached;
         updateSeriesMetadata(cached);
@@ -1130,7 +1131,7 @@ void SeriesDetailsViewModel::onSeriesDetailsNotModified(const QString &seriesId)
             emit seriesLoaded();
         }
     } else {
-        qWarning() << "SeriesDetailsViewModel::onSeriesDetailsNotModified but no cache found";
+        qCWarning(lcViewModels) << "SeriesDetailsViewModel::onSeriesDetailsNotModified but no cache found";
         setLoading(false);
     }
 }
@@ -1141,7 +1142,7 @@ void SeriesDetailsViewModel::onSeasonsLoaded(const QString &parentId, const QJso
         return;
     }
 
-    qDebug() << "SeriesDetailsViewModel::onSeasonsLoaded" << parentId << items.size()
+    qCDebug(lcViewModels) << "SeriesDetailsViewModel::onSeasonsLoaded" << parentId << items.size()
              << "seasons elapsed(ms):" << m_seasonsTimer.elapsed();
     m_loadingSeasons = false;
 
@@ -1154,7 +1155,7 @@ void SeriesDetailsViewModel::onSeasonsLoaded(const QString &parentId, const QJso
         if (item.value("Type").toString() == "Season") {
             // Filter out empty seasons (ChildCount == 0)
             if (item.contains("ChildCount") && item.value("ChildCount").toInt() == 0) {
-                qDebug() << "Filtering out empty season:" << item.value("Name").toString();
+                qCDebug(lcViewModels) << "Filtering out empty season:" << item.value("Name").toString();
                 continue;
             }
             m_seasons.append(item);
@@ -1194,20 +1195,20 @@ void SeriesDetailsViewModel::onItemsNotModified(const QString &parentId)
 {
     QJsonArray cached;
     if (!loadItemsFromCache(parentId, cached, /*requireFresh*/false)) {
-        qWarning() << "SeriesDetailsViewModel::onItemsNotModified but no cache for" << parentId;
+        qCWarning(lcViewModels) << "SeriesDetailsViewModel::onItemsNotModified but no cache for" << parentId;
         return;
     }
 
     if (parentId == m_seriesId) {
-        qDebug() << "SeriesDetailsViewModel: Seasons not modified, using cached data";
+        qCDebug(lcViewModels) << "SeriesDetailsViewModel: Seasons not modified, using cached data";
         onSeasonsLoaded(parentId, cached);
     } else if (parentId == m_selectedSeasonId) {
-        qDebug() << "SeriesDetailsViewModel: Episodes not modified, using cached data for season" << parentId;
+        qCDebug(lcViewModels) << "SeriesDetailsViewModel: Episodes not modified, using cached data for season" << parentId;
         onEpisodesLoaded(parentId, cached);
     } else if (m_prefetchSeasonIds.contains(parentId)) {
         storeItemsCache(parentId, cached);
         m_prefetchSeasonIds.remove(parentId);
-        qDebug() << "SeriesDetailsViewModel: Prefetch not modified for" << parentId;
+        qCDebug(lcViewModels) << "SeriesDetailsViewModel: Prefetch not modified for" << parentId;
     }
 }
 
@@ -1217,7 +1218,7 @@ void SeriesDetailsViewModel::onEpisodesLoaded(const QString &parentId, const QJs
         return;
     }
 
-    qDebug() << "SeriesDetailsViewModel::onEpisodesLoaded" << parentId << items.size()
+    qCDebug(lcViewModels) << "SeriesDetailsViewModel::onEpisodesLoaded" << parentId << items.size()
              << "episodes elapsed(ms):" << m_episodesTimer.elapsed();
     m_loadingEpisodes = false;
     setLoading(false);
@@ -1247,7 +1248,7 @@ void SeriesDetailsViewModel::onEpisodesLoaded(const QString &parentId, const QJs
         // Filter out missing episodes - they have LocationType == "Virtual"
         QString locationType = item.value("LocationType").toString();
         if (locationType == "Virtual") {
-            qDebug() << "Filtering out missing episode:" << item.value("Name").toString()
+            qCDebug(lcViewModels) << "Filtering out missing episode:" << item.value("Name").toString()
                      << "S" << item.value("ParentIndexNumber").toInt()
                      << "E" << item.value("IndexNumber").toInt();
             continue;
@@ -1265,7 +1266,7 @@ void SeriesDetailsViewModel::onEpisodesLoaded(const QString &parentId, const QJs
             int airsBeforeEpisode = item.contains("AirsBeforeEpisodeNumber") ? 
                                     item.value("AirsBeforeEpisodeNumber").toInt() : -1;
             
-            qDebug() << "Special episode:" << item.value("Name").toString()
+            qCDebug(lcViewModels) << "Special episode:" << item.value("Name").toString()
                      << "AirsBeforeSeason:" << airsBeforeSeason
                      << "AirsAfterSeason:" << airsAfterSeason
                      << "AirsBeforeEpisode:" << airsBeforeEpisode;
@@ -1339,7 +1340,7 @@ void SeriesDetailsViewModel::onEpisodesLoaded(const QString &parentId, const QJs
         midSeasonSpecialCount += specials.size();
     }
 
-    qDebug() << "SeriesDetailsViewModel: Final episode count:" << episodesArray.size()
+    qCDebug(lcViewModels) << "SeriesDetailsViewModel: Final episode count:" << episodesArray.size()
              << "(Regular:" << regularEpisodes.size()
              << "Specials before season:" << specialsBefore.size()
              << "Specials mid-season:" << midSeasonSpecialCount
@@ -1360,7 +1361,7 @@ void SeriesDetailsViewModel::onNextEpisodeLoaded(const QString &seriesId,
         return;
     }
 
-    qDebug() << "SeriesDetailsViewModel::onNextEpisodeLoaded" << seriesId;
+    qCDebug(lcViewModels) << "SeriesDetailsViewModel::onNextEpisodeLoaded" << seriesId;
     updateNextEpisode(episodeData);
 }
 
@@ -1373,7 +1374,7 @@ void SeriesDetailsViewModel::onNextEpisodeFailed(const QString &seriesId,
         return;
     }
 
-    qWarning() << "SeriesDetailsViewModel next episode error:" << error;
+    qCWarning(lcViewModels) << "SeriesDetailsViewModel next episode error:" << error;
 }
 
 void SeriesDetailsViewModel::onSeriesWatchedStatusChanged(const QString &seriesId)
@@ -1382,7 +1383,7 @@ void SeriesDetailsViewModel::onSeriesWatchedStatusChanged(const QString &seriesI
         return;
     }
 
-    qDebug() << "SeriesDetailsViewModel::onSeriesWatchedStatusChanged" << seriesId;
+    qCDebug(lcViewModels) << "SeriesDetailsViewModel::onSeriesWatchedStatusChanged" << seriesId;
     
     // Toggle watched state (we don't get the actual value from the signal)
     m_isWatched = !m_isWatched;
@@ -1442,7 +1443,7 @@ void SeriesDetailsViewModel::onSimilarItemsFailed(const QString &itemId, const Q
         emit similarItemsLoadingChanged();
     }
 
-    qWarning() << "SeriesDetailsViewModel similar items error:" << error;
+    qCWarning(lcViewModels) << "SeriesDetailsViewModel similar items error:" << error;
 }
 
 void SeriesDetailsViewModel::onErrorOccurred(const QString &endpoint, const QString &error)
@@ -1454,7 +1455,7 @@ void SeriesDetailsViewModel::onErrorOccurred(const QString &endpoint, const QStr
         return;
     }
 
-    qWarning() << "SeriesDetailsViewModel error:" << endpoint << error;
+    qCWarning(lcViewModels) << "SeriesDetailsViewModel error:" << endpoint << error;
     m_loadingSeries = false;
     m_loadingSeasons = false;
     m_loadingEpisodes = false;
@@ -1497,10 +1498,10 @@ void SeriesDetailsViewModel::onEpisodeDetailsNotModified(const QString &itemId,
         return;
     }
 
-    qWarning() << "SeriesDetailsViewModel::onEpisodeDetailsNotModified missing local cache for" << itemId;
+    qCWarning(lcViewModels) << "SeriesDetailsViewModel::onEpisodeDetailsNotModified missing local cache for" << itemId;
     if (itemId == m_focusedEpisodeDetailId && m_libraryService) {
         if (m_episodeDetailRetried.contains(itemId)) {
-            qWarning() << "SeriesDetailsViewModel::onEpisodeDetailsNotModified stopping repeated retry for" << itemId;
+            qCWarning(lcViewModels) << "SeriesDetailsViewModel::onEpisodeDetailsNotModified stopping repeated retry for" << itemId;
             m_episodeDetailRetried.remove(itemId);
             stopFocusedEpisodeDetailsLoadingFor(itemId);
             return;
@@ -1526,7 +1527,7 @@ void SeriesDetailsViewModel::onEpisodeDetailsFailed(const QString &itemId,
     finishEpisodeDetailsRequest(itemId);
     m_episodeDetailRetried.remove(itemId);
 
-    qWarning() << "SeriesDetailsViewModel focused episode details error for" << itemId << ":" << error;
+    qCWarning(lcViewModels) << "SeriesDetailsViewModel focused episode details error for" << itemId << ":" << error;
 
     if (itemId == m_focusedEpisodeDetailId || m_pendingEpisodeDetailIds.isEmpty()) {
         stopFocusedEpisodeDetailsLoadingFor(m_focusedEpisodeDetailId == itemId ? itemId : QString());
@@ -1565,7 +1566,7 @@ void SeriesDetailsViewModel::onFocusedEpisodeChaptersFailed(const QString &itemI
     }
 
     m_pendingEpisodeChapterIds.remove(itemId);
-    qWarning() << "SeriesDetailsViewModel focused episode chapters error for" << itemId << ":" << error;
+    qCWarning(lcViewModels) << "SeriesDetailsViewModel focused episode chapters error for" << itemId << ":" << error;
 
     if (itemId == m_focusedEpisodeChapterId) {
         m_focusedEpisodeChapters.clear();
@@ -1662,7 +1663,7 @@ void SeriesDetailsViewModel::updateSeriesMetadata(const QJsonObject &data)
     } else if (!m_title.isEmpty()) {
         // Fallback to title search if no IDs?
         // Maybe later. For now, rely on IDs.
-        qDebug() << "No IDs for MDBList, skipping.";
+        qCDebug(lcViewModels) << "No IDs for MDBList, skipping.";
     }
     
     // Trigger AniList fetch if we have IMDb ID

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,23 @@ target_link_libraries(LibraryCacheStoreTest
 
 add_test(NAME LibraryCacheStoreTest COMMAND LibraryCacheStoreTest)
 
+add_executable(LoggingConfigTest
+    LoggingConfigTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/LoggingConfig.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/Logger.cpp
+)
+
+target_include_directories(LoggingConfigTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+target_link_libraries(LoggingConfigTest
+    PRIVATE
+        Qt6::Core
+        GTest::gtest
+        GTest::gtest_main
+)
+
+add_test(NAME LoggingConfigTest COMMAND LoggingConfigTest)
+
 # Player backend abstraction tests
 add_executable(PlayerBackendFactoryTest
     PlayerBackendFactoryTest.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ add_executable(LoggingConfigTest
     LoggingConfigTest.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/LoggingConfig.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/Logger.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/BloomLogging.cpp
 )
 
 target_include_directories(LoggingConfigTest PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/tests/LoggingConfigTest.cpp
+++ b/tests/LoggingConfigTest.cpp
@@ -16,3 +16,11 @@ TEST(LoggingConfigTest, defaultQtRulesSilencesImageCacheInInfoMode)
     const QString rules = LoggingConfig::defaultQtRules(LoggingConfig::Level::Info);
     EXPECT_TRUE(rules.contains(QStringLiteral("bloom.imagecache.debug=false")));
 }
+
+
+TEST(LoggingConfigTest, defaultInfoRulesSilenceImageCacheInfo)
+{
+    const QString rules = LoggingConfig::defaultQtRules(LoggingConfig::Level::Info);
+    EXPECT_TRUE(rules.contains(QStringLiteral("bloom.imagecache.info=false")));
+    EXPECT_TRUE(rules.contains(QStringLiteral("bloom.viewmodels.info=false")));
+}

--- a/tests/LoggingConfigTest.cpp
+++ b/tests/LoggingConfigTest.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+#include "utils/LoggingConfig.h"
+
+TEST(LoggingConfigTest, levelFromStringRecognizesAliases)
+{
+    EXPECT_EQ(LoggingConfig::levelFromString(QStringLiteral("info")), LoggingConfig::Level::Info);
+    EXPECT_EQ(LoggingConfig::levelFromString(QStringLiteral("INFO")), LoggingConfig::Level::Info);
+    EXPECT_EQ(LoggingConfig::levelFromString(QStringLiteral("debug")), LoggingConfig::Level::Debug);
+    EXPECT_EQ(LoggingConfig::levelFromString(QStringLiteral("verbose")), LoggingConfig::Level::Debug);
+    EXPECT_EQ(LoggingConfig::levelFromString(QStringLiteral("quiet")), LoggingConfig::Level::Quiet);
+    EXPECT_EQ(LoggingConfig::levelFromString(QStringLiteral("unknown")), LoggingConfig::Level::Info);
+}
+
+TEST(LoggingConfigTest, defaultQtRulesSilencesImageCacheInInfoMode)
+{
+    const QString rules = LoggingConfig::defaultQtRules(LoggingConfig::Level::Info);
+    EXPECT_TRUE(rules.contains(QStringLiteral("bloom.imagecache.debug=false")));
+}

--- a/tests/LoggingConfigTest.cpp
+++ b/tests/LoggingConfigTest.cpp
@@ -15,12 +15,31 @@ TEST(LoggingConfigTest, defaultQtRulesSilencesImageCacheInInfoMode)
 {
     const QString rules = LoggingConfig::defaultQtRules(LoggingConfig::Level::Info);
     EXPECT_TRUE(rules.contains(QStringLiteral("bloom.imagecache.debug=false")));
+    EXPECT_FALSE(rules.contains(QStringLiteral("bloom.imagecache.debug=true")));
 }
-
 
 TEST(LoggingConfigTest, defaultInfoRulesSilenceImageCacheInfo)
 {
     const QString rules = LoggingConfig::defaultQtRules(LoggingConfig::Level::Info);
     EXPECT_TRUE(rules.contains(QStringLiteral("bloom.imagecache.info=false")));
     EXPECT_TRUE(rules.contains(QStringLiteral("bloom.viewmodels.info=false")));
+    EXPECT_TRUE(rules.contains(QStringLiteral("*.info=true")));
+    EXPECT_TRUE(rules.contains(QStringLiteral("*.warning=true")));
+    EXPECT_TRUE(rules.contains(QStringLiteral("*.critical=true")));
+}
+
+TEST(LoggingConfigTest, defaultDebugRulesEnableVerboseCategories)
+{
+    const QString rules = LoggingConfig::defaultQtRules(LoggingConfig::Level::Debug);
+    EXPECT_EQ(rules, QStringLiteral("*.debug=true\n*.info=true"));
+    EXPECT_FALSE(rules.contains(QStringLiteral("bloom.imagecache.debug=false")));
+    EXPECT_FALSE(rules.contains(QStringLiteral("=false")));
+}
+
+TEST(LoggingConfigTest, defaultQuietRulesDisableInfoAndDebug)
+{
+    const QString rules = LoggingConfig::defaultQtRules(LoggingConfig::Level::Quiet);
+    EXPECT_EQ(rules, QStringLiteral("*.debug=false\n*.info=false"));
+    EXPECT_FALSE(rules.contains(QStringLiteral("bloom.imagecache.debug=true")));
+    EXPECT_FALSE(rules.contains(QStringLiteral("*.info=true")));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Updates

### In-app log level selector
- **Settings → About & Account → Log Level** (below update controls, above Sign Out)
- Options: **Normal** (`info`), **Verbose** (`debug`), **Quiet** (warnings only)
- Applies immediately via `LoggingConfig::apply()` when changed
- Uses the same themed `ComboBox` pattern as Update Channel, with full keyboard/gamepad navigation

### ConfigManager
- `Q_PROPERTY(QString logLevel ...)` with get/set, persist to `settings.logging.level`
- Implemented missing `getLogLevel()` / `getQtLoggingRules()` / `setLogLevel()`

### Review fixes (previous commit)
- `--verbose` wired through to `ApplicationInitializer`
- `LoggingConfig::apply()` restored at startup
- `DisplayManager` includes `BloomLogging.h` on all platforms
- Expanded logging categories table in docs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dee3765-fcde-4b97-9863-ac9fa001206d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dee3765-fcde-4b97-9863-ac9fa001206d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add categorized Qt logging with runtime log-level control via config and UI
> - Introduces `BloomLogging.h`/`BloomLogging.cpp` to centralize all `Q_LOGGING_CATEGORY` declarations (e.g. `bloom.auth`, `bloom.playback`, `bloom.imagecache`) and migrates uncategorized `qDebug`/`qWarning` calls across the codebase to use these categories.
> - Adds `LoggingConfig` (`levelFromString`, `defaultQtRules`, `apply`) to translate a log-level string (`debug`, `info`, `quiet`) into `QLoggingCategory` filter rules applied at startup and when the level changes at runtime.
> - Extends `ConfigManager` with a `logLevel` property (`getLogLevel`/`setLogLevel`) that persists to config, applies filter rules immediately via `LoggingConfig::apply`, and emits `logLevelChanged`.
> - Adds a 'Log verbosity' combo box to the About/Account settings screen bound to `ConfigManager.logLevel`, and shows a toast when the setting is saved.
> - Adds a `--verbose`/`-v` CLI flag that forces debug-level logging at startup via `ApplicationInitializer`.
> - Behavioral Change: at the default `info` level, `bloom.imagecache` debug/info messages are now suppressed; switching to `debug` enables all `*.debug` output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9a9438.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --verbose / -v flag to enable full debug logging for a session.
  * Added a Log Level control in Settings > About Account; changes take effect immediately.

* **Documentation**
  * New docs covering logging settings, Qt logging categories, and developer logging conventions.

* **UI**
  * Settings now show a "Settings saved" toast when log level changes; improved keyboard focus/navigation around the log level control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->