### PR TITLE
(feat): ux overhaul

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ endif()
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Quick QuickControls2 Network Sql Concurrent Multimedia Test ShaderTools LinguistTools)
 find_package(Qt6 COMPONENTS MultimediaQuick QUIET)
 include(CTest)
+if(BUILD_TESTING)
+    find_package(GTest REQUIRED)
+endif()
 
 # Platform-specific secure storage dependencies
 if(UNIX AND NOT APPLE)

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN pacman -Syu --noconfirm --needed \
     sqlite \
     mpv \
     git \
+    gtest \
     libsecret \
     pkgconf
 

--- a/docs/developer_notes.md
+++ b/docs/developer_notes.md
@@ -8,6 +8,7 @@ QML & Focus
 - For keyboard/remote UX, `InputModeManager` should detect pointer vs keyboard navigation; hide cursor while navigating via keyboard.
 - Use `Qt.callLater` to restore focus after async view/model updates or cache reloads.
 - Settings UX: keep explicit `KeyNavigation`/`Keys` wiring on interactive rows and preserve the home-style rotating backdrop + gradient readability overlay used by `SettingsScreen.qml`.
+- Global app-shell shortcuts live in `Main.qml`; ESC on the root home screen opens the power menu, while deeper screens keep the normal back-stack behavior.
 
 C++ conventions
 - PascalCase class names, camelCase method names, `m_` prefix for member variables.

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -204,6 +204,7 @@ UI Components for Track Selection
   - Left group: audio/subtitle icon buttons (runtime track cycling via `PlayerController`).
   - Center group: skip back 10s, previous chapter, play/pause, next chapter, skip forward 10s.
   - Right group: volume icon button opens a native volume panel (slider + muted state) with left/right keyboard/gamepad adjustment and Enter/Space mute toggle.
+  - Direct playback shortcuts: `+`/`=` or media volume-up increases volume, `-` or media volume-down decreases volume, `V` opens the volume panel, `A` opens the audio track selector, and `S`/`T`/`C` open the subtitle selector.
   - Progress row: clickable seek track, current/total time labels, and keyboard seek via left/right.
   - Escape first dismisses visible playback chrome (full controls, seek preview, skip-intro popup, or open track/volume panels); a second Escape stops playback when the overlay is already hidden. The header back control exits playback immediately while controls are visible.
   - Trickplay preview bubble: renders processed Jellyfin trickplay thumbnails from `PlayerController` and is hidden entirely when trickplay images are unavailable.

--- a/docs/services.md
+++ b/docs/services.md
@@ -19,6 +19,7 @@ Key services
 - `TrickplayProcessor` — Uses `AuthenticationService` (network) + `PlaybackService` (tile URLs) to build trickplay binaries.
 - `ThemeSongManager` — Uses `LibraryService` for theme songs plus `ConfigManager` and `PlayerController` for state.
 - `InputModeManager` — Pointer/keyboard detection and cursor management.
+- `SystemPowerController` — QML-facing app/system power actions for the home power menu; saves config before quit/restart/shutdown requests.
 - `UpdateService` — Fetches per-channel update manifests, determines whether an update is available, gates the startup-only popup, and exposes update actions/state to QML.
 
 Initialization order (recommended)
@@ -37,8 +38,9 @@ Initialization order (recommended)
 13. ViewModels — e.g., LibraryViewModel, SeriesDetailsViewModel (depend on LibraryService).
 14. SidebarSettings — UI preference persistence for the shell/sidebar state.
 15. UiSoundController — depends on ConfigManager for UI sound settings.
-16. SessionManager — shared session reporting/coordination service.
-17. UpdateService — depends on ConfigManager and PlayerController, and owns the current update provider/applier wiring.
+16. SystemPowerController — depends on ConfigManager for pre-action config saves and is exposed to QML.
+17. SessionManager — shared session reporting/coordination service.
+18. UpdateService — depends on ConfigManager and PlayerController, and owns the current update provider/applier wiring.
 
 Usage
 - Register services at main startup using `ServiceLocator::registerService<T>(&instance);`.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,8 @@ qt_add_executable(Bloom
     utils/DisplayManager.h
     utils/SidebarSettings.h
     utils/SidebarSettings.cpp
+    utils/SystemPowerController.h
+    utils/SystemPowerController.cpp
     utils/GpuMemoryTrimmer.h
     utils/GpuMemoryTrimmer.cpp
     utils/Logger.h

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -21,6 +21,7 @@
 #include "viewmodels/MovieDetailsViewModel.h"
 #include "viewmodels/UpNextRecommendationsViewModel.h"
 #include "utils/SidebarSettings.h"
+#include "utils/SystemPowerController.h"
 #include "ui/UiSoundController.h"
 #include "utils/GpuMemoryTrimmer.h"
 #include "utils/Logger.h"
@@ -275,6 +276,10 @@ void ApplicationInitializer::registerServices()
     // 9. UI Sound Controller
     m_uiSoundController = std::make_unique<UiSoundController>(m_configManager.get());
     ServiceLocator::registerService<UiSoundController>(m_uiSoundController.get());
+
+    // 9.5 System power/controller actions exposed to the home power menu
+    m_systemPowerController = std::make_unique<SystemPowerController>(m_configManager.get());
+    ServiceLocator::registerService<SystemPowerController>(m_systemPowerController.get());
 
     // 10. SessionManager - Depends on ConfigManager and SecretStore
     m_sessionManager = std::make_unique<SessionManager>(m_configManager.get(), m_secretStore.get());

--- a/src/core/ApplicationInitializer.h
+++ b/src/core/ApplicationInitializer.h
@@ -25,6 +25,7 @@ class UpNextRecommendationsViewModel;
 class ISecretStore;
 class SidebarSettings;
 class UiSoundController;
+class SystemPowerController;
 class SessionManager;
 class SessionService;
 class UpdateService;
@@ -115,6 +116,7 @@ private:
     std::unique_ptr<UpNextRecommendationsViewModel> m_upNextRecommendationsViewModel;
     std::unique_ptr<SidebarSettings> m_sidebarSettings;
     std::unique_ptr<UiSoundController> m_uiSoundController;
+    std::unique_ptr<SystemPowerController> m_systemPowerController;
     std::unique_ptr<SessionManager> m_sessionManager;
     std::unique_ptr<SessionService> m_sessionService;
     std::unique_ptr<UpdateService> m_updateService;

--- a/src/ui/EmbeddedPlaybackOverlay.qml
+++ b/src/ui/EmbeddedPlaybackOverlay.qml
@@ -391,16 +391,25 @@ FocusScope {
         }
 
         if (event.key === Qt.Key_V) {
+            if (event.isAutoRepeat) {
+                return true
+            }
             openVolumeSelector()
             return true
         }
 
         if (event.key === Qt.Key_A) {
+            if (event.isAutoRepeat) {
+                return true
+            }
             openAudioSelector()
             return true
         }
 
         if (event.key === Qt.Key_S || event.key === Qt.Key_T || event.key === Qt.Key_C) {
+            if (event.isAutoRepeat) {
+                return true
+            }
             openSubtitleSelector()
             return true
         }

--- a/src/ui/EmbeddedPlaybackOverlay.qml
+++ b/src/ui/EmbeddedPlaybackOverlay.qml
@@ -372,6 +372,43 @@ FocusScope {
         showControls()
     }
 
+    function handlePlaybackShortcut(event) {
+        if (!overlayActive) {
+            return false
+        }
+
+        if (event.key === Qt.Key_Plus
+                || event.key === Qt.Key_Equal
+                || event.key === Qt.Key_VolumeUp) {
+            adjustVolumeBy(5)
+            return true
+        }
+
+        if (event.key === Qt.Key_Minus
+                || event.key === Qt.Key_Underscore
+                || event.key === Qt.Key_VolumeDown) {
+            adjustVolumeBy(-5)
+            return true
+        }
+
+        if (event.key === Qt.Key_V) {
+            openVolumeSelector()
+            return true
+        }
+
+        if (event.key === Qt.Key_A) {
+            openAudioSelector()
+            return true
+        }
+
+        if (event.key === Qt.Key_S || event.key === Qt.Key_T || event.key === Qt.Key_C) {
+            openSubtitleSelector()
+            return true
+        }
+
+        return false
+    }
+
     function handleDirectionalKey(direction) {
         if (!overlayActive) {
             return false
@@ -680,6 +717,10 @@ FocusScope {
                 && (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Space)) {
             event.accepted = true
             root.triggerActiveSkip()
+            return
+        }
+        if (root.handlePlaybackShortcut(event)) {
+            event.accepted = true
             return
         }
         if (event.key === Qt.Key_Left) {

--- a/src/ui/EmbeddedPlaybackOverlay.qml
+++ b/src/ui/EmbeddedPlaybackOverlay.qml
@@ -385,7 +385,6 @@ FocusScope {
         }
 
         if (event.key === Qt.Key_Minus
-                || event.key === Qt.Key_Underscore
                 || event.key === Qt.Key_VolumeDown) {
             adjustVolumeBy(-5)
             return true

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -101,6 +101,21 @@ Window {
         })
     }
 
+    function isOnRootHomeScreen() {
+        var item = stackView.currentItem
+        return isLoggedIn
+                && stackView.depth === 1
+                && item
+                && item["navigationId"] === "home"
+    }
+
+    function openHomePowerMenu() {
+        if (!isOnRootHomeScreen() || homePowerDialog.opened) {
+            return
+        }
+        homePowerDialog.open()
+    }
+
     function ensurePlaybackOverlayFocus() {
         if (!embeddedPlaybackActive) {
             return
@@ -375,6 +390,185 @@ Window {
         id: mediaSourceSelectionDialogLoader
         active: false
         sourceComponent: MediaSourceSelectionDialog {
+        }
+    }
+
+    component PowerMenuButton: Button {
+        id: powerMenuButton
+        property string iconText: ""
+        property bool destructive: false
+        Layout.fillWidth: true
+        Layout.preferredHeight: Math.round(64 * Theme.layoutScale)
+        focusPolicy: Qt.StrongFocus
+        activeFocusOnTab: true
+        leftPadding: Math.round(18 * Theme.layoutScale)
+        rightPadding: Math.round(18 * Theme.layoutScale)
+
+        Keys.onReturnPressed: function(event) {
+            event.accepted = true
+            clicked()
+        }
+        Keys.onEnterPressed: function(event) {
+            event.accepted = true
+            clicked()
+        }
+        Keys.onSpacePressed: function(event) {
+            event.accepted = true
+            clicked()
+        }
+
+        contentItem: RowLayout {
+            spacing: Math.round(14 * Theme.layoutScale)
+
+            Text {
+                text: powerMenuButton.iconText
+                font.family: Theme.fontIcon
+                font.pixelSize: Math.round(28 * Theme.layoutScale)
+                color: powerMenuButton.destructive ? Theme.errorColor : Theme.textPrimary
+                Layout.alignment: Qt.AlignVCenter
+            }
+
+            Text {
+                text: powerMenuButton.text
+                font.family: Theme.fontPrimary
+                font.pixelSize: Theme.fontSizeBody
+                font.weight: Font.DemiBold
+                color: Theme.textPrimary
+                elide: Text.ElideRight
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignVCenter
+            }
+        }
+
+        background: Rectangle {
+            radius: Theme.radiusSmall
+            color: {
+                if (powerMenuButton.down) return Theme.buttonSecondaryBackgroundPressed
+                if (powerMenuButton.hovered || powerMenuButton.activeFocus) return Theme.buttonSecondaryBackgroundHover
+                return Theme.buttonSecondaryBackground
+            }
+            border.width: powerMenuButton.activeFocus ? Theme.buttonFocusBorderWidth : 1
+            border.color: powerMenuButton.activeFocus ? Theme.focusBorder : Theme.buttonSecondaryBorder
+        }
+    }
+
+    Dialog {
+        id: homePowerDialog
+        parent: Overlay.overlay
+        modal: true
+        focus: true
+        anchors.centerIn: parent
+        width: Math.min(Math.round(430 * Theme.layoutScale),
+                        Math.max(0, window.width - (Theme.spacingLarge * 2)))
+        padding: Theme.spacingLarge
+
+        function restoreHomeFocus() {
+            Qt.callLater(function() {
+                var item = stackView.currentItem
+                if (item && item.visible && typeof item["restoreFocusState"] === "function") {
+                    item["restoreFocusState"]()
+                } else if (item && typeof item["forceActiveFocus"] === "function") {
+                    item.forceActiveFocus()
+                }
+            })
+        }
+
+        function runPowerAction(action) {
+            if (action()) {
+                close()
+                return
+            }
+            if (SystemPowerController.lastError.length > 0) {
+                toast.show(SystemPowerController.lastError)
+            }
+        }
+
+        onOpened: Qt.callLater(function() { quitButton.forceActiveFocus() })
+        onClosed: restoreHomeFocus()
+        onRejected: close()
+
+        Keys.onPressed: function(event) {
+            if (event.key === Qt.Key_Escape || event.key === Qt.Key_Back || event.key === Qt.Key_Backspace) {
+                event.accepted = true
+                close()
+            }
+        }
+
+        background: Rectangle {
+            color: Theme.cardBackground
+            radius: Theme.radiusMedium
+            border.color: Theme.cardBorder
+            border.width: 1
+        }
+
+        header: Item {
+            implicitHeight: powerHeaderColumn.implicitHeight + (Theme.spacingLarge * 2)
+
+            Column {
+                id: powerHeaderColumn
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.margins: Theme.spacingLarge
+                spacing: Theme.spacingSmall
+
+                Text {
+                    text: qsTr("Power")
+                    font.family: Theme.fontPrimary
+                    font.pixelSize: Theme.fontSizeTitle
+                    font.weight: Font.DemiBold
+                    color: Theme.textPrimary
+                }
+
+                Text {
+                    width: parent.width
+                    text: qsTr("Choose an action for this session.")
+                    font.family: Theme.fontPrimary
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.textSecondary
+                    wrapMode: Text.WordWrap
+                }
+            }
+        }
+
+        contentItem: ColumnLayout {
+            spacing: Theme.spacingSmall
+
+            PowerMenuButton {
+                id: quitButton
+                text: qsTr("Quit")
+                iconText: Icons.close
+                KeyNavigation.down: restartAppButton
+                onClicked: homePowerDialog.runPowerAction(function() { return SystemPowerController.quitApplication() })
+            }
+
+            PowerMenuButton {
+                id: restartAppButton
+                text: qsTr("Restart App")
+                iconText: Icons.refresh
+                KeyNavigation.up: quitButton
+                KeyNavigation.down: restartPcButton
+                onClicked: homePowerDialog.runPowerAction(function() { return SystemPowerController.restartApplication() })
+            }
+
+            PowerMenuButton {
+                id: restartPcButton
+                text: qsTr("Restart PC")
+                iconText: Icons.refresh
+                destructive: true
+                KeyNavigation.up: restartAppButton
+                KeyNavigation.down: shutdownButton
+                onClicked: homePowerDialog.runPowerAction(function() { return SystemPowerController.restartComputer() })
+            }
+
+            PowerMenuButton {
+                id: shutdownButton
+                text: qsTr("Shutdown")
+                iconText: Icons.power
+                destructive: true
+                KeyNavigation.up: restartPcButton
+                onClicked: homePowerDialog.runPowerAction(function() { return SystemPowerController.shutdownComputer() })
+            }
         }
     }
 
@@ -1248,6 +1442,19 @@ Window {
                 stackView.pop()
                 Qt.callLater(updateSidebarNavigation)
             }
+        }
+    }
+
+    Shortcut {
+        sequences: ["Esc"]
+        enabled: !PlayerController.isPlaybackActive
+                 && isOnRootHomeScreen()
+                 && !sidebarProxy.expanded
+                 && !homePowerDialog.opened
+                 && !(updateDialogLoader.item && updateDialogLoader.item.visible)
+        onActivated: {
+            if (InputModeManager.pointerActive) UiSoundController.playBack()
+            openHomePowerMenu()
         }
     }
     

--- a/src/ui/WindowManager.cpp
+++ b/src/ui/WindowManager.cpp
@@ -6,6 +6,7 @@
 #include "utils/DisplayManager.h"
 #include "ui/ResponsiveLayoutManager.h"
 #include "utils/SidebarSettings.h"
+#include "utils/SystemPowerController.h"
 #include "utils/InputModeManager.h"
 #include "ui/UiSoundController.h"
 #include "player/PlayerController.h"
@@ -156,6 +157,7 @@ void WindowManager::exposeContextProperties(ApplicationInitializer& appInit)
     context->setContextProperty("ResponsiveLayoutManager", ServiceLocator::get<ResponsiveLayoutManager>());
     
     context->setContextProperty("UiSoundController", ServiceLocator::get<UiSoundController>());
+    context->setContextProperty("SystemPowerController", ServiceLocator::get<SystemPowerController>());
 
     context->setContextProperty("AuthenticationService", ServiceLocator::get<AuthenticationService>());
     context->setContextProperty("LibraryService", ServiceLocator::get<LibraryService>());

--- a/src/utils/SystemPowerController.cpp
+++ b/src/utils/SystemPowerController.cpp
@@ -90,7 +90,12 @@ bool SystemPowerController::runCheckedPowerCommand(const QString& program, const
         return false;
     }
 
-    if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0) {
+    if (process.exitStatus() == QProcess::CrashExit) {
+        setLastError(tr("%1 crashed before completing the power request.").arg(program));
+        return false;
+    }
+
+    if (process.exitCode() != 0) {
         QString detail = QString::fromLocal8Bit(process.readAllStandardError()).trimmed();
         if (detail.isEmpty()) {
             detail = QString::fromLocal8Bit(process.readAllStandardOutput()).trimmed();
@@ -106,9 +111,6 @@ bool SystemPowerController::runCheckedPowerCommand(const QString& program, const
 
 void SystemPowerController::setLastError(const QString& error)
 {
-    if (m_lastError == error) {
-        return;
-    }
     m_lastError = error;
     emit lastErrorChanged();
 }

--- a/src/utils/SystemPowerController.cpp
+++ b/src/utils/SystemPowerController.cpp
@@ -35,12 +35,17 @@ bool SystemPowerController::restartApplication()
         arguments.removeFirst();
     }
 
+    if (m_configManager) {
+        m_configManager->save();
+    }
+
     if (!QProcess::startDetached(program, arguments, QDir::currentPath())) {
         setLastError(tr("Failed to launch a new Bloom process."));
         return false;
     }
 
-    return quitApplication();
+    QCoreApplication::quit();
+    return true;
 }
 
 bool SystemPowerController::restartComputer()

--- a/src/utils/SystemPowerController.cpp
+++ b/src/utils/SystemPowerController.cpp
@@ -1,0 +1,89 @@
+#include "SystemPowerController.h"
+
+#include "utils/ConfigManager.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QProcess>
+
+SystemPowerController::SystemPowerController(ConfigManager* configManager,
+                                             QObject* parent)
+    : QObject(parent)
+    , m_configManager(configManager)
+{
+}
+
+bool SystemPowerController::quitApplication()
+{
+    if (m_configManager) {
+        m_configManager->save();
+    }
+    QCoreApplication::quit();
+    return true;
+}
+
+bool SystemPowerController::restartApplication()
+{
+    const QString program = QCoreApplication::applicationFilePath();
+    if (program.isEmpty()) {
+        setLastError(tr("Cannot restart Bloom because the executable path is unavailable."));
+        return false;
+    }
+
+    QStringList arguments = QCoreApplication::arguments();
+    if (!arguments.isEmpty()) {
+        arguments.removeFirst();
+    }
+
+    if (!QProcess::startDetached(program, arguments, QDir::currentPath())) {
+        setLastError(tr("Failed to launch a new Bloom process."));
+        return false;
+    }
+
+    return quitApplication();
+}
+
+bool SystemPowerController::restartComputer()
+{
+#if defined(Q_OS_WIN)
+    return startDetached(QStringLiteral("shutdown"), { QStringLiteral("/r"), QStringLiteral("/t"), QStringLiteral("0") });
+#elif defined(Q_OS_MACOS)
+    return startDetached(QStringLiteral("/sbin/shutdown"), { QStringLiteral("-r"), QStringLiteral("now") });
+#else
+    return startDetached(QStringLiteral("systemctl"), { QStringLiteral("reboot") });
+#endif
+}
+
+bool SystemPowerController::shutdownComputer()
+{
+#if defined(Q_OS_WIN)
+    return startDetached(QStringLiteral("shutdown"), { QStringLiteral("/s"), QStringLiteral("/t"), QStringLiteral("0") });
+#elif defined(Q_OS_MACOS)
+    return startDetached(QStringLiteral("/sbin/shutdown"), { QStringLiteral("-h"), QStringLiteral("now") });
+#else
+    return startDetached(QStringLiteral("systemctl"), { QStringLiteral("poweroff") });
+#endif
+}
+
+bool SystemPowerController::startDetached(const QString& program, const QStringList& arguments)
+{
+    if (m_configManager) {
+        m_configManager->save();
+    }
+
+    if (QProcess::startDetached(program, arguments)) {
+        return true;
+    }
+
+    setLastError(tr("Failed to start %1.").arg(program));
+    return false;
+}
+
+void SystemPowerController::setLastError(const QString& error)
+{
+    if (m_lastError == error) {
+        return;
+    }
+    m_lastError = error;
+    emit lastErrorChanged();
+}

--- a/src/utils/SystemPowerController.cpp
+++ b/src/utils/SystemPowerController.cpp
@@ -51,37 +51,57 @@ bool SystemPowerController::restartApplication()
 bool SystemPowerController::restartComputer()
 {
 #if defined(Q_OS_WIN)
-    return startDetached(QStringLiteral("shutdown"), { QStringLiteral("/r"), QStringLiteral("/t"), QStringLiteral("0") });
+    return runCheckedPowerCommand(QStringLiteral("shutdown"), { QStringLiteral("/r"), QStringLiteral("/t"), QStringLiteral("0") });
 #elif defined(Q_OS_MACOS)
-    return startDetached(QStringLiteral("/sbin/shutdown"), { QStringLiteral("-r"), QStringLiteral("now") });
+    return runCheckedPowerCommand(QStringLiteral("/sbin/shutdown"), { QStringLiteral("-r"), QStringLiteral("now") });
 #else
-    return startDetached(QStringLiteral("systemctl"), { QStringLiteral("reboot") });
+    return runCheckedPowerCommand(QStringLiteral("systemctl"), { QStringLiteral("reboot") });
 #endif
 }
 
 bool SystemPowerController::shutdownComputer()
 {
 #if defined(Q_OS_WIN)
-    return startDetached(QStringLiteral("shutdown"), { QStringLiteral("/s"), QStringLiteral("/t"), QStringLiteral("0") });
+    return runCheckedPowerCommand(QStringLiteral("shutdown"), { QStringLiteral("/s"), QStringLiteral("/t"), QStringLiteral("0") });
 #elif defined(Q_OS_MACOS)
-    return startDetached(QStringLiteral("/sbin/shutdown"), { QStringLiteral("-h"), QStringLiteral("now") });
+    return runCheckedPowerCommand(QStringLiteral("/sbin/shutdown"), { QStringLiteral("-h"), QStringLiteral("now") });
 #else
-    return startDetached(QStringLiteral("systemctl"), { QStringLiteral("poweroff") });
+    return runCheckedPowerCommand(QStringLiteral("systemctl"), { QStringLiteral("poweroff") });
 #endif
 }
 
-bool SystemPowerController::startDetached(const QString& program, const QStringList& arguments)
+bool SystemPowerController::runCheckedPowerCommand(const QString& program, const QStringList& arguments)
 {
     if (m_configManager) {
         m_configManager->save();
     }
 
-    if (QProcess::startDetached(program, arguments)) {
-        return true;
+    QProcess process;
+    process.start(program, arguments);
+    if (!process.waitForStarted(3000)) {
+        setLastError(tr("Failed to start %1: %2").arg(program, process.errorString()));
+        return false;
     }
 
-    setLastError(tr("Failed to start %1.").arg(program));
-    return false;
+    if (!process.waitForFinished(5000)) {
+        process.kill();
+        process.waitForFinished(1000);
+        setLastError(tr("%1 did not finish. Check system power permissions.").arg(program));
+        return false;
+    }
+
+    if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0) {
+        QString detail = QString::fromLocal8Bit(process.readAllStandardError()).trimmed();
+        if (detail.isEmpty()) {
+            detail = QString::fromLocal8Bit(process.readAllStandardOutput()).trimmed();
+        }
+        setLastError(detail.isEmpty()
+                         ? tr("%1 failed with exit code %2.").arg(program).arg(process.exitCode())
+                         : detail);
+        return false;
+    }
+
+    return true;
 }
 
 void SystemPowerController::setLastError(const QString& error)

--- a/src/utils/SystemPowerController.h
+++ b/src/utils/SystemPowerController.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+class ConfigManager;
+
+class SystemPowerController : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString lastError READ lastError NOTIFY lastErrorChanged)
+
+public:
+    explicit SystemPowerController(ConfigManager* configManager, QObject* parent = nullptr);
+
+    QString lastError() const { return m_lastError; }
+
+    Q_INVOKABLE bool quitApplication();
+    Q_INVOKABLE bool restartApplication();
+    Q_INVOKABLE bool restartComputer();
+    Q_INVOKABLE bool shutdownComputer();
+
+signals:
+    void lastErrorChanged();
+
+private:
+    bool startDetached(const QString& program, const QStringList& arguments);
+    void setLastError(const QString& error);
+
+    ConfigManager* m_configManager = nullptr;
+    QString m_lastError;
+};

--- a/src/utils/SystemPowerController.h
+++ b/src/utils/SystemPowerController.h
@@ -25,7 +25,7 @@ signals:
     void lastErrorChanged();
 
 private:
-    bool startDetached(const QString& program, const QStringList& arguments);
+    bool runCheckedPowerCommand(const QString& program, const QStringList& arguments);
     void setLastError(const QString& error);
 
     ConfigManager* m_configManager = nullptr;


### PR DESCRIPTION
## Summary
- Add direct playback keyboard shortcuts for volume, audio tracks, and subtitle tracks.
- Add an ESC-triggered power menu on the root home screen with quit, app restart, PC restart, and shutdown actions.
- Expose a small `SystemPowerController` service to QML and document the new UX behavior.
- Restore the canonical Docker build by installing `gtest` in the build image and declaring the `GTest` CMake dependency when tests are enabled.

## Validation
- `./scripts/build-docker.sh`
- `docker run --rm --network=host -v "$(pwd):/workspace" bloom-build bash -c 'cd /workspace/build-docker && cmake .. -G Ninja -DBUILD_TESTING=OFF && ninja'`
- `docker run --rm -v "$(pwd):/workspace" bloom-build bash -c '/usr/lib/qt6/bin/qmllint -I /workspace/build-docker/src -I /usr/lib/qt6/qml /workspace/build-docker/src/BloomUI/ui/Main.qml /workspace/build-docker/src/BloomUI/ui/EmbeddedPlaybackOverlay.qml'`
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add power menu and keyboard shortcuts to the home screen and playback overlay
> - Adds a new `SystemPowerController` service ([SystemPowerController.cpp](https://github.com/crowquillx/Bloom/pull/61/files#diff-85b728231c1584a14736c93790b9299040fbb14803423f6dc3edb184b88b5a2e)) that exposes quit, restart app, restart PC, and shutdown actions to QML, saving config before executing and reporting errors via `lastError`.
> - Pressing `Esc` on the root home screen (when no sidebar, playback, or dialog is active) opens a modal power dialog in [Main.qml](https://github.com/crowquillx/Bloom/pull/61/files#diff-f4773d055809f8f8ae1877220a16747bc781215089a7b6b7eb33e5b444a27be5) with the four power actions.
> - Adds keyboard/media-key shortcuts to [EmbeddedPlaybackOverlay.qml](https://github.com/crowquillx/Bloom/pull/61/files#diff-751291eab37e3edc8b0215dfcbffd3d478827844a1f97a824910affa2af6a216): `+`/`-`/volume keys adjust volume by 5, and `V`/`A`/`S` open the volume, audio, and subtitle selectors.
> - `SystemPowerController` is registered at startup in [ApplicationInitializer.cpp](https://github.com/crowquillx/Bloom/pull/61/files#diff-15dbb3ebfdab20dc6f9ae86dcfaf00df3fae5b3cfe7398e389199ab24cf590dc) and exposed to QML as a context property via [WindowManager.cpp](https://github.com/crowquillx/Bloom/pull/61/files#diff-fcbb6b32484cdf7bd19ce605a85ff71eebcb965c693809ce7fbc02d35e15f785).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edbf9ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->