### PR TITLE
test(contracts): add provider compatibility baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ If unsure whether a change requires `AGENTS.md` or `docs/` updates, open an issu
 See also:
 - docs/build.md     — Nix build, packaging, CI, and Windows instructions
 - docs/playback.md  — mpv and playback/reporting integration
+- docs/provider-compatibility.md — provider-neutral server contract matrix, reproducible Jellyfin/Silo pins, and native API assumptions
 - docs/media-segments.md — External intro/recap/credits provider integration and precedence
 - docs/hero-banner.md — Home hero sources, settings, focus behavior, and backdrop synchronization
 - docs/theme.md     — Theme.qml tokens and design system

--- a/docs/provider-compatibility.md
+++ b/docs/provider-compatibility.md
@@ -1,0 +1,243 @@
+# Provider compatibility and contract baseline
+
+This page defines the server contract baseline for [issue #74](https://github.com/crowquillx/Bloom/issues/74), the first increment of the Silo support epic. It records Bloom's current MediaBrowser/Jellyfin wire assumptions, the Silo compatibility result, and the native Silo assumptions needed by later provider adapters.
+
+The machine-readable source is [`tests/contracts/provider-contracts.json`](../tests/contracts/provider-contracts.json). Its validator requires semantic evidence for every result; an HTTP `200` alone never means a feature is supported.
+
+## Support terminology
+
+- **Silo compatibility support**: Bloom connects to Silo's optional Jellyfin compatibility listener. The native API is not used, and household-profile login has compatibility-specific limitations.
+- **Experimental native Silo support**: Bloom connects to `/api/v1`, but the complete release matrix has not passed.
+- **First-class Silo support**: Bloom connects to `/api/v1` without the compatibility listener and passes the authentication, profile, catalog, playback, recovery, and platform gates in issue #73.
+
+These labels describe a connection's protocol mode, not an application-wide provider choice. A future provider can add another protocol surface and deployment to the contract matrix without changing existing Jellyfin or Silo rows.
+
+Contract outcomes are:
+
+| Outcome | Meaning |
+|---|---|
+| `supported` | The required payload and observable behavior work. |
+| `partial` | The core journey works, but requested behavior or data is ignored or absent. |
+| `stubbed` | A route returns a success-shaped placeholder without the required behavior. |
+| `missing` | The route is absent or cannot provide fields Bloom needs. |
+| `not-applicable` | A deployment does not expose that protocol surface. |
+
+## Reproducible server pins
+
+The baseline was prepared from:
+
+| Component | Pin |
+|---|---|
+| Bloom | `571218325258fae98e5606f4b84cf92ff0c5b1e6` |
+| Jellyfin control | `10.11.10`, `docker.io/jellyfin/jellyfin@sha256:f66273e014b307e4ac46778845ebc1e9ee24b2e57c1fc17d5ec5ac3015649bfa` |
+| Silo | `8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6` |
+| Silo image | `ghcr.io/silo-server/silo-server@sha256:944ee9821de1d6a61876c9b7b06daa358118163d1e5f9b3aa9f5437856fd06e9` (tag `8044eb8`) |
+
+Container digests are immutable. Short-SHA tags are included only for operator readability.
+
+### Silo compatibility deployment
+
+Silo exposes separate listeners:
+
+| Surface | Typical compose host port | Use in this baseline |
+|---|---:|---|
+| Native web/API | `8090` | Onboarding, admin settings, and native probes |
+| Jellyfin compatibility | `8096` | Bloom compatibility target |
+| Audiobookshelf compatibility | `13378` | Out of scope |
+
+Ports are deployment configuration, not protocol identity.
+
+1. Clone Silo and check out the pinned revision.
+2. Copy `.env.example` to `.env`. Set `MEDIA_ROOT` to a test library, set a durable `SILO_DATA_ROOT`, and generate the required `SECRET_KEY`.
+3. Pin `SILO_IMAGE` to the digest above.
+4. Start the bundled PostgreSQL, Redis, and Silo services.
+5. Complete onboarding at `http://127.0.0.1:8090`, add a movie and series library, and enable Jellyfin-compatible app support. The setting requires a Silo restart.
+6. Point Bloom at `http://127.0.0.1:8096`, not the native port.
+
+Example Fish session after editing `.env`:
+
+```fish
+set -x SILO_IMAGE ghcr.io/silo-server/silo-server@sha256:944ee9821de1d6a61876c9b7b06daa358118163d1e5f9b3aa9f5437856fd06e9
+docker compose up -d
+curl --fail --silent http://127.0.0.1:8090/api/v1/health | jq
+curl --fail --silent http://127.0.0.1:8096/System/Info | jq
+```
+
+The compatibility listener may be unbound before it is enabled. A connection refusal on `8096` is therefore different from invalid credentials.
+
+For the baseline library, use at least:
+
+- one movie with a poster, backdrop, chapter, external subtitle, and external provider IDs;
+- one series with a season and at least two episodes;
+- one episode with progress and intro/credits markers;
+- one alternate-version or multipart title where available.
+
+Silo compatibility household login uses `username#profile`. PIN-protected profiles additionally use `password#pin`. A single non-PIN profile matching the account name may be selected without suffixes. This is compatibility behavior only; native Bloom support must use Silo's account/profile/PIN API.
+
+### Jellyfin control deployment
+
+Run the pinned Jellyfin image with separate config/cache/media directories, finish its setup, and create the same minimum libraries and user-state scenarios. For example:
+
+```fish
+set jellyfin_image docker.io/jellyfin/jellyfin@sha256:f66273e014b307e4ac46778845ebc1e9ee24b2e57c1fc17d5ec5ac3015649bfa
+podman run --rm --name bloom-jellyfin-contract \
+  -p 18096:8096 \
+  -v $PWD/.contract-data/jellyfin/config:/config \
+  -v $PWD/.contract-data/jellyfin/cache:/cache \
+  -v /path/to/test-media:/media:ro \
+  $jellyfin_image
+```
+
+The live deployments are intentionally not started inside `nix flake check`. They require operator-owned media, credentials, mutable databases, and platform playback checks. The checked-in validator keeps the matrix complete and immutable between live runs.
+
+Run the same provider-neutral probe against either MediaBrowser deployment. The password is read from the environment and is never written to the report:
+
+```fish
+set -x BLOOM_CONTRACT_USERNAME bloom-contract
+read --silent --prompt-str 'Contract password: ' BLOOM_CONTRACT_PASSWORD
+set -gx BLOOM_CONTRACT_PASSWORD $BLOOM_CONTRACT_PASSWORD
+
+python3 tests/contracts/run_live_contracts.py \
+  --deployment silo-8044eb8-compat \
+  --base-url http://127.0.0.1:8096 \
+  --allow-mutations \
+  --output .contract-data/silo-report.json
+
+python3 tests/contracts/run_live_contracts.py \
+  --deployment jellyfin-supported \
+  --base-url http://127.0.0.1:18096 \
+  --allow-mutations \
+  --output .contract-data/jellyfin-report.json
+```
+
+The live driver is selected by protocol surface (`mediabrowser-v1` today), while expectations are selected by deployment. New providers can add a surface driver and deployment without adding product checks to existing probes. Mutating probes are opt-in. Played/favorite probes restore their exact original booleans; playback reporting can change resume state, so run it only with a dedicated fixture account/library. The harness never forwards a MediaBrowser token to a different origin and refuses automatic redirects; opaque cross-origin URLs are fetched without Bloom authorization headers.
+
+## Bloom's current MediaBrowser contract
+
+`AuthenticationService`, `LibraryService`, `PlaybackService`, and `SessionService` currently own the wire contract. Provider-specific JSON is still visible above those services; issues #75 and #76 will move it behind adapters and canonical models.
+
+Shared assumptions:
+
+- Base URLs have trailing slashes removed before endpoint concatenation.
+- Requests send `Content-Type: application/json` and a `MediaBrowser` authorization header with Bloom client, desktop device, stable device ID, version, and optional token.
+- Authentication expects `AccessToken`, `User.Id`, and `User.Name`.
+- Lists generally use `{ "Items": [...], "TotalRecordCount": n }`.
+- Jellyfin time is in 100-nanosecond ticks. Ticks must not escape the future Jellyfin adapter.
+- Current image, stream, subtitle, and trickplay URLs may contain `api_key`; later artwork/playback boundaries must replace persistent token-bearing URLs.
+- Bloom derives the home continue-watching rail from Next Up items whose `UserData.PlaybackPositionTicks` is positive.
+- Application logout is currently local. `SessionService` uses `/Sessions/{id}/Logout` only for remote-session revocation.
+
+## Compatibility results
+
+This is the human-readable summary. Exact call sites, required semantics, and evidence are in the JSON matrix.
+
+| Journey or route | Jellyfin 10.11.10 | Silo `8044eb8` compatibility | Effect in Bloom |
+|---|---|---|---|
+| Authenticate and validate `/Users/*` | Supported | Partial | Basic/single-profile login works; multi-profile/PIN requires suffix syntax. |
+| Views, items, item details | Supported | Partial | Core browsing works; some optional fields/advanced query parameters are absent or ignored. |
+| Latest, Next Up, search | Supported | Supported | Home and basic search should populate. |
+| Paging and basic sort/type filters | Supported | Supported | Core library navigation works. |
+| Advanced item filters | Supported | Partial | `Items/Filters` and Studios are stubs; genre identity differs; UI choices can silently do nothing. |
+| Standard item artwork | Supported | Supported | Posters/backdrops/thumbs/logos work. |
+| Chapter image route | Supported | Missing | Chapter thumbnails fail even though chapter metadata may exist. |
+| `POST /Items/{id}/PlaybackInfo` | Supported | Partial | Direct/HLS playback works through a permissive fallback profile; negotiation is not Bloom-specific. |
+| Range-capable direct stream | Supported | Supported | mpv direct playback and seeking are the strongest compatibility path. |
+| `/Videos/{id}/AdditionalParts` | Supported | Missing | Bloom receives a nonfatal `404`; multipart playback is unavailable. |
+| Trickplay metadata and tiles | Supported | Missing | Seek previews are unavailable. |
+| `/Sessions/Playing*` reporting | Supported | Partial | Resume/progress and teardown work; some Bloom payload fields are ignored. |
+| Played/favorite mutations | Supported | Supported | User-state controls work. |
+| `/Items/{id}/Ancestors` | Supported | Missing | Episodic library/profile context resolution degrades. |
+| Plugin `/Episode/{id}/IntroSkipperSegments` | Optional/partial | Missing | Bloom misses Silo's native markers and falls back to external providers. |
+| Standard `/MediaSegments/{id}` | Supported | Supported | Silo exposes markers, but Bloom does not yet call this route. |
+| `GET /Sessions` | Supported | Stubbed | Active Sessions is empty. |
+| `/Sessions/{id}/Logout` | Supported | Missing | Remote revocation fails; Silo only has caller logout at `/Sessions/Logout`. |
+| Provider IDs | Supported | Missing | `ProviderIds` is omitted from serialized details, weakening Seerr and external metadata/segment matching. |
+| Theme songs | Supported | Stubbed | Series theme songs are unavailable. |
+| External subtitle `DeliveryUrl` | Partial in Bloom | Partial in Bloom | Servers can advertise it; Bloom currently drops the URL before playback. |
+| Conditional JSON `ETag`/`304` | Supported | Missing | Functional refresh, but no efficient not-modified path. |
+| Expired/revoked token returns `401` | Supported | Supported | Authentication failure is detectable; Bloom's service handling is not yet centralized. |
+
+### Meaningful assertions for live runs
+
+A route is not supported merely because it returns `200`. Live evidence should include:
+
+- login yields a non-empty token and stable user/profile identity; invalid login returns `401`;
+- pages do not overlap, sort is observable, and filters change results as requested;
+- `PlaybackInfo` contains a non-empty play session and a usable media source URL;
+- a stream range request returns `206` with the requested `Content-Range`;
+- progress, watched, and favorite mutations are observable on a subsequent item read and are restored after the test;
+- session stop tears down playback resources;
+- a stub is recorded as `stubbed` even when its JSON shape deserializes successfully;
+- `ETag` support requires a validator round trip that returns `304` while unchanged;
+- external subtitle support requires the advertised URL to be fetchable and passed to mpv.
+
+## Native Silo contract decisions for later issues
+
+Native Silo detection uses `GET /api/v1/health` and requires `server_id`. Do not identify Silo from compatibility `/System/Info`, which intentionally reports `ProductName: "Jellyfin Server"` and an emulated version.
+
+### Authentication and profiles
+
+Required route groups:
+
+```text
+GET  /api/v1/auth/providers
+POST /api/v1/auth/login
+POST /api/v1/auth/refresh
+GET  /api/v1/auth/me
+POST /api/v1/auth/logout
+GET  /api/v1/auth/sessions
+DELETE /api/v1/auth/sessions/{id}
+
+GET  /api/v1/profiles
+POST /api/v1/profiles/{id}/verify-pin
+```
+
+Use bearer access tokens, refresh once after a native `401`, and store access/refresh tokens only in the platform secret store. Send `X-Profile-Id` after selection and `X-Profile-Token` after PIN verification. Client/device identity is represented by `X-Silo-Client`, `X-Silo-Client-Version`, `X-Silo-Device-Id`, `X-Silo-Device-Name`, and `X-Silo-Device-Platform`; which are mandatory remains an upstream question.
+
+### Catalog identity
+
+The initial catalog surface is:
+
+```text
+GET  /api/v1/user/libraries
+GET  /api/v1/catalog
+POST /api/v1/catalog/query
+GET  /api/v1/catalog/items/{id}
+GET  /api/v1/catalog/items/{id}/versions
+GET  /api/v1/catalog/series/{id}/seasons
+GET  /api/v1/catalog/series/{id}/seasons/{number}/episodes
+```
+
+Use `content_id` for catalog and profile-state identity and `file_id` for playback. Bloom-owned references must also carry `connectionId`, preventing collisions across servers and future providers. Convert native durations to milliseconds at the adapter boundary.
+
+Native artwork may be opaque, presigned, and expiring. Cache identity must be a token-free Bloom `ArtworkRef`; refetch the owning catalog/detail resource when a fetch URL expires.
+
+### Playback
+
+Probe `GET /api/v1/playback/capability`. At the pinned revision, protocol v3 advertises `media3_only` and Media3-oriented engine semantics. Bloom/mpv should use the legacy native start envelope until Silo documents an mpv-compatible v3 contract. A finalized provider-neutral playback descriptor must own URLs, headers, track normalization, session IDs, reporting, and recovery; `PlayerController` must not construct provider query parameters.
+
+## Open upstream contract questions
+
+Upstream coordination started in [Silo Server #431](https://github.com/Silo-Server/silo-server/issues/431) (third-party native HTPC/mpv contract) and [#432](https://github.com/Silo-Server/silo-server/issues/432) (compatibility profile discovery).
+
+Before native implementation is called stable, coordinate with Silo maintainers on:
+
+1. A public server-info response carrying product, build revision, and native API revision.
+2. Public stability/deprecation guarantees for `/api/v1`.
+3. The supported capability-discovery set for optional routes.
+4. The guaranteed lifetime of the legacy native playback envelope.
+5. An mpv-capable protocol-v3 contract rather than `media3_only` semantics.
+6. Required versus advisory Silo client/device headers.
+7. Long-term compatibility profile discovery instead of typed `#profile`/`#pin` suffixes.
+8. Trademark boundaries for referential text and any bundled artwork. Bloom should not bundle Silo logos without explicit permission.
+
+## Validation
+
+The offline validator checks matrix completeness, immutable image pins, deployment coverage, native route/header decisions, and semantic assertions:
+
+```fish
+python3 tests/contracts/validate_contracts.py
+python3 -m unittest discover -s tests/contracts -p provider_contracts_test.py
+```
+
+It is also registered as `ProviderContractValidationTest` in CTest and runs in the Nix test derivation.

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -4,6 +4,7 @@
   cmake,
   ninja,
   pkg-config,
+  python3,
   gtest,
   libsecret,
   mpv,
@@ -20,6 +21,7 @@ stdenv.mkDerivation {
     cmake
     ninja
     pkg-config
+    python3
     qt6.wrapQtAppsHook
   ];
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,12 @@
 enable_testing()
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+add_test(
+    NAME ProviderContractValidationTest
+    COMMAND ${Python3_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/contracts/provider_contracts_test.py
+)
+
 set(UPDATER_SOURCES
     ${CMAKE_SOURCE_DIR}/src/updates/IUpdateProvider.cpp
     ${CMAKE_SOURCE_DIR}/src/updates/IUpdateApplier.cpp

--- a/tests/contracts/provider-contracts.json
+++ b/tests/contracts/provider-contracts.json
@@ -1,0 +1,494 @@
+{
+  "schemaVersion": 1,
+  "snapshot": {
+    "bloomRevision": "571218325258fae98e5606f4b84cf92ff0c5b1e6",
+    "jellyfinVersion": "10.11.10",
+    "jellyfinImage": "docker.io/jellyfin/jellyfin@sha256:f66273e014b307e4ac46778845ebc1e9ee24b2e57c1fc17d5ec5ac3015649bfa",
+    "siloRevision": "8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6",
+    "siloImage": "ghcr.io/silo-server/silo-server@sha256:944ee9821de1d6a61876c9b7b06daa358118163d1e5f9b3aa9f5437856fd06e9",
+    "siloImageTag": "8044eb8"
+  },
+  "outcomes": {
+    "supported": "Bloom-required behavior and payload semantics are present.",
+    "partial": "The core path is usable, but some requested behavior or data is ignored or absent.",
+    "stubbed": "The route returns a success-shaped placeholder without the required behavior.",
+    "missing": "The route is absent or cannot provide fields Bloom requires.",
+    "not-applicable": "The deployment does not expose this protocol surface."
+  },
+  "surfaces": [
+    {
+      "id": "mediabrowser-v1",
+      "description": "The Jellyfin/Emby-shaped wire contract currently consumed by Bloom.",
+      "timeUnit": "ticks-100ns",
+      "authorizationProfile": "MediaBrowser Client=Bloom, Device=Desktop, DeviceId, Version, Token"
+    },
+    {
+      "id": "silo-native-v1",
+      "description": "Silo's native /api/v1 surface; documented for later adapters and not consumed in this issue.",
+      "timeUnit": "milliseconds",
+      "authorizationProfile": "Bearer access token plus profile and device headers"
+    }
+  ],
+  "deployments": [
+    {
+      "id": "jellyfin-supported",
+      "product": "Jellyfin",
+      "protocolMode": "native",
+      "surface": "mediabrowser-v1",
+      "supportLabel": "existing-jellyfin-support"
+    },
+    {
+      "id": "silo-8044eb8-compat",
+      "product": "Silo Server",
+      "protocolMode": "compatibility",
+      "surface": "mediabrowser-v1",
+      "supportLabel": "silo-compatibility-support"
+    },
+    {
+      "id": "silo-8044eb8-native",
+      "product": "Silo Server",
+      "protocolMode": "native",
+      "surface": "silo-native-v1",
+      "supportLabel": "research-only"
+    }
+  ],
+  "coverageRequirements": [
+    "auth.login",
+    "auth.validate",
+    "auth.invalid",
+    "catalog.views",
+    "catalog.items",
+    "catalog.details",
+    "catalog.latest",
+    "catalog.next-up",
+    "catalog.search",
+    "catalog.filters",
+    "artwork.standard",
+    "artwork.chapter",
+    "playback.info",
+    "playback.range-stream",
+    "playback.additional-parts",
+    "playback.trickplay",
+    "playback.report",
+    "state.played",
+    "state.favorite",
+    "hierarchy.ancestors",
+    "segments.plugin-intro-skipper",
+    "segments.standard",
+    "sessions.list",
+    "sessions.revoke",
+    "metadata.provider-ids",
+    "metadata.theme-songs",
+    "subtitles.delivery-url",
+    "cache.conditional-refresh",
+    "errors.expired-session"
+  ],
+  "contracts": [
+    {
+      "id": "auth.login",
+      "journey": "authentication",
+      "bloomCaller": "AuthenticationService::authenticate",
+      "method": "POST",
+      "path": "/Users/AuthenticateByName",
+      "requestSemantics": ["JSON body contains Username and Pw", "MediaBrowser client identity is sent before a token exists"],
+      "requiredSemantics": ["Response has a non-empty AccessToken", "Response User has non-empty Id and Name"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard Jellyfin password login contract."},
+        "silo-8044eb8-compat": {"outcome": "partial", "evidence": "Works for a single matching profile; multi-profile/PIN login requires username#profile and password#pin."}
+      }
+    },
+    {
+      "id": "auth.validate",
+      "journey": "authentication",
+      "bloomCaller": "AuthenticationService::validateAccessToken",
+      "method": "GET",
+      "path": "/Users/{userId}",
+      "requestSemantics": ["MediaBrowser token is present"],
+      "requiredSemantics": ["Valid token returns HTTP 200", "Returned user identity matches the authenticated profile"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Used for restart/session restoration."},
+        "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Compat pseudo-user identity is stable for the account/profile pair."}
+      }
+    },
+    {
+      "id": "auth.invalid",
+      "journey": "authentication",
+      "bloomCaller": "AuthenticationService::onAuthenticateFinished",
+      "method": "POST",
+      "path": "/Users/AuthenticateByName",
+      "requestSemantics": ["Invalid Pw is submitted"],
+      "requiredSemantics": ["Invalid credentials return HTTP 401 rather than a success-shaped error"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Bloom maps 401 to invalid credentials."},
+        "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Compat maps failed account/profile/PIN resolution to 401."}
+      }
+    },
+    {
+      "id": "catalog.views",
+      "journey": "catalog",
+      "bloomCaller": "LibraryService::getViews",
+      "method": "GET",
+      "path": "/Users/{userId}/Views",
+      "requestSemantics": ["Authenticated profile userId is part of the route"],
+      "requiredSemantics": ["Response Items contains stable library Id and Name values"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard user views contract."},
+        "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Profile-visible libraries are mapped to Jellyfin view DTOs."}
+      }
+    },
+    {
+      "id": "catalog.items",
+      "journey": "catalog",
+      "bloomCaller": "LibraryService::getItems",
+      "method": "GET",
+      "path": "/Users/{userId}/Items",
+      "requestSemantics": ["Bloom sends paging, sort, item type, recursive, field, image and optional filter parameters"],
+      "requiredSemantics": ["Response has Items and TotalRecordCount", "StartIndex and Limit produce stable non-overlapping pages", "Requested sort order is honored"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Control deployment for the current query contract."},
+        "silo-8044eb8-compat": {"outcome": "partial", "evidence": "Core paging/search/type/sort are implemented; several advanced parameters are ignored."}
+      }
+    },
+    {
+      "id": "catalog.details",
+      "journey": "catalog",
+      "bloomCaller": "LibraryService::getItem/getSeriesDetails",
+      "method": "GET",
+      "path": "/Users/{userId}/Items/{itemId}",
+      "requestSemantics": ["Bloom requests rich PascalCase fields including UserData, ProviderIds, People and MediaSources"],
+      "requiredSemantics": ["Id, Type and Name are non-empty", "UserData carries played/favorite/resume state when available"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard item detail contract."},
+        "silo-8044eb8-compat": {"outcome": "partial", "evidence": "Core movie/series/season/episode details work; some optional fields are empty."}
+      }
+    },
+    {
+      "id": "catalog.latest",
+      "journey": "catalog",
+      "bloomCaller": "LibraryService::getLatestMedia",
+      "method": "GET",
+      "path": "/Users/{userId}/Items/Latest",
+      "requestSemantics": ["ParentId and rich Fields are requested"],
+      "requiredSemantics": ["Returned items belong to the requested visible library", "Items are ordered as latest media"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard latest-items contract."},
+        "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Latest handler is backed by catalog data."}
+      }
+    },
+    {
+      "id": "catalog.next-up",
+      "journey": "catalog",
+      "bloomCaller": "LibraryService::getNextUp",
+      "method": "GET",
+      "path": "/Shows/NextUp",
+      "requestSemantics": ["UserId, Limit and rich episode Fields are requested"],
+      "requiredSemantics": ["Items are playable episodes", "UserData.PlaybackPositionTicks distinguishes Bloom's continue-watching rail"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard Next Up contract."},
+        "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Next Up repository and profile watch state are wired."}
+      }
+    },
+    {
+      "id": "catalog.search",
+      "journey": "catalog",
+      "bloomCaller": "LibraryService::search",
+      "method": "GET",
+      "path": "/Users/{userId}/Items",
+      "requestSemantics": ["SearchTerm is percent-encoded and item types are Movie,Series"],
+      "requiredSemantics": ["Matches correspond to the search term", "Limit is honored"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard item search."},
+        "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Catalog search provider backs the compat item query."}
+      }
+    },
+    {
+      "id": "catalog.filters",
+      "journey": "catalog",
+      "bloomCaller": "LibraryService::getFilterOptions",
+      "method": "GET",
+      "path": "/Items/Filters + /Genres + /Studios",
+      "requestSemantics": ["UserId, ParentId, IncludeItemTypes and Recursive are sent"],
+      "requiredSemantics": ["Genres, tags and studios reflect the selected library", "Values can be passed back to the item query using the same identity semantics"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Control for filter facet names and item query semantics."},
+        "silo-8044eb8-compat": {"outcome": "partial", "evidence": "Genres are backed, Items/Filters and Studios are empty stubs; Silo expects genre IDs while Bloom sends names."}
+      }
+    },
+    {
+      "id": "artwork.standard",
+      "journey": "artwork",
+      "bloomCaller": "LibraryService::getImageUrl/getCachedImageUrl",
+      "method": "GET",
+      "path": "/Items/{itemId}/Images/{imageType}",
+      "requestSemantics": ["Bloom may send fillWidth, quality, tag and api_key in the URL"],
+      "requiredSemantics": ["Response is image data for Primary, Backdrop, Thumb or Logo", "Opaque image variants remain fetchable"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard item image routes."},
+        "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Compat image routes proxy/cache catalog artwork."}
+      }
+    },
+    {
+      "id": "artwork.chapter",
+      "journey": "artwork",
+      "bloomCaller": "LibraryService::getCachedChapterThumbnailUrl",
+      "method": "GET",
+      "path": "/Items/{itemId}/Images/Chapter/{index}",
+      "requestSemantics": ["Bloom sends maxWidth, api_key and an image tag"],
+      "requiredSemantics": ["Response is the requested chapter thumbnail rather than generic artwork"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Chapter image type is part of Jellyfin's image contract."},
+        "silo-8044eb8-compat": {"outcome": "missing", "evidence": "Chapter is not a supported compat image type at the pinned revision."}
+      }
+    },
+    {
+      "id": "playback.info",
+      "journey": "playback",
+      "bloomCaller": "PlaybackService::getPlaybackInfo",
+      "method": "POST",
+      "path": "/Items/{itemId}/PlaybackInfo",
+      "requestSemantics": ["UserId is a query parameter and Bloom currently sends an empty JSON object"],
+      "requiredSemantics": ["PlaySessionId is non-empty", "At least one MediaSource has a stable Id and usable direct or transcode URL", "Audio/subtitle stream indices and defaults are preserved"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard PlaybackInfo negotiation."},
+        "silo-8044eb8-compat": {"outcome": "partial", "evidence": "Permissive fallback profile provides direct/HLS playback, but negotiation is not Bloom-specific and HLS is the only compat transcode delivery."}
+      }
+    },
+    {
+      "id": "playback.range-stream",
+      "journey": "playback",
+      "bloomCaller": "mpv via LibraryService/PlaybackInfo URL",
+      "method": "GET",
+      "path": "/Videos/{itemId}/stream",
+      "requestSemantics": ["mpv issues byte-range requests against a static/direct URL", "api_key or playback-session fallback authorizes the request"],
+      "requiredSemantics": ["Range request returns HTTP 206", "Content-Range matches the requested bytes", "Seeking does not require a Jellyfin-specific player"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Control for mpv direct playback and seeking."},
+        "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Static stream uses range-capable file serving and playback-session auth fallback."}
+      }
+    },
+    {
+      "id": "playback.additional-parts",
+      "journey": "playback",
+      "bloomCaller": "PlaybackService::getAdditionalParts",
+      "method": "GET",
+      "path": "/Videos/{itemId}/AdditionalParts",
+      "requestSemantics": ["UserId is sent"],
+      "requiredSemantics": ["Items lists every ordered multipart item with a non-empty Id"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Used to build Bloom multipart playlists."},
+        "silo-8044eb8-compat": {"outcome": "missing", "evidence": "No route is registered; Bloom treats the 404 as nonfatal but multipart playback is unavailable."}
+      }
+    },
+    {
+      "id": "playback.trickplay",
+      "journey": "playback",
+      "bloomCaller": "PlaybackService::getTrickplayInfo/TrickplayProcessor",
+      "method": "GET",
+      "path": "/Items/{itemId}?Fields=Trickplay and /Videos/{itemId}/Trickplay/{width}/{index}.jpg",
+      "requestSemantics": ["Bloom reads nested Trickplay metadata, then downloads indexed tiles"],
+      "requiredSemantics": ["Metadata describes dimensions, tile grid, thumbnail count and interval", "Every referenced tile route returns the matching image"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Current Jellyfin trickplay metadata/tile contract."},
+        "silo-8044eb8-compat": {"outcome": "missing", "evidence": "Trickplay metadata is an empty map and tile routes are not registered."}
+      }
+    },
+    {
+      "id": "playback.report",
+      "journey": "playback",
+      "bloomCaller": "PlaybackService::reportPlaybackStarted/Progress/Paused/Resumed/Stopped",
+      "method": "POST",
+      "path": "/Sessions/Playing*",
+      "requestSemantics": ["Bloom sends ticks, play session/source IDs, selected stream indices and state/event names"],
+      "requiredSemantics": ["Progress is observable on a subsequent item read", "Pause/resume do not complete playback", "Stopped tears down the playback session"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard Jellyfin session reporting lifecycle."},
+        "silo-8044eb8-compat": {"outcome": "partial", "evidence": "Resume/progress and teardown work, but only part of Bloom's payload is consumed and an early start can precede upstream session creation."}
+      }
+    },
+    {
+      "id": "state.played",
+      "journey": "user-state",
+      "bloomCaller": "LibraryService/PlaybackService mark played methods",
+      "method": "POST/DELETE",
+      "path": "/Users/{userId}/PlayedItems/{itemId}",
+      "requestSemantics": ["Mutation uses an empty body"],
+      "requiredSemantics": ["Subsequent item UserData.Played reflects the mutation"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard played-state mutation."},
+        "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Legacy played routes update profile watch state."}
+      }
+    },
+    {
+      "id": "state.favorite",
+      "journey": "user-state",
+      "bloomCaller": "LibraryService favorite methods",
+      "method": "POST/DELETE",
+      "path": "/Users/{userId}/FavoriteItems/{itemId}",
+      "requestSemantics": ["Mutation uses an empty body"],
+      "requiredSemantics": ["Subsequent item UserData.IsFavorite reflects the mutation"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard favorite mutation."},
+        "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Legacy favorite routes update profile state."}
+      }
+    },
+    {
+      "id": "hierarchy.ancestors",
+      "journey": "catalog",
+      "bloomCaller": "LibraryService::resolveLibraryForItem",
+      "method": "GET",
+      "path": "/Items/{itemId}/Ancestors",
+      "requestSemantics": ["UserId is sent"],
+      "requiredSemantics": ["Array contains a CollectionFolder ancestor with stable Id/CollectionType for episodic items"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Used to resolve library-scoped playback preferences."},
+        "silo-8044eb8-compat": {"outcome": "missing", "evidence": "No compat ancestor route is registered."}
+      }
+    },
+    {
+      "id": "segments.plugin-intro-skipper",
+      "journey": "segments",
+      "bloomCaller": "PlaybackService::getMediaSegments",
+      "method": "GET",
+      "path": "/Episode/{itemId}/IntroSkipperSegments",
+      "requestSemantics": ["Bloom currently probes the Jellyfin Intro Skipper plugin route"],
+      "requiredSemantics": ["Valid Introduction/Credits/Recap/Preview entries contain numeric Start and End seconds", "A missing optional plugin degrades quietly"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "partial", "evidence": "Available only when the optional Intro Skipper plugin is installed."},
+        "silo-8044eb8-compat": {"outcome": "missing", "evidence": "Only Timestamps/IntroTimestamps stubs and the standard MediaSegments route are registered."}
+      }
+    },
+    {
+      "id": "segments.standard",
+      "journey": "segments",
+      "bloomCaller": "Not currently called; target for canonical adapter work",
+      "method": "GET",
+      "path": "/MediaSegments/{itemId}",
+      "requestSemantics": ["Authenticated item marker lookup"],
+      "requiredSemantics": ["Items carry Type plus StartTicks/EndTicks with ordered non-negative ranges", "Intro, Outro, Recap and Preview map without plugin-specific fields"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard Jellyfin media-segments endpoint on supported releases."},
+        "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Compat maps native file markers to a Jellyfin MediaSegments envelope; Bloom does not yet consume it."}
+      }
+    },
+    {
+      "id": "sessions.list",
+      "journey": "sessions",
+      "bloomCaller": "SessionService::refreshSessions",
+      "method": "GET",
+      "path": "/Sessions",
+      "requestSemantics": ["Authenticated request expects a JSON array"],
+      "requiredSemantics": ["Active sessions include stable Id and device/client identity", "Current session can be identified by DeviceId"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Populates Bloom's Active Sessions screen."},
+        "silo-8044eb8-compat": {"outcome": "stubbed", "evidence": "Handler intentionally returns an empty array and ignores active playback/session state."}
+      }
+    },
+    {
+      "id": "sessions.revoke",
+      "journey": "sessions",
+      "bloomCaller": "SessionService::terminateSession",
+      "method": "POST",
+      "path": "/Sessions/{sessionId}/Logout",
+      "requestSemantics": ["Target session Id is part of the route"],
+      "requiredSemantics": ["The named remote session is revoked while the caller remains authenticated"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Standard remote session revocation."},
+        "silo-8044eb8-compat": {"outcome": "missing", "evidence": "Only POST /Sessions/Logout for the caller's compat token exists."}
+      }
+    },
+    {
+      "id": "metadata.provider-ids",
+      "journey": "metadata",
+      "bloomCaller": "PlaybackService context, Seerr and external segment providers",
+      "method": "GET",
+      "path": "/Users/{userId}/Items/{itemId}?Fields=ProviderIds",
+      "requestSemantics": ["ProviderIds is explicitly requested"],
+      "requiredSemantics": ["Known external IDs are emitted using Jellyfin keys such as Imdb, Tmdb and Tvdb"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "External integrations depend on these IDs."},
+        "silo-8044eb8-compat": {"outcome": "missing", "evidence": "Mapping initializes ProviderIds empty and omits the field from the serialized detail response at the pinned revision."}
+      }
+    },
+    {
+      "id": "metadata.theme-songs",
+      "journey": "metadata",
+      "bloomCaller": "LibraryService::getThemeSongs",
+      "method": "GET",
+      "path": "/Items/{seriesId}/ThemeSongs",
+      "requestSemantics": ["UserId is sent"],
+      "requiredSemantics": ["Items contains playable theme media IDs that can be resolved to stream URLs"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Optional series ambience feature used by Bloom."},
+        "silo-8044eb8-compat": {"outcome": "stubbed", "evidence": "Dedicated handler returns an empty ThemeMediaResult."}
+      }
+    },
+    {
+      "id": "subtitles.delivery-url",
+      "journey": "playback",
+      "bloomCaller": "PlaybackInfo parsing and PlayerController track selection",
+      "method": "GET",
+      "path": "PlaybackInfo MediaStreams[].DeliveryUrl",
+      "requestSemantics": ["External subtitle tracks may advertise a provider URL"],
+      "requiredSemantics": ["DeliveryUrl is preserved and resolved without changing opaque query parameters", "Selected external subtitle is supplied to mpv"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "partial", "evidence": "Server advertises delivery URLs, but Bloom's current model does not preserve the field."},
+        "silo-8044eb8-compat": {"outcome": "partial", "evidence": "Compat advertises and serves downloaded subtitles; Bloom currently drops DeliveryUrl."}
+      }
+    },
+    {
+      "id": "cache.conditional-refresh",
+      "journey": "cache",
+      "bloomCaller": "LibraryService item/list/detail cache validation",
+      "method": "GET",
+      "path": "/Users/{userId}/Items*",
+      "requestSemantics": ["Bloom replays ETag/Last-Modified as If-None-Match/If-Modified-Since"],
+      "requiredSemantics": ["Unchanged representation returns HTTP 304", "Changed representation returns HTTP 200 with a new validator"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Control for Bloom's not-modified cache signals."},
+        "silo-8044eb8-compat": {"outcome": "missing", "evidence": "Compat item/catalog refresh does not meaningfully implement conditional JSON revalidation."}
+      }
+    },
+    {
+      "id": "errors.expired-session",
+      "journey": "authentication",
+      "bloomCaller": "AuthenticationService and service-specific 401 handling",
+      "method": "GET/POST",
+      "path": "authenticated catalog and playback routes",
+      "requestSemantics": ["Expired or revoked token is sent"],
+      "requiredSemantics": ["Server consistently returns HTTP 401", "Playback may defer client logout until teardown", "No protected payload is returned"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Control for current Jellyfin session expiry behavior."},
+        "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Compat token authentication rejects missing/expired/revoked sessions with 401."}
+      }
+    }
+  ],
+  "nativeSiloContract": {
+    "detection": {
+      "method": "GET",
+      "path": "/api/v1/health",
+      "requiredFields": ["status", "server_id"],
+      "notes": ["server_id identifies one installation reached through multiple URLs", "Do not infer Silo from compatibility /System/Info"]
+    },
+    "authenticationRoutes": ["GET /api/v1/auth/providers", "POST /api/v1/auth/login", "POST /api/v1/auth/refresh", "GET /api/v1/auth/me", "POST /api/v1/auth/logout", "GET /api/v1/auth/sessions", "DELETE /api/v1/auth/sessions/{id}"],
+    "profileRoutes": ["GET /api/v1/profiles", "POST /api/v1/profiles/{id}/verify-pin"],
+    "catalogRoutes": ["GET /api/v1/user/libraries", "GET /api/v1/catalog", "POST /api/v1/catalog/query", "GET /api/v1/catalog/items/{id}", "GET /api/v1/catalog/items/{id}/versions", "GET /api/v1/catalog/series/{id}/seasons", "GET /api/v1/catalog/series/{id}/seasons/{number}/episodes"],
+    "playbackRoutes": ["GET /api/v1/playback/capability", "POST /api/v1/playback/start", "POST /api/v1/playback/{session_id}/progress", "DELETE /api/v1/playback/{session_id}"],
+    "requiredHeaders": ["Authorization: Bearer <access token>", "X-Profile-Id after profile selection", "X-Profile-Token after successful PIN verification", "X-Silo-Client", "X-Silo-Client-Version", "X-Silo-Device-Id", "X-Silo-Device-Name", "X-Silo-Device-Platform"],
+    "identityRules": ["Use content_id for catalog and user-state identity", "Use file_id for playback", "Use milliseconds inside Bloom", "Treat native artwork URLs as expiring fetch locations, not cache identities"],
+    "playbackDecision": "Use the legacy native playback envelope until Silo documents an mpv-compatible protocol-v3 contract; v3 currently advertises media3_only."
+  },
+  "upstreamIssues": [
+    "https://github.com/Silo-Server/silo-server/issues/431",
+    "https://github.com/Silo-Server/silo-server/issues/432"
+  ],
+  "openUpstreamQuestions": [
+    "Is /api/v1 additive-only policy a public client guarantee, and how are deprecations announced?",
+    "Can health or a public server-info response expose product, build revision and native API revision without authentication?",
+    "Which capability endpoints form the supported discovery contract for third-party native clients?",
+    "What is the guaranteed lifetime of the legacy native playback envelope?",
+    "Will protocol v3 define an mpv-capable engine contract rather than media3_only semantics?",
+    "Which client/device headers are required versus advisory for third-party clients?",
+    "Is username#profile/password#pin the long-term compatibility-profile UX?",
+    "May Bloom use the Silo name referentially without bundling logo artwork?"
+  ]
+}

--- a/tests/contracts/provider_contracts_test.py
+++ b/tests/contracts/provider_contracts_test.py
@@ -1,0 +1,94 @@
+import copy
+import json
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+
+CONTRACT_DIR = Path(__file__).resolve().parent
+if str(CONTRACT_DIR) not in sys.path:
+    sys.path.insert(0, str(CONTRACT_DIR))
+
+from run_live_contracts import DRIVERS, HttpTransport, Response
+from validate_contracts import ContractValidationError, load_and_validate, validate_contract_data
+
+
+class ProviderContractValidationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.contract_path = CONTRACT_DIR / "provider-contracts.json"
+        cls.valid_data = json.loads(cls.contract_path.read_text(encoding="utf-8"))
+
+    def test_checked_in_contract_is_valid(self):
+        validated = load_and_validate(self.contract_path)
+        self.assertGreater(len(validated["contracts"]), 20)
+
+    def test_rejects_status_only_semantics(self):
+        for rule in ("HTTP status is 200", "Returns HTTP 404"):
+            with self.subTest(rule=rule):
+                data = copy.deepcopy(self.valid_data)
+                data["contracts"][0]["requiredSemantics"] = [rule]
+
+                with self.assertRaisesRegex(ContractValidationError, "not only an HTTP status"):
+                    validate_contract_data(data)
+
+    def test_rejects_missing_deployment_expectation(self):
+        data = copy.deepcopy(self.valid_data)
+        del data["contracts"][0]["expectations"]["silo-8044eb8-compat"]
+
+        with self.assertRaisesRegex(ContractValidationError, "every mediabrowser-v1 deployment"):
+            validate_contract_data(data)
+
+    def test_rejects_mutable_image_pin(self):
+        data = copy.deepcopy(self.valid_data)
+        data["snapshot"]["siloImage"] = "ghcr.io/silo-server/silo-server:latest"
+
+        with self.assertRaisesRegex(ContractValidationError, "immutable sha256 digest"):
+            validate_contract_data(data)
+
+    def test_rejects_uncovered_required_gap(self):
+        data = copy.deepcopy(self.valid_data)
+        data["coverageRequirements"].append("playback.untracked-gap")
+
+        with self.assertRaisesRegex(ContractValidationError, "missing contracts"):
+            validate_contract_data(data)
+
+    def test_rejects_non_object_native_detection(self):
+        data = copy.deepcopy(self.valid_data)
+        data["nativeSiloContract"]["detection"] = "present-but-invalid"
+
+        with self.assertRaisesRegex(ContractValidationError, "detection must be an object"):
+            validate_contract_data(data)
+
+    def test_live_drivers_are_registered_by_protocol_surface(self):
+        self.assertIn("mediabrowser-v1", DRIVERS)
+        self.assertNotIn("jellyfin-supported", DRIVERS)
+        self.assertNotIn("silo-8044eb8-compat", DRIVERS)
+
+    def test_live_response_parser_accepts_json_envelopes(self):
+        response = Response(200, {"Content-Type": "application/json"}, b'{"Items": []}')
+        self.assertEqual(response.json(), {"Items": []})
+        malformed = Response(200, {"Content-Type": "text/html"}, b"not-json")
+        self.assertIsNone(malformed.json())
+
+    def test_transport_converts_network_failure_to_response(self):
+        class FailingOpener:
+            def open(self, request, timeout):
+                raise urllib.error.URLError("offline")
+
+        transport = HttpTransport("https://media.example", 1)
+        transport._opener = FailingOpener()
+        response = transport.request("GET", "/System/Info")
+        self.assertEqual(response.status, 0)
+        self.assertIn("offline", response.headers["X-Bloom-Transport-Error"])
+
+    def test_transport_only_trusts_configured_origin(self):
+        transport = HttpTransport("https://media.example:8443", 1)
+        self.assertTrue(transport.is_same_origin("/Videos/item/stream"))
+        self.assertTrue(transport.is_same_origin("https://media.example:8443/Videos/item/stream"))
+        self.assertFalse(transport.is_same_origin("https://cdn.example/Videos/item/stream"))
+        self.assertFalse(transport.is_same_origin("http://media.example:8443/Videos/item/stream"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/contracts/run_live_contracts.py
+++ b/tests/contracts/run_live_contracts.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""Run Bloom's MediaBrowser contract probes against an operator-owned server."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from validate_contracts import load_and_validate
+
+
+@dataclass
+class Response:
+    status: int
+    headers: dict[str, str]
+    body: bytes
+
+    def json(self):
+        if not self.body:
+            return None
+        try:
+            return json.loads(self.body)
+        except json.JSONDecodeError:
+            return None
+
+
+@dataclass
+class ProbeResult:
+    contract: str
+    expected: str
+    observed: str
+    passed: bool
+    evidence: str
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Keep credentials on the configured origin by refusing automatic redirects."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+class HttpTransport:
+    def __init__(self, base_url: str, timeout: float):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self._base_origin = self._origin(self.base_url)
+        self._opener = urllib.request.build_opener(NoRedirectHandler())
+
+    @staticmethod
+    def _origin(url: str):
+        parsed = urllib.parse.urlsplit(url)
+        scheme = parsed.scheme.lower()
+        hostname = (parsed.hostname or "").lower()
+        port = parsed.port or (443 if scheme == "https" else 80 if scheme == "http" else None)
+        return scheme, hostname, port
+
+    def is_same_origin(self, url: str):
+        return not url.startswith(("http://", "https://")) or self._origin(url) == self._base_origin
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        headers: dict[str, str] | None = None,
+        json_body: Any = None,
+        raw_body: bytes | None = None,
+    ):
+        url = path if path.startswith(("http://", "https://")) else self.base_url + path
+        body = raw_body
+        request_headers = dict(headers or {})
+        if json_body is not None:
+            body = json.dumps(json_body).encode("utf-8")
+            request_headers.setdefault("Content-Type", "application/json")
+        request = urllib.request.Request(url, data=body, headers=request_headers, method=method)
+        try:
+            with self._opener.open(request, timeout=self.timeout) as reply:
+                return Response(reply.status, dict(reply.headers.items()), reply.read())
+        except urllib.error.HTTPError as error:
+            return Response(error.code, dict(error.headers.items()), error.read())
+        except (urllib.error.URLError, TimeoutError) as error:
+            return Response(0, {"X-Bloom-Transport-Error": str(error)}, b"")
+
+
+class MediaBrowserV1Probe:
+    """The current Bloom wire surface. Other protocol drivers can be added beside it."""
+
+    def __init__(self, transport: HttpTransport, username: str, password: str, version: str):
+        self.transport = transport
+        self.username = username
+        self.password = password
+        self.version = version
+        self.token = ""
+        self.user_id = ""
+        self.variables: dict[str, str] = {}
+
+    def headers(self, token: str | None = None, device_id: str = "bloom-contract-baseline"):
+        auth = (
+            f'MediaBrowser Client="Bloom Contract", Device="Desktop", '
+            f'DeviceId="{device_id}", Version="{self.version}"'
+        )
+        effective_token = self.token if token is None else token
+        if effective_token:
+            auth += f', Token="{effective_token}"'
+        return {"Authorization": auth, "Content-Type": "application/json"}
+
+    def request(self, method: str, path: str, **kwargs: Any):
+        headers = dict(self.headers()) if self.transport.is_same_origin(path) else {}
+        headers.update(kwargs.pop("headers", {}))
+        return self.transport.request(method, path, headers=headers, **kwargs)
+
+    @staticmethod
+    def _items(payload: Any):
+        if isinstance(payload, list):
+            return payload
+        if isinstance(payload, dict) and isinstance(payload.get("Items"), list):
+            return payload["Items"]
+        return []
+
+    @staticmethod
+    def _outcome_for_missing(response: Response):
+        return "missing" if response.status in {404, 405, 501} else "partial"
+
+    def follow_redirect_once(self, response: Response, original_path: str, *, headers: dict[str, str] | None = None):
+        if response.status not in {301, 302, 303, 307, 308}:
+            return response
+        location = response.headers.get("Location")
+        if not location:
+            return response
+        original_url = urllib.parse.urljoin(self.transport.base_url + "/", original_path)
+        target = urllib.parse.urljoin(original_url, location)
+        return self.request("GET", target, headers=headers or {})
+
+    def authenticate(self):
+        response = self.transport.request(
+            "POST",
+            "/Users/AuthenticateByName",
+            headers=self.headers(token=""),
+            json_body={"Username": self.username, "Pw": self.password},
+        )
+        try:
+            payload = response.json() or {}
+        except json.JSONDecodeError:
+            payload = {}
+        self.token = payload.get("AccessToken", "") if isinstance(payload, dict) else ""
+        user = payload.get("User", {}) if isinstance(payload, dict) else {}
+        self.user_id = user.get("Id", "") if isinstance(user, dict) else ""
+        if self.token and self.user_id and user.get("Name"):
+            return "supported", f"authenticated profile {user['Name']!r} with a stable user id"
+        return self._outcome_for_missing(response), f"login returned HTTP {response.status} without required identity fields"
+
+    def run(self, expected: dict[str, str], allow_mutations: bool):
+        results: list[ProbeResult] = []
+
+        def record(contract: str, observed: str, evidence: str):
+            wanted = expected[contract]
+            passed = observed == "inconclusive" or observed == wanted or (wanted == "partial" and observed == "supported")
+            results.append(ProbeResult(contract, wanted, observed, passed, evidence))
+
+        outcome, evidence = self.authenticate()
+        record("auth.login", outcome if outcome != "supported" else expected["auth.login"], evidence)
+        if not self.token or not self.user_id:
+            return results
+
+        invalid = self.transport.request(
+            "POST",
+            "/Users/AuthenticateByName",
+            headers=self.headers(token=""),
+            json_body={"Username": self.username, "Pw": self.password + "-invalid-contract-probe"},
+        )
+        record("auth.invalid", "supported" if invalid.status == 401 else "partial", f"invalid login returned HTTP {invalid.status}")
+
+        validation = self.request("GET", f"/Users/{urllib.parse.quote(self.user_id)}")
+        valid_payload = validation.json() if validation.status == 200 else {}
+        record(
+            "auth.validate",
+            "supported" if isinstance(valid_payload, dict) and valid_payload.get("Id") == self.user_id else "partial",
+            f"session validation returned HTTP {validation.status} with matching identity={isinstance(valid_payload, dict) and valid_payload.get('Id') == self.user_id}",
+        )
+
+        expired = self.request("GET", f"/Users/{urllib.parse.quote(self.user_id)}", headers=self.headers(token=self.token + "-revoked"))
+        record("errors.expired-session", "supported" if expired.status == 401 else "partial", f"invalid token returned HTTP {expired.status}")
+
+        views_response = self.request("GET", f"/Users/{urllib.parse.quote(self.user_id)}/Views")
+        views = self._items(views_response.json() if views_response.status == 200 else None)
+        library = next((item for item in views if isinstance(item, dict) and item.get("Id")), None)
+        record("catalog.views", "supported" if library else "partial", f"found {len(views)} visible views")
+        if library:
+            self.variables["libraryId"] = str(library["Id"])
+
+        query = {
+            "Recursive": "true",
+            "IncludeItemTypes": "Movie,Episode",
+            "SortBy": "SortName",
+            "SortOrder": "Ascending",
+            "StartIndex": "0",
+            "Limit": "5",
+            "Fields": "Overview,ProviderIds,UserData,ImageTags,BackdropImageTags,MediaSources,Chapters,Trickplay",
+            "EnableImages": "true",
+        }
+        if library:
+            query["ParentId"] = str(library["Id"])
+        items_path = f"/Users/{urllib.parse.quote(self.user_id)}/Items?{urllib.parse.urlencode(query)}"
+        items_response = self.request("GET", items_path)
+        items_payload = items_response.json() if items_response.status == 200 else None
+        items = self._items(items_payload)
+        total_count = items_payload.get("TotalRecordCount") if isinstance(items_payload, dict) else None
+        item = next((entry for entry in items if isinstance(entry, dict) and entry.get("Id")), None)
+        first_ids = [str(entry["Id"]) for entry in items if isinstance(entry, dict) and entry.get("Id")]
+        first_names = [str(entry.get("Name", "")).casefold() for entry in items if isinstance(entry, dict)]
+        paging_ok = len(first_ids) == len(set(first_ids)) and first_names == sorted(first_names)
+        second_count = 0
+        if isinstance(total_count, int) and total_count > len(items):
+            second_query = dict(query)
+            second_query["StartIndex"] = str(len(items))
+            second_path = f"/Users/{urllib.parse.quote(self.user_id)}/Items?{urllib.parse.urlencode(second_query)}"
+            second_response = self.request("GET", second_path)
+            second_items = self._items(second_response.json() if second_response.status == 200 else None)
+            second_ids = [str(entry["Id"]) for entry in second_items if isinstance(entry, dict) and entry.get("Id")]
+            second_count = len(second_items)
+            paging_ok = paging_ok and second_response.status == 200 and not set(first_ids).intersection(second_ids)
+        item_contract = expected["catalog.items"] if item is not None and isinstance(total_count, int) and paging_ok else "missing"
+        record("catalog.items", item_contract, f"first page has {len(items)} items, second page has {second_count}, TotalRecordCount={total_count!r}, unique/sorted pages={paging_ok}")
+        if not item:
+            return results
+
+        item_id = str(item["Id"])
+        title = str(item.get("Name") or "")
+        self.variables["itemId"] = item_id
+        item_type = str(item.get("Type") or "")
+        if item_type == "Episode":
+            self.variables["episodeId"] = item_id
+        if item.get("SeriesId"):
+            self.variables["seriesId"] = str(item["SeriesId"])
+
+        detail_path = f"/Users/{urllib.parse.quote(self.user_id)}/Items/{urllib.parse.quote(item_id)}?Fields=Overview,ProviderIds,People,MediaSources,Chapters,Trickplay"
+        detail_response = self.request("GET", detail_path)
+        detail = detail_response.json() if detail_response.status == 200 else {}
+        detail_ok = isinstance(detail, dict) and detail.get("Id") == item_id and detail.get("Type") and detail.get("Name")
+        record("catalog.details", expected["catalog.details"] if detail_ok else "missing", f"detail required fields present={bool(detail_ok)}")
+
+        latest_query = {"Limit": "10", "Fields": "UserData,ProviderIds"}
+        if library:
+            latest_query["ParentId"] = str(library["Id"])
+        latest = self.request("GET", f"/Users/{urllib.parse.quote(self.user_id)}/Items/Latest?{urllib.parse.urlencode(latest_query)}")
+        latest_items = self._items(latest.json() if latest.status == 200 else None)
+        latest_ids = [str(entry["Id"]) for entry in latest_items if isinstance(entry, dict) and entry.get("Id")]
+        latest_ok = bool(latest_ids) and len(latest_ids) == len(latest_items) == len(set(latest_ids))
+        record("catalog.latest", "supported" if latest_ok else "inconclusive" if latest.status == 200 else "missing", f"latest returned {len(latest_items)} items with stable unique ids={latest_ok}")
+
+        next_up = self.request("GET", f"/Shows/NextUp?{urllib.parse.urlencode({'UserId': self.user_id, 'Limit': '10', 'Fields': 'UserData,SeriesId'})}")
+        next_items = self._items(next_up.json() if next_up.status == 200 else None)
+        next_shape_ok = bool(next_items) and next_up.status == 200 and all(
+            isinstance(entry, dict) and entry.get("Id") and entry.get("Type") == "Episode"
+            for entry in next_items
+        )
+        record("catalog.next-up", "supported" if next_shape_ok else "inconclusive" if next_up.status == 200 else "partial", f"Next Up returned HTTP {next_up.status} and {len(next_items)} usable episode items")
+
+        next_episode = next(
+            (entry for entry in next_items if isinstance(entry, dict) and entry.get("Id") and entry.get("Type") == "Episode"),
+            None,
+        )
+        if next_episode:
+            self.variables["episodeId"] = str(next_episode["Id"])
+        elif "episodeId" not in self.variables:
+            episode_query = {"IncludeItemTypes": "Episode", "Recursive": "true", "Limit": "1"}
+            episode_response = self.request(
+                "GET",
+                f"/Users/{urllib.parse.quote(self.user_id)}/Items?{urllib.parse.urlencode(episode_query)}",
+            )
+            episode_items = self._items(episode_response.json() if episode_response.status == 200 else None)
+            episode = next(
+                (entry for entry in episode_items if isinstance(entry, dict) and entry.get("Id") and entry.get("Type") == "Episode"),
+                None,
+            )
+            if episode:
+                self.variables["episodeId"] = str(episode["Id"])
+            else:
+                series_query = {"IncludeItemTypes": "Series", "Recursive": "true", "Limit": "1"}
+                series_response = self.request(
+                    "GET",
+                    f"/Users/{urllib.parse.quote(self.user_id)}/Items?{urllib.parse.urlencode(series_query)}",
+                )
+                series_items = self._items(series_response.json() if series_response.status == 200 else None)
+                series = next(
+                    (entry for entry in series_items if isinstance(entry, dict) and entry.get("Id") and entry.get("Type") == "Series"),
+                    None,
+                )
+                if series:
+                    self.variables["seriesId"] = str(series["Id"])
+                    episodes_response = self.request(
+                        "GET",
+                        f"/Shows/{urllib.parse.quote(str(series['Id']))}/Episodes?{urllib.parse.urlencode({'UserId': self.user_id, 'Limit': '1'})}",
+                    )
+                    episodes = self._items(episodes_response.json() if episodes_response.status == 200 else None)
+                    episode = next(
+                        (entry for entry in episodes if isinstance(entry, dict) and entry.get("Id") and entry.get("Type") == "Episode"),
+                        None,
+                    )
+                    if episode:
+                        self.variables["episodeId"] = str(episode["Id"])
+
+        search_term = title.split()[0] if title else "contract"
+        search_query = {"SearchTerm": search_term, "IncludeItemTypes": "Movie,Series,Episode", "Recursive": "true", "Limit": "20"}
+        search = self.request("GET", f"/Users/{urllib.parse.quote(self.user_id)}/Items?{urllib.parse.urlencode(search_query)}")
+        search_items = self._items(search.json() if search.status == 200 else None)
+        search_matches = any(search_term.casefold() in str(entry.get("Name", "")).casefold() for entry in search_items if isinstance(entry, dict))
+        record("catalog.search", "supported" if search_matches else "partial", f"search for {search_term!r} returned {len(search_items)} items with a matching title={search_matches}")
+
+        facet_query = {"UserId": self.user_id, "Limit": "500"}
+        if library:
+            facet_query["ParentId"] = str(library["Id"])
+        facets = []
+        for path in ("/Items/Filters", "/Genres", "/Studios"):
+            response = self.request("GET", f"{path}?{urllib.parse.urlencode(facet_query)}")
+            payload = response.json() if response.status == 200 else None
+            facets.append((path, response.status, payload))
+        non_empty = sum(bool(self._items(payload)) or (isinstance(payload, dict) and any(bool(value) for value in payload.values())) for _, _, payload in facets)
+        filter_outcome = "supported" if non_empty == 3 else "partial" if all(status == 200 for _, status, _ in facets) else "missing"
+        record("catalog.filters", filter_outcome, f"{non_empty}/3 facet responses contained data")
+
+        image_tags = detail.get("ImageTags", {}) if isinstance(detail, dict) else {}
+        if isinstance(image_tags, dict) and image_tags.get("Primary"):
+            image_path = f"/Items/{urllib.parse.quote(item_id)}/Images/Primary?maxWidth=64"
+            image = self.request("GET", image_path)
+            image = self.follow_redirect_once(image, image_path)
+            content_type = image.headers.get("Content-Type", "")
+            image_ok = image.status == 200 and content_type.startswith("image/") and bool(image.body)
+            record("artwork.standard", "supported" if image_ok else "partial", f"Primary image returned HTTP {image.status}, {content_type!r}, {len(image.body)} bytes")
+        else:
+            record("artwork.standard", "inconclusive", "selected fixture item has no Primary image tag")
+
+        chapters = detail.get("Chapters", []) if isinstance(detail, dict) else []
+        chapter = chapters[0] if isinstance(chapters, list) and chapters else None
+        chapter_response = self.request("GET", f"/Items/{urllib.parse.quote(item_id)}/Images/Chapter/0?maxWidth=64")
+        chapter_observed = "supported" if chapter_response.status == 200 and chapter_response.headers.get("Content-Type", "").startswith("image/") else self._outcome_for_missing(chapter_response)
+        record("artwork.chapter", chapter_observed, f"chapter metadata present={bool(chapter)}; route returned HTTP {chapter_response.status}")
+
+        provider_ids = detail.get("ProviderIds") if isinstance(detail, dict) else None
+        provider_observed = "supported" if isinstance(provider_ids, dict) and any(provider_ids.values()) else "stubbed" if isinstance(provider_ids, dict) else "missing"
+        record("metadata.provider-ids", provider_observed, f"provider id keys={sorted(provider_ids) if isinstance(provider_ids, dict) else []}")
+
+        etag_response = self.request("GET", detail_path)
+        etag = etag_response.headers.get("ETag") or etag_response.headers.get("Etag")
+        if etag:
+            conditional = self.request("GET", detail_path, headers={"If-None-Match": etag})
+            cache_observed = "supported" if conditional.status == 304 else "partial"
+            cache_evidence = f"ETag round trip returned HTTP {conditional.status}"
+        else:
+            cache_observed = "missing"
+            cache_evidence = "detail response provided no ETag"
+        record("cache.conditional-refresh", cache_observed, cache_evidence)
+
+        additional = self.request("GET", f"/Videos/{urllib.parse.quote(item_id)}/AdditionalParts?{urllib.parse.urlencode({'UserId': self.user_id})}")
+        additional_items = self._items(additional.json() if additional.status == 200 else None)
+        if additional.status == 200 and additional_items:
+            additional_observed = (
+                "supported"
+                if all(isinstance(entry, dict) and entry.get("Id") for entry in additional_items)
+                else "partial"
+            )
+        elif additional.status == 200:
+            additional_observed = "inconclusive"
+        else:
+            additional_observed = self._outcome_for_missing(additional)
+        record("playback.additional-parts", additional_observed, f"route returned HTTP {additional.status} with {len(additional_items)} parts")
+
+        ancestors = self.request("GET", f"/Items/{urllib.parse.quote(item_id)}/Ancestors?{urllib.parse.urlencode({'UserId': self.user_id})}")
+        ancestor_payload = ancestors.json() if ancestors.status == 200 else None
+        ancestor_ok = isinstance(ancestor_payload, list) and any(isinstance(entry, dict) and entry.get("Type") == "CollectionFolder" and entry.get("Id") for entry in ancestor_payload)
+        record("hierarchy.ancestors", "supported" if ancestor_ok else self._outcome_for_missing(ancestors), f"route returned HTTP {ancestors.status}; usable collection ancestor={ancestor_ok}")
+
+        trickplay = detail.get("Trickplay") if isinstance(detail, dict) else None
+        trickplay_observed = "supported" if isinstance(trickplay, dict) and bool(trickplay) else "missing"
+        record("playback.trickplay", trickplay_observed, f"Trickplay metadata has entries={bool(trickplay)}")
+
+        episode_id = self.variables.get("episodeId")
+        if episode_id:
+            plugin_segments = self.request("GET", f"/Episode/{urllib.parse.quote(episode_id)}/IntroSkipperSegments")
+            plugin_payload = plugin_segments.json() if plugin_segments.status == 200 else None
+            plugin_valid = isinstance(plugin_payload, dict) and any(
+                isinstance(value, dict) and value.get("Valid") for value in plugin_payload.values()
+            )
+            plugin_observed = "supported" if plugin_valid else self._outcome_for_missing(plugin_segments)
+            if plugin_segments.status == 200 and not plugin_valid:
+                plugin_observed = "stubbed"
+            record("segments.plugin-intro-skipper", plugin_observed, f"episode route returned HTTP {plugin_segments.status}; valid segment={plugin_valid}")
+        else:
+            record("segments.plugin-intro-skipper", "inconclusive", "fixture exposes no episode for the episode-specific plugin probe")
+
+        standard_segments = self.request("GET", f"/MediaSegments/{urllib.parse.quote(item_id)}")
+        segment_payload = standard_segments.json() if standard_segments.status == 200 else None
+        segment_items = self._items(segment_payload)
+        segments_shape_ok = standard_segments.status == 200 and isinstance(segment_payload, dict) and isinstance(segment_payload.get("Items"), list)
+        segments_semantic_ok = segments_shape_ok and bool(segment_items) and all(
+            isinstance(segment, dict)
+            and segment.get("Type")
+            and isinstance(segment.get("StartTicks"), int)
+            and isinstance(segment.get("EndTicks"), int)
+            and 0 <= segment["StartTicks"] < segment["EndTicks"]
+            for segment in segment_items
+        )
+        record("segments.standard", "supported" if segments_semantic_ok else "inconclusive" if segments_shape_ok else self._outcome_for_missing(standard_segments), f"route returned HTTP {standard_segments.status} with {len(segment_items)} valid markers={segments_semantic_ok}")
+
+        sessions = self.request("GET", "/Sessions")
+        sessions_payload = sessions.json() if sessions.status == 200 else None
+        if isinstance(sessions_payload, list) and sessions_payload:
+            sessions_observed = "supported"
+        elif isinstance(sessions_payload, list):
+            sessions_observed = "stubbed"
+        else:
+            sessions_observed = self._outcome_for_missing(sessions)
+        record("sessions.list", sessions_observed, f"route returned HTTP {sessions.status} with {len(sessions_payload) if isinstance(sessions_payload, list) else 0} sessions")
+
+        if expected["sessions.revoke"] == "supported" and allow_mutations:
+            secondary_login = self.transport.request(
+                "POST",
+                "/Users/AuthenticateByName",
+                headers=self.headers(token="", device_id="bloom-contract-revocation-target"),
+                json_body={"Username": self.username, "Pw": self.password},
+            )
+            secondary_payload = secondary_login.json() if secondary_login.status == 200 else {}
+            secondary_token = secondary_payload.get("AccessToken", "") if isinstance(secondary_payload, dict) else ""
+            secondary_session = secondary_payload.get("SessionInfo", {}) if isinstance(secondary_payload, dict) else {}
+            secondary_session_id = secondary_session.get("Id", "") if isinstance(secondary_session, dict) else ""
+            if secondary_token and secondary_session_id:
+                revoke = self.request("POST", f"/Sessions/{urllib.parse.quote(secondary_session_id)}/Logout", raw_body=b"")
+                revoked_validation = self.transport.request(
+                    "GET",
+                    f"/Users/{urllib.parse.quote(self.user_id)}",
+                    headers=self.headers(token=secondary_token, device_id="bloom-contract-revocation-target"),
+                )
+                revoke_ok = revoke.status in {200, 204} and revoked_validation.status == 401
+                record("sessions.revoke", "supported" if revoke_ok else "partial", f"target revoke HTTP {revoke.status}; revoked token validation HTTP {revoked_validation.status}")
+            else:
+                record("sessions.revoke", "partial", "could not create an isolated secondary session for revocation")
+        elif expected["sessions.revoke"] == "supported":
+            record("sessions.revoke", "inconclusive", "revocation probe skipped; pass --allow-mutations to create and revoke an isolated session")
+        else:
+            revoke = self.request("POST", "/Sessions/nonexistent-contract-session/Logout", raw_body=b"")
+            revoke_observed = "missing" if revoke.status in {404, 405} else "partial"
+            record("sessions.revoke", revoke_observed, f"named-session logout probe returned HTTP {revoke.status}")
+
+        series_id = self.variables.get("seriesId", item_id)
+        themes = self.request("GET", f"/Items/{urllib.parse.quote(series_id)}/ThemeSongs?{urllib.parse.urlencode({'UserId': self.user_id})}")
+        theme_items = self._items(themes.json() if themes.status == 200 else None)
+        theme_observed = "supported" if theme_items else "stubbed" if themes.status == 200 else self._outcome_for_missing(themes)
+        record("metadata.theme-songs", theme_observed, f"route returned HTTP {themes.status} with {len(theme_items)} theme items")
+
+        playback = self.request(
+            "POST",
+            f"/Items/{urllib.parse.quote(item_id)}/PlaybackInfo?{urllib.parse.urlencode({'UserId': self.user_id})}",
+            json_body={},
+        )
+        playback_payload = playback.json() if playback.status == 200 else {}
+        play_session = playback_payload.get("PlaySessionId", "") if isinstance(playback_payload, dict) else ""
+        media_sources = playback_payload.get("MediaSources", []) if isinstance(playback_payload, dict) else []
+        source = media_sources[0] if isinstance(media_sources, list) and media_sources else {}
+        stream_url = source.get("DirectStreamUrl") or source.get("TranscodingUrl") if isinstance(source, dict) else None
+        info_ok = bool(play_session and isinstance(source, dict) and source.get("Id") and stream_url)
+        record("playback.info", expected["playback.info"] if info_ok else "missing", f"play session present={bool(play_session)}, media sources={len(media_sources) if isinstance(media_sources, list) else 0}, usable URL={bool(stream_url)}")
+
+        media_streams = source.get("MediaStreams", []) if isinstance(source, dict) else []
+        external_subtitles = [stream for stream in media_streams if isinstance(stream, dict) and stream.get("IsExternal")]
+        delivery_urls = [stream.get("DeliveryUrl") or stream.get("DeliveryURL") for stream in external_subtitles]
+        subtitle_observed = "supported" if any(delivery_urls) else "partial"
+        record("subtitles.delivery-url", subtitle_observed, f"external subtitle tracks={len(external_subtitles)}, delivery URLs={sum(bool(url) for url in delivery_urls)}")
+
+        if stream_url:
+            absolute_stream = urllib.parse.urljoin(self.transport.base_url + "/", str(stream_url))
+            ranged = self.request("GET", absolute_stream, headers={"Range": "bytes=0-31"})
+            ranged = self.follow_redirect_once(ranged, absolute_stream, headers={"Range": "bytes=0-31"})
+            content_range = ranged.headers.get("Content-Range", "")
+            range_ok = ranged.status == 206 and content_range.startswith("bytes 0-31/") and len(ranged.body) == 32
+            record("playback.range-stream", "supported" if range_ok else "partial", f"range returned HTTP {ranged.status}, Content-Range={content_range!r}, bytes={len(ranged.body)}")
+        else:
+            record("playback.range-stream", "missing", "PlaybackInfo provided no stream URL")
+
+        if allow_mutations and play_session and isinstance(source, dict) and source.get("Id"):
+            report = {
+                "ItemId": item_id,
+                "MediaSourceId": source["Id"],
+                "PlaySessionId": play_session,
+                "PositionTicks": 10_000_000,
+                "CanSeek": True,
+                "IsPaused": False,
+                "PlayMethod": "DirectPlay",
+            }
+            started = self.request("POST", "/Sessions/Playing", json_body=report)
+            progressed = self.request("POST", "/Sessions/Playing/Progress", json_body={**report, "PositionTicks": 20_000_000, "EventName": "TimeUpdate"})
+            progress_detail = self.request("GET", detail_path)
+            progress_payload = progress_detail.json() if progress_detail.status == 200 else {}
+            progress_user_data = progress_payload.get("UserData", {}) if isinstance(progress_payload, dict) else {}
+            progress_observable = (
+                isinstance(progress_user_data, dict)
+                and (
+                    int(progress_user_data.get("PlaybackPositionTicks") or 0) > 0
+                    or bool(progress_user_data.get("Played"))
+                )
+            )
+            stopped = self.request("POST", "/Sessions/Playing/Stopped", json_body={**report, "PositionTicks": 20_000_000, "EventName": "Stop"})
+            report_ok = all(response.status in {200, 204} for response in (started, progressed, stopped)) and progress_observable
+            report_observed = expected["playback.report"] if report_ok else "missing"
+            record("playback.report", report_observed, f"start/progress/stop HTTP statuses={started.status}/{progressed.status}/{stopped.status}; progress observable={progress_observable}")
+        elif not allow_mutations:
+            record("playback.report", expected["playback.report"], "reporting probe skipped; pass --allow-mutations with a dedicated fixture account")
+        else:
+            record("playback.report", "missing", "no playback session was available for reporting")
+
+        if allow_mutations:
+            encoded_user = urllib.parse.quote(self.user_id)
+            encoded_item = urllib.parse.quote(item_id)
+            original_user_data = detail.get("UserData", {}) if isinstance(detail, dict) else {}
+            for contract, suffix, field in (
+                ("state.played", "PlayedItems", "Played"),
+                ("state.favorite", "FavoriteItems", "IsFavorite"),
+            ):
+                state_path = f"/Users/{encoded_user}/{suffix}/{encoded_item}"
+                original_state = bool(original_user_data.get(field)) if isinstance(original_user_data, dict) else False
+                mutation_method = "DELETE" if original_state else "POST"
+                restore_method = "POST" if original_state else "DELETE"
+                changed = self.request(mutation_method, state_path, raw_body=b"")
+                changed_detail = self.request("GET", detail_path)
+                changed_payload = changed_detail.json() if changed_detail.status == 200 else {}
+                changed_state = bool(changed_payload.get("UserData", {}).get(field)) if isinstance(changed_payload, dict) else original_state
+                restored = self.request(restore_method, state_path, raw_body=b"")
+                restored_detail = self.request("GET", detail_path)
+                restored_payload = restored_detail.json() if restored_detail.status == 200 else {}
+                restored_state = bool(restored_payload.get("UserData", {}).get(field)) if isinstance(restored_payload, dict) else not original_state
+                state_ok = (
+                    changed.status in {200, 204}
+                    and changed_state != original_state
+                    and restored.status in {200, 204}
+                    and restored_state == original_state
+                )
+                record(
+                    contract,
+                    "supported" if state_ok else "partial",
+                    f"original={original_state}, mutate HTTP {changed.status}, observable={changed_state}, restore HTTP {restored.status}, restored={restored_state}",
+                )
+        else:
+            for contract in ("state.played", "state.favorite"):
+                record(contract, expected[contract], "mutation probe skipped; pass --allow-mutations to verify and restore state")
+
+        return results
+
+
+DRIVERS = {"mediabrowser-v1": MediaBrowserV1Probe}
+
+
+def main(argv: list[str] | None = None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--deployment", required=True, help="deployment id from provider-contracts.json")
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--username", default=os.environ.get("BLOOM_CONTRACT_USERNAME", ""))
+    parser.add_argument("--password-env", default="BLOOM_CONTRACT_PASSWORD", help="environment variable containing the password")
+    parser.add_argument("--version", default="0.0-contract")
+    parser.add_argument("--timeout", type=float, default=20.0)
+    parser.add_argument("--allow-mutations", action="store_true")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--matrix", type=Path, default=Path(__file__).with_name("provider-contracts.json"))
+    args = parser.parse_args(argv)
+
+    password = os.environ.get(args.password_env, "")
+    if not args.username or not password:
+        parser.error(f"--username/BLOOM_CONTRACT_USERNAME and {args.password_env} are required")
+
+    data = load_and_validate(args.matrix)
+    deployment = next((item for item in data["deployments"] if item["id"] == args.deployment), None)
+    if not deployment:
+        parser.error(f"unknown deployment {args.deployment!r}")
+    surface = deployment["surface"]
+    driver_type = DRIVERS.get(surface)
+    if not driver_type:
+        parser.error(f"no live probe driver is registered for surface {surface!r}")
+
+    expected = {
+        contract["id"]: contract["expectations"][args.deployment]["outcome"]
+        for contract in data["contracts"]
+        if args.deployment in contract["expectations"]
+    }
+    driver = driver_type(HttpTransport(args.base_url, args.timeout), args.username, password, args.version)
+    results = driver.run(expected, args.allow_mutations)
+
+    for result in results:
+        mark = "SKIP" if result.observed == "inconclusive" else "PASS" if result.passed else "FAIL"
+        print(f"{mark:4} {result.contract:34} expected={result.expected:9} observed={result.observed:12} {result.evidence}")
+
+    report = {
+        "schemaVersion": 1,
+        "deployment": args.deployment,
+        "baseUrl": args.base_url,
+        "results": [asdict(result) for result in results],
+    }
+    if args.output:
+        args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    failed = [result for result in results if not result.passed]
+    inconclusive = [result for result in results if result.observed == "inconclusive"]
+    print(f"\n{len(results) - len(failed) - len(inconclusive)}/{len(results)} probes matched the baseline; {len(inconclusive)} inconclusive")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/contracts/validate_contracts.py
+++ b/tests/contracts/validate_contracts.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Validate Bloom's provider contract baseline without contacting a server."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ALLOWED_OUTCOMES = {"supported", "partial", "stubbed", "missing", "not-applicable"}
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_IMAGE_RE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+HTTP_STATUS_RE = re.compile(r"\bHTTP\s+\d{3}\b", re.IGNORECASE)
+
+
+class ContractValidationError(ValueError):
+    pass
+
+
+def _require(condition: bool, message: str):
+    if not condition:
+        raise ContractValidationError(message)
+
+
+def _has_behavior_semantics(rule: str):
+    without_codes = HTTP_STATUS_RE.sub("", rule)
+    without_status_words = re.sub(r"\b(?:http|status|returns?)\b", "", without_codes, flags=re.IGNORECASE)
+    return re.search(r"[A-Za-z]{3,}", without_status_words) is not None
+
+
+def _unique_ids(values: list[dict[str, Any]], section: str):
+    ids = [value.get("id") for value in values]
+    _require(all(isinstance(value, str) and value for value in ids), f"{section} entries need non-empty ids")
+    _require(len(ids) == len(set(ids)), f"{section} ids must be unique")
+    return set(ids)
+
+
+def validate_contract_data(data: dict[str, Any]):
+    _require(data.get("schemaVersion") == 1, "schemaVersion must be 1")
+
+    outcomes = data.get("outcomes")
+    _require(isinstance(outcomes, dict), "outcomes must be an object")
+    _require(set(outcomes) == ALLOWED_OUTCOMES, "outcomes must define the complete status vocabulary")
+    _require(all(isinstance(value, str) and value.strip() for value in outcomes.values()), "outcome descriptions must be non-empty")
+
+    surfaces = data.get("surfaces")
+    deployments = data.get("deployments")
+    contracts = data.get("contracts")
+    _require(isinstance(surfaces, list) and surfaces, "surfaces must be a non-empty array")
+    _require(isinstance(deployments, list) and deployments, "deployments must be a non-empty array")
+    _require(isinstance(contracts, list) and contracts, "contracts must be a non-empty array")
+
+    surface_ids = _unique_ids(surfaces, "surface")
+    deployment_ids = _unique_ids(deployments, "deployment")
+    contract_ids = _unique_ids(contracts, "contract")
+
+    for deployment in deployments:
+        _require(deployment.get("surface") in surface_ids, f"deployment {deployment['id']} references an unknown surface")
+        _require(deployment.get("protocolMode") in {"native", "compatibility"}, f"deployment {deployment['id']} has an invalid protocolMode")
+        _require(bool(deployment.get("supportLabel")), f"deployment {deployment['id']} needs a supportLabel")
+
+    media_browser_deployments = {
+        deployment["id"] for deployment in deployments if deployment.get("surface") == "mediabrowser-v1"
+    }
+    _require(media_browser_deployments, "at least one mediabrowser-v1 deployment is required")
+
+    for contract in contracts:
+        contract_id = contract["id"]
+        for field in ("journey", "bloomCaller", "method", "path"):
+            _require(isinstance(contract.get(field), str) and contract[field].strip(), f"{contract_id} needs {field}")
+
+        request_semantics = contract.get("requestSemantics")
+        required_semantics = contract.get("requiredSemantics")
+        _require(isinstance(request_semantics, list) and request_semantics, f"{contract_id} needs requestSemantics")
+        _require(isinstance(required_semantics, list) and required_semantics, f"{contract_id} needs requiredSemantics")
+        _require(
+            all(isinstance(rule, str) and rule.strip() for rule in request_semantics + required_semantics),
+            f"{contract_id} semantics must be non-empty strings",
+        )
+        _require(
+            any(_has_behavior_semantics(rule) for rule in required_semantics),
+            f"{contract_id} must assert payload or behavior semantics, not only an HTTP status",
+        )
+
+        expectations = contract.get("expectations")
+        _require(isinstance(expectations, dict), f"{contract_id} expectations must be an object")
+        _require(set(expectations) == media_browser_deployments, f"{contract_id} must cover every mediabrowser-v1 deployment")
+        for deployment_id, expectation in expectations.items():
+            _require(isinstance(expectation, dict), f"{contract_id}/{deployment_id} expectation must be an object")
+            _require(expectation.get("outcome") in ALLOWED_OUTCOMES, f"{contract_id}/{deployment_id} has an invalid outcome")
+            _require(isinstance(expectation.get("evidence"), str) and expectation["evidence"].strip(), f"{contract_id}/{deployment_id} needs evidence")
+
+    required_coverage = data.get("coverageRequirements")
+    _require(isinstance(required_coverage, list) and required_coverage, "coverageRequirements must be a non-empty array")
+    _require(len(required_coverage) == len(set(required_coverage)), "coverageRequirements must be unique")
+    missing_coverage = set(required_coverage) - contract_ids
+    _require(not missing_coverage, f"coverage requirements missing contracts: {', '.join(sorted(missing_coverage))}")
+
+    snapshot = data.get("snapshot")
+    _require(isinstance(snapshot, dict), "snapshot must be an object")
+    _require(SHA_RE.fullmatch(snapshot.get("bloomRevision", "")) is not None, "snapshot bloomRevision must be a full Git SHA")
+    _require(isinstance(snapshot.get("jellyfinVersion"), str) and snapshot["jellyfinVersion"], "snapshot jellyfinVersion must be non-empty")
+    _require(DIGEST_IMAGE_RE.fullmatch(snapshot.get("jellyfinImage", "")) is not None, "snapshot jellyfinImage must use an immutable sha256 digest")
+    _require(SHA_RE.fullmatch(snapshot.get("siloRevision", "")) is not None, "snapshot siloRevision must be a full Git SHA")
+    _require(DIGEST_IMAGE_RE.fullmatch(snapshot.get("siloImage", "")) is not None, "snapshot siloImage must use an immutable sha256 digest")
+    _require(snapshot.get("siloImageTag") == snapshot["siloRevision"][:7], "snapshot siloImageTag must match the Silo revision")
+
+    native = data.get("nativeSiloContract")
+    _require(isinstance(native, dict), "nativeSiloContract must be an object")
+    for field in ("detection", "authenticationRoutes", "profileRoutes", "catalogRoutes", "playbackRoutes", "requiredHeaders", "identityRules", "playbackDecision"):
+        _require(bool(native.get(field)), f"nativeSiloContract needs {field}")
+    _require(isinstance(native.get("detection"), dict), "nativeSiloContract detection must be an object")
+    _require(native["detection"].get("path") == "/api/v1/health", "native detection must use /api/v1/health")
+    _require("server_id" in native["detection"].get("requiredFields", []), "native health detection must require server_id")
+
+    upstream_issues = data.get("upstreamIssues")
+    _require(isinstance(upstream_issues, list) and upstream_issues, "upstreamIssues must be a non-empty array")
+    _require(all(isinstance(url, str) and url.startswith("https://github.com/") for url in upstream_issues), "upstreamIssues entries must be GitHub URLs")
+
+    questions = data.get("openUpstreamQuestions")
+    _require(isinstance(questions, list) and questions, "openUpstreamQuestions must be a non-empty array")
+    _require(all(isinstance(question, str) and question.strip() for question in questions), "openUpstreamQuestions entries must be non-empty")
+
+
+def load_and_validate(path: Path):
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ContractValidationError(f"could not read {path}: {error}") from error
+    _require(isinstance(data, dict), "contract root must be an object")
+    validate_contract_data(data)
+    return data
+
+
+def main(argv: list[str] | None = None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path",
+        nargs="?",
+        type=Path,
+        default=Path(__file__).with_name("provider-contracts.json"),
+        help="path to the provider contract JSON",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        data = load_and_validate(args.path)
+    except ContractValidationError as error:
+        print(f"provider contract validation failed: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"validated {len(data['contracts'])} contracts across "
+        f"{len(data['deployments'])} deployments"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a provider-neutral contract matrix for Bloom's current MediaBrowser surface, pinned Jellyfin/Silo deployments, and researched native Silo `/api/v1` assumptions
- add offline validation that rejects mutable pins, missing deployment/gap coverage, and HTTP-status-only support claims
- add an opt-in live protocol-surface probe for auth, catalog, artwork, playback/range/reporting, user state, sessions, and known compatibility gaps
- document support labels, reproducible deployment steps, exact compatibility outcomes, native identity/header/playback decisions, and upstream coordination

The matrix is keyed by protocol surface and deployment rather than application-wide Jellyfin/Silo conditionals, so future sources can add a driver and deployment without changing existing contracts.

Closes #74
Parent: #73

## Live baseline

Pinned Silo `8044eb84` / image digest `sha256:944ee9…`:

- 27/29 probes matched with 0 failures
- 2 probes were explicitly inconclusive rather than falsely marked supported: fresh-profile Next Up had no qualifying item, and the fixture had no marker-bearing item for `/MediaSegments/{id}`
- verified login/invalid credentials/session validation, views/items/details/latest/search/facets, authenticated artwork, PlaybackInfo, `206` byte-range streaming, observable progress reporting, stop, and reversible played/favorite changes
- confirmed missing/stubbed/partial behavior for every tracked gap

Upstream follow-ups:
- https://github.com/Silo-Server/silo-server/issues/431
- https://github.com/Silo-Server/silo-server/issues/432

## Test plan

- `python3 tests/contracts/validate_contracts.py`
- `python3 tests/contracts/provider_contracts_test.py` (8 tests)
- live pinned Silo probe with `--allow-mutations` (27 matched, 2 inconclusive, 0 failed)
- `./scripts/dev-build.sh`
- CTest excluding the existing environment-sensitive visual/cache targets (16/16 passed)
- `nixfmt --check nix/tests.nix`
- `nix flake check --no-write-lock-file`
- `nix build --no-write-lock-file`

## Documentation

See [`docs/provider-compatibility.md`](docs/provider-compatibility.md). A maintainer review of the compatibility classifications and native contract assumptions is requested.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider compatibility baseline and contract validation test suite
> - Adds a machine-readable contract baseline in [provider-contracts.json](https://github.com/crowquillx/Bloom/pull/82/files#diff-2a216c50c1fad4fe6dce897b6519c6e1524c05ed671cb4a4e54a6aa0bae1502b) defining snapshot pins, outcome vocabulary, deployment expectations, and coverage requirements for MediaBrowser-compatible providers.
> - Introduces [validate_contracts.py](https://github.com/crowquillx/Bloom/pull/82/files#diff-c796108f4afadc19cf07232ef16692824090cee73a39a6558e1e572cfedbc5d8) for static validation of the contracts JSON, enforcing schema version, unique IDs, behavioral semantics, immutable image digests, and native detection rules.
> - Adds [run_live_contracts.py](https://github.com/crowquillx/Bloom/pull/82/files#diff-dbd3a4f5e81451692b1e278654458ebb3894cb2483c1887a87688a957f768c4c), a CLI tool that probes a live MediaBrowser-v1 server across auth, catalog, artwork, streaming, and playback endpoints, emitting structured PASS/FAIL results and an optional JSON report.
> - Registers a `ProviderContractValidationTest` in [tests/CMakeLists.txt](https://github.com/crowquillx/Bloom/pull/82/files#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0d) so CTest runs the Python-based contract tests; adds `python3` to the Nix test environment in [nix/tests.nix](https://github.com/crowquillx/Bloom/pull/82/files#diff-dc9ff4dd9dff6351f0c6906e7fb2fff39714f2f8fbaed9fb2785abdc8de401cb).
> - Adds [docs/provider-compatibility.md](https://github.com/crowquillx/Bloom/pull/82/files#diff-3987006cff865e212a082c0700225fb735facfc0545f17d81a835af8986e040a) documenting the compatibility baseline, server pins, and validation steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b6afad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added provider compatibility guidance covering Jellyfin and Silo behavior, deployment setup, API assumptions, validation evidence, and open contract questions.
  - Documented native Silo API expectations and compatibility outcomes across authentication, browsing, playback, sessions, subtitles, and artwork.

- **Tests**
  - Added automated contract validation for provider expectations, deployment coverage, immutable image references, response handling, and origin security.
  - Added live HTTP contract probes with pass/fail reporting and optional JSON output.
  - Integrated provider contract checks into the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->