### PR TITLE
feat: add screensaver

### DIFF
--- a/.github/actions/setup-nsis/action.yml
+++ b/.github/actions/setup-nsis/action.yml
@@ -1,5 +1,5 @@
 name: Setup NSIS
-description: Installs NSIS with Chocolatey retry and fallback to official installer
+description: Installs NSIS with Chocolatey retry and fallback to official portable archive
 runs:
   using: composite
   steps:
@@ -11,6 +11,7 @@ runs:
 
         if (Test-Path $nsisExe) {
           Write-Host "NSIS already present at $nsisExe"
+          "BLOOM_NSIS_EXE=$nsisExe" >> $env:GITHUB_ENV
           exit 0
         }
 
@@ -21,6 +22,7 @@ runs:
             choco install nsis -y --no-progress
             if (Test-Path $nsisExe) {
               Write-Host "NSIS installed via Chocolatey at $nsisExe"
+              "BLOOM_NSIS_EXE=$nsisExe" >> $env:GITHUB_ENV
               exit 0
             }
           } catch {
@@ -34,21 +36,30 @@ runs:
           }
         }
 
-        Write-Warning "Chocolatey installation did not succeed. Falling back to official NSIS installer."
-        $installerPath = Join-Path $env:RUNNER_TEMP "nsis-3.11-setup.exe"
-        $downloadUrl = "https://prdownloads.sourceforge.net/nsis/nsis-3.11-setup.exe?download"
-        Invoke-WebRequest -Uri $downloadUrl -OutFile $installerPath
-        $expectedSha256 = "38d49f8fe09b1c332b01d0940e57b7258f4447733643273a01c59959ad9d3b0a"
-        $actualSha256 = (Get-FileHash -Path $installerPath -Algorithm SHA256).Hash.ToLower()
+        Write-Warning "Chocolatey installation did not succeed. Falling back to official NSIS archive."
+        $archivePath = Join-Path $env:RUNNER_TEMP "nsis-3.11.zip"
+        $downloadUrl = "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.11/nsis-3.11.zip"
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath
+        $expectedSha256 = "c7d27f780ddb6cffb4730138cd1591e841f4b7edb155856901cdf5f214394fa1"
+        $actualSha256 = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLower()
         if ($actualSha256 -ne $expectedSha256) {
-          Write-Error "NSIS installer checksum mismatch. Expected: $expectedSha256, Actual: $actualSha256"
+          Write-Error "NSIS archive checksum mismatch. Expected: $expectedSha256, Actual: $actualSha256"
           exit 1
         }
-        Start-Process -FilePath $installerPath -ArgumentList "/S" -Wait -NoNewWindow
+        $nsisRoot = Join-Path $env:RUNNER_TOOL_CACHE "nsis\3.11"
+        if (Test-Path $nsisRoot) {
+          Remove-Item -Path $nsisRoot -Recurse -Force
+        }
+        New-Item -ItemType Directory -Path $nsisRoot -Force | Out-Null
+        Expand-Archive -Path $archivePath -DestinationPath $nsisRoot -Force
+        $fallbackNsisExe = Join-Path $nsisRoot "nsis-3.11\makensis.exe"
 
-        if (-not (Test-Path $nsisExe)) {
-          Write-Error "NSIS installation failed after Chocolatey retries and fallback installer."
+        if (-not (Test-Path $fallbackNsisExe)) {
+          Write-Error "NSIS setup failed after Chocolatey retries and fallback archive."
           exit 1
         }
 
-        Write-Host "NSIS installed via fallback at $nsisExe"
+        $fallbackNsisBin = Split-Path -Parent $fallbackNsisExe
+        "$fallbackNsisBin" >> $env:GITHUB_PATH
+        "BLOOM_NSIS_EXE=$fallbackNsisExe" >> $env:GITHUB_ENV
+        Write-Host "NSIS available via fallback at $fallbackNsisExe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
       - uses: ./.github/actions/setup-nsis
       - name: Build installer
         shell: pwsh
-        run: '& "C:\Program Files (x86)\NSIS\makensis.exe" installer.nsi'
+        run: '& "$env:BLOOM_NSIS_EXE" installer.nsi'
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Bloom-Windows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ QML & Focus
 Stack: C++23 (Qt 6/QML) • CMake • mpv (external JSON IPC)
 Keep as much logic as possible in C++ (network, data models, services); QML for UI, animations, and theming.
 
-Key files: `src/core/ServiceLocator.h`, `utils/ConfigManager.*`, `network/JellyfinClient.*`, `player/*`, `ui/Theme.qml`, `ui/ResponsiveLayoutManager.*`.
+Key files: `src/core/ServiceLocator.h`, `utils/ConfigManager.*`, `network/JellyfinClient.*`, `player/*`, `ui/Theme.qml`, `ui/ResponsiveLayoutManager.*`, `src/ui/ScreensaverController.*`, `src/ui/ScreensaverOverlay.qml`.
 
 Conventions: C++ PascalCase classes, camelCase methods, `m_` prefix; QML PascalCase components, camelCase props; use `FocusScope` for navigable views; keep `Theme.qml` as the single source for tokens.
 
@@ -20,6 +20,7 @@ Playback & API: Key endpoints `/Users/{userId}/Items`, `/Shows/NextUp`, `/Playba
 
 Windows embedded playback guardrail (regression prevention):
 - When using `win-libmpv` embedded playback (`--wid` child window), playback controls MUST render in a dedicated transparent top-level overlay `Window` synced to the app window geometry.
+- Any app-level overlay that must be visible during Windows embedded playback (for example the screensaver while paused) MUST also render in a synced top-level overlay `Window`.
 - Do NOT rely on in-scene sibling layering above `VideoSurface` for Windows embedded playback; native child-window composition can occlude QML overlays.
 - Any PR touching Windows playback layering/geometry (`src/ui/Main.qml`, `src/ui/VideoSurface.qml`, `src/ui/EmbeddedPlaybackOverlay.qml`, `src/player/backend/WindowsMpvBackend.*`) must include manual runtime validation: controls visible above video, and no video move/clip during show/hide, resize, minimize/restore, maximize, and fullscreen transitions.
 
@@ -73,6 +74,7 @@ See also:
 - docs/responsive.md — Deprecated: see docs/theme.md for ResponsiveLayoutManager
 - docs/developer_notes.md — Conventions, focus, QML patterns, and best practices
 - docs/viewmodels.md — BaseViewModel patterns and MovieDetailsViewModel
+- docs/screensaver.md — in-app OLED-safe screensaver controller, arming rules, focus contract, and known limitations
 - docs/conventional-commits.md — commit messages must follow the Conventional Commits spec so tooling and changelogs stay accurate
 
 License: See `LICENSE`.

--- a/config/app.example.json
+++ b/config/app.example.json
@@ -1,5 +1,5 @@
 {
-    "version": 23,
+    "version": 25,
     "settings": {
         "mpv": {
             "path": "mpv",
@@ -47,7 +47,12 @@
         "ui": {
             "backdrop_rotation_interval": 30000,
             "launch_in_fullscreen": false,
-            "ui_animations_enabled": true
+            "ui_animations_enabled": true,
+            "screensaver": {
+                "enabled": false,
+                "mode": "libraryBackdrops",
+                "timeout_seconds": 300
+            }
         },
         "manualDpiScaleOverride": 1.0,
         "mpv_profiles": {

--- a/docs/build.md
+++ b/docs/build.md
@@ -149,6 +149,10 @@ targets so `run-windows-tests.ps1` has something to run:
 The Windows scripts and GitHub workflow read Qt and libmpv pins from
 `packaging/dependencies.json`.
 
+Windows CI installs NSIS through `.github/actions/setup-nsis`. The action first
+tries Chocolatey, then falls back to the checksum-pinned official NSIS archive
+and exposes the selected `makensis.exe` path through `BLOOM_NSIS_EXE`.
+
 ## Dependency policy
 
 Bloom tracks current `nixos-unstable` and the latest portable/Windows

--- a/docs/config.md
+++ b/docs/config.md
@@ -9,7 +9,7 @@ Overview
 
 Responsibilities
 - Persist session information: server URL, access tokens (obfuscated or protected as feasible).
-- Persist app-specific settings: `playbackCompletionThreshold`, `autoplayNextEpisode`, `backdropRotationInterval`, mpv extra flags.
+- Persist app-specific settings: `playbackCompletionThreshold`, `autoplayNextEpisode`, `backdropRotationInterval`, `screensaver*`, mpv extra flags.
 - Emit change signals to allow QML to react to setting updates.
 
 Best practices
@@ -50,6 +50,7 @@ MPV profile management
 - Config v22 adds the protected `ArtCNN`, `ArtCNN-Deband`, `nnedi3`, and `nnedi3-deband` built-ins without changing existing default, library, or series assignments.
 - Config v23 adds profile-level `hdr_metadata_mode` and `windows_10bit_output` fields. Missing fields default to `target` and `false`; canonical shader-heavy anime built-ins move to `windows_render_api=vulkan` unless the stored profile was customized.
 - Config v24 adds startup buffering mode settings. `settings.playback.startup_buffering_mode` defaults to `normal`; `settings.library_startup_buffering_modes` stores optional per-library overrides keyed by Jellyfin library ID. Valid values are `normal` and `remote-mount`; missing library entries use the global value.
+- Config v25 adds OLED-safe screensaver settings under `settings.ui.screensaver`: `enabled` (default false), `mode` (default `libraryBackdrops`), and `timeout_seconds` (default 300).
 - Built-in profile behavior: `Low Quality` uses mpv `--profile=fast`; `Medium Quality` uses `--profile=high-quality`; `High Quality` uses `--profile=high-quality` plus bundled FSRCNNX, KrigBilateral, and SSimDownscaler GLSL shaders loaded from `~~/shaders/...`. The ArtCNN/nnedi3 profiles use `--profile=high-quality`, `--hwdec=no`, a single selected bundled shader, Gandhi Sans Bold subtitle styling from `~~/fonts`, and optional mpv deband tuning for the `-Deband` variants.
 - Settings > MPV > Edit Profiles > Import Config creates a new profile from an existing `mpv.conf`. v1 imports only global top-level options before the first `[profile]` section and stores them as normalized `extra_args` entries (`--option=value` or `--option`) in `settings.mpv_profiles`; it never overwrites an existing profile.
 - MPV profile import/save/load normalizes one surrounding quote pair from `--option=value` and stores common shader aliases (`--glsl-shader`, `--glsl-shader-append`, `--glsl-shaders`, `--glsl-shaders-append`) as ordered `--glsl-shaders-append=...` entries. On playback, Bloom emits a single `--glsl-shaders-clr` before the profile shader appends so multiple shaders load in profile order while replacing any inherited shader list.
@@ -121,6 +122,10 @@ UI settings
 - `settings.ui.launch_in_fullscreen` (Q_PROPERTY `launchInFullscreen`): When true, the application starts in fullscreen mode. Default true; configurable via Settings > Display > Launch in Fullscreen.
 - `settings.ui.backdrop_rotation_interval`: Backdrop rotation interval in milliseconds. Default 30000 (30 seconds).
 - `settings.ui.ui_animations_enabled` (Q_PROPERTY `uiAnimationsEnabled`): Toggle the QML transition/animation flourishes for keyboard/remote navigation; defaults to true but can be toggled to reduce GPU load.
+- `settings.ui.screensaver.enabled` (Q_PROPERTY `screensaverEnabled`): Enables the in-app OLED-safe screensaver. Default false.
+- `settings.ui.screensaver.mode` (Q_PROPERTY `screensaverMode`): `libraryBackdrops`, `bouncingLogo`, or `black`. Default `libraryBackdrops`.
+- `settings.ui.screensaver.timeout_seconds` (Q_PROPERTY `screensaverTimeoutSeconds`): Inactivity timeout before activation. Default 300 seconds; Settings > Display edits it in minutes.
+- Screensaver debug override: set `BLOOM_SCREENSAVER_DEBUG=1` to force-enable for one run without persisting, and optionally set `BLOOM_SCREENSAVER_DEBUG_TIMEOUT_MS=3000` or another positive millisecond value for fast testing.
 
 Update settings
 - `settings.updates.channel` (Q_PROPERTY `updateChannel`): Update track to query. Valid values are `stable` and `dev`. Default `stable`.

--- a/docs/developer_notes.md
+++ b/docs/developer_notes.md
@@ -12,6 +12,7 @@ QML & Focus
 - Settings dropdowns should use `SettingsComboBox` instead of raw `ComboBox` so primitive and role-based models render the selected text reliably after async model/index updates.
 - Settings boolean controls should use `SettingsToggleRow` for consistent focus treatment, accessibility metadata, and keyboard/gamepad toggling.
 - Global app-shell shortcuts live in `Main.qml`; ESC on the root home screen opens the power menu, while deeper screens keep the normal back-stack behavior.
+- The screensaver is controlled by `ScreensaverController` and rendered by `ScreensaverOverlay.qml`. It may activate during app navigation or paused playback, but playing/loading/buffering video must always cancel or block activation.
 
 C++ conventions
 - PascalCase class names, camelCase method names, `m_` prefix for member variables.
@@ -30,6 +31,7 @@ Performance
 - Offload heavy JSON parsing or expensive calculations to background threads and report results back to the UI thread.
 - Reuse delegates and avoid excessive property bindings that cause frequent re-evaluations.
 - Home rotating backdrops should use `LibraryService.getHomeBackdropItems(limit)` (single lightweight random query over recursive media) instead of only section-bound lists like Next Up/Latest.
+- Screensaver artwork should use `LibraryService.getScreensaverItems(limit)` so the Home backdrop query stays lightweight while the screensaver gets synopsis/logo metadata.
 
 Coding style
 - Keep components small and single-purpose.

--- a/docs/hero-banner.md
+++ b/docs/hero-banner.md
@@ -40,3 +40,35 @@ Leaving the hero resets to carousel mode. Auto-cycle pauses during focus, scroll
 When backdrop synchronization is enabled, the selected hero image drives Home's existing
 cross-fading backdrop and pauses normal backdrop rotation. Settings are stored below
 `settings.ui.hero_banner` and exposed on the Settings > Home page.
+
+## Transitions
+
+When the hero item changes (manual cycle via Left/Right, or auto-cycle), the banner
+animates rather than snapping:
+
+- **In-card backdrop cross-fade**: `heroCard` carries two stacked `Image`s
+  (`heroBackdropA`/`heroBackdropB`) and a `showBackdropA` toggle. On
+  `currentBackdropUrlChanged`, the new URL is loaded into the inactive image and the
+  toggle flips when that image reaches `Image.Ready`, so the in-card backdrop cross-fades
+  over `Theme.durationFade` in lockstep with Home's full-screen backdrop cross-fade.
+- **Content transition**: `contentLoader` (logo/title/badge/metadata/buttons) is driven
+  by a `SequentialAnimation` (`heroTransition`) wrapping a `transitionToIndex(newIndex,
+  direction)` helper. Each half runs `Theme.durationFade / 2`:
+  1. Fade `contentOpacity 1 → 0` and slide `contentSlideX → -contentSlideOffset *
+     direction` (old content exits in the navigation direction).
+  2. `ScriptAction` commits `currentIndex = pendingIndex` and parks the slide offset on
+     the opposite side.
+  3. Fade `contentOpacity 0 → 1` and slide `contentSlideX → 0` (new content enters from
+     the navigation direction).
+  The total `Theme.durationFade` matches the backdrop cross-fade, so the content swap
+  lands at the backdrop's midpoint.
+- **Rapid cycling**: an in-flight transition is force-completed (the pending index is
+  committed and visual state is reset) before the next transition starts, so no hero item
+  is ever skipped or left stuck invisible.
+- **Page indicator dots** animate their `width` and `color` over `Theme.durationNormal`.
+
+All three animations are gated by `Theme.uiAnimationsEnabled`: when animations are
+disabled, `Theme.durationFade`/`Theme.durationNormal` resolve to `0`, so all transitions
+collapse to an instantaneous swap and the behavior matches the previous instant change.
+Initial load and model refresh (`onHeroModelChanged`) bypass the transition and assign
+`currentIndex` directly.

--- a/docs/screensaver.md
+++ b/docs/screensaver.md
@@ -1,0 +1,34 @@
+In-App Screensaver
+
+Components
+- `ScreensaverController` (`src/ui/ScreensaverController.{h,cpp}`) is a `QObject` installed as an app-level event filter on `QGuiApplication`. It arms a single-shot `QTimer`; on timeout it sets `m_active` and emits `activeChanged`.
+- `ScreensaverOverlay.qml` (`src/ui/ScreensaverOverlay.qml`) renders the active mode and fetches artwork via `LibraryService.getScreensaverItems(80)` when it becomes visible and `items.length === 0`.
+- `Main.qml` hosts the overlay inline under `Overlay.overlay` for normal app idle states. During Windows embedded playback, it hosts the same overlay in a dedicated top-level `Window` synced to the app window so the native mpv child window cannot occlude it while playback is paused.
+- Modes (ConfigManager `screensaverMode`): `libraryBackdrops` (cycling backdrops with metadata/logo placement), `bouncingLogo` (bouncing logo over artwork), `black` (no artwork; just a black screen).
+- Debug env vars: `BLOOM_SCREENSAVER_DEBUG=1` forces the screensaver enabled regardless of config; `BLOOM_SCREENSAVER_DEBUG_TIMEOUT_MS=<ms>` overrides the timeout (clamped to 250..60000, default 3000). Intended for manual smoke testing.
+
+Arming contract
+- `canArm()` requires `effectiveEnabled && m_appWindowVisible && m_auth->isAuthenticated() && !playbackBlocksScreensaver()`.
+- `playbackBlocksScreensaver()` returns true when `PlayerController` is in `Playing`, `Loading`, or `Buffering` state, OR when `PlayerController::awaitingNextEpisodeResolution()` is true (i.e. the Up Next overlay is awaiting the next-episode resolution). When any of these become true, the controller calls `dismiss()` (if active) and reschedules, so the screensaver cannot arm behind the Up Next overlay.
+- The app-level event filter calls `dismiss()` (and swallows the event) on the first activity event while active; otherwise it calls `schedule()`. `noteActivity()` is the invokable equivalent.
+- `AuthenticationService` `loggedOut`/`sessionExpired` dismiss and reschedule; `loginSuccess` reschedules.
+- `appWindowVisible` is bound in `Main.qml` to `window.visible && window.visibility !== Window.Minimized` and dismissal/reschedule happens on hide.
+
+Focus contract
+- The overlay's `focus: visible` takes focus as soon as it becomes visible. The dismissing keypress is swallowed by the event filter, so the underlying view would not re-take focus on its own.
+- `ScreensaverOverlay` snapshots the configured `focusWindow.activeFocusItem` on `ScreensaverController.activeChanged` (true) into `savedFocusItem`; inline hosts pass the app window, and detached hosts also pass the app window rather than the overlay window. This must run on `activeChanged` rather than `onVisibleChanged`, because `onVisibleChanged` runs after the overlay has already taken focus.
+- On dismiss (`onVisibleChanged` else branch), it calls `Qt.callLater(function() { if (savedFocusItem && savedFocusItem.parent && typeof savedFocusItem.forceActiveFocus === "function") savedFocusItem.forceActiveFocus(); savedFocusItem = null })`. The guard handles the case where the previously focused item was destroyed (e.g. by a stack pop during idle).
+
+Stale artwork on logout
+- `ScreensaverOverlay` only fetches `getScreensaverItems` when `items.length === 0`, so a previous user's candidate set would otherwise persist across a logout/login as a different user.
+- `Connections` to `AuthenticationService.onLoggedOut` and `onSessionExpired` call `resetArtwork()`, which clears `items`, `currentIndex`, `placementIndex`, resets `showBackdropA`, and blanks `backdropAUrl`/`backdropBUrl`. It does NOT fetch; the existing `onVisibleChanged` guard refetches on the next activation.
+
+Known limitation (until a later phase ships)
+- There is no OS-level screensaver/DPMS/system idle inhibit. On most Linux desktop environments the OS idle timer runs in parallel with Bloom's internal timer and may blank or lock the screen before the Bloom overlay is visible. This phase only addresses the in-app overlay.
+
+Settings
+- `Display > Screensaver` (`src/ui/settings/DisplaySettings.qml`):
+  - Enable Screensaver toggle (`screensaverEnabled`).
+  - Mode combo (`screensaverMode`): libraryBackdrops | bouncingLogo | black.
+  - Timeout spinbox in minutes, range 1..1440 (24 h). Bound to `ConfigManager.screensaverTimeoutSeconds` via `Math.max(1, Math.round(.../60))` and persisted as seconds via `Math.max(1, newValue) * 60`.
+- ConfigManager clamps `screensaverTimeoutSeconds` to 15..86400 (seconds). The spinbox ceiling of 1440 min (86400 s) matches the upper bound, so persisted values round-trip without silent downgrading. Config migration v24 -> v25 adds the `screensaver` object with these defaults.

--- a/docs/screensaver.md
+++ b/docs/screensaver.md
@@ -2,9 +2,10 @@ In-App Screensaver
 
 Components
 - `ScreensaverController` (`src/ui/ScreensaverController.{h,cpp}`) is a `QObject` installed as an app-level event filter on `QGuiApplication`. It arms a single-shot `QTimer`; on timeout it sets `m_active` and emits `activeChanged`.
-- `ScreensaverOverlay.qml` (`src/ui/ScreensaverOverlay.qml`) renders the active mode and fetches artwork via `LibraryService.getScreensaverItems(80)` when it becomes visible and `items.length === 0`.
+- `ScreensaverOverlay.qml` (`src/ui/ScreensaverOverlay.qml`) renders the active mode and requests artwork via `LibraryService.getScreensaverItems(80)` when it becomes visible and `items.length === 0`.
 - `Main.qml` hosts the overlay inline under `Overlay.overlay` for normal app idle states. During Windows embedded playback, it hosts the same overlay in a dedicated top-level `Window` synced to the app window so the native mpv child window cannot occlude it while playback is paused.
 - Modes (ConfigManager `screensaverMode`): `libraryBackdrops` (cycling backdrops with metadata/logo placement), `bouncingLogo` (bouncing logo over artwork), `black` (no artwork; just a black screen).
+- Artwork mode consumes UI-ready items from `LibraryService.getScreensaverItems(limit)`. The service owns auth/session guarding, stale-reply suppression, backdrop filtering, and image URL derivation before emitting `screensaverItemsLoaded`.
 - Debug env vars: `BLOOM_SCREENSAVER_DEBUG=1` forces the screensaver enabled regardless of config; `BLOOM_SCREENSAVER_DEBUG_TIMEOUT_MS=<ms>` overrides the timeout (clamped to 250..60000, default 3000). Intended for manual smoke testing.
 
 Arming contract

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,8 @@ qt_add_executable(Bloom
     ui/ImageCacheProvider.cpp
     ui/UiSoundController.h
     ui/UiSoundController.cpp
+    ui/ScreensaverController.h
+    ui/ScreensaverController.cpp
     ui/ResponsiveLayoutManager.h
     ui/ResponsiveLayoutManager.cpp
     security/ISecretStore.h
@@ -211,6 +213,7 @@ qt_add_qml_module(Bloom
         ui/MpvProfileEditor.qml
         ui/VideoSurface.qml
         ui/EmbeddedPlaybackOverlay.qml
+        ui/ScreensaverOverlay.qml
         ui/TrackSelector.qml
         ui/WheelStepScroller.qml
         ui/MediaInfoPanel.qml

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -23,6 +23,7 @@
 #include "utils/SidebarSettings.h"
 #include "utils/SystemPowerController.h"
 #include "ui/UiSoundController.h"
+#include "ui/ScreensaverController.h"
 #include "utils/GpuMemoryTrimmer.h"
 #include "utils/Logger.h"
 #include "utils/LoggingConfig.h"
@@ -252,6 +253,22 @@ void ApplicationInitializer::registerServices()
     // 5. InputModeManager - Depends on QGuiApplication
     m_inputModeManager = std::make_unique<InputModeManager>(m_app);
     ServiceLocator::registerService<InputModeManager>(m_inputModeManager.get());
+
+    // 5.5 ScreensaverController - Depends on app input, config, playback, and auth
+    if (isTestMode) {
+        m_screensaverController = std::make_unique<ScreensaverController>(
+            m_app,
+            m_configManager.get(),
+            m_playerController.get(),
+            m_mockAuthService.get());
+    } else {
+        m_screensaverController = std::make_unique<ScreensaverController>(
+            m_app,
+            m_configManager.get(),
+            m_playerController.get(),
+            m_authService.get());
+    }
+    ServiceLocator::registerService<ScreensaverController>(m_screensaverController.get());
     
     // 6. LibraryViewModel
     m_libraryViewModel = std::make_unique<LibraryViewModel>();

--- a/src/core/ApplicationInitializer.h
+++ b/src/core/ApplicationInitializer.h
@@ -31,6 +31,7 @@ class SessionService;
 class UpdateService;
 class MockAuthenticationService;
 class MockLibraryService;
+class ScreensaverController;
 
 /**
  * @brief Owns and wires all application-level services during startup.
@@ -121,6 +122,7 @@ private:
     std::unique_ptr<SessionService> m_sessionService;
     std::unique_ptr<UpdateService> m_updateService;
     std::unique_ptr<ResponsiveLayoutManager> m_responsiveLayoutManager;
+    std::unique_ptr<ScreensaverController> m_screensaverController;
     
     // Test mode mock services
     std::unique_ptr<MockAuthenticationService> m_mockAuthService;

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -239,6 +239,23 @@ void AuthenticationService::restoreSession(const QString &serverUrl, const QStri
     });
 }
 
+void AuthenticationService::seedSession(const QString &serverUrl,
+                                        const QString &userId,
+                                        const QString &accessToken,
+                                        const QString &username)
+{
+    m_serverUrl = normalizeUrl(serverUrl);
+    m_userId = userId;
+    m_accessToken = accessToken;
+    m_username = username;
+    m_sessionExpiredPending = false;
+    m_sessionExpiredEmitted = false;
+
+    emit serverUrlChanged();
+    emit userIdChanged();
+    emit authenticatedChanged();
+}
+
 void AuthenticationService::logout()
 {
     qCDebug(lcAuth) << "Logging out user:" << m_userId;

--- a/src/network/AuthenticationService.h
+++ b/src/network/AuthenticationService.h
@@ -114,6 +114,12 @@ signals:
     void authenticatedChanged();
     void isRestoringSessionChanged();
 
+protected:
+    void seedSession(const QString &serverUrl,
+                     const QString &userId,
+                     const QString &accessToken,
+                     const QString &username = QString());
+
 private slots:
     void onAuthenticateFinished(QNetworkReply *reply);
 

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -789,6 +789,57 @@ void LibraryService::getHomeBackdropItems(int limit)
     (*fetchPage)(0);
 }
 
+void LibraryService::getScreensaverItems(int limit)
+{
+    if (!m_authService->isAuthenticated()) {
+        NetworkError error;
+        error.endpoint = "getScreensaverItems";
+        error.code = -1;
+        error.userMessage = tr("Not authenticated");
+        emitError(error);
+        return;
+    }
+
+    const int requestedLimit = qBound(10, limit > 0 ? limit : 80, 200);
+    const QStringList fields = {
+        "Id",
+        "Name",
+        "Overview",
+        "Type",
+        "SeriesName",
+        "SeriesId",
+        "ImageTags",
+        "BackdropImageTags",
+        "ParentBackdropImageTags",
+        "ParentBackdropItemId",
+        "ParentId",
+        "ProductionYear"
+    };
+
+    const QString endpoint = QString("/Users/%1/Items?Recursive=true&IncludeItemTypes=Movie,Series&SortBy=Random&Fields=%2&EnableImages=true&EnableImageTypes=Backdrop,Logo&ImageTypeLimit=1&EnableTotalRecordCount=false&Limit=%3")
+                                 .arg(m_authService->getUserId())
+                                 .arg(fields.join(","))
+                                 .arg(requestedLimit);
+
+    sendRequestWithRetry(endpoint,
+        [this, endpoint]() {
+            QNetworkRequest request = m_authService->createRequest(endpoint);
+            return m_authService->networkManager()->get(request);
+        },
+        [this](QNetworkReply *reply) {
+            const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+            if (!doc.isObject()) {
+                NetworkError error;
+                error.endpoint = "getScreensaverItems";
+                error.code = -2;
+                error.userMessage = tr("Invalid screensaver response");
+                emitError(error);
+                return;
+            }
+            emit screensaverItemsLoaded(doc.object().value("Items").toArray());
+        });
+}
+
 // ============================================================================
 // Generic Item Details
 // ============================================================================

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -801,6 +801,7 @@ void LibraryService::getScreensaverItems(int limit)
     }
 
     const int requestedLimit = qBound(10, limit > 0 ? limit : 80, 200);
+    const QString requestUserId = m_authService->getUserId();
     const QStringList fields = {
         "Id",
         "Name",
@@ -817,7 +818,7 @@ void LibraryService::getScreensaverItems(int limit)
     };
 
     const QString endpoint = QString("/Users/%1/Items?Recursive=true&IncludeItemTypes=Movie,Series&SortBy=Random&Fields=%2&EnableImages=true&EnableImageTypes=Backdrop,Logo&ImageTypeLimit=1&EnableTotalRecordCount=false&Limit=%3")
-                                 .arg(m_authService->getUserId())
+                                 .arg(requestUserId)
                                  .arg(fields.join(","))
                                  .arg(requestedLimit);
 
@@ -826,7 +827,10 @@ void LibraryService::getScreensaverItems(int limit)
             QNetworkRequest request = m_authService->createRequest(endpoint);
             return m_authService->networkManager()->get(request);
         },
-        [this](QNetworkReply *reply) {
+        [this, requestUserId](QNetworkReply *reply) {
+            if (!m_authService->isAuthenticated() || m_authService->getUserId() != requestUserId) {
+                return;
+            }
             const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
             if (!doc.isObject()) {
                 NetworkError error;

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -840,7 +840,46 @@ void LibraryService::getScreensaverItems(int limit)
                 emitError(error);
                 return;
             }
-            emit screensaverItemsLoaded(doc.object().value("Items").toArray());
+            QJsonArray filteredItems;
+            const QJsonArray items = doc.object().value("Items").toArray();
+            for (const QJsonValue &value : items) {
+                QJsonObject item = value.toObject();
+                QString itemId = item.value("Id").toString();
+                QString tag;
+                const QJsonArray backdropTags = item.value("BackdropImageTags").toArray();
+                if (!backdropTags.isEmpty()) {
+                    tag = backdropTags.first().toString();
+                } else {
+                    tag = item.value("ImageTags").toObject().value("Backdrop").toString();
+                }
+
+                const QJsonArray parentBackdropTags = item.value("ParentBackdropImageTags").toArray();
+                if (tag.isEmpty() && !parentBackdropTags.isEmpty()) {
+                    tag = parentBackdropTags.first().toString();
+                    itemId = item.value("ParentBackdropItemId").toString(
+                        item.value("SeriesId").toString(item.value("Id").toString()));
+                }
+
+                if (itemId.isEmpty() || tag.isEmpty()) {
+                    continue;
+                }
+
+                QString backdropUrl = getCachedImageUrlWithWidth(itemId, QStringLiteral("Backdrop"), 1920);
+                if (backdropUrl.isEmpty()) {
+                    continue;
+                }
+                backdropUrl += QStringLiteral("?tag=") + tag;
+                item.insert(QStringLiteral("BackdropUrl"), backdropUrl);
+
+                if (item.value("ImageTags").toObject().contains(QStringLiteral("Logo"))) {
+                    item.insert(QStringLiteral("LogoUrl"),
+                                getCachedImageUrlWithWidth(item.value("Id").toString(),
+                                                           QStringLiteral("Logo"),
+                                                           700));
+                }
+                filteredItems.append(item);
+            }
+            emit screensaverItemsLoaded(filteredItems);
         });
 }
 

--- a/src/network/LibraryService.h
+++ b/src/network/LibraryService.h
@@ -93,6 +93,9 @@ public:
     
     // Fast global backdrop pool for Home screen rotation (limit <= 0 means all)
     Q_INVOKABLE virtual void getHomeBackdropItems(int limit = 0);
+
+    // Random OLED-safe screensaver candidates with artwork and synopsis metadata.
+    Q_INVOKABLE virtual void getScreensaverItems(int limit = 80);
     
     // Generic Item Details
     Q_INVOKABLE virtual void getItem(const QString &itemId);
@@ -164,6 +167,7 @@ signals:
     void nextUpLoaded(const QJsonArray &items);
     void latestMediaLoaded(const QString &parentId, const QJsonArray &items);
     void homeBackdropItemsLoaded(const QJsonArray &items);
+    void screensaverItemsLoaded(const QJsonArray &items);
     void seriesDetailsLoaded(const QString &seriesId, const QJsonObject &seriesData);
     void seriesDetailsNotModified(const QString &seriesId);
     void similarItemsLoaded(const QString &itemId, const QJsonArray &items);

--- a/src/test/MockAuthenticationService.cpp
+++ b/src/test/MockAuthenticationService.cpp
@@ -9,8 +9,8 @@ MockAuthenticationService::MockAuthenticationService(ISecretStore *secretStore, 
 
 void MockAuthenticationService::initialize(ConfigManager *configManager)
 {
-    // Initialize the base class to set up config manager and secret store members
-    AuthenticationService::initialize(configManager);
+    Q_UNUSED(configManager)
+
     seedSession(QStringLiteral("test://mock"),
                 QStringLiteral("test-user-001"),
                 QStringLiteral("test-access-token-001"),

--- a/src/test/MockAuthenticationService.cpp
+++ b/src/test/MockAuthenticationService.cpp
@@ -9,13 +9,15 @@ MockAuthenticationService::MockAuthenticationService(ISecretStore *secretStore, 
 
 void MockAuthenticationService::initialize(ConfigManager *configManager)
 {
-    // Use restoreSession to set server URL and internal state consistently
-    // Set this BEFORE base initialization so that any base class logic that relies on
-    // established session state sees the mock values immediately (avoiding network restoration).
-    restoreSession(QStringLiteral("test://mock"), QStringLiteral("test-user-001"), QStringLiteral("test-access-token-001"));
-
     // Initialize the base class to set up config manager and secret store members
     AuthenticationService::initialize(configManager);
+    seedSession(QStringLiteral("test://mock"),
+                QStringLiteral("test-user-001"),
+                QStringLiteral("test-access-token-001"),
+                QStringLiteral("Test User"));
+    emit loginSuccess(QStringLiteral("test-user-001"),
+                      QStringLiteral("test-access-token-001"),
+                      QStringLiteral("Test User"));
     
     qCDebug(lcTest) << "MockAuthenticationService: Initialized with pre-authenticated session";
 }
@@ -26,22 +28,22 @@ void MockAuthenticationService::authenticate(const QString &serverUrl, const QSt
     
     qCDebug(lcTest) << "MockAuthenticationService::authenticate(" << serverUrl << "," << username << ")";
     
-    // Immediately emit success
-    emit loginSuccess("test-user-001", "test-access-token-001", username);
+    seedSession(serverUrl, QStringLiteral("test-user-001"), QStringLiteral("test-access-token-001"), username);
+    emit loginSuccess(QStringLiteral("test-user-001"), QStringLiteral("test-access-token-001"), username);
 }
 
 void MockAuthenticationService::restoreSession(const QString &serverUrl, const QString &userId, const QString &accessToken)
 {
     qCDebug(lcTest) << "MockAuthenticationService::restoreSession(" << serverUrl << "," << userId << ")";
     
-    // Immediately emit success
+    seedSession(serverUrl, userId, accessToken);
     emit loginSuccess(userId, accessToken, QString());
 }
 
 void MockAuthenticationService::logout()
 {
     qCDebug(lcTest) << "MockAuthenticationService::logout()";
-    
+    seedSession(QString(), QString(), QString());
     emit loggedOut();
 }
 

--- a/src/test/MockLibraryService.cpp
+++ b/src/test/MockLibraryService.cpp
@@ -292,7 +292,8 @@ void MockLibraryService::getScreensaverItems(int limit)
     }
 
     QJsonArray result;
-    const int count = (limit > 0) ? qMin(limit, allItems.size()) : allItems.size();
+    const int requestedLimit = qBound(10, limit > 0 ? limit : 80, 200);
+    const int count = qMin(requestedLimit, allItems.size());
     for (int i = 0; i < count; ++i) {
         result.append(allItems[i]);
     }

--- a/src/test/MockLibraryService.cpp
+++ b/src/test/MockLibraryService.cpp
@@ -293,9 +293,35 @@ void MockLibraryService::getScreensaverItems(int limit)
 
     QJsonArray result;
     const int requestedLimit = qBound(10, limit > 0 ? limit : 80, 200);
-    const int count = qMin(requestedLimit, allItems.size());
-    for (int i = 0; i < count; ++i) {
-        result.append(allItems[i]);
+    for (int i = 0; i < allItems.size() && result.size() < requestedLimit; ++i) {
+        QJsonObject item = allItems[i].toObject();
+        QString itemId = item.value("Id").toString();
+        QString tag;
+        const QJsonArray backdropTags = item.value("BackdropImageTags").toArray();
+        if (!backdropTags.isEmpty()) {
+            tag = backdropTags.first().toString();
+        } else {
+            tag = item.value("ImageTags").toObject().value("Backdrop").toString();
+        }
+        const QJsonArray parentBackdropTags = item.value("ParentBackdropImageTags").toArray();
+        if (tag.isEmpty() && !parentBackdropTags.isEmpty()) {
+            tag = parentBackdropTags.first().toString();
+            itemId = item.value("ParentBackdropItemId").toString(
+                item.value("SeriesId").toString(item.value("Id").toString()));
+        }
+        if (itemId.isEmpty() || tag.isEmpty()) {
+            continue;
+        }
+        item.insert(QStringLiteral("BackdropUrl"),
+                    getCachedImageUrlWithWidth(itemId, QStringLiteral("Backdrop"), 1920)
+                        + QStringLiteral("?tag=") + tag);
+        if (item.value("ImageTags").toObject().contains(QStringLiteral("Logo"))) {
+            item.insert(QStringLiteral("LogoUrl"),
+                        getCachedImageUrlWithWidth(item.value("Id").toString(),
+                                                   QStringLiteral("Logo"),
+                                                   700));
+        }
+        result.append(item);
     }
 
     qCDebug(lcTest) << "MockLibraryService::getScreensaverItems(" << limit << ") ->" << result.size() << "items";

--- a/src/test/MockLibraryService.cpp
+++ b/src/test/MockLibraryService.cpp
@@ -281,6 +281,26 @@ void MockLibraryService::getHomeBackdropItems(int limit)
     emit homeBackdropItemsLoaded(result);
 }
 
+void MockLibraryService::getScreensaverItems(int limit)
+{
+    QJsonArray allItems;
+    for (const QJsonValue &val : m_movies["Items"].toArray()) {
+        allItems.append(val);
+    }
+    for (const QJsonValue &val : m_series["Items"].toArray()) {
+        allItems.append(val);
+    }
+
+    QJsonArray result;
+    const int count = (limit > 0) ? qMin(limit, allItems.size()) : allItems.size();
+    for (int i = 0; i < count; ++i) {
+        result.append(allItems[i]);
+    }
+
+    qCDebug(lcTest) << "MockLibraryService::getScreensaverItems(" << limit << ") ->" << result.size() << "items";
+    emit screensaverItemsLoaded(result);
+}
+
 void MockLibraryService::getItem(const QString &itemId)
 {
     getItem(itemId, QString());

--- a/src/test/MockLibraryService.h
+++ b/src/test/MockLibraryService.h
@@ -47,6 +47,7 @@ public:
     
     // Global home backdrop pool
     Q_INVOKABLE void getHomeBackdropItems(int limit = 0) override;
+    Q_INVOKABLE void getScreensaverItems(int limit = 80) override;
     
     // Generic Item Details - searches all fixture items
     Q_INVOKABLE void getItem(const QString &itemId) override;

--- a/src/ui/HeroBanner.qml
+++ b/src/ui/HeroBanner.qml
@@ -11,6 +11,15 @@ FocusScope {
     property int currentIndex: 0
     property bool scrolling: false
     property bool actionsFocused: false
+
+    // Hero item transition state. Commits happen mid-transition via a ScriptAction
+    // so logo/title/badge/metadata/buttons update while content is invisible.
+    property int pendingIndex: 0
+    property int pendingDirection: 0
+    property real contentOpacity: 1.0
+    property real contentSlideX: 0
+    readonly property real contentSlideOffset: Theme.spacingLarge
+
     readonly property bool hasContent: heroModel && heroModel.length > 0
     readonly property var currentItem: hasContent ? heroModel[Math.min(currentIndex, heroModel.length - 1)] : null
     readonly property string currentBackdropUrl: imageUrl(currentItem, "Backdrop", Math.round(width * 2))
@@ -90,9 +99,23 @@ FocusScope {
         return "S" + String(item.ParentIndexNumber || 0).padStart(2, "0")
              + "E" + String(item.IndexNumber || 0).padStart(2, "0")
     }
+    function transitionToIndex(newIndex, direction) {
+        if (heroTransition.running) {
+            if (newIndex === pendingIndex) return
+            heroTransition.stop()
+            currentIndex = pendingIndex
+            contentOpacity = 1.0
+            contentSlideX = 0
+        }
+        if (newIndex === currentIndex) return
+        pendingDirection = direction
+        pendingIndex = newIndex
+        heroTransition.start()
+    }
+
     function cycle(delta) {
         if (!hasContent || heroModel.length < 2) return
-        currentIndex = (currentIndex + delta + heroModel.length) % heroModel.length
+        transitionToIndex((currentIndex + delta + heroModel.length) % heroModel.length, delta)
         cycleTimer.stop()
         manualPause.restart()
     }
@@ -352,7 +375,15 @@ FocusScope {
         }
     }
 
-    onHeroModelChanged: currentIndex = Math.min(currentIndex, Math.max(0, heroModel.length - 1))
+    onHeroModelChanged: {
+        if (heroTransition.running) {
+            heroTransition.stop()
+            currentIndex = pendingIndex
+            contentOpacity = 1.0
+            contentSlideX = 0
+        }
+        currentIndex = Math.min(currentIndex, Math.max(0, heroModel.length - 1))
+    }
     onActiveFocusChanged: {
         if (!activeFocus)
             resetToCarousel()
@@ -404,9 +435,42 @@ FocusScope {
         running: ConfigManager.heroBannerEnabled && ConfigManager.heroBannerAutoCycleEnabled
                  && root.heroModel.length > 1 && !root.activeFocus && !root.buttonsFocused
                  && !root.actionsFocused && !root.scrolling && !PlayerController.isPlaybackActive && !manualPause.running
-        onTriggered: root.currentIndex = (root.currentIndex + 1) % root.heroModel.length
+        onTriggered: root.transitionToIndex((root.currentIndex + 1) % root.heroModel.length, 1)
     }
     Timer { id: manualPause; interval: 3000 }
+
+    // Directional cross-fade content transition. The two halves are each
+    // Theme.durationFade / 2, so the swap lands at the midpoint of the in-card
+    // backdrop cross-fade (which runs full Theme.durationFade). With animations
+    // disabled, all durations are 0 and the swap is instantaneous.
+    SequentialAnimation {
+        id: heroTransition
+        running: false
+
+        ParallelAnimation {
+            NumberAnimation { target: root; property: "contentOpacity"; to: 0.0; duration: Theme.durationFade / 2; easing.type: Easing.OutQuad }
+            NumberAnimation { target: root; property: "contentSlideX"; to: -root.contentSlideOffset * (root.pendingDirection || 1); duration: Theme.durationFade / 2; easing.type: Easing.OutQuad }
+        }
+        ScriptAction {
+            script: {
+                root.currentIndex = root.pendingIndex
+                root.contentSlideX = root.contentSlideOffset * (root.pendingDirection || 1)
+            }
+        }
+        ParallelAnimation {
+            NumberAnimation { target: root; property: "contentOpacity"; to: 1.0; duration: Theme.durationFade / 2; easing.type: Easing.InQuad }
+            NumberAnimation { target: root; property: "contentSlideX"; to: 0; duration: Theme.durationFade / 2; easing.type: Easing.InQuad }
+        }
+    }
+
+    onCurrentBackdropUrlChanged: {
+        var target = heroCard.showBackdropA ? heroBackdropB : heroBackdropA
+        if (target.source.toString() === currentBackdropUrl && target.status === Image.Ready) {
+            heroCard.showBackdropA = (target === heroBackdropA)
+            return
+        }
+        target.source = currentBackdropUrl
+    }
 
     Rectangle {
         id: heroCard
@@ -420,12 +484,41 @@ FocusScope {
         scale: root.activeFocus && !root.actionsFocused ? 1.01 : 1
         Behavior on scale { NumberAnimation { duration: Theme.uiAnimationsEnabled ? Theme.durationShort : 0 } }
 
+        property bool showBackdropA: true
+
+        function checkBackdropStatus(img) {
+            if (img.status !== Image.Ready) return
+            // Only switch if this image is the one we last pointed at the current URL.
+            if (img.source.toString() !== root.currentBackdropUrl) return
+            showBackdropA = (img === heroBackdropA)
+        }
+
         Image {
+            id: heroBackdropA
             anchors.fill: parent
-            source: root.currentBackdropUrl
             fillMode: Image.PreserveAspectCrop
             asynchronous: true
             cache: true
+            opacity: heroCard.showBackdropA ? 1.0 : 0.0
+            Behavior on opacity { NumberAnimation { duration: Theme.durationFade } enabled: Theme.uiAnimationsEnabled }
+            onStatusChanged: heroCard.checkBackdropStatus(this)
+
+            layer.enabled: true
+            layer.effect: MultiEffect {
+                maskEnabled: true
+                maskSource: heroMask
+            }
+        }
+
+        Image {
+            id: heroBackdropB
+            anchors.fill: parent
+            fillMode: Image.PreserveAspectCrop
+            asynchronous: true
+            cache: true
+            opacity: heroCard.showBackdropA ? 0.0 : 1.0
+            Behavior on opacity { NumberAnimation { duration: Theme.durationFade } enabled: Theme.uiAnimationsEnabled }
+            onStatusChanged: heroCard.checkBackdropStatus(this)
 
             layer.enabled: true
             layer.effect: MultiEffect {
@@ -458,6 +551,8 @@ FocusScope {
             id: contentLoader
             anchors.fill: parent
             z: 1
+            opacity: root.contentOpacity
+            transform: Translate { x: root.contentSlideX }
             sourceComponent: root.combinedLayout ? combinedLayoutComponent : splitLayoutComponent
 
             onSourceComponentChanged: Qt.callLater(root.reapplyHeroPlacements)
@@ -476,6 +571,8 @@ FocusScope {
                     height: Theme.spacingSmall
                     radius: height / 2
                     color: index === root.currentIndex ? Theme.accentPrimary : Theme.textSecondary
+                    Behavior on width { NumberAnimation { duration: Theme.durationNormal; easing.type: Easing.OutCubic } enabled: Theme.uiAnimationsEnabled }
+                    Behavior on color { ColorAnimation { duration: Theme.durationNormal } enabled: Theme.uiAnimationsEnabled }
                 }
             }
         }

--- a/src/ui/HeroBanner.qml
+++ b/src/ui/HeroBanner.qml
@@ -18,11 +18,14 @@ FocusScope {
     property int pendingDirection: 0
     property real contentOpacity: 1.0
     property real contentSlideX: 0
+    property bool committingPendingIndex: false
     readonly property real contentSlideOffset: Theme.spacingLarge
 
     readonly property bool hasContent: heroModel && heroModel.length > 0
     readonly property var currentItem: hasContent ? heroModel[Math.min(currentIndex, heroModel.length - 1)] : null
-    readonly property string currentBackdropUrl: imageUrl(currentItem, "Backdrop", Math.round(width * 2))
+    readonly property int backdropIndex: heroTransition.running ? pendingIndex : currentIndex
+    readonly property var backdropItem: hasContent ? heroModel[Math.min(backdropIndex, heroModel.length - 1)] : null
+    readonly property string currentBackdropUrl: imageUrl(backdropItem, "Backdrop", Math.round(width * 2))
     readonly property string currentLogoUrl: logoImageUrl(currentItem)
     readonly property bool buttonsFocused: contentLoader.item
                                          && contentLoader.item.playButton
@@ -103,7 +106,6 @@ FocusScope {
         if (heroTransition.running) {
             if (newIndex === pendingIndex) return
             heroTransition.stop()
-            currentIndex = pendingIndex
             contentOpacity = 1.0
             contentSlideX = 0
         }
@@ -378,11 +380,18 @@ FocusScope {
     onHeroModelChanged: {
         if (heroTransition.running) {
             heroTransition.stop()
-            currentIndex = pendingIndex
             contentOpacity = 1.0
             contentSlideX = 0
         }
         currentIndex = Math.min(currentIndex, Math.max(0, heroModel.length - 1))
+    }
+    onCurrentIndexChanged: {
+        if (heroTransition.running && !committingPendingIndex) {
+            pendingIndex = currentIndex
+            heroTransition.stop()
+            contentOpacity = 1.0
+            contentSlideX = 0
+        }
     }
     onActiveFocusChanged: {
         if (!activeFocus)
@@ -453,7 +462,9 @@ FocusScope {
         }
         ScriptAction {
             script: {
+                root.committingPendingIndex = true
                 root.currentIndex = root.pendingIndex
+                root.committingPendingIndex = false
                 root.contentSlideX = root.contentSlideOffset * (root.pendingDirection || 1)
             }
         }
@@ -464,9 +475,14 @@ FocusScope {
     }
 
     onCurrentBackdropUrlChanged: {
+        if (currentBackdropUrl === "") {
+            heroCard.clearBackdrop()
+            return
+        }
         var target = heroCard.showBackdropA ? heroBackdropB : heroBackdropA
         if (target.source.toString() === currentBackdropUrl && target.status === Image.Ready) {
             heroCard.showBackdropA = (target === heroBackdropA)
+            heroCard.showBackdropNeutral = false
             return
         }
         target.source = currentBackdropUrl
@@ -485,11 +501,34 @@ FocusScope {
         Behavior on scale { NumberAnimation { duration: Theme.uiAnimationsEnabled ? Theme.durationShort : 0 } }
 
         property bool showBackdropA: true
+        property bool showBackdropNeutral: true
+
+        function clearBackdrop() {
+            showBackdropNeutral = true
+            if (showBackdropA) {
+                heroBackdropB.source = ""
+            } else {
+                heroBackdropA.source = ""
+            }
+        }
 
         function checkBackdropStatus(img) {
+            if (img.source.toString() === "") {
+                if (root.currentBackdropUrl === "") {
+                    clearBackdrop()
+                }
+                return
+            }
+            if (img.status === Image.Error) {
+                if (img.source.toString() === root.currentBackdropUrl) {
+                    clearBackdrop()
+                }
+                return
+            }
             if (img.status !== Image.Ready) return
             // Only switch if this image is the one we last pointed at the current URL.
             if (img.source.toString() !== root.currentBackdropUrl) return
+            showBackdropNeutral = false
             showBackdropA = (img === heroBackdropA)
         }
 
@@ -499,7 +538,7 @@ FocusScope {
             fillMode: Image.PreserveAspectCrop
             asynchronous: true
             cache: true
-            opacity: heroCard.showBackdropA ? 1.0 : 0.0
+            opacity: !heroCard.showBackdropNeutral && heroCard.showBackdropA ? 1.0 : 0.0
             Behavior on opacity { NumberAnimation { duration: Theme.durationFade } enabled: Theme.uiAnimationsEnabled }
             onStatusChanged: heroCard.checkBackdropStatus(this)
 
@@ -516,7 +555,7 @@ FocusScope {
             fillMode: Image.PreserveAspectCrop
             asynchronous: true
             cache: true
-            opacity: heroCard.showBackdropA ? 0.0 : 1.0
+            opacity: !heroCard.showBackdropNeutral && !heroCard.showBackdropA ? 1.0 : 0.0
             Behavior on opacity { NumberAnimation { duration: Theme.durationFade } enabled: Theme.uiAnimationsEnabled }
             onStatusChanged: heroCard.checkBackdropStatus(this)
 

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -27,6 +27,12 @@ Window {
 
         startupUpdateTimer.start()
     }
+
+    Binding {
+        target: ScreensaverController
+        property: "appWindowVisible"
+        value: window.visible && window.visibility !== Window.Minimized
+    }
     
     // ========================================
     // Font Loader for Material Symbols
@@ -62,6 +68,7 @@ Window {
     }
     readonly property bool embeddedPlaybackActive: PlayerController.supportsEmbeddedVideo && PlayerController.isPlaybackActive
     readonly property bool useDetachedPlaybackOverlayWindow: Qt.platform.os === "windows"
+    readonly property bool useDetachedScreensaverWindow: useDetachedPlaybackOverlayWindow && embeddedPlaybackActive
     readonly property bool playbackOverlayNavigationActive: embeddedPlaybackActive
                                                          && (activeEmbeddedPlaybackOverlay.fullControlsVisible
                                                              || activeEmbeddedPlaybackOverlay.chapterMode)
@@ -161,6 +168,7 @@ Window {
                      && window.visible
                      && window.visibility !== Window.Minimized
                      && embeddedPlaybackActive
+                     && !ScreensaverController.active
         x: window.x
         y: window.y
         width: window.width
@@ -172,6 +180,33 @@ Window {
         EmbeddedPlaybackOverlay {
             id: embeddedPlaybackOverlayDetached
             anchors.fill: parent
+        }
+    }
+
+    Window {
+        id: screensaverWindow
+        flags: Qt.Tool | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
+        transientParent: window
+        modality: Qt.NonModal
+        color: "black"
+        visible: useDetachedScreensaverWindow
+                     && window.visible
+                     && window.visibility !== Window.Minimized
+                     && ScreensaverController.active
+        x: window.x
+        y: window.y
+        width: window.width
+        height: window.height
+        onVisibleChanged: {
+            if (visible) {
+                requestActivate()
+            }
+        }
+
+        ScreensaverOverlay {
+            anchors.fill: parent
+            active: ScreensaverController.active
+            focusWindow: window
         }
     }
 
@@ -383,6 +418,14 @@ Window {
                 })
             }
         }
+    }
+
+    ScreensaverOverlay {
+        parent: Overlay.overlay
+        anchors.fill: parent
+        z: 100000
+        active: ScreensaverController.active && !useDetachedScreensaverWindow
+        focusWindow: window
     }
 
     Loader {

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -212,6 +212,7 @@ Window {
             active: useDetachedScreensaverWindow && ScreensaverController.active
             focusWindow: embeddedOverlayWindow
             restoreWindow: window
+            restoreWindowEligible: window.appWindowEligible
         }
     }
 
@@ -431,6 +432,7 @@ Window {
         z: 100000
         active: ScreensaverController.active && !useDetachedScreensaverWindow
         focusWindow: window
+        restoreWindowEligible: window.appWindowEligible
     }
 
     Loader {

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -31,7 +31,7 @@ Window {
     Binding {
         target: ScreensaverController
         property: "appWindowVisible"
-        value: window.visible && window.visibility !== Window.Minimized
+        value: window.appWindowEligible
     }
     
     // ========================================
@@ -77,6 +77,9 @@ Window {
     readonly property bool awaitingUpNextTransition: PlayerController.awaitingNextEpisodeResolution
                                                   && !PlayerController.isPlaybackActive
     property bool pendingStartupUpdatePopup: false
+    readonly property bool appWindowEligible: window.visible
+                                           && window.visibility !== Window.Minimized
+                                           && Qt.application.state === Qt.ApplicationActive
 
     function ensureMediaSourceSelectionDialog() {
         if (!mediaSourceSelectionDialogLoader.active) {
@@ -188,25 +191,27 @@ Window {
         flags: Qt.Tool | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
         transientParent: window
         modality: Qt.NonModal
-        color: "black"
+        color: "transparent"
         visible: useDetachedScreensaverWindow
-                     && window.visible
-                     && window.visibility !== Window.Minimized
+                     && window.appWindowEligible
                      && ScreensaverController.active
         x: window.x
         y: window.y
         width: window.width
         height: window.height
         onVisibleChanged: {
-            if (visible) {
+            if (visible && window.appWindowEligible) {
                 requestActivate()
+            } else if (!visible && window.appWindowEligible) {
+                window.requestActivate()
             }
         }
 
         ScreensaverOverlay {
             anchors.fill: parent
-            active: ScreensaverController.active
-            focusWindow: window
+            active: useDetachedScreensaverWindow && ScreensaverController.active
+            focusWindow: embeddedOverlayWindow
+            restoreWindow: window
         }
     }
 

--- a/src/ui/ScreensaverController.cpp
+++ b/src/ui/ScreensaverController.cpp
@@ -31,6 +31,10 @@ ScreensaverController::ScreensaverController(QGuiApplication *app,
     if (m_config) {
         connect(m_config, &ConfigManager::screensaverEnabledChanged, this, [this]() {
             emit effectiveSettingsChanged();
+            if (!effectiveEnabled()) {
+                dismiss();
+                return;
+            }
             schedule();
         });
         connect(m_config, &ConfigManager::screensaverModeChanged, this, [this]() {
@@ -167,10 +171,7 @@ bool ScreensaverController::eventCountsAsActivity(QEvent *event) const
 {
     switch (event->type()) {
     case QEvent::KeyPress:
-    {
-        auto *keyEvent = static_cast<QKeyEvent*>(event);
-        return keyEvent && !keyEvent->isAutoRepeat();
-    }
+        return true;
     case QEvent::MouseMove:
     case QEvent::MouseButtonPress:
     case QEvent::MouseButtonRelease:

--- a/src/ui/ScreensaverController.cpp
+++ b/src/ui/ScreensaverController.cpp
@@ -1,0 +1,219 @@
+#include "ScreensaverController.h"
+
+#include "network/AuthenticationService.h"
+#include "player/PlayerController.h"
+#include "utils/ConfigManager.h"
+
+#include <QEvent>
+#include <QGuiApplication>
+#include <QKeyEvent>
+#include <QProcessEnvironment>
+#include <QWheelEvent>
+
+ScreensaverController::ScreensaverController(QGuiApplication *app,
+                                             ConfigManager *config,
+                                             PlayerController *player,
+                                             AuthenticationService *auth,
+                                             QObject *parent)
+    : QObject(parent)
+    , m_app(app)
+    , m_config(config)
+    , m_player(player)
+    , m_auth(auth)
+{
+    m_timer.setSingleShot(true);
+    connect(&m_timer, &QTimer::timeout, this, &ScreensaverController::activate);
+
+    if (m_app) {
+        m_app->installEventFilter(this);
+    }
+
+    if (m_config) {
+        connect(m_config, &ConfigManager::screensaverEnabledChanged, this, [this]() {
+            emit effectiveSettingsChanged();
+            schedule();
+        });
+        connect(m_config, &ConfigManager::screensaverModeChanged, this, [this]() {
+            emit effectiveSettingsChanged();
+        });
+        connect(m_config, &ConfigManager::screensaverTimeoutSecondsChanged, this, [this]() {
+            emit effectiveSettingsChanged();
+            schedule();
+        });
+    }
+
+    if (m_player) {
+        connect(m_player, &PlayerController::playbackStateChanged, this, [this]() {
+            if (playbackBlocksScreensaver()) {
+                dismiss();
+            }
+            schedule();
+        });
+        connect(m_player, &PlayerController::awaitingNextEpisodeResolutionChanged, this, [this]() {
+            if (playbackBlocksScreensaver()) {
+                dismiss();
+            }
+            schedule();
+        });
+    }
+
+    if (m_auth) {
+        connect(m_auth, &AuthenticationService::loginSuccess, this, [this]() {
+            schedule();
+        });
+        connect(m_auth, &AuthenticationService::loggedOut, this, [this]() {
+            dismiss();
+            schedule();
+        });
+        connect(m_auth, &AuthenticationService::sessionExpired, this, [this]() {
+            dismiss();
+            schedule();
+        });
+    }
+
+    schedule();
+}
+
+bool ScreensaverController::effectiveEnabled() const
+{
+    return debugForceEnabled() || (m_config && m_config->getScreensaverEnabled());
+}
+
+QString ScreensaverController::mode() const
+{
+    return m_config ? m_config->getScreensaverMode() : QStringLiteral("libraryBackdrops");
+}
+
+int ScreensaverController::timeoutMs() const
+{
+    if (debugForceEnabled()) {
+        return debugTimeoutMs();
+    }
+    const int seconds = m_config ? m_config->getScreensaverTimeoutSeconds() : 300;
+    return qBound(15000, seconds * 1000, 86400000);
+}
+
+void ScreensaverController::setAppWindowVisible(bool visible)
+{
+    if (m_appWindowVisible == visible) {
+        return;
+    }
+    m_appWindowVisible = visible;
+    emit appWindowVisibleChanged();
+    if (!m_appWindowVisible) {
+        dismiss();
+    }
+    schedule();
+}
+
+void ScreensaverController::noteActivity()
+{
+    if (m_active) {
+        dismiss();
+        return;
+    }
+    schedule();
+}
+
+void ScreensaverController::dismiss()
+{
+    if (!m_active) {
+        return;
+    }
+    m_active = false;
+    emit activeChanged();
+    schedule();
+}
+
+bool ScreensaverController::eventFilter(QObject *watched, QEvent *event)
+{
+    Q_UNUSED(watched)
+    if (!eventCountsAsActivity(event)) {
+        return QObject::eventFilter(watched, event);
+    }
+
+    if (m_active) {
+        dismiss();
+        return true;
+    }
+
+    schedule();
+    return QObject::eventFilter(watched, event);
+}
+
+bool ScreensaverController::canArm() const
+{
+    return effectiveEnabled()
+           && m_appWindowVisible
+           && m_auth
+           && m_auth->isAuthenticated()
+           && !playbackBlocksScreensaver();
+}
+
+bool ScreensaverController::playbackBlocksScreensaver() const
+{
+    if (!m_player) {
+        return false;
+    }
+
+    const PlayerController::PlaybackState state = m_player->playbackState();
+    return state == PlayerController::Playing
+           || state == PlayerController::Loading
+           || state == PlayerController::Buffering
+           || m_player->awaitingNextEpisodeResolution();
+}
+
+bool ScreensaverController::eventCountsAsActivity(QEvent *event) const
+{
+    switch (event->type()) {
+    case QEvent::KeyPress:
+    {
+        auto *keyEvent = static_cast<QKeyEvent*>(event);
+        return keyEvent && !keyEvent->isAutoRepeat();
+    }
+    case QEvent::MouseMove:
+    case QEvent::MouseButtonPress:
+    case QEvent::MouseButtonRelease:
+    case QEvent::Wheel:
+    case QEvent::TouchBegin:
+    case QEvent::TouchUpdate:
+    case QEvent::TabletMove:
+    case QEvent::TabletPress:
+    case QEvent::TabletRelease:
+        return true;
+    default:
+        return false;
+    }
+}
+
+void ScreensaverController::schedule()
+{
+    m_timer.stop();
+    if (m_active || !canArm()) {
+        return;
+    }
+    m_timer.start(timeoutMs());
+}
+
+void ScreensaverController::activate()
+{
+    if (!canArm() || m_active) {
+        schedule();
+        return;
+    }
+    m_active = true;
+    emit activeChanged();
+}
+
+bool ScreensaverController::debugForceEnabled() const
+{
+    const QByteArray value = qgetenv("BLOOM_SCREENSAVER_DEBUG").trimmed().toLower();
+    return value == "1" || value == "true" || value == "yes" || value == "on";
+}
+
+int ScreensaverController::debugTimeoutMs() const
+{
+    bool ok = false;
+    const int value = QString::fromUtf8(qgetenv("BLOOM_SCREENSAVER_DEBUG_TIMEOUT_MS")).toInt(&ok);
+    return ok && value > 0 ? qBound(250, value, 60000) : 3000;
+}

--- a/src/ui/ScreensaverController.h
+++ b/src/ui/ScreensaverController.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <QObject>
+#include <QTimer>
+
+class QGuiApplication;
+class QEvent;
+class ConfigManager;
+class PlayerController;
+class AuthenticationService;
+
+class ScreensaverController : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool active READ active NOTIFY activeChanged)
+    Q_PROPERTY(bool effectiveEnabled READ effectiveEnabled NOTIFY effectiveSettingsChanged)
+    Q_PROPERTY(QString mode READ mode NOTIFY effectiveSettingsChanged)
+    Q_PROPERTY(int timeoutMs READ timeoutMs NOTIFY effectiveSettingsChanged)
+    Q_PROPERTY(bool appWindowVisible READ appWindowVisible WRITE setAppWindowVisible NOTIFY appWindowVisibleChanged)
+
+public:
+    explicit ScreensaverController(QGuiApplication *app,
+                                   ConfigManager *config,
+                                   PlayerController *player,
+                                   AuthenticationService *auth,
+                                   QObject *parent = nullptr);
+
+    bool active() const { return m_active; }
+    bool effectiveEnabled() const;
+    QString mode() const;
+    int timeoutMs() const;
+    bool appWindowVisible() const { return m_appWindowVisible; }
+
+    Q_INVOKABLE void setAppWindowVisible(bool visible);
+    Q_INVOKABLE void noteActivity();
+    Q_INVOKABLE void dismiss();
+
+signals:
+    void activeChanged();
+    void effectiveSettingsChanged();
+    void appWindowVisibleChanged();
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+    bool canArm() const;
+    bool playbackBlocksScreensaver() const;
+    bool eventCountsAsActivity(QEvent *event) const;
+    void schedule();
+    void activate();
+    bool debugForceEnabled() const;
+    int debugTimeoutMs() const;
+
+    QGuiApplication *m_app = nullptr;
+    ConfigManager *m_config = nullptr;
+    PlayerController *m_player = nullptr;
+    AuthenticationService *m_auth = nullptr;
+    QTimer m_timer;
+    bool m_active = false;
+    bool m_appWindowVisible = false;
+};

--- a/src/ui/ScreensaverOverlay.qml
+++ b/src/ui/ScreensaverOverlay.qml
@@ -20,7 +20,6 @@ Item {
     property var savedFocusItem: null
     property var restoreWindow: null
     property string savedNavigationMode: "pointer"
-    property string requestedUserId: ""
     property string currentBackdropUrl: showBackdropA ? backdropAUrl : backdropBUrl
     property var currentItem: currentIndex >= 0 && currentIndex < items.length ? items[currentIndex] : ({})
     property real logoX: Math.round(width * 0.08)
@@ -34,18 +33,20 @@ Item {
 
     onVisibleChanged: {
         if (visible) {
+            restoreWindow = restoreWindow || focusWindow || root.Window.window || null
             if (typeof InputModeManager !== "undefined") {
                 savedNavigationMode = InputModeManager.pointerActive ? "pointer" : "keyboard"
                 InputModeManager.setNavigationMode("keyboard")
                 InputModeManager.hideCursor(true)
             }
             if (artworkMode && items.length === 0) {
-                requestedUserId = AuthenticationService.userId || ""
                 LibraryService.getScreensaverItems(80)
             }
             selectNextItem()
             cycleTimer.restart()
-            bounceTimer.restart()
+            if (bouncingLogoMode) {
+                bounceTimer.restart()
+            }
         } else {
             cycleTimer.stop()
             bounceTimer.stop()
@@ -72,6 +73,7 @@ Item {
         target: ScreensaverController
         function onActiveChanged() {
             if (root.active) {
+                restoreWindow = restoreWindow || focusWindow || root.Window.window || null
                 savedFocusItem = root.focusWindow
                         ? root.focusWindow.activeFocusItem
                         : root.Window.activeFocusItem
@@ -83,10 +85,10 @@ Item {
         target: AuthenticationService
         function onLoggedOut() { root.resetArtwork() }
         function onSessionExpired() { root.resetArtwork() }
+        function onSessionExpiredAfterPlayback() { root.resetArtwork() }
     }
 
     function resetArtwork() {
-        requestedUserId = ""
         root.items = []
         root.currentIndex = -1
         root.placementIndex = 0
@@ -95,35 +97,12 @@ Item {
         root.backdropBUrl = ""
     }
 
-    function imageUrlFor(item, imageType, width) {
-        if (!item || !item.Id)
-            return ""
-        return LibraryService.getCachedImageUrlWithWidth(item.Id, imageType, width)
-    }
-
     function backdropUrlFor(item) {
-        if (!item)
-            return ""
-        var itemId = item.Id || ""
-        var tag = ""
-        if (item.BackdropImageTags && item.BackdropImageTags.length > 0) {
-            tag = item.BackdropImageTags[0]
-        } else if (item.ImageTags && item.ImageTags.Backdrop) {
-            tag = item.ImageTags.Backdrop
-        } else if (item.ParentBackdropImageTags && item.ParentBackdropImageTags.length > 0) {
-            tag = item.ParentBackdropImageTags[0]
-            itemId = item.ParentBackdropItemId || item.SeriesId || item.Id || ""
-        }
-        if (!itemId || !tag)
-            return ""
-        var url = LibraryService.getCachedImageUrlWithWidth(itemId, "Backdrop", 1920)
-        return url ? url + "?tag=" + tag : ""
+        return item && item.BackdropUrl ? item.BackdropUrl : ""
     }
 
     function logoUrlFor(item) {
-        return item && item.ImageTags && item.ImageTags.Logo
-                ? LibraryService.getCachedImageUrlWithWidth(item.Id, "Logo", 700)
-                : ""
+        return item && item.LogoUrl ? item.LogoUrl : ""
     }
 
     function selectNextItem() {
@@ -362,20 +341,10 @@ Item {
     Connections {
         target: LibraryService
         function onScreensaverItemsLoaded(loadedItems) {
-            if (!AuthenticationService.authenticated
-                    || !root.visible
-                    || root.requestedUserId === ""
-                    || AuthenticationService.userId !== root.requestedUserId) {
+            if (!root.visible) {
                 return
             }
-            var filtered = []
-            for (var i = 0; loadedItems && i < loadedItems.length; ++i) {
-                var item = loadedItems[i]
-                if (root.backdropUrlFor(item) !== "") {
-                    filtered.push(item)
-                }
-            }
-            root.items = filtered
+            root.items = loadedItems || []
             root.currentIndex = -1
             root.selectNextItem()
         }

--- a/src/ui/ScreensaverOverlay.qml
+++ b/src/ui/ScreensaverOverlay.qml
@@ -19,6 +19,7 @@ Item {
     property string backdropBUrl: ""
     property var savedFocusItem: null
     property var restoreWindow: null
+    property bool restoreWindowEligible: true
     property string savedNavigationMode: "pointer"
     property string currentBackdropUrl: showBackdropA ? backdropAUrl : backdropBUrl
     property var currentItem: currentIndex >= 0 && currentIndex < items.length ? items[currentIndex] : ({})
@@ -55,7 +56,7 @@ Item {
                     InputModeManager.setNavigationMode(savedNavigationMode)
                     InputModeManager.hideCursor(savedNavigationMode !== "pointer")
                 }
-                if (restoreWindow && typeof restoreWindow.requestActivate === "function") {
+                if (restoreWindowEligible && restoreWindow && typeof restoreWindow.requestActivate === "function") {
                     restoreWindow.requestActivate()
                 }
                 if (savedFocusItem && savedFocusItem.parent && typeof savedFocusItem.forceActiveFocus === "function") {

--- a/src/ui/ScreensaverOverlay.qml
+++ b/src/ui/ScreensaverOverlay.qml
@@ -1,0 +1,357 @@
+import QtQuick
+import QtQuick.Window
+import QtQuick.Effects
+import BloomUI
+
+Item {
+    id: root
+    anchors.fill: parent
+    visible: active
+    focus: visible
+
+    property bool active: ScreensaverController.active
+    property var focusWindow: null
+    property var items: []
+    property int currentIndex: -1
+    property int placementIndex: 0
+    property bool showBackdropA: true
+    property string backdropAUrl: ""
+    property string backdropBUrl: ""
+    property var savedFocusItem: null
+    property string currentBackdropUrl: showBackdropA ? backdropAUrl : backdropBUrl
+    property var currentItem: currentIndex >= 0 && currentIndex < items.length ? items[currentIndex] : ({})
+    property real logoX: Math.round(width * 0.08)
+    property real logoY: Math.round(height * 0.10)
+    property real logoDx: 2.4
+    property real logoDy: 1.8
+
+    readonly property bool artworkMode: ScreensaverController.mode !== "black"
+    readonly property bool bouncingLogoMode: ScreensaverController.mode === "bouncingLogo"
+    readonly property var placements: ["bottomLeft", "topRight", "bottomRight", "topLeft", "bottomCenter", "topCenter"]
+
+    onVisibleChanged: {
+        if (visible) {
+            if (artworkMode && items.length === 0) {
+                LibraryService.getScreensaverItems(80)
+            }
+            selectNextItem()
+            cycleTimer.restart()
+            bounceTimer.restart()
+        } else {
+            cycleTimer.stop()
+            bounceTimer.stop()
+            Qt.callLater(function() {
+                if (savedFocusItem && savedFocusItem.parent && typeof savedFocusItem.forceActiveFocus === "function") {
+                    savedFocusItem.forceActiveFocus()
+                }
+                savedFocusItem = null
+            })
+        }
+    }
+
+    onWidthChanged: clampLogo()
+    onHeightChanged: clampLogo()
+
+    Connections {
+        target: ScreensaverController
+        function onActiveChanged() {
+            if (root.active) {
+                savedFocusItem = root.focusWindow
+                        ? root.focusWindow.activeFocusItem
+                        : root.Window.activeFocusItem
+            }
+        }
+    }
+
+    Connections {
+        target: AuthenticationService
+        function onLoggedOut() { root.resetArtwork() }
+        function onSessionExpired() { root.resetArtwork() }
+    }
+
+    function resetArtwork() {
+        root.items = []
+        root.currentIndex = -1
+        root.placementIndex = 0
+        root.showBackdropA = true
+        root.backdropAUrl = ""
+        root.backdropBUrl = ""
+    }
+
+    function imageUrlFor(item, imageType, width) {
+        if (!item || !item.Id)
+            return ""
+        return LibraryService.getCachedImageUrlWithWidth(item.Id, imageType, width)
+    }
+
+    function backdropUrlFor(item) {
+        if (!item)
+            return ""
+        var itemId = item.Id || ""
+        var tag = ""
+        if (item.BackdropImageTags && item.BackdropImageTags.length > 0) {
+            tag = item.BackdropImageTags[0]
+        } else if (item.ImageTags && item.ImageTags.Backdrop) {
+            tag = item.ImageTags.Backdrop
+        } else if (item.ParentBackdropImageTags && item.ParentBackdropImageTags.length > 0) {
+            tag = item.ParentBackdropImageTags[0]
+            itemId = item.ParentBackdropItemId || item.SeriesId || item.Id || ""
+        }
+        if (!itemId || !tag)
+            return ""
+        var url = LibraryService.getCachedImageUrlWithWidth(itemId, "Backdrop", 1920)
+        return url ? url + "?tag=" + tag : ""
+    }
+
+    function logoUrlFor(item) {
+        return item && item.ImageTags && item.ImageTags.Logo
+                ? LibraryService.getCachedImageUrlWithWidth(item.Id, "Logo", 700)
+                : ""
+    }
+
+    function selectNextItem() {
+        if (!artworkMode || items.length === 0) {
+            currentIndex = -1
+            return
+        }
+
+        currentIndex = (currentIndex + 1) % items.length
+        placementIndex = (placementIndex + 1) % placements.length
+        var nextUrl = backdropUrlFor(currentItem)
+        if (showBackdropA) {
+            backdropBUrl = nextUrl
+        } else {
+            backdropAUrl = nextUrl
+        }
+        showBackdropA = !showBackdropA
+        resetLogoPosition()
+    }
+
+    function resetLogoPosition() {
+        logoX = Math.round(Math.max(Theme.spacingLarge, width * (0.08 + ((placementIndex % 3) * 0.12))))
+        logoY = Math.round(Math.max(Theme.spacingLarge, height * (0.10 + ((placementIndex % 2) * 0.16))))
+        logoDx = placementIndex % 2 === 0 ? 2.4 : -2.4
+        logoDy = placementIndex % 3 === 0 ? 1.8 : -1.8
+        clampLogo()
+    }
+
+    function clampLogo() {
+        var maxX = Math.max(0, width - bouncingLogo.width - Theme.spacingLarge)
+        var maxY = Math.max(0, height - bouncingLogo.height - Theme.spacingLarge)
+        logoX = Math.max(Theme.spacingLarge, Math.min(maxX, logoX))
+        logoY = Math.max(Theme.spacingLarge, Math.min(maxY, logoY))
+    }
+
+    function metadataPositionFor(placement, blockWidth, blockHeight) {
+        var margin = Math.round(64 * Theme.layoutScale)
+        var centeredX = Math.round(Math.max(margin, (root.width - blockWidth) / 2))
+        var rightX = Math.max(margin, root.width - blockWidth - margin)
+        var bottomY = Math.max(margin, root.height - blockHeight - margin)
+        if (placement === "topLeft")
+            return { x: margin, y: margin }
+        if (placement === "topRight")
+            return { x: rightX, y: margin }
+        if (placement === "bottomRight")
+            return { x: rightX, y: bottomY }
+        if (placement === "topCenter")
+            return { x: centeredX, y: margin }
+        if (placement === "bottomCenter")
+            return { x: centeredX, y: bottomY }
+        return { x: margin, y: bottomY }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: "black"
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        enabled: root.visible
+        hoverEnabled: enabled
+        acceptedButtons: Qt.AllButtons
+        preventStealing: true
+        z: 1000
+        onPressed: function(mouse) { mouse.accepted = true }
+        onReleased: function(mouse) { mouse.accepted = true }
+        onClicked: function(mouse) { mouse.accepted = true }
+        onWheel: function(wheel) { wheel.accepted = true }
+    }
+
+    Item {
+        anchors.fill: parent
+        visible: root.artworkMode
+        opacity: 0.55
+
+        Image {
+            id: backdropA
+            anchors.fill: parent
+            source: root.backdropAUrl
+            fillMode: Image.PreserveAspectCrop
+            asynchronous: true
+            cache: true
+            opacity: root.showBackdropA ? 1 : 0
+            scale: root.showBackdropA && root.visible ? 1.04 : 1.0
+            Behavior on opacity { NumberAnimation { duration: Theme.uiAnimationsEnabled ? 1600 : 0 } }
+            Behavior on scale { NumberAnimation { duration: Theme.uiAnimationsEnabled ? 12000 : 0 } }
+            layer.enabled: true
+            layer.effect: MultiEffect {
+                saturation: 0.72
+                brightness: -0.18
+            }
+        }
+
+        Image {
+            id: backdropB
+            anchors.fill: parent
+            source: root.backdropBUrl
+            fillMode: Image.PreserveAspectCrop
+            asynchronous: true
+            cache: true
+            opacity: root.showBackdropA ? 0 : 1
+            scale: !root.showBackdropA && root.visible ? 1.04 : 1.0
+            Behavior on opacity { NumberAnimation { duration: Theme.uiAnimationsEnabled ? 1600 : 0 } }
+            Behavior on scale { NumberAnimation { duration: Theme.uiAnimationsEnabled ? 12000 : 0 } }
+            layer.enabled: true
+            layer.effect: MultiEffect {
+                saturation: 0.72
+                brightness: -0.18
+            }
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        visible: root.artworkMode
+        color: "black"
+        opacity: 0.42
+    }
+
+    Column {
+        id: metadataBlock
+        visible: root.artworkMode && root.currentIndex >= 0
+        width: Math.min(Math.round(620 * Theme.layoutScale), root.width - Math.round(128 * Theme.layoutScale))
+        spacing: Theme.spacingMedium
+        x: root.metadataPositionFor(root.placements[root.placementIndex], width, height).x
+        y: root.metadataPositionFor(root.placements[root.placementIndex], width, height).y
+
+        Behavior on x { NumberAnimation { duration: Theme.uiAnimationsEnabled ? 900 : 0; easing.type: Easing.InOutQuad } }
+        Behavior on y { NumberAnimation { duration: Theme.uiAnimationsEnabled ? 900 : 0; easing.type: Easing.InOutQuad } }
+
+        Image {
+            id: staticLogo
+            source: root.logoUrlFor(root.currentItem)
+            width: metadataBlock.width
+            height: Math.round(150 * Theme.layoutScale)
+            fillMode: Image.PreserveAspectFit
+            sourceSize.width: 700
+            asynchronous: true
+            visible: !root.bouncingLogoMode && source.toString().length > 0 && status !== Image.Error
+            opacity: 0.82
+        }
+
+        Text {
+            text: root.currentItem.Name || root.currentItem.SeriesName || ""
+            visible: !root.bouncingLogoMode && !staticLogo.visible
+            width: metadataBlock.width
+            color: Qt.rgba(1, 1, 1, 0.78)
+            font.family: Theme.fontPrimary
+            font.bold: true
+            font.pixelSize: Math.round(42 * Theme.layoutScale)
+            wrapMode: Text.WordWrap
+            maximumLineCount: 2
+            elide: Text.ElideRight
+        }
+
+        Text {
+            text: root.currentItem.Overview || ""
+            width: metadataBlock.width
+            color: Qt.rgba(1, 1, 1, 0.62)
+            font.family: Theme.fontPrimary
+            font.pixelSize: Math.round(20 * Theme.layoutScale)
+            lineHeight: 1.15
+            wrapMode: Text.WordWrap
+            maximumLineCount: 4
+            elide: Text.ElideRight
+            visible: text.length > 0
+        }
+    }
+
+    Image {
+        id: bouncingLogo
+        visible: root.artworkMode && root.bouncingLogoMode && root.currentIndex >= 0
+        source: root.logoUrlFor(root.currentItem)
+        x: root.logoX
+        y: root.logoY
+        width: Math.min(Math.round(320 * Theme.layoutScale), root.width * 0.28)
+        height: Math.round(130 * Theme.layoutScale)
+        fillMode: Image.PreserveAspectFit
+        sourceSize.width: 700
+        asynchronous: true
+        opacity: 0.72
+    }
+
+    Text {
+        visible: root.artworkMode && root.bouncingLogoMode && bouncingLogo.status === Image.Error
+        text: root.currentItem.Name || ""
+        x: root.logoX
+        y: root.logoY
+        width: Math.min(Math.round(360 * Theme.layoutScale), root.width * 0.32)
+        color: Qt.rgba(1, 1, 1, 0.70)
+        font.family: Theme.fontPrimary
+        font.bold: true
+        font.pixelSize: Math.round(32 * Theme.layoutScale)
+        wrapMode: Text.WordWrap
+        maximumLineCount: 2
+        elide: Text.ElideRight
+    }
+
+    Timer {
+        id: cycleTimer
+        interval: 12000
+        repeat: true
+        running: root.visible && root.artworkMode
+        onTriggered: root.selectNextItem()
+    }
+
+    Timer {
+        id: bounceTimer
+        interval: 16
+        repeat: true
+        running: root.visible && root.bouncingLogoMode
+        onTriggered: {
+            var logoWidth = bouncingLogo.visible ? bouncingLogo.width : Math.min(Math.round(360 * Theme.layoutScale), root.width * 0.32)
+            var logoHeight = bouncingLogo.visible ? bouncingLogo.height : Math.round(90 * Theme.layoutScale)
+            var minX = Theme.spacingLarge
+            var minY = Theme.spacingLarge
+            var maxX = Math.max(minX, root.width - logoWidth - Theme.spacingLarge)
+            var maxY = Math.max(minY, root.height - logoHeight - Theme.spacingLarge)
+            root.logoX += root.logoDx
+            root.logoY += root.logoDy
+            if (root.logoX <= minX || root.logoX >= maxX) {
+                root.logoDx = -root.logoDx
+                root.logoX = Math.max(minX, Math.min(maxX, root.logoX))
+            }
+            if (root.logoY <= minY || root.logoY >= maxY) {
+                root.logoDy = -root.logoDy
+                root.logoY = Math.max(minY, Math.min(maxY, root.logoY))
+            }
+        }
+    }
+
+    Connections {
+        target: LibraryService
+        function onScreensaverItemsLoaded(loadedItems) {
+            var filtered = []
+            for (var i = 0; loadedItems && i < loadedItems.length; ++i) {
+                var item = loadedItems[i]
+                if (root.backdropUrlFor(item) !== "") {
+                    filtered.push(item)
+                }
+            }
+            root.items = filtered
+            root.currentIndex = -1
+            root.selectNextItem()
+        }
+    }
+}

--- a/src/ui/ScreensaverOverlay.qml
+++ b/src/ui/ScreensaverOverlay.qml
@@ -18,6 +18,9 @@ Item {
     property string backdropAUrl: ""
     property string backdropBUrl: ""
     property var savedFocusItem: null
+    property var restoreWindow: null
+    property string savedNavigationMode: "pointer"
+    property string requestedUserId: ""
     property string currentBackdropUrl: showBackdropA ? backdropAUrl : backdropBUrl
     property var currentItem: currentIndex >= 0 && currentIndex < items.length ? items[currentIndex] : ({})
     property real logoX: Math.round(width * 0.08)
@@ -31,7 +34,13 @@ Item {
 
     onVisibleChanged: {
         if (visible) {
+            if (typeof InputModeManager !== "undefined") {
+                savedNavigationMode = InputModeManager.pointerActive ? "pointer" : "keyboard"
+                InputModeManager.setNavigationMode("keyboard")
+                InputModeManager.hideCursor(true)
+            }
             if (artworkMode && items.length === 0) {
+                requestedUserId = AuthenticationService.userId || ""
                 LibraryService.getScreensaverItems(80)
             }
             selectNextItem()
@@ -41,6 +50,13 @@ Item {
             cycleTimer.stop()
             bounceTimer.stop()
             Qt.callLater(function() {
+                if (typeof InputModeManager !== "undefined") {
+                    InputModeManager.setNavigationMode(savedNavigationMode)
+                    InputModeManager.hideCursor(savedNavigationMode !== "pointer")
+                }
+                if (restoreWindow && typeof restoreWindow.requestActivate === "function") {
+                    restoreWindow.requestActivate()
+                }
                 if (savedFocusItem && savedFocusItem.parent && typeof savedFocusItem.forceActiveFocus === "function") {
                     savedFocusItem.forceActiveFocus()
                 }
@@ -70,6 +86,7 @@ Item {
     }
 
     function resetArtwork() {
+        requestedUserId = ""
         root.items = []
         root.currentIndex = -1
         root.placementIndex = 0
@@ -292,7 +309,10 @@ Item {
     }
 
     Text {
-        visible: root.artworkMode && root.bouncingLogoMode && bouncingLogo.status === Image.Error
+        visible: root.artworkMode
+                 && root.bouncingLogoMode
+                 && root.currentIndex >= 0
+                 && (bouncingLogo.source.toString().length === 0 || bouncingLogo.status === Image.Error)
         text: root.currentItem.Name || ""
         x: root.logoX
         y: root.logoY
@@ -342,6 +362,12 @@ Item {
     Connections {
         target: LibraryService
         function onScreensaverItemsLoaded(loadedItems) {
+            if (!AuthenticationService.authenticated
+                    || !root.visible
+                    || root.requestedUserId === ""
+                    || AuthenticationService.userId !== root.requestedUserId) {
+                return
+            }
             var filtered = []
             for (var i = 0; loadedItems && i < loadedItems.length; ++i) {
                 var item = loadedItems[i]

--- a/src/ui/SettingsScreen.qml
+++ b/src/ui/SettingsScreen.qml
@@ -87,6 +87,9 @@ FocusScope {
         function onHeroBannerLibraryIdsChanged() { root.scheduleSettingsSavedToast() }
         function onHeroBannerLogoPlacementChanged() { root.scheduleSettingsSavedToast() }
         function onHeroBannerInfoPlacementChanged() { root.scheduleSettingsSavedToast() }
+        function onScreensaverEnabledChanged() { root.scheduleSettingsSavedToast() }
+        function onScreensaverModeChanged() { root.scheduleSettingsSavedToast() }
+        function onScreensaverTimeoutSecondsChanged() { root.scheduleSettingsSavedToast() }
     }
 
     signal signOutRequested()

--- a/src/ui/WindowManager.cpp
+++ b/src/ui/WindowManager.cpp
@@ -6,6 +6,7 @@
 #include "utils/DisplayManager.h"
 #include "ui/ResponsiveLayoutManager.h"
 #include "utils/SidebarSettings.h"
+#include "ui/ScreensaverController.h"
 #include "utils/SystemPowerController.h"
 #include "utils/InputModeManager.h"
 #include "ui/UiSoundController.h"
@@ -157,6 +158,7 @@ void WindowManager::exposeContextProperties(ApplicationInitializer& appInit)
     context->setContextProperty("ResponsiveLayoutManager", ServiceLocator::get<ResponsiveLayoutManager>());
     
     context->setContextProperty("UiSoundController", ServiceLocator::get<UiSoundController>());
+    context->setContextProperty("ScreensaverController", ServiceLocator::get<ScreensaverController>());
     context->setContextProperty("SystemPowerController", ServiceLocator::get<SystemPowerController>());
 
     context->setContextProperty("AuthenticationService", ServiceLocator::get<AuthenticationService>());

--- a/src/ui/qmldir
+++ b/src/ui/qmldir
@@ -21,6 +21,7 @@ UnwatchedBadge 1.0 UnwatchedBadge.qml
 Sidebar 1.0 Sidebar.qml
 MediaProgressBar 1.0 MediaProgressBar.qml
 MpvProfileEditor 1.0 MpvProfileEditor.qml
+ScreensaverOverlay 1.0 ScreensaverOverlay.qml
 TrackSelector 1.0 TrackSelector.qml
 MediaInfoPanel 1.0 MediaInfoPanel.qml
 ToastNotification 1.0 ToastNotification.qml
@@ -28,7 +29,6 @@ UpNextScreen 1.0 UpNextScreen.qml
 A11yButton 1.0 A11yButton.qml
 RetryButton 1.0 RetryButton.qml
 singleton AccessibilityHelpers 1.0 AccessibilityHelpers.qml
-
 
 
 

--- a/src/ui/settings/DisplaySettings.qml
+++ b/src/ui/settings/DisplaySettings.qml
@@ -8,7 +8,7 @@ FocusScope {
 
     signal requestReturnToRail()
 
-    readonly property Item preferredEntryItem: themeCombo
+    readonly property Item preferredEntryItem: screensaverEnabledRow
     property Item _lastFocusedItem: null
 
     function enterFromRail() {
@@ -34,6 +34,11 @@ FocusScope {
 
     function previousColorSchemeControl() {
         return flavorRow.visible ? flavorCombo : themeCombo
+    }
+
+    function screensaverModeIndex() {
+        var values = ["libraryBackdrops", "bouncingLogo", "black"]
+        return Math.max(0, values.indexOf(ConfigManager.screensaverMode))
     }
 
     function syncThemeVariants(themeName, useDefaults) {
@@ -136,6 +141,84 @@ FocusScope {
                 width: flickable.width - 2 * Theme.spacingSmall
                 spacing: Theme.spacingMedium
 
+                // --- Screensaver ---
+                Text {
+                    text: qsTr("Screensaver")
+                    font.pixelSize: Theme.fontSizeBody
+                    font.family: Theme.fontPrimary
+                    font.weight: Font.DemiBold
+                    color: Theme.textPrimary
+                }
+
+                SettingsToggleRow {
+                    id: screensaverEnabledRow
+                    label: qsTr("Enable Screensaver")
+                    description: qsTr("Start an OLED-safe overlay after the app is idle.")
+                    checked: ConfigManager.screensaverEnabled
+                    ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
+                    onToggled: function(value) { ConfigManager.screensaverEnabled = value }
+                    onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
+                    KeyNavigation.down: screensaverModeCombo
+                }
+
+                SettingsComboBox {
+                    id: screensaverModeCombo
+                    Layout.preferredWidth: Math.round(300 * Theme.layoutScale)
+                    enabled: ConfigManager.screensaverEnabled
+                    model: [qsTr("Library Backdrops"), qsTr("Bouncing Logo"), qsTr("Black Screen")]
+
+                    property bool _syncingFromConfig: false
+                    function modeValues() {
+                        return ["libraryBackdrops", "bouncingLogo", "black"]
+                    }
+                    function applyModeAt(index) {
+                        if (_syncingFromConfig || index < 0) return
+                        var values = modeValues()
+                        if (index >= values.length) return
+                        ConfigManager.screensaverMode = values[index]
+                    }
+                    function syncFromConfig() {
+                        _syncingFromConfig = true
+                        currentIndex = root.screensaverModeIndex()
+                        _syncingFromConfig = false
+                    }
+
+                    Component.onCompleted: syncFromConfig()
+                    Connections {
+                        target: ConfigManager
+                        function onScreensaverModeChanged() { screensaverModeCombo.syncFromConfig() }
+                    }
+                    onSelectionAccepted: function(index) { applyModeAt(index) }
+                    onActivated: function(index) { applyModeAt(index) }
+                    onActiveFocusChanged: {
+                        if (activeFocus) {
+                            root._lastFocusedItem = this
+                            flickable.ensureFocusVisible(this)
+                        }
+                    }
+                    KeyNavigation.up: screensaverEnabledRow
+                    KeyNavigation.down: screensaverTimeoutRow
+                }
+
+                SettingsSpinBoxRow {
+                    id: screensaverTimeoutRow
+                    label: qsTr("Screensaver timeout")
+                    description: qsTr("Minutes of inactivity before the screensaver starts.")
+                    from: 1
+                    to: 1440
+                    stepSize: 1
+                    unit: "min"
+                    value: Math.max(1, Math.round(ConfigManager.screensaverTimeoutSeconds / 60))
+                    enabled: ConfigManager.screensaverEnabled
+                    ensureVisible: function(item) { flickable.ensureFocusVisible(item) }
+                    onSpinBoxValueChanged: ConfigManager.screensaverTimeoutSeconds = Math.max(1, newValue) * 60
+                    onActiveFocusChanged: { if (activeFocus) root._lastFocusedItem = this }
+                    KeyNavigation.up: screensaverModeCombo
+                    KeyNavigation.down: themeCombo
+                }
+
+                SettingsGroupDivider { Layout.fillWidth: true }
+
                 // --- Theme ---
                 RowLayout {
                     Layout.fillWidth: true
@@ -187,7 +270,7 @@ FocusScope {
 
                         Keys.onUpPressed: function(event) {
                             if (!popup.visible) {
-                                // First control — nowhere to go
+                                screensaverTimeoutRow.forceActiveFocus()
                             }
                         }
                         Keys.onDownPressed: function(event) {

--- a/src/ui/settings/DisplaySettings.qml
+++ b/src/ui/settings/DisplaySettings.qml
@@ -270,7 +270,11 @@ FocusScope {
 
                         Keys.onUpPressed: function(event) {
                             if (!popup.visible) {
-                                screensaverTimeoutRow.forceActiveFocus()
+                                if (ConfigManager.screensaverEnabled) {
+                                    screensaverTimeoutRow.forceActiveFocus()
+                                } else {
+                                    screensaverEnabledRow.forceActiveFocus()
+                                }
                             }
                         }
                         Keys.onDownPressed: function(event) {

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -2371,6 +2371,86 @@ QString ConfigManager::getHeroBannerInfoPlacement() const
     return QStringLiteral("bottomLeft");
 }
 
+QString ConfigManager::normalizeScreensaverMode(const QString &raw) const
+{
+    const QString normalized = raw.trimmed();
+    if (normalized == QStringLiteral("libraryBackdrops")
+        || normalized == QStringLiteral("bouncingLogo")
+        || normalized == QStringLiteral("black")) {
+        return normalized;
+    }
+    return QStringLiteral("libraryBackdrops");
+}
+
+QJsonObject ConfigManager::readScreensaverObject() const
+{
+    const QJsonObject settings = m_config.value(QStringLiteral("settings")).toObject();
+    const QJsonObject ui = settings.value(QStringLiteral("ui")).toObject();
+    QJsonObject screensaver = ui.value(QStringLiteral("screensaver")).toObject();
+    if (!screensaver.contains(QStringLiteral("enabled"))) {
+        screensaver[QStringLiteral("enabled")] = false;
+    }
+    screensaver[QStringLiteral("mode")] =
+        normalizeScreensaverMode(screensaver.value(QStringLiteral("mode")).toString());
+    const int timeout = screensaver.value(QStringLiteral("timeout_seconds")).toInt(300);
+    screensaver[QStringLiteral("timeout_seconds")] = qBound(15, timeout, 86400);
+    return screensaver;
+}
+
+void ConfigManager::writeScreensaverObject(const QJsonObject &screensaver)
+{
+    QJsonObject settings = m_config.value(QStringLiteral("settings")).toObject();
+    QJsonObject ui = settings.value(QStringLiteral("ui")).toObject();
+    ui[QStringLiteral("screensaver")] = screensaver;
+    settings[QStringLiteral("ui")] = ui;
+    m_config[QStringLiteral("settings")] = settings;
+    save();
+}
+
+void ConfigManager::setScreensaverEnabled(bool enabled)
+{
+    if (enabled == getScreensaverEnabled()) return;
+    QJsonObject screensaver = readScreensaverObject();
+    screensaver[QStringLiteral("enabled")] = enabled;
+    writeScreensaverObject(screensaver);
+    emit screensaverEnabledChanged();
+}
+
+bool ConfigManager::getScreensaverEnabled() const
+{
+    return readScreensaverObject().value(QStringLiteral("enabled")).toBool(false);
+}
+
+void ConfigManager::setScreensaverMode(const QString &mode)
+{
+    const QString normalized = normalizeScreensaverMode(mode);
+    if (normalized == getScreensaverMode()) return;
+    QJsonObject screensaver = readScreensaverObject();
+    screensaver[QStringLiteral("mode")] = normalized;
+    writeScreensaverObject(screensaver);
+    emit screensaverModeChanged();
+}
+
+QString ConfigManager::getScreensaverMode() const
+{
+    return readScreensaverObject().value(QStringLiteral("mode")).toString(QStringLiteral("libraryBackdrops"));
+}
+
+void ConfigManager::setScreensaverTimeoutSeconds(int seconds)
+{
+    const int normalized = qBound(15, seconds, 86400);
+    if (normalized == getScreensaverTimeoutSeconds()) return;
+    QJsonObject screensaver = readScreensaverObject();
+    screensaver[QStringLiteral("timeout_seconds")] = normalized;
+    writeScreensaverObject(screensaver);
+    emit screensaverTimeoutSecondsChanged();
+}
+
+int ConfigManager::getScreensaverTimeoutSeconds() const
+{
+    return readScreensaverObject().value(QStringLiteral("timeout_seconds")).toInt(300);
+}
+
 void ConfigManager::setUpdateChannel(const QString &channel)
 {
     const QString normalized = normalizeUpdateChannelValue(channel);
@@ -3556,6 +3636,31 @@ public:
         newConfig[QStringLiteral("settings")] = settings;
         return newConfig;
     }
+
+    static QJsonObject migrateV24ToV25(const QJsonObject &oldConfig)
+    {
+        QJsonObject newConfig = oldConfig;
+        newConfig[QStringLiteral("version")] = 25;
+
+        QJsonObject settings = newConfig[QStringLiteral("settings")].toObject();
+        QJsonObject ui = settings.value(QStringLiteral("ui")).toObject();
+        QJsonObject screensaver = ui.value(QStringLiteral("screensaver")).toObject();
+        if (!screensaver.contains(QStringLiteral("enabled"))) {
+            screensaver[QStringLiteral("enabled")] = false;
+        }
+        const QString mode = screensaver.value(QStringLiteral("mode")).toString();
+        if (mode != QStringLiteral("libraryBackdrops")
+            && mode != QStringLiteral("bouncingLogo")
+            && mode != QStringLiteral("black")) {
+            screensaver[QStringLiteral("mode")] = QStringLiteral("libraryBackdrops");
+        }
+        screensaver[QStringLiteral("timeout_seconds")] =
+            qBound(15, screensaver.value(QStringLiteral("timeout_seconds")).toInt(300), 86400);
+        ui[QStringLiteral("screensaver")] = screensaver;
+        settings[QStringLiteral("ui")] = ui;
+        newConfig[QStringLiteral("settings")] = settings;
+        return newConfig;
+    }
 };
 }
 
@@ -3768,6 +3873,14 @@ bool ConfigManager::migrateConfig()
                 qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
+        } else if (version == 24) {
+            m_config = ConfigMigrator::migrateV24ToV25(m_config);
+            if (m_config.contains("version") && m_config["version"].isDouble()) {
+                version = m_config["version"].toInt();
+            } else {
+                qWarning() << "Migration produced invalid config (no version)";
+                return false;
+            }
         } else {
             qWarning() << "Unknown config version during migration:" << version;
             return false;
@@ -3873,6 +3986,12 @@ QJsonObject ConfigManager::defaultConfig() const
     heroBanner["logo_placement"] = QStringLiteral("bottomLeft");
     heroBanner["info_placement"] = QStringLiteral("bottomLeft");
     ui["hero_banner"] = heroBanner;
+
+    QJsonObject screensaver;
+    screensaver["enabled"] = false;
+    screensaver["mode"] = QStringLiteral("libraryBackdrops");
+    screensaver["timeout_seconds"] = 300;
+    ui["screensaver"] = screensaver;
 
     settings["ui"] = ui;
 

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -93,6 +93,9 @@ class ConfigManager : public QObject
     Q_PROPERTY(bool uiSoundsEnabled READ getUiSoundsEnabled WRITE setUiSoundsEnabled NOTIFY uiSoundsEnabledChanged)
     Q_PROPERTY(int uiSoundsVolume READ getUiSoundsVolume WRITE setUiSoundsVolume NOTIFY uiSoundsVolumeChanged)
     Q_PROPERTY(bool performanceModeEnabled READ getPerformanceModeEnabled WRITE setPerformanceModeEnabled NOTIFY performanceModeEnabledChanged)
+    Q_PROPERTY(bool screensaverEnabled READ getScreensaverEnabled WRITE setScreensaverEnabled NOTIFY screensaverEnabledChanged)
+    Q_PROPERTY(QString screensaverMode READ getScreensaverMode WRITE setScreensaverMode NOTIFY screensaverModeChanged)
+    Q_PROPERTY(int screensaverTimeoutSeconds READ getScreensaverTimeoutSeconds WRITE setScreensaverTimeoutSeconds NOTIFY screensaverTimeoutSecondsChanged)
     
     // Video Settings
     Q_PROPERTY(bool enableFramerateMatching READ getEnableFramerateMatching WRITE setEnableFramerateMatching NOTIFY enableFramerateMatchingChanged)
@@ -287,6 +290,14 @@ public:
     // Backdrop Rotation Interval (milliseconds)
     void setBackdropRotationInterval(int ms);
     int getBackdropRotationInterval() const;
+
+    // OLED-safe screensaver
+    void setScreensaverEnabled(bool enabled);
+    bool getScreensaverEnabled() const;
+    void setScreensaverMode(const QString &mode);
+    QString getScreensaverMode() const;
+    void setScreensaverTimeoutSeconds(int seconds);
+    int getScreensaverTimeoutSeconds() const;
 
     // Launch in Fullscreen
     void setLaunchInFullscreen(bool enabled);
@@ -570,6 +581,9 @@ signals:
     void heroBannerLibraryIdsChanged();
     void heroBannerLogoPlacementChanged();
     void heroBannerInfoPlacementChanged();
+    void screensaverEnabledChanged();
+    void screensaverModeChanged();
+    void screensaverTimeoutSecondsChanged();
 
 private:
     QString normalizeLogLevelValue(const QString &level) const;
@@ -581,12 +595,15 @@ private:
     QString normalizeHeroBannerSource(const QString &raw) const;
     QString normalizeHeroBannerLogoPlacement(const QString &raw) const;
     QString normalizeHeroBannerInfoPlacement(const QString &raw) const;
+    QString normalizeScreensaverMode(const QString &raw) const;
+    QJsonObject readScreensaverObject() const;
+    void writeScreensaverObject(const QJsonObject &screensaver);
     QJsonObject readHeroBannerObject() const;
     void writeHeroBannerObject(const QJsonObject &heroBanner);
     bool envOverridesRoundedPreprocess(bool current) const;
 
     QJsonObject m_config;
 
-    static constexpr int kCurrentConfigVersion = 24;
+    static constexpr int kCurrentConfigVersion = 25;
     QJsonObject defaultConfig() const;
 };

--- a/tests/ConfigManagerThemeTest.cpp
+++ b/tests/ConfigManagerThemeTest.cpp
@@ -17,6 +17,7 @@ class ConfigManagerThemeTest : public QObject
 private slots:
     void defaultsIncludeThemeVariants();
     void defaultsContainNewBuiltinMpvProfiles();
+    void screensaverDefaultsAndSettersPersist();
     void themeVariantSettersPersistAndEmit();
     void v19MigrationAddsThemeVariantSettings();
     void v20MigrationRenamesDefaultProfileAssignments();
@@ -28,6 +29,7 @@ private slots:
     void mpvProfileHdrAndWindowsOutputFieldsDefaultAndPersist();
     void hdrMpvArgsUseProfileMetadataMode();
     void v23MigrationPreservesCustomizedBuiltInProfiles();
+    void v24MigrationAddsScreensaverSettings();
     void startupBufferingModesDefaultNormalizeAndPersist();
     void bundledMpvShadersAreCopied();
     void bundledMpvFontsAreCopied();
@@ -254,6 +256,45 @@ void ConfigManagerThemeTest::defaultsContainNewBuiltinMpvProfiles()
     QVERIFY(!names.contains(QStringLiteral("Default")));
 }
 
+void ConfigManagerThemeTest::screensaverDefaultsAndSettersPersist()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation configIsolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+
+    QCOMPARE(config.getScreensaverEnabled(), false);
+    QCOMPARE(config.getScreensaverMode(), QStringLiteral("libraryBackdrops"));
+    QCOMPARE(config.getScreensaverTimeoutSeconds(), 300);
+
+    QSignalSpy enabledSpy(&config, &ConfigManager::screensaverEnabledChanged);
+    QSignalSpy modeSpy(&config, &ConfigManager::screensaverModeChanged);
+    QSignalSpy timeoutSpy(&config, &ConfigManager::screensaverTimeoutSecondsChanged);
+
+    config.setScreensaverEnabled(true);
+    config.setScreensaverMode(QStringLiteral("bouncingLogo"));
+    config.setScreensaverTimeoutSeconds(120);
+
+    QCOMPARE(enabledSpy.count(), 1);
+    QCOMPARE(modeSpy.count(), 1);
+    QCOMPARE(timeoutSpy.count(), 1);
+
+    config.setScreensaverMode(QStringLiteral("invalid"));
+    QCOMPARE(config.getScreensaverMode(), QStringLiteral("libraryBackdrops"));
+    QCOMPARE(modeSpy.count(), 2);
+
+    config.setScreensaverTimeoutSeconds(1);
+    QCOMPARE(config.getScreensaverTimeoutSeconds(), 15);
+
+    ConfigManager reloaded;
+    reloaded.load();
+    QCOMPARE(reloaded.getScreensaverEnabled(), true);
+    QCOMPARE(reloaded.getScreensaverMode(), QStringLiteral("libraryBackdrops"));
+    QCOMPARE(reloaded.getScreensaverTimeoutSeconds(), 15);
+}
+
 void ConfigManagerThemeTest::themeVariantSettersPersistAndEmit()
 {
     QTemporaryDir tempDir;
@@ -313,7 +354,7 @@ void ConfigManagerThemeTest::v19MigrationAddsThemeVariantSettings()
     QFile migratedFile(ConfigManager::getConfigPath());
     QVERIFY(migratedFile.open(QIODevice::ReadOnly));
     const QJsonObject migrated = QJsonDocument::fromJson(migratedFile.readAll()).object();
-    QCOMPARE(migrated.value(QStringLiteral("version")).toInt(), 24);
+    QCOMPARE(migrated.value(QStringLiteral("version")).toInt(), 25);
     const QJsonObject ui = migrated.value(QStringLiteral("settings")).toObject().value(QStringLiteral("ui")).toObject();
     QVERIFY(ui.contains(QStringLiteral("theme_flavor")));
     QCOMPARE(ui.value(QStringLiteral("theme_color_scheme")).toString(), QStringLiteral("blue"));
@@ -607,6 +648,43 @@ void ConfigManagerThemeTest::v23MigrationPreservesCustomizedBuiltInProfiles()
              QStringLiteral("vulkan"));
     QCOMPARE(config.getMpvProfile(QStringLiteral("nnedi3-deband")).value(QStringLiteral("windowsRenderApi")).toString(),
 	             QStringLiteral("vulkan"));
+}
+
+void ConfigManagerThemeTest::v24MigrationAddsScreensaverSettings()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation configIsolation(tempDir.path());
+
+    QVERIFY(QDir().mkpath(ConfigManager::getConfigDir()));
+    QJsonObject configObject = minimalV22ConfigWithCustomizedAnimeProfile();
+    configObject[QStringLiteral("version")] = 24;
+    QJsonObject settings = configObject.value(QStringLiteral("settings")).toObject();
+    settings[QStringLiteral("ui")] = QJsonObject{{QStringLiteral("theme"), QStringLiteral("Jellyfin")}};
+    configObject[QStringLiteral("settings")] = settings;
+
+    QFile configFile(ConfigManager::getConfigPath());
+    QVERIFY(configFile.open(QIODevice::WriteOnly));
+    configFile.write(QJsonDocument(configObject).toJson(QJsonDocument::Indented));
+    configFile.close();
+
+    ConfigManager config;
+    config.load();
+
+    QCOMPARE(config.getScreensaverEnabled(), false);
+    QCOMPARE(config.getScreensaverMode(), QStringLiteral("libraryBackdrops"));
+    QCOMPARE(config.getScreensaverTimeoutSeconds(), 300);
+    config.save();
+
+    QFile migratedFile(ConfigManager::getConfigPath());
+    QVERIFY(migratedFile.open(QIODevice::ReadOnly));
+    const QJsonObject migrated = QJsonDocument::fromJson(migratedFile.readAll()).object();
+    QCOMPARE(migrated.value(QStringLiteral("version")).toInt(), 25);
+    const QJsonObject ui = migrated.value(QStringLiteral("settings")).toObject().value(QStringLiteral("ui")).toObject();
+    const QJsonObject screensaver = ui.value(QStringLiteral("screensaver")).toObject();
+    QCOMPARE(screensaver.value(QStringLiteral("enabled")).toBool(), false);
+    QCOMPARE(screensaver.value(QStringLiteral("mode")).toString(), QStringLiteral("libraryBackdrops"));
+    QCOMPARE(screensaver.value(QStringLiteral("timeout_seconds")).toInt(), 300);
 }
 
 void ConfigManagerThemeTest::startupBufferingModesDefaultNormalizeAndPersist()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OLED-safe screensaver settings (enable/disable, mode, timeout) with sensible defaults and config migration.
  * Introduced a new screensaver experience with artwork/logo modes that pauses when the app is active and blocks during playback.
  * Enhanced hero banner transitions with smoother animated cross-fades/slides.

* **Bug Fixes**
  * Improved screensaver activation/dismissal based on window visibility, user activity, authentication, and playback state.
  * Updated always-visible overlay behavior for Windows embedded playback to keep the screensaver properly visible.

* **Documentation**
  * Expanded screensaver, configuration, and developer guidance (including new debug/testing knobs).

* **Tests**
  * Added coverage for screensaver settings defaults, validation, persistence, and migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add in-app screensaver with artwork slideshow and bouncing logo modes
> - Adds `ScreensaverController` (C++) that monitors idle input via an app-wide event filter and activates the screensaver after a configurable timeout (default 300s), dismissing on user activity or active playback.
> - Adds `ScreensaverOverlay.qml` that displays either a library artwork slideshow with cross-fades and metadata, a bouncing logo, or a black screen; captures all input and manages focus/cursor while active.
> - Adds screensaver settings (enabled, mode, timeout) to `ConfigManager` with validation/clamping, a config schema migration from v24→v25, and UI controls in the Display settings screen.
> - On Windows with embedded playback, the overlay is hosted in a detached always-on-top window; on other platforms it uses the main `Overlay.overlay`.
> - Adds `LibraryService.getScreensaverItems()` to fetch a random bounded set of items with backdrop and logo URLs for the screensaver artwork pool.
> - Improves `HeroBanner` with directional cross-fade transitions and dual-layer backdrop cross-fade during index changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a8e496.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->