### PR TITLE
refactor(network): add provider transport boundaries

### DIFF
--- a/docs/developer_notes.md
+++ b/docs/developer_notes.md
@@ -41,7 +41,8 @@ Coding style
 
 Useful utilities
 - `PlayerProcessManager` for mpv lifecycle.
-- `JellyfinClient` for network operations and request retriers.
+- `HttpTransport` for shared HTTP execution/retry/cancellation policy.
+- `IProviderRequestFactory` implementations for provider URL/header construction.
 - `ConfigManager` for settings and QML exposures.
 
 Logging

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -71,21 +71,19 @@ If a write, verification, or deletion fails, the old config/keychain entry remai
 
 Provider-neutral credential keys do not include the rotating device ID. Device rotation first resolves any pending legacy entry and aborts if the credential cannot be preserved.
 
-## Incremental boundaries
+## Request, authentication, and transport boundaries
 
-The remaining issue #75 work should preserve these directions:
+`IProviderRequestFactory` owns provider-specific URL and authorization-header construction. `JellyfinRequestFactory` is the only production source of the `MediaBrowser` header and also redacts token-bearing query parameters before URLs reach logs.
 
-1. Extract provider request factories so MediaBrowser and Silo headers are created only inside their adapters.
-2. Introduce a shared HTTP transport for execution, cancellation, redaction, retry policy, error mapping, and provider-directed `401` recovery.
-3. Place Jellyfin authentication behind `IProviderAuthenticator` while retaining the current QML-facing façade.
-4. Namespace persisted preferences and caches by `connectionId` before enabling multiple live providers.
-5. Add Silo authentication only after the native adapter can own access/refresh/profile token behavior.
+`IProviderAuthenticator` owns provider login payloads, response parsing, and validation routes. `JellyfinAuthenticator` implements the existing AuthenticateByName flow while `AuthenticationService` remains the stable QML-facing session façade.
 
-QML must not select protocol routes, construct provider headers, or read credentials.
+`HttpTransport` owns the shared `QNetworkAccessManager` and centralizes retry/backoff, cancellation, error mapping, redacted request logging, and unauthorized policy. Catalog and remote-session `401` responses expire immediately; playback reads can defer expiry until playback stops. Canceled work is never retried. `SessionService` uses the shared transport instead of a private network manager.
+
+The remaining issue #75 work is connection-scoping persisted preferences/caches and extracting provider route/JSON behavior behind catalog/playback/session adapter interfaces. QML must not select protocol routes, construct provider headers, or read credentials. Native Silo authentication remains deferred until its adapter can own access, refresh, and profile-token behavior.
 
 ## Verification
 
-Connection and credential migration tests cover:
+Connection, credential, request-factory, and transport tests cover:
 
 - v27 Jellyfin metadata migration
 - token exclusion from `app.json`
@@ -93,6 +91,8 @@ Connection and credential migration tests cover:
 - verified legacy keychain copy and cleanup
 - failed-copy recovery
 - multiple persisted connections and active selection
+- Jellyfin header/authentication wire ownership and URL redaction
+- transient retry, non-retryable cancellation/client failures, and unauthorized policy
 
 Use the blessed project checks:
 

--- a/docs/provider-compatibility.md
+++ b/docs/provider-compatibility.md
@@ -114,13 +114,13 @@ The live driver is selected by protocol surface (`mediabrowser-v1` today), while
 
 ## Bloom's current MediaBrowser contract
 
-`AuthenticationService`, `LibraryService`, `PlaybackService`, and `SessionService` currently own the wire contract. Provider-specific JSON is still visible above those services; issues #75 and #76 will move it behind adapters and canonical models.
+`JellyfinRequestFactory` owns MediaBrowser URL/header construction and `JellyfinAuthenticator` owns the login/validation wire contract. `HttpTransport` owns shared execution policy. `LibraryService`, `PlaybackService`, and `SessionService` still own provider routes and response JSON; the remaining #75/#76 adapter work moves those details behind catalog, playback, and remote-session boundaries.
 
 Shared assumptions:
 
 - Base URLs have trailing slashes removed before endpoint concatenation.
-- Requests send `Content-Type: application/json` and a `MediaBrowser` authorization header with Bloom client, desktop device, stable device ID, version, and optional token.
-- Authentication expects `AccessToken`, `User.Id`, and `User.Name`.
+- `JellyfinRequestFactory` sends `Content-Type: application/json` and a `MediaBrowser` authorization header with Bloom client, desktop device, stable device ID, version, and optional token.
+- `JellyfinAuthenticator` expects `AccessToken`, `User.Id`, and `User.Name`.
 - Lists generally use `{ "Items": [...], "TotalRecordCount": n }`.
 - Jellyfin time is in 100-nanosecond ticks. Ticks must not escape the future Jellyfin adapter.
 - Current image, stream, subtitle, and trickplay URLs may contain `api_key`; later artwork/playback boundaries must replace persistent token-bearing URLs.
@@ -155,7 +155,7 @@ This is the human-readable summary. Exact call sites, required semantics, and ev
 | Theme songs | Supported | Stubbed | Series theme songs are unavailable. |
 | External subtitle `DeliveryUrl` | Partial in Bloom | Partial in Bloom | Servers can advertise it; Bloom currently drops the URL before playback. |
 | Conditional JSON `ETag`/`304` | Supported | Missing | Functional refresh, but no efficient not-modified path. |
-| Expired/revoked token returns `401` | Supported | Supported | Authentication failure is detectable; Bloom's service handling is not yet centralized. |
+| Expired/revoked token returns `401` | Supported | Supported | Bloom centralizes catalog, playback, and remote-session expiry policy through the shared transport/session façade. |
 
 ### Meaningful assertions for live runs
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -11,7 +11,10 @@ Key services
 - `IPlayerBackend` — Playback backend abstraction registered in `ServiceLocator`.
 - `ExternalMpvBackend` — External mpv process/IPC backend adapter (primary rollback path on Linux/non-Windows).
 - `PlayerProcessManager` — Manages external mpv process & IPC (used by `ExternalMpvBackend`).
-- `AuthenticationService` — Login, logout, session persistence, token validation; owns shared `QNetworkAccessManager`.
+- `HttpTransport` — Owns the shared `QNetworkAccessManager` and central retry, cancellation, error, redaction, and unauthorized-response policy.
+- `IProviderRequestFactory` / `JellyfinRequestFactory` — Provider-owned URL and authorization-header construction.
+- `IProviderAuthenticator` / `JellyfinAuthenticator` — Provider-owned login payload, response parsing, and validation routes.
+- `AuthenticationService` — Stable QML façade for login, logout, session persistence, and token validation; delegates provider wire details and HTTP execution.
 - `LibraryService` — Library views/items, series details, search, reusable chapter metadata, image/theme-song URLs.
 - `PlaybackService` — Playback reporting, stream info, media segments, trickplay URLs and info.
 - `MediaSegmentProviderService` — Fetches and normalizes external intro/recap/credits/preview markers from configured providers; used by `PlaybackService` after server segment lookup.
@@ -27,8 +30,9 @@ Key services
 Initialization order (recommended)
 1. ConfigManager — loads configs, path info, and active `ServerConnection` metadata.
 2. IPlayerBackend — created by `PlayerBackendFactory` (`win-libmpv` on Windows; platform-selected backend elsewhere).
-3. AuthenticationService — handles the current Jellyfin session façade, uses `CredentialStore`, and provides the shared `QNetworkAccessManager` until transport extraction is complete.
-4. LibraryService — depends on AuthenticationService.
+3. HttpTransport and provider request/authentication implementations — own shared HTTP execution and Jellyfin wire construction.
+4. AuthenticationService — stable session façade; depends on `CredentialStore`, `HttpTransport`, `IProviderRequestFactory`, and `IProviderAuthenticator`.
+4.1. LibraryService — depends on AuthenticationService and uses its shared transport.
 5. InputModeManager — depends on QGuiApplication.
 5.1. InputBindingManager — depends on QGuiApplication + ConfigManager.
 6. MediaSegmentProviderService — depends on AuthenticationService + ConfigManager.

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -55,6 +55,7 @@ stdenv.mkDerivation {
       LoggingConfigTest \
       ConfigManagerThemeTest \
       ConnectionPersistenceTest \
+      ProviderTransportTest \
       InputBindingManagerTest \
       PlayerBackendFactoryTest \
       PlayerControllerAutoplayContextTest \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,12 @@ qt_add_executable(Bloom
     core/ServiceLocator.cpp
     providers/ServerConnection.h
     providers/ServerConnection.cpp
+    providers/IProviderAuthenticator.h
+    providers/IProviderRequestFactory.h
+    providers/jellyfin/JellyfinAuthenticator.h
+    providers/jellyfin/JellyfinAuthenticator.cpp
+    providers/jellyfin/JellyfinRequestFactory.h
+    providers/jellyfin/JellyfinRequestFactory.cpp
     resources/fonts.qrc
     resources/sounds.qrc
     resources/images.qrc
@@ -33,6 +39,8 @@ qt_add_executable(Bloom
     player/backend/MpvEmbeddedShaderUtils.cpp
     network/AuthenticationService.h
     network/AuthenticationService.cpp
+    network/HttpTransport.h
+    network/HttpTransport.cpp
     network/LibraryService.h
     network/LibraryService.cpp
     network/NextEpisodeResolver.h

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -11,6 +11,7 @@
 #include "security/SecretStoreFactory.h"
 #include "security/ISecretStore.h"
 #include "network/AuthenticationService.h"
+#include "network/HttpTransport.h"
 #include "network/LibraryService.h"
 #include "network/PlaybackService.h"
 #include "network/MediaSegmentProviderService.h"
@@ -31,6 +32,10 @@
 #include "utils/BloomLogging.h"
 #include "network/SessionManager.h"
 #include "network/SessionService.h"
+#include "providers/IProviderAuthenticator.h"
+#include "providers/IProviderRequestFactory.h"
+#include "providers/jellyfin/JellyfinAuthenticator.h"
+#include "providers/jellyfin/JellyfinRequestFactory.h"
 #include "updates/UpdateService.h"
 #include "test/TestModeController.h"
 #include "test/MockAuthenticationService.h"
@@ -210,15 +215,24 @@ void ApplicationInitializer::registerServices()
         // 2.5 SecretStore - Create platform-specific secure storage
         m_secretStore = SecretStoreFactory::create();
         
-        // 3. AuthenticationService - Depends on SecretStore
-        m_authService = std::make_unique<AuthenticationService>(m_secretStore.get());
+        // 3. Provider-neutral transport and Jellyfin wire adapters
+        m_httpTransport = std::make_unique<HttpTransport>();
+        m_providerRequestFactory = std::make_unique<JellyfinRequestFactory>();
+        m_providerAuthenticator = std::make_unique<JellyfinAuthenticator>();
+
+        // 3.1 AuthenticationService - stable façade over provider boundaries
+        m_authService = std::make_unique<AuthenticationService>(
+            m_secretStore.get(),
+            m_httpTransport.get(),
+            m_providerRequestFactory.get(),
+            m_providerAuthenticator.get());
         ServiceLocator::registerService<AuthenticationService>(m_authService.get());
         
-        // 3.1 LibraryService - Depends on AuthenticationService
+        // 3.2 LibraryService - Depends on AuthenticationService
         m_libraryService = std::make_unique<LibraryService>(m_authService.get());
         ServiceLocator::registerService<LibraryService>(m_libraryService.get());
         
-        // 3.2 PlaybackService - Depends on AuthenticationService
+        // 3.3 PlaybackService - Depends on AuthenticationService
         m_mediaSegmentProviderService = std::make_unique<MediaSegmentProviderService>(m_authService.get(), m_configManager.get());
         ServiceLocator::registerService<MediaSegmentProviderService>(m_mediaSegmentProviderService.get());
         m_playbackService = std::make_unique<PlaybackService>(m_authService.get(),
@@ -226,7 +240,7 @@ void ApplicationInitializer::registerServices()
                                                               m_mediaSegmentProviderService.get());
         ServiceLocator::registerService<PlaybackService>(m_playbackService.get());
         
-        // 3.3 SeerrService - Depends on AuthenticationService + ConfigManager
+        // 3.4 SeerrService - Depends on AuthenticationService + ConfigManager
         m_seerrService = std::make_unique<SeerrService>(m_authService.get(), m_configManager.get());
         ServiceLocator::registerService<SeerrService>(m_seerrService.get());
         

--- a/src/core/ApplicationInitializer.h
+++ b/src/core/ApplicationInitializer.h
@@ -23,7 +23,10 @@ class LibraryViewModel;
 class SeriesDetailsViewModel;
 class MovieDetailsViewModel;
 class UpNextRecommendationsViewModel;
+class IProviderAuthenticator;
+class IProviderRequestFactory;
 class ISecretStore;
+class HttpTransport;
 class SidebarSettings;
 class UiSoundController;
 class SystemPowerController;
@@ -103,7 +106,10 @@ private:
     std::unique_ptr<IPlayerBackend> m_playerBackend;
     // ISecretStore — owned here, raw pointer passed to AuthenticationService
     std::unique_ptr<ISecretStore> m_secretStore;
-    
+    std::unique_ptr<HttpTransport> m_httpTransport;
+    std::unique_ptr<IProviderRequestFactory> m_providerRequestFactory;
+    std::unique_ptr<IProviderAuthenticator> m_providerAuthenticator;
+
     std::unique_ptr<AuthenticationService> m_authService;
     std::unique_ptr<LibraryService> m_libraryService;
     std::unique_ptr<PlaybackService> m_playbackService;

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -1,7 +1,11 @@
 #include "AuthenticationService.h"
+#include "HttpTransport.h"
 #include "../security/ISecretStore.h"
 #include "../utils/ConfigManager.h"
-#include "config/version.h"
+#include "providers/IProviderAuthenticator.h"
+#include "providers/IProviderRequestFactory.h"
+#include "providers/jellyfin/JellyfinAuthenticator.h"
+#include "providers/jellyfin/JellyfinRequestFactory.h"
 #include <QNetworkRequest>
 #include <QUrl>
 #include <QJsonDocument>
@@ -13,9 +17,52 @@
 
 AuthenticationService::AuthenticationService(ISecretStore *secretStore, QObject *parent)
     : QObject(parent)
-    , m_nam(new QNetworkAccessManager(this))
+    , m_ownedTransport(std::make_unique<HttpTransport>())
+    , m_ownedRequestFactory(std::make_unique<JellyfinRequestFactory>())
+    , m_ownedProviderAuthenticator(std::make_unique<JellyfinAuthenticator>())
+    , m_transport(m_ownedTransport.get())
+    , m_requestFactory(m_ownedRequestFactory.get())
+    , m_providerAuthenticator(m_ownedProviderAuthenticator.get())
     , m_secretStore(secretStore)
 {
+    m_transport->setUrlRedactor([this](const QUrl &url) {
+        return m_requestFactory->redactedUrl(url);
+    });
+    connect(m_transport, &HttpTransport::unauthorized,
+            this, &AuthenticationService::handleUnauthorized);
+}
+
+AuthenticationService::AuthenticationService(ISecretStore *secretStore,
+                                               HttpTransport *transport,
+                                               IProviderRequestFactory *requestFactory,
+                                               IProviderAuthenticator *providerAuthenticator,
+                                               QObject *parent)
+    : QObject(parent)
+    , m_transport(transport)
+    , m_requestFactory(requestFactory)
+    , m_providerAuthenticator(providerAuthenticator)
+    , m_secretStore(secretStore)
+{
+    Q_ASSERT(m_transport);
+    Q_ASSERT(m_requestFactory);
+    Q_ASSERT(m_providerAuthenticator);
+    m_transport->setUrlRedactor([this](const QUrl &url) {
+        return m_requestFactory->redactedUrl(url);
+    });
+    connect(m_transport, &HttpTransport::unauthorized,
+            this, &AuthenticationService::handleUnauthorized);
+}
+
+AuthenticationService::~AuthenticationService()
+{
+    if (m_transport) {
+        m_transport->setUrlRedactor({});
+    }
+}
+
+QNetworkAccessManager *AuthenticationService::networkManager() const
+{
+    return m_transport->networkManager();
 }
 
 void AuthenticationService::initialize(ConfigManager *configManager)
@@ -120,64 +167,60 @@ QString AuthenticationService::normalizeUrl(const QString &url)
 
 QNetworkRequest AuthenticationService::createRequest(const QString &endpoint) const
 {
-    QUrl url(m_serverUrl + endpoint);
-    QNetworkRequest request(url);
-    
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    
-    // Build authorization header with unique device ID
-    QString deviceId = m_configManager ? m_configManager->getDeviceId() : "bloom-desktop-fallback";
-    QString authHeader = QString("MediaBrowser Client=\"Bloom\", Device=\"Desktop\", DeviceId=\"%1\", Version=\"%2\"").arg(deviceId, QString::fromUtf8(BLOOM_VERSION));
-    if (!m_accessToken.isEmpty()) {
-        authHeader += QString(", Token=\"%1\"").arg(m_accessToken);
-    }
-    request.setRawHeader("Authorization", authHeader.toUtf8());
-    
-    return request;
+    ProviderRequestContext context;
+    context.baseUrl = m_serverUrl;
+    context.accessToken = m_accessToken;
+    context.deviceId = m_configManager
+        ? m_configManager->getDeviceId()
+        : QStringLiteral("bloom-desktop-fallback");
+    return m_requestFactory->createRequest(context, endpoint);
 }
 
 void AuthenticationService::authenticate(const QString &serverUrl, const QString &username, const QString &password)
 {
     m_serverUrl = normalizeUrl(serverUrl);
-    
-    QJsonObject body;
-    body["Username"] = username;
-    body["Pw"] = password;
-    
-    QNetworkRequest request = createRequest("/Users/AuthenticateByName");
-    
-    QNetworkReply *reply = m_nam->post(request, QJsonDocument(body).toJson());
-    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
-        onAuthenticateFinished(reply);
-    });
+
+    const ProviderAuthenticationRequest authenticationRequest =
+        m_providerAuthenticator->createLoginRequest(username, password);
+    const QNetworkRequest request = createRequest(authenticationRequest.endpoint);
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::Ignore;
+
+    m_transport->sendWithRetry(
+        this,
+        authenticationRequest.endpoint,
+        [this, request, body = authenticationRequest.body]() {
+            return networkManager()->post(request, body);
+        },
+        [this](QNetworkReply *reply) {
+            onAuthenticateFinished(reply);
+        },
+        [this](const NetworkError &error) {
+            if (error.code == 401) {
+                emit loginError(tr("Invalid username or password"));
+                return;
+            }
+            const QString detail = error.userMessage.isEmpty()
+                ? tr("Could not connect to server. Please check the URL and your network connection.")
+                : error.userMessage;
+            emit loginError(tr("Authentication failed: %1").arg(detail));
+        },
+        options);
 }
 
 void AuthenticationService::onAuthenticateFinished(QNetworkReply *reply)
 {
-    reply->deleteLater();
-    
-    if (reply->error() != QNetworkReply::NoError) {
-        int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-        QString errorMessage;
-        
-        if (statusCode == 401) {
-            errorMessage = tr("Invalid username or password");
-        } else if (statusCode == 0) {
-            errorMessage = tr("Could not connect to server. Please check the URL and your network connection.");
-        } else {
-            errorMessage = tr("Authentication failed: %1").arg(reply->errorString());
-        }
-        
-        emit loginError(errorMessage);
+    const ProviderAuthenticationResult authentication =
+        m_providerAuthenticator->parseLoginResponse(reply->readAll());
+    if (!authentication.isValid()) {
+        emit loginError(tr("Authentication response was incomplete."));
         return;
     }
-    
-    QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-    QJsonObject obj = doc.object();
-    
-    m_accessToken = obj["AccessToken"].toString();
-    m_userId = obj["User"].toObject()["Id"].toString();
-    m_username = obj["User"].toObject()["Name"].toString();
+
+    m_accessToken = authentication.accessToken;
+    m_userId = authentication.accountId;
+    m_username = authentication.username;
     
     qCDebug(lcAuth) << "Authentication successful. User ID:" << m_userId << "Username:" << m_username;
 
@@ -352,21 +395,24 @@ void AuthenticationService::checkPendingSessionExpiry()
 
 bool AuthenticationService::checkForSessionExpiry(QNetworkReply *reply, bool deferLogout)
 {
-    int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    
-    if (statusCode == 401) {
-        qCWarning(lcAuth) << "Received 401 Unauthorized - session expired";
-        
-        if (deferLogout) {
-            // During playback, defer the logout until playback ends
-            m_sessionExpiredPending = true;
-        } else if (!m_sessionExpiredEmitted) {
-            m_sessionExpiredEmitted = true;
-            emit sessionExpired();
-        }
-        return true;
+    const int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    if (statusCode != 401) {
+        return false;
     }
-    return false;
+
+    handleUnauthorized(deferLogout);
+    return true;
+}
+
+void AuthenticationService::handleUnauthorized(bool deferLogout)
+{
+    qCWarning(lcAuth) << "Received 401 Unauthorized - session expired";
+    if (deferLogout) {
+        m_sessionExpiredPending = true;
+    } else if (!m_sessionExpiredEmitted) {
+        m_sessionExpiredEmitted = true;
+        emit sessionExpired();
+    }
 }
 
 void AuthenticationService::validateAccessToken(std::function<void(bool)> callback)
@@ -376,21 +422,27 @@ void AuthenticationService::validateAccessToken(std::function<void(bool)> callba
         return;
     }
     
-    // Make a lightweight API call to validate the token
-    QNetworkRequest request = createRequest(QString("/Users/%1").arg(m_userId));
-    QNetworkReply *reply = m_nam->get(request);
-    
-    connect(reply, &QNetworkReply::finished, this, [this, reply, callback]() {
-        reply->deleteLater();
-        
-        int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-        bool valid = (reply->error() == QNetworkReply::NoError && statusCode == 200);
-        
-        if (!valid) {
-            qCDebug(lcAuth) << "Token validation failed. Status:" << statusCode 
-                     << "Error:" << reply->errorString();
-        }
-        
-        callback(valid);
-    });
+    const QString endpoint = m_providerAuthenticator->sessionValidationEndpoint(m_userId);
+    const QNetworkRequest request = createRequest(endpoint);
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::Ignore;
+
+    m_transport->sendWithRetry(
+        this,
+        endpoint,
+        [this, request]() {
+            return networkManager()->get(request);
+        },
+        [callback](QNetworkReply *reply) {
+            const int statusCode = reply->attribute(
+                QNetworkRequest::HttpStatusCodeAttribute).toInt();
+            callback(statusCode == 200);
+        },
+        [callback](const NetworkError &error) {
+            qCDebug(lcAuth) << "Token validation failed. Status/error:" << error.code
+                            << error.userMessage;
+            callback(false);
+        },
+        options);
 }

--- a/src/network/AuthenticationService.h
+++ b/src/network/AuthenticationService.h
@@ -5,14 +5,18 @@
 #include <QNetworkReply>
 #include <QString>
 #include <functional>
+#include <memory>
 #include <QFutureWatcher>
 #include <QtConcurrent>
 
 #include "providers/ServerConnection.h"
 #include "security/CredentialStore.h"
 
+class IProviderAuthenticator;
+class IProviderRequestFactory;
 class ISecretStore;
 class ConfigManager;
+class HttpTransport;
 
 /**
  * @brief Handles user authentication, session management, and token validation.
@@ -35,7 +39,12 @@ class AuthenticationService : public QObject
 
 public:
     explicit AuthenticationService(ISecretStore *secretStore = nullptr, QObject *parent = nullptr);
-    virtual ~AuthenticationService() = default;
+    AuthenticationService(ISecretStore *secretStore,
+                          HttpTransport *transport,
+                          IProviderRequestFactory *requestFactory,
+                          IProviderAuthenticator *providerAuthenticator,
+                          QObject *parent = nullptr);
+    virtual ~AuthenticationService();
     
     /**
      * @brief Initialize service and attempt to restore session asynchronously
@@ -90,7 +99,8 @@ public:
      * @brief Get the shared network access manager
      * @return Pointer to QNetworkAccessManager (owned by this service)
      */
-    QNetworkAccessManager* networkManager() const { return m_nam; }
+    QNetworkAccessManager* networkManager() const;
+    HttpTransport* transport() const { return m_transport; }
     
     /**
      * @brief Create a network request with authentication headers
@@ -130,7 +140,12 @@ private slots:
     void onAuthenticateFinished(QNetworkReply *reply);
 
 private:
-    QNetworkAccessManager *m_nam;
+    std::unique_ptr<HttpTransport> m_ownedTransport;
+    std::unique_ptr<IProviderRequestFactory> m_ownedRequestFactory;
+    std::unique_ptr<IProviderAuthenticator> m_ownedProviderAuthenticator;
+    HttpTransport *m_transport = nullptr;
+    IProviderRequestFactory *m_requestFactory = nullptr;
+    IProviderAuthenticator *m_providerAuthenticator = nullptr;
     QString m_serverUrl;
     QString m_accessToken;
     QString m_userId;
@@ -158,6 +173,7 @@ private:
     QFutureWatcher<RestorationResult> m_restorationWatcher;
     
     QString normalizeUrl(const QString &url);
+    void handleUnauthorized(bool deferLogout);
     
     /**
      * @brief Validate the current access token by making a test API call

--- a/src/network/HttpTransport.cpp
+++ b/src/network/HttpTransport.cpp
@@ -1,0 +1,187 @@
+#include "HttpTransport.h"
+
+#include <QLoggingCategory>
+#include <QNetworkRequest>
+#include <QTimer>
+#include <QUrl>
+
+Q_LOGGING_CATEGORY(lcHttpTransport, "bloom.network.transport")
+
+HttpRequestHandle::HttpRequestHandle(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void HttpRequestHandle::cancel()
+{
+    if (m_canceled) {
+        return;
+    }
+    m_canceled = true;
+    if (m_reply) {
+        m_reply->abort();
+    } else {
+        deleteLater();
+    }
+}
+
+HttpTransport::HttpTransport(QObject *parent)
+    : QObject(parent)
+    , m_networkManager(new QNetworkAccessManager(this))
+{
+}
+
+HttpTransport::HttpTransport(QNetworkAccessManager *networkManager, QObject *parent)
+    : QObject(parent)
+    , m_networkManager(networkManager ? networkManager : new QNetworkAccessManager(this))
+{
+}
+
+void HttpTransport::setUrlRedactor(UrlRedactor redactor)
+{
+    m_urlRedactor = std::move(redactor);
+}
+
+HttpRequestHandle *HttpTransport::sendWithRetry(QObject *context,
+                                                const QString &endpoint,
+                                                RequestFactory requestFactory,
+                                                ResponseHandler responseHandler,
+                                                FailureHandler failureHandler,
+                                                HttpRequestOptions options)
+{
+    auto *handle = new HttpRequestHandle(this);
+    const QPointer<QObject> guardedContext(context ? context : this);
+    if (context) {
+        connect(context, &QObject::destroyed, handle, [handle]() {
+            handle->cancel();
+            handle->deleteLater();
+        });
+    }
+
+    startAttempt(handle,
+                 guardedContext,
+                 endpoint,
+                 requestFactory,
+                 responseHandler,
+                 failureHandler,
+                 options,
+                 0);
+    return handle;
+}
+
+void HttpTransport::startAttempt(const QPointer<HttpRequestHandle> &handle,
+                                 const QPointer<QObject> &context,
+                                 const QString &endpoint,
+                                 const RequestFactory &requestFactory,
+                                 const ResponseHandler &responseHandler,
+                                 const FailureHandler &failureHandler,
+                                 const HttpRequestOptions &options,
+                                 int attemptNumber)
+{
+    if (!handle || !context || handle->isCanceled()) {
+        return;
+    }
+
+    QNetworkReply *reply = requestFactory ? requestFactory() : nullptr;
+    if (!reply) {
+        NetworkError error;
+        error.code = -1;
+        error.endpoint = endpoint;
+        error.userMessage = tr("Unable to create network request.");
+        error.technicalDetails = QStringLiteral("Request factory returned no reply");
+        if (failureHandler) {
+            failureHandler(error);
+        }
+        handle->deleteLater();
+        return;
+    }
+
+    handle->m_reply = reply;
+    connect(reply, &QNetworkReply::finished, reply, &QObject::deleteLater);
+    qCDebug(lcHttpTransport) << "Sending request"
+                             << redactedEndpoint(endpoint, reply)
+                             << "attempt" << (attemptNumber + 1)
+                             << "of" << options.retryPolicy.maxRetries;
+
+    connect(reply, &QNetworkReply::finished, context,
+            [this, handle, context, endpoint, requestFactory, responseHandler,
+             failureHandler, options, attemptNumber, reply]() {
+        if (!handle || !context) {
+            return;
+        }
+
+        handle->m_reply.clear();
+
+        if (handle->isCanceled()
+            || reply->error() == QNetworkReply::OperationCanceledError) {
+            handle->deleteLater();
+            return;
+        }
+
+        if (reply->error() == QNetworkReply::NoError) {
+            if (responseHandler) {
+                responseHandler(reply);
+            }
+            handle->deleteLater();
+            return;
+        }
+
+        const int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        NetworkError error = ErrorHandler::createError(reply, endpoint);
+
+        if (httpStatus == 401) {
+            error.code = 401;
+            if (options.unauthorizedPolicy != UnauthorizedPolicy::Ignore) {
+                const bool defer = options.unauthorizedPolicy == UnauthorizedPolicy::DeferSessionExpiry;
+                emit unauthorized(defer);
+                error.userMessage = tr("Session expired. Please log in again.");
+            }
+        }
+
+        const bool shouldRetry = !handle->isCanceled()
+            && options.retryEnabled
+            && options.retryPolicy.retryOnTransient
+            && reply->error() != QNetworkReply::OperationCanceledError
+            && ErrorHandler::isTransientError(reply->error())
+            && !ErrorHandler::isClientError(httpStatus)
+            && attemptNumber < options.retryPolicy.maxRetries - 1;
+
+        if (shouldRetry) {
+            const int delayMs = ErrorHandler::calculateBackoffDelay(
+                attemptNumber, options.retryPolicy);
+            qCInfo(lcHttpTransport) << "Retrying request"
+                                    << redactedEndpoint(endpoint, reply)
+                                    << "in" << delayMs << "ms";
+            QTimer::singleShot(delayMs, this,
+                               [this, handle, context, endpoint, requestFactory,
+                                responseHandler, failureHandler, options, attemptNumber]() {
+                startAttempt(handle,
+                             context,
+                             endpoint,
+                             requestFactory,
+                             responseHandler,
+                             failureHandler,
+                             options,
+                             attemptNumber + 1);
+            });
+            return;
+        }
+
+        if (failureHandler) {
+            failureHandler(error);
+        }
+        handle->deleteLater();
+    });
+}
+
+QString HttpTransport::redactedEndpoint(const QString &endpoint, const QNetworkReply *reply) const
+{
+    const QUrl url = reply ? reply->request().url() : QUrl(endpoint);
+    if (m_urlRedactor) {
+        return m_urlRedactor(url);
+    }
+
+    QUrl redacted = url;
+    redacted.setUserInfo(QString());
+    return redacted.toString(QUrl::FullyEncoded);
+}

--- a/src/network/HttpTransport.h
+++ b/src/network/HttpTransport.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "network/Types.h"
+
+#include <QNetworkAccessManager>
+#include <QPointer>
+#include <functional>
+
+class HttpRequestHandle final : public QObject
+{
+public:
+    explicit HttpRequestHandle(QObject *parent = nullptr);
+
+    void cancel();
+    bool isCanceled() const { return m_canceled; }
+
+private:
+    friend class HttpTransport;
+
+    bool m_canceled = false;
+    QPointer<QNetworkReply> m_reply;
+};
+
+enum class UnauthorizedPolicy {
+    Ignore,
+    ExpireSession,
+    DeferSessionExpiry
+};
+
+struct HttpRequestOptions {
+    RetryPolicy retryPolicy;
+    bool retryEnabled = true;
+    UnauthorizedPolicy unauthorizedPolicy = UnauthorizedPolicy::Ignore;
+};
+
+/**
+ * @brief Shared HTTP execution, retry, cancellation, and error-policy boundary.
+ *
+ * Request factories remain provider-owned. HttpTransport owns request execution
+ * policy and emits a provider-neutral unauthorized signal for session handling.
+ */
+class HttpTransport final : public QObject
+{
+    Q_OBJECT
+
+public:
+    using RequestFactory = std::function<QNetworkReply *()>;
+    using ResponseHandler = std::function<void(QNetworkReply *)>;
+    using FailureHandler = std::function<void(const NetworkError &)>;
+    using UrlRedactor = std::function<QString(const QUrl &)>;
+
+    explicit HttpTransport(QObject *parent = nullptr);
+    explicit HttpTransport(QNetworkAccessManager *networkManager, QObject *parent = nullptr);
+
+    QNetworkAccessManager *networkManager() const { return m_networkManager; }
+    void setUrlRedactor(UrlRedactor redactor);
+
+    HttpRequestHandle *sendWithRetry(QObject *context,
+                                     const QString &endpoint,
+                                     RequestFactory requestFactory,
+                                     ResponseHandler responseHandler,
+                                     FailureHandler failureHandler = FailureHandler(),
+                                     HttpRequestOptions options = HttpRequestOptions());
+
+signals:
+    void unauthorized(bool deferSessionExpiry);
+
+private:
+    QNetworkAccessManager *m_networkManager = nullptr;
+    UrlRedactor m_urlRedactor;
+
+    void startAttempt(const QPointer<HttpRequestHandle> &handle,
+                      const QPointer<QObject> &context,
+                      const QString &endpoint,
+                      const RequestFactory &requestFactory,
+                      const ResponseHandler &responseHandler,
+                      const FailureHandler &failureHandler,
+                      const HttpRequestOptions &options,
+                      int attemptNumber);
+    QString redactedEndpoint(const QString &endpoint, const QNetworkReply *reply = nullptr) const;
+};

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -1,5 +1,6 @@
 #include "LibraryService.h"
 #include "AuthenticationService.h"
+#include "HttpTransport.h"
 #include "NextEpisodeResolver.h"
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -230,6 +231,7 @@ QString LibraryItemQuery::cacheKey() const
 LibraryService::LibraryService(AuthenticationService *authService, QObject *parent)
     : QObject(parent)
     , m_authService(authService)
+    , m_transport(authService ? authService->transport() : nullptr)
     , m_retryPolicy{3, 1000, true}
 {
 }
@@ -244,73 +246,36 @@ void LibraryService::sendRequestWithRetry(const QString &endpoint,
                                            FailureHandler failureHandler,
                                            int attemptNumber)
 {
-    qCDebug(lcLibrary) << "Sending request to:" << endpoint 
-                            << "attempt:" << (attemptNumber + 1) << "/" << m_retryPolicy.maxRetries;
-    
-    QNetworkReply *reply = requestFactory();
-    
-    connect(reply, &QNetworkReply::finished, this, [this, reply, endpoint, requestFactory, responseHandler, failureHandler, attemptNumber]() {
-        handleReplyWithRetry(reply, endpoint, requestFactory, responseHandler, failureHandler, attemptNumber);
-    });
-}
-
-void LibraryService::handleReplyWithRetry(QNetworkReply *reply,
-                                           const QString &endpoint,
-                                           RequestFactory requestFactory,
-                                           ResponseHandler responseHandler,
-                                           FailureHandler failureHandler,
-                                           int attemptNumber)
-{
-    reply->deleteLater();
-    
-    if (reply->error() == QNetworkReply::NoError) {
-        qCDebug(lcLibrary) << "Request succeeded:" << endpoint;
-        responseHandler(reply);
-        return;
-    }
-    
-    // Get HTTP status code
-    int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    
-    NetworkError netError = ErrorHandler::createError(reply, endpoint);
-
-    // Check for 401 Unauthorized - session expired
-    if (httpStatus == 401) {
-        qCWarning(lcLibrary) << "Session expired (401) for endpoint:" << endpoint
-                                  << "userMessage:" << netError.userMessage;
+    Q_UNUSED(attemptNumber)
+    if (!m_transport) {
+        NetworkError error;
+        error.code = -1;
+        error.endpoint = endpoint;
+        error.userMessage = tr("Network transport is unavailable.");
         if (failureHandler) {
-            failureHandler(netError);
+            failureHandler(error);
         } else {
-            emitError(netError);
+            emitError(error);
         }
         return;
     }
-    
-    qCWarning(lcLibrary) << "Request failed:" << endpoint
-                              << "Error:" << reply->error()
-                              << "HTTP Status:" << httpStatus
-                              << "Attempt:" << (attemptNumber + 1);
-    
-    // Check if we should retry
-    bool shouldRetry = m_retryPolicy.retryOnTransient 
-                       && ErrorHandler::isTransientError(reply->error())
-                       && !ErrorHandler::isClientError(httpStatus)
-                       && attemptNumber < m_retryPolicy.maxRetries - 1;
-    
-    if (shouldRetry) {
-        int delayMs = ErrorHandler::calculateBackoffDelay(attemptNumber, m_retryPolicy);
-        qCInfo(lcLibrary) << "Retrying request to:" << endpoint << "in" << delayMs << "ms";
-        
-        QTimer::singleShot(delayMs, this, [this, endpoint, requestFactory, responseHandler, failureHandler, attemptNumber]() {
-            sendRequestWithRetry(endpoint, requestFactory, responseHandler, failureHandler, attemptNumber + 1);
-        });
-    } else {
-        if (failureHandler) {
-            failureHandler(netError);
-        } else {
-            emitError(netError);
-        }
-    }
+
+    HttpRequestOptions options;
+    options.retryPolicy = m_retryPolicy;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    m_transport->sendWithRetry(
+        this,
+        endpoint,
+        std::move(requestFactory),
+        std::move(responseHandler),
+        [this, failureHandler = std::move(failureHandler)](const NetworkError &error) {
+            if (failureHandler) {
+                failureHandler(error);
+            } else {
+                emitError(error);
+            }
+        },
+        options);
 }
 
 void LibraryService::emitError(const NetworkError &error)
@@ -1312,6 +1277,7 @@ void LibraryService::markSeriesWatched(const QString &seriesId)
     QNetworkReply *reply = m_authService->networkManager()->post(request, QByteArray());
     connect(reply, &QNetworkReply::finished, this, [this, reply, seriesId]() {
         reply->deleteLater();
+        if (m_authService->checkForSessionExpiry(reply)) return;
         if (reply->error() == QNetworkReply::NoError) {
             emit seriesWatchedStatusChanged(seriesId);
         }
@@ -1328,6 +1294,7 @@ void LibraryService::markSeriesUnwatched(const QString &seriesId)
     QNetworkReply *reply = m_authService->networkManager()->deleteResource(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply, seriesId]() {
         reply->deleteLater();
+        if (m_authService->checkForSessionExpiry(reply)) return;
         if (reply->error() == QNetworkReply::NoError) {
             emit seriesWatchedStatusChanged(seriesId);
         }
@@ -1345,6 +1312,7 @@ void LibraryService::markItemPlayed(const QString &itemId)
     QNetworkReply *reply = m_authService->networkManager()->post(request, QByteArray());
     connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
         reply->deleteLater();
+        if (m_authService->checkForSessionExpiry(reply)) return;
         if (reply->error() == QNetworkReply::NoError) {
             emit itemPlayedStatusChanged(itemId, true);
         }
@@ -1361,6 +1329,7 @@ void LibraryService::markItemUnplayed(const QString &itemId)
     QNetworkReply *reply = m_authService->networkManager()->deleteResource(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
         reply->deleteLater();
+        if (m_authService->checkForSessionExpiry(reply)) return;
         if (reply->error() == QNetworkReply::NoError) {
             emit itemPlayedStatusChanged(itemId, false);
         }
@@ -1378,6 +1347,7 @@ void LibraryService::markItemFavorite(const QString &itemId)
     QNetworkReply *reply = m_authService->networkManager()->post(request, QByteArray());
     connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
         reply->deleteLater();
+        if (m_authService->checkForSessionExpiry(reply)) return;
         if (reply->error() == QNetworkReply::NoError) {
             emit favoriteStatusChanged(itemId, true);
         }
@@ -1394,6 +1364,7 @@ void LibraryService::markItemUnfavorite(const QString &itemId)
     QNetworkReply *reply = m_authService->networkManager()->deleteResource(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
         reply->deleteLater();
+        if (m_authService->checkForSessionExpiry(reply)) return;
         if (reply->error() == QNetworkReply::NoError) {
             emit favoriteStatusChanged(itemId, false);
         }

--- a/src/network/LibraryService.h
+++ b/src/network/LibraryService.h
@@ -15,6 +15,7 @@
 #include "Types.h"  // Shared data structs and error helpers
 
 class AuthenticationService;
+class HttpTransport;
 
 struct LibraryItemQuery {
     QString parentId;
@@ -199,6 +200,7 @@ signals:
 
 private:
     AuthenticationService *m_authService;
+    HttpTransport *m_transport = nullptr;
     RetryPolicy m_retryPolicy;
     
     // Retry mechanism types
@@ -211,13 +213,6 @@ private:
                                ResponseHandler responseHandler,
                                FailureHandler failureHandler = FailureHandler(),
                                int attemptNumber = 0);
-    
-    void handleReplyWithRetry(QNetworkReply *reply,
-                               const QString &endpoint,
-                               RequestFactory requestFactory,
-                               ResponseHandler responseHandler,
-                               FailureHandler failureHandler,
-                               int attemptNumber);
     
     void emitError(const NetworkError &error);
 

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -1,5 +1,6 @@
 #include "PlaybackService.h"
 #include "AuthenticationService.h"
+#include "HttpTransport.h"
 #include "MediaSegmentProviderService.h"
 #include "../utils/ConfigManager.h"
 #include <QJsonDocument>
@@ -50,6 +51,7 @@ PlaybackService::PlaybackService(AuthenticationService *authService,
                                  QObject *parent)
     : QObject(parent)
     , m_authService(authService)
+    , m_transport(authService ? authService->transport() : nullptr)
     , m_configManager(configManager)
     , m_mediaSegmentProviderService(mediaSegmentProviderService)
     , m_retryPolicy{3, 1000, true}
@@ -66,67 +68,38 @@ void PlaybackService::sendRequestWithRetry(const QString &endpoint,
                                             FailureHandler failureHandler,
                                             int attemptNumber)
 {
-    qCDebug(lcPlayback) << "Sending request to:" << endpoint 
-                             << "attempt:" << (attemptNumber + 1) << "/" << m_retryPolicy.maxRetries;
-    
-    QNetworkReply *reply = requestFactory();
-    
-    connect(reply, &QNetworkReply::finished, this, [this, reply, endpoint, requestFactory, responseHandler, failureHandler, attemptNumber]() {
-        handleReplyWithRetry(reply, endpoint, requestFactory, responseHandler, failureHandler, attemptNumber);
-    });
-}
-
-void PlaybackService::handleReplyWithRetry(QNetworkReply *reply,
-                                            const QString &endpoint,
-                                            RequestFactory requestFactory,
-                                            ResponseHandler responseHandler,
-                                            FailureHandler failureHandler,
-                                            int attemptNumber)
-{
-    reply->deleteLater();
-    
-    if (reply->error() == QNetworkReply::NoError) {
-        qCDebug(lcPlayback) << "Request succeeded:" << endpoint;
-        responseHandler(reply);
-        return;
-    }
-    
-    int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-
-    if (httpStatus == 401) {
-        qCWarning(lcPlayback) << "Session expired (401) for endpoint:" << endpoint;
-        m_authService->checkForSessionExpiry(reply, true);
+    Q_UNUSED(attemptNumber)
+    if (!m_transport) {
         NetworkError error;
+        error.code = -1;
         error.endpoint = endpoint;
-        error.code = httpStatus;
-        error.userMessage = tr("Session expired. Please log in again.");
-        if (failureHandler) failureHandler(error);
+        error.userMessage = tr("Network transport is unavailable.");
+        emitError(error);
+        if (failureHandler) {
+            failureHandler(error);
+        }
         return;
     }
-    
-    NetworkError netError = ErrorHandler::createError(reply, endpoint);
-    
-    qCWarning(lcPlayback) << "Request failed:" << endpoint
-                               << "Error:" << reply->error()
-                               << "HTTP Status:" << httpStatus
-                               << "Attempt:" << (attemptNumber + 1);
-    
-    bool shouldRetry = m_retryPolicy.retryOnTransient 
-                       && ErrorHandler::isTransientError(reply->error())
-                       && !ErrorHandler::isClientError(httpStatus)
-                       && attemptNumber < m_retryPolicy.maxRetries - 1;
-    
-    if (shouldRetry) {
-        int delayMs = ErrorHandler::calculateBackoffDelay(attemptNumber, m_retryPolicy);
-        qCInfo(lcPlayback) << "Retrying request to:" << endpoint << "in" << delayMs << "ms";
-        
-        QTimer::singleShot(delayMs, this, [this, endpoint, requestFactory, responseHandler, failureHandler, attemptNumber]() {
-            sendRequestWithRetry(endpoint, requestFactory, responseHandler, failureHandler, attemptNumber + 1);
-        });
-    } else {
-        emitError(netError);
-        if (failureHandler) failureHandler(netError);
-    }
+
+    HttpRequestOptions options;
+    options.retryPolicy = m_retryPolicy;
+    options.unauthorizedPolicy = UnauthorizedPolicy::DeferSessionExpiry;
+    m_transport->sendWithRetry(
+        this,
+        endpoint,
+        std::move(requestFactory),
+        std::move(responseHandler),
+        [this, failureHandler = std::move(failureHandler)](const NetworkError &error) {
+            if (error.code == 401 && failureHandler) {
+                failureHandler(error);
+                return;
+            }
+            emitError(error);
+            if (failureHandler) {
+                failureHandler(error);
+            }
+        },
+        options);
 }
 
 void PlaybackService::emitError(const NetworkError &error)

--- a/src/network/PlaybackService.h
+++ b/src/network/PlaybackService.h
@@ -8,6 +8,7 @@
 
 class AuthenticationService;
 class ConfigManager;
+class HttpTransport;
 class MediaSegmentProviderService;
 
 /**
@@ -119,6 +120,7 @@ signals:
 
 private:
     AuthenticationService *m_authService;
+    HttpTransport *m_transport = nullptr;
     ConfigManager *m_configManager = nullptr;
     MediaSegmentProviderService *m_mediaSegmentProviderService = nullptr;
     RetryPolicy m_retryPolicy;
@@ -133,13 +135,6 @@ private:
                                ResponseHandler responseHandler,
                                FailureHandler failureHandler = FailureHandler(),
                                int attemptNumber = 0);
-    
-    void handleReplyWithRetry(QNetworkReply *reply,
-                               const QString &endpoint,
-                               RequestFactory requestFactory,
-                               ResponseHandler responseHandler,
-                               FailureHandler failureHandler,
-                               int attemptNumber);
     
     void emitError(const NetworkError &error);
     QList<MediaSegmentInfo> parseIntroSkipperSegments(const QString &itemId, const QJsonObject &obj) const;

--- a/src/network/SessionService.cpp
+++ b/src/network/SessionService.cpp
@@ -1,5 +1,6 @@
 #include "SessionService.h"
 #include "AuthenticationService.h"
+#include "HttpTransport.h"
 #include "../utils/ConfigManager.h"
 #include <QNetworkRequest>
 #include <QUrl>
@@ -31,7 +32,7 @@ QVariantMap SessionInfo::toVariantMap() const
 SessionService::SessionService(AuthenticationService *authService, QObject *parent)
     : QObject(parent)
     , m_authService(authService)
-    , m_nam(new QNetworkAccessManager(this))
+    , m_transport(authService ? authService->transport() : nullptr)
 {
     if (authService) {
         m_deviceId = getDeviceId();
@@ -45,16 +46,31 @@ void SessionService::fetchActiveSessions()
         emit operationFailed(m_errorString);
         return;
     }
+    if (!m_transport) {
+        setErrorString("Network transport unavailable");
+        emit operationFailed(m_errorString);
+        return;
+    }
 
     setIsLoading(true);
     setErrorString(QString());
 
-    QNetworkRequest request = createAuthenticatedRequest("/Sessions");
-    QNetworkReply *reply = m_nam->get(request);
-
-    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
-        onFetchSessionsFinished(reply);
-    });
+    const QString endpoint = QStringLiteral("/Sessions");
+    HttpRequestOptions options;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    m_transport->sendWithRetry(
+        this,
+        endpoint,
+        [this, endpoint]() {
+            return m_authService->networkManager()->get(createAuthenticatedRequest(endpoint));
+        },
+        [this](QNetworkReply *reply) { onFetchSessionsFinished(reply); },
+        [this](const NetworkError &error) {
+            setIsLoading(false);
+            setErrorString(error.userMessage);
+            emit operationFailed(error.userMessage);
+        },
+        options);
 }
 
 void SessionService::revokeSession(const QString &sessionId)
@@ -70,18 +86,36 @@ void SessionService::revokeSession(const QString &sessionId)
         emit operationFailed(m_errorString);
         return;
     }
+    if (!m_transport) {
+        setErrorString("Network transport unavailable");
+        emit operationFailed(m_errorString);
+        return;
+    }
 
     setIsLoading(true);
     setErrorString(QString());
 
     // Jellyfin uses POST /Sessions/{id}/Logout to revoke a session
     QString endpoint = QString("/Sessions/%1/Logout").arg(sessionId);
-    QNetworkRequest request = createAuthenticatedRequest(endpoint);
-    QNetworkReply *reply = m_nam->post(request, QByteArray());
-
-    connect(reply, &QNetworkReply::finished, this, [this, reply, sessionId]() {
-        onRevokeSessionFinished(reply, sessionId);
-    });
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    m_transport->sendWithRetry(
+        this,
+        endpoint,
+        [this, endpoint]() {
+            return m_authService->networkManager()->post(
+                createAuthenticatedRequest(endpoint), QByteArray());
+        },
+        [this, sessionId](QNetworkReply *reply) {
+            onRevokeSessionFinished(reply, sessionId);
+        },
+        [this](const NetworkError &error) {
+            setIsLoading(false);
+            setErrorString(error.userMessage);
+            emit operationFailed(error.userMessage);
+        },
+        options);
 }
 
 void SessionService::revokeAllOtherSessions()
@@ -159,18 +193,7 @@ bool SessionService::isCurrentSession(const QString &sessionId) const
 
 void SessionService::onFetchSessionsFinished(QNetworkReply *reply)
 {
-    reply->deleteLater();
     setIsLoading(false);
-
-    if (reply->error() != QNetworkReply::NoError) {
-        int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-        QString error = QString("Failed to fetch sessions: %1 (HTTP %2)")
-                            .arg(reply->errorString())
-                            .arg(statusCode);
-        setErrorString(error);
-        emit operationFailed(error);
-        return;
-    }
 
     QByteArray data = reply->readAll();
     QJsonDocument doc = QJsonDocument::fromJson(data);
@@ -231,21 +254,9 @@ void SessionService::onFetchSessionsFinished(QNetworkReply *reply)
     qCDebug(lcAuth) << "SessionService: Loaded" << m_sessions.size() << "sessions, current:" << m_currentSessionId;
 }
 
-void SessionService::onRevokeSessionFinished(QNetworkReply *reply, QString sessionId)
+void SessionService::onRevokeSessionFinished(QNetworkReply *, QString sessionId)
 {
-    reply->deleteLater();
     setIsLoading(false);
-
-    int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-
-    if (reply->error() != QNetworkReply::NoError && statusCode != 204) {
-        QString error = QString("Failed to revoke session: %1 (HTTP %2)")
-                            .arg(reply->errorString())
-                            .arg(statusCode);
-        setErrorString(error);
-        emit operationFailed(error);
-        return;
-    }
 
     // Check if we revoked our own session
     if (sessionId == m_currentSessionId) {

--- a/src/network/SessionService.h
+++ b/src/network/SessionService.h
@@ -7,6 +7,7 @@
 #include <QDateTime>
 
 class AuthenticationService;
+class HttpTransport;
 
 /**
  * @brief Session information structure
@@ -104,7 +105,7 @@ private slots:
 
 private:
     AuthenticationService *m_authService;
-    QNetworkAccessManager *m_nam;
+    HttpTransport *m_transport = nullptr;
     QVariantList m_sessions;
     bool m_isLoading = false;
     QString m_errorString;

--- a/src/network/Types.cpp
+++ b/src/network/Types.cpp
@@ -509,7 +509,6 @@ bool ErrorHandler::isTransientError(QNetworkReply::NetworkError error)
         case QNetworkReply::RemoteHostClosedError:
         case QNetworkReply::HostNotFoundError:
         case QNetworkReply::TimeoutError:
-        case QNetworkReply::OperationCanceledError:
         case QNetworkReply::TemporaryNetworkFailureError:
         case QNetworkReply::NetworkSessionFailedError:
         case QNetworkReply::ProxyConnectionClosedError:

--- a/src/providers/IProviderAuthenticator.h
+++ b/src/providers/IProviderAuthenticator.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+
+struct ProviderAuthenticationRequest {
+    QString endpoint;
+    QByteArray body;
+};
+
+struct ProviderAuthenticationResult {
+    QString accessToken;
+    QString accountId;
+    QString username;
+
+    bool isValid() const
+    {
+        return !accessToken.isEmpty() && !accountId.isEmpty();
+    }
+};
+
+/**
+ * @brief Provider-owned authentication wire contract.
+ *
+ * Implementations own login/validation routes, request payloads, and response
+ * parsing while AuthenticationService remains the stable QML-facing façade.
+ */
+class IProviderAuthenticator
+{
+public:
+    virtual ~IProviderAuthenticator() = default;
+
+    virtual ProviderAuthenticationRequest createLoginRequest(const QString &username,
+                                                              const QString &password) const = 0;
+    virtual QString sessionValidationEndpoint(const QString &accountId) const = 0;
+    virtual ProviderAuthenticationResult parseLoginResponse(const QByteArray &response) const = 0;
+};

--- a/src/providers/IProviderRequestFactory.h
+++ b/src/providers/IProviderRequestFactory.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QNetworkRequest>
+#include <QString>
+#include <QUrl>
+
+struct ProviderRequestContext {
+    QString baseUrl;
+    QString accessToken;
+    QString deviceId;
+};
+
+/**
+ * @brief Provider-owned HTTP request construction boundary.
+ *
+ * Implementations own provider-specific authorization headers, URL assembly,
+ * and redaction rules. Callers provide only connection/authentication state and
+ * a provider endpoint.
+ */
+class IProviderRequestFactory
+{
+public:
+    virtual ~IProviderRequestFactory() = default;
+
+    virtual QNetworkRequest createRequest(const ProviderRequestContext &context,
+                                          const QString &endpoint) const = 0;
+    virtual QString redactedUrl(const QUrl &url) const = 0;
+};

--- a/src/providers/jellyfin/JellyfinAuthenticator.cpp
+++ b/src/providers/jellyfin/JellyfinAuthenticator.cpp
@@ -1,0 +1,35 @@
+#include "JellyfinAuthenticator.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+ProviderAuthenticationRequest JellyfinAuthenticator::createLoginRequest(
+    const QString &username,
+    const QString &password) const
+{
+    QJsonObject body;
+    body[QStringLiteral("Username")] = username;
+    body[QStringLiteral("Pw")] = password;
+    return {
+        QStringLiteral("/Users/AuthenticateByName"),
+        QJsonDocument(body).toJson()
+    };
+}
+
+QString JellyfinAuthenticator::sessionValidationEndpoint(const QString &accountId) const
+{
+    return QStringLiteral("/Users/%1").arg(accountId);
+}
+
+ProviderAuthenticationResult JellyfinAuthenticator::parseLoginResponse(
+    const QByteArray &response) const
+{
+    const QJsonObject root = QJsonDocument::fromJson(response).object();
+    const QJsonObject user = root.value(QStringLiteral("User")).toObject();
+
+    ProviderAuthenticationResult result;
+    result.accessToken = root.value(QStringLiteral("AccessToken")).toString();
+    result.accountId = user.value(QStringLiteral("Id")).toString();
+    result.username = user.value(QStringLiteral("Name")).toString();
+    return result;
+}

--- a/src/providers/jellyfin/JellyfinAuthenticator.h
+++ b/src/providers/jellyfin/JellyfinAuthenticator.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "providers/IProviderAuthenticator.h"
+
+class JellyfinAuthenticator final : public IProviderAuthenticator
+{
+public:
+    ProviderAuthenticationRequest createLoginRequest(const QString &username,
+                                                      const QString &password) const override;
+    QString sessionValidationEndpoint(const QString &accountId) const override;
+    ProviderAuthenticationResult parseLoginResponse(const QByteArray &response) const override;
+};

--- a/src/providers/jellyfin/JellyfinRequestFactory.cpp
+++ b/src/providers/jellyfin/JellyfinRequestFactory.cpp
@@ -1,0 +1,56 @@
+#include "JellyfinRequestFactory.h"
+
+#include "config/version.h"
+
+#include <QUrlQuery>
+
+namespace {
+QString normalizedBaseUrl(const QString &baseUrl)
+{
+    QString normalized = baseUrl.trimmed();
+    while (normalized.endsWith(QLatin1Char('/'))) {
+        normalized.chop(1);
+    }
+    return normalized;
+}
+
+bool isSensitiveQueryItem(const QString &name)
+{
+    return name.compare(QStringLiteral("api_key"), Qt::CaseInsensitive) == 0
+        || name.compare(QStringLiteral("X-Emby-Token"), Qt::CaseInsensitive) == 0
+        || name.compare(QStringLiteral("access_token"), Qt::CaseInsensitive) == 0
+        || name.compare(QStringLiteral("token"), Qt::CaseInsensitive) == 0;
+}
+}
+
+QNetworkRequest JellyfinRequestFactory::createRequest(const ProviderRequestContext &context,
+                                                       const QString &endpoint) const
+{
+    const QUrl url(normalizedBaseUrl(context.baseUrl)
+                   + (endpoint.startsWith(QLatin1Char('/')) ? endpoint
+                                                           : QLatin1Char('/') + endpoint));
+    QNetworkRequest request(url);
+    request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));
+
+    QString authorization = QStringLiteral(
+        "MediaBrowser Client=\"Bloom\", Device=\"Desktop\", DeviceId=\"%1\", Version=\"%2\"")
+                                .arg(context.deviceId, QString::fromUtf8(BLOOM_VERSION));
+    if (!context.accessToken.isEmpty()) {
+        authorization += QStringLiteral(", Token=\"%1\"").arg(context.accessToken);
+    }
+    request.setRawHeader("Authorization", authorization.toUtf8());
+    return request;
+}
+
+QString JellyfinRequestFactory::redactedUrl(const QUrl &url) const
+{
+    QUrl redacted = url;
+    QUrlQuery source(url);
+    QUrlQuery filtered;
+    for (const auto &[name, value] : source.queryItems(QUrl::FullyDecoded)) {
+        filtered.addQueryItem(name,
+                              isSensitiveQueryItem(name) ? QStringLiteral("[REDACTED]") : value);
+    }
+    redacted.setQuery(filtered);
+    return redacted.toString(QUrl::FullyEncoded | QUrl::RemoveUserInfo);
+}

--- a/src/providers/jellyfin/JellyfinRequestFactory.h
+++ b/src/providers/jellyfin/JellyfinRequestFactory.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "providers/IProviderRequestFactory.h"
+
+class JellyfinRequestFactory final : public IProviderRequestFactory
+{
+public:
+    QNetworkRequest createRequest(const ProviderRequestContext &context,
+                                  const QString &endpoint) const override;
+    QString redactedUrl(const QUrl &url) const override;
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,12 @@ set(TEST_LOGGING_SOURCES
     ${CMAKE_SOURCE_DIR}/src/utils/BloomLogging.cpp
 )
 
+set(TEST_PROVIDER_BOUNDARY_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/network/HttpTransport.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinAuthenticator.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinRequestFactory.cpp
+)
+
 set(TEST_CONFIG_SOURCES
     ${CMAKE_SOURCE_DIR}/src/providers/ServerConnection.cpp
     ${CMAKE_SOURCE_DIR}/src/security/CredentialStore.cpp
@@ -53,6 +59,7 @@ add_executable(SeriesDetailsCacheTest
     ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${TEST_PROVIDER_BOUNDARY_SOURCES}
     ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/DetailViewCache.cpp
     ${TEST_CONFIG_SOURCES}
@@ -95,6 +102,7 @@ add_executable(LibraryItemQueryTest
     LibraryItemQueryTest.cpp
     ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${TEST_PROVIDER_BOUNDARY_SOURCES}
     ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
     ${TEST_CONFIG_SOURCES}
@@ -171,6 +179,29 @@ target_link_libraries(ConnectionPersistenceTest
 )
 
 add_test(NAME ConnectionPersistenceTest COMMAND ConnectionPersistenceTest)
+
+add_executable(ProviderTransportTest
+    ProviderTransportTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/HttpTransport.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinAuthenticator.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinRequestFactory.cpp
+    ${TEST_LOGGING_SOURCES}
+)
+
+target_include_directories(ProviderTransportTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+target_link_libraries(ProviderTransportTest
+    PRIVATE
+        Qt6::Core
+        Qt6::Network
+        Qt6::Test
+)
+
+add_test(NAME ProviderTransportTest COMMAND ProviderTransportTest)
 
 add_executable(InputBindingManagerTest
     InputBindingManagerTest.cpp
@@ -255,6 +286,7 @@ add_executable(PlayerControllerAutoplayContextTest
     ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${TEST_PROVIDER_BOUNDARY_SOURCES}
     ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/TrackPreferencesManager.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/DisplayManager.cpp
@@ -283,6 +315,7 @@ add_executable(MediaSegmentProviderServiceTest
     MediaSegmentProviderServiceTest.cpp
     ${CMAKE_SOURCE_DIR}/src/network/MediaSegmentProviderService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${TEST_PROVIDER_BOUNDARY_SOURCES}
     ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
     ${TEST_CONFIG_SOURCES}
 )
@@ -369,6 +402,7 @@ add_executable(SimilarItemsRetryTest
     ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${TEST_PROVIDER_BOUNDARY_SOURCES}
     ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/DetailViewCache.cpp
     ${CMAKE_SOURCE_DIR}/src/test/MockLibraryService.cpp
@@ -399,6 +433,7 @@ add_executable(UpNextRecommendationsViewModelTest
     ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/network/SeerrService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${TEST_PROVIDER_BOUNDARY_SOURCES}
     ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
     ${TEST_CONFIG_SOURCES}
 )
@@ -502,6 +537,7 @@ qt_add_executable(VisualRegressionTest
     ${TEST_CONFIG_SOURCES}
     # Network sources
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${TEST_PROVIDER_BOUNDARY_SOURCES}
     ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/network/PlaybackService.cpp

--- a/tests/ProviderTransportTest.cpp
+++ b/tests/ProviderTransportTest.cpp
@@ -1,0 +1,286 @@
+#include <QtTest/QtTest>
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkRequest>
+#include <QPointer>
+#include <QSignalSpy>
+#include <QTimer>
+#include <cstring>
+
+#include "network/HttpTransport.h"
+#include "providers/IProviderAuthenticator.h"
+#include "providers/IProviderRequestFactory.h"
+#include "providers/jellyfin/JellyfinAuthenticator.h"
+#include "providers/jellyfin/JellyfinRequestFactory.h"
+
+namespace {
+
+class FakeReply final : public QNetworkReply
+{
+public:
+    FakeReply(const QNetworkRequest &request,
+              NetworkError error,
+              int statusCode,
+              QByteArray payload,
+              QObject *parent)
+        : QNetworkReply(parent)
+        , m_payload(std::move(payload))
+    {
+        setRequest(request);
+        setUrl(request.url());
+        setAttribute(QNetworkRequest::HttpStatusCodeAttribute, statusCode);
+        if (error != NoError) {
+            setError(error, QStringLiteral("test network error"));
+        }
+        open(QIODevice::ReadOnly);
+        QTimer::singleShot(0, this, [this]() { finish(); });
+    }
+
+    void abort() override
+    {
+        if (isFinished()) {
+            return;
+        }
+        setError(OperationCanceledError, QStringLiteral("canceled"));
+    }
+
+    qint64 bytesAvailable() const override
+    {
+        return (m_payload.size() - m_offset) + QNetworkReply::bytesAvailable();
+    }
+
+protected:
+    qint64 readData(char *data, qint64 maxSize) override
+    {
+        const qint64 remaining = m_payload.size() - m_offset;
+        const qint64 count = qMin(maxSize, remaining);
+        if (count <= 0) {
+            return -1;
+        }
+        memcpy(data, m_payload.constData() + m_offset, static_cast<size_t>(count));
+        m_offset += count;
+        return count;
+    }
+
+private:
+    void finish()
+    {
+        if (isFinished()) {
+            return;
+        }
+        setFinished(true);
+        if (!m_payload.isEmpty()) {
+            emit readyRead();
+        }
+        emit finished();
+    }
+
+    QByteArray m_payload;
+    qint64 m_offset = 0;
+};
+
+QNetworkRequest requestFor(const QString &path)
+{
+    return QNetworkRequest(QUrl(QStringLiteral("https://media.example.test") + path));
+}
+
+} // namespace
+
+class ProviderTransportTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void jellyfinRequestFactoryBuildsHeaderWithAndWithoutToken();
+    void jellyfinRequestFactoryNormalizesUrlAndRedactsSecrets();
+    void jellyfinAuthenticatorOwnsLoginAndValidationWireContract();
+    void transportRetriesTransientFailures();
+    void transportDoesNotRetryClientErrors();
+    void transportSuppressesCancellationCallbacks();
+    void transportEmitsUnauthorizedPolicy();
+    void cancellationIsNotClassifiedAsTransient();
+};
+
+void ProviderTransportTest::jellyfinRequestFactoryBuildsHeaderWithAndWithoutToken()
+{
+    JellyfinRequestFactory factory;
+    ProviderRequestContext context;
+    context.baseUrl = QStringLiteral("https://media.example.test/");
+    context.deviceId = QStringLiteral("device-1");
+
+    const QNetworkRequest anonymous = factory.createRequest(context, QStringLiteral("/System/Info"));
+    const QByteArray anonymousHeader = anonymous.rawHeader("Authorization");
+    QVERIFY(anonymousHeader.startsWith("MediaBrowser "));
+    QVERIFY(anonymousHeader.contains("DeviceId=\"device-1\""));
+    QVERIFY(!anonymousHeader.contains("Token="));
+
+    context.accessToken = QStringLiteral("secret-token");
+    const QNetworkRequest authenticated = factory.createRequest(context, QStringLiteral("/Users/user-1"));
+    QCOMPARE(authenticated.url(), QUrl(QStringLiteral("https://media.example.test/Users/user-1")));
+    QVERIFY(authenticated.rawHeader("Authorization").contains("Token=\"secret-token\""));
+}
+
+void ProviderTransportTest::jellyfinRequestFactoryNormalizesUrlAndRedactsSecrets()
+{
+    JellyfinRequestFactory factory;
+    ProviderRequestContext context;
+    context.baseUrl = QStringLiteral("https://media.example.test///");
+    context.deviceId = QStringLiteral("device-1");
+
+    const QNetworkRequest request = factory.createRequest(context, QStringLiteral("Items/item-1"));
+    QCOMPARE(request.url(), QUrl(QStringLiteral("https://media.example.test/Items/item-1")));
+
+    const QString redacted = factory.redactedUrl(QUrl(
+        QStringLiteral("https://user:password@media.example.test/Items/item-1?api_key=secret&width=480")));
+    QVERIFY(!redacted.contains(QStringLiteral("secret")));
+    QVERIFY(!redacted.contains(QStringLiteral("user")));
+    QVERIFY(!redacted.contains(QStringLiteral("password")));
+    QVERIFY(redacted.contains(QStringLiteral("%5BREDACTED%5D"))
+            || redacted.contains(QStringLiteral("[REDACTED]")));
+    QVERIFY(redacted.contains(QStringLiteral("width=480")));
+}
+
+void ProviderTransportTest::jellyfinAuthenticatorOwnsLoginAndValidationWireContract()
+{
+    JellyfinAuthenticator authenticator;
+    const ProviderAuthenticationRequest request = authenticator.createLoginRequest(
+        QStringLiteral("Alice"), QStringLiteral("password"));
+    QCOMPARE(request.endpoint, QStringLiteral("/Users/AuthenticateByName"));
+    const QJsonObject body = QJsonDocument::fromJson(request.body).object();
+    QCOMPARE(body.value(QStringLiteral("Username")).toString(), QStringLiteral("Alice"));
+    QCOMPARE(body.value(QStringLiteral("Pw")).toString(), QStringLiteral("password"));
+    QCOMPARE(authenticator.sessionValidationEndpoint(QStringLiteral("user-1")),
+             QStringLiteral("/Users/user-1"));
+
+    const QByteArray response = R"({"AccessToken":"token-1","User":{"Id":"user-1","Name":"Alice"}})";
+    const ProviderAuthenticationResult result = authenticator.parseLoginResponse(response);
+    QVERIFY(result.isValid());
+    QCOMPARE(result.accessToken, QStringLiteral("token-1"));
+    QCOMPARE(result.accountId, QStringLiteral("user-1"));
+    QCOMPARE(result.username, QStringLiteral("Alice"));
+}
+
+void ProviderTransportTest::transportRetriesTransientFailures()
+{
+    HttpTransport transport;
+    int attempts = 0;
+    int successes = 0;
+    int failures = 0;
+    HttpRequestOptions options;
+    options.retryPolicy = RetryPolicy{3, 0, true};
+
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/Items"),
+        [&]() -> QNetworkReply * {
+            ++attempts;
+            const auto error = attempts < 3 ? QNetworkReply::TimeoutError
+                                            : QNetworkReply::NoError;
+            return new FakeReply(requestFor(QStringLiteral("/Items")), error,
+                                 error == QNetworkReply::NoError ? 200 : 0,
+                                 QByteArray(), &transport);
+        },
+        [&](QNetworkReply *) { ++successes; },
+        [&](const NetworkError &) { ++failures; },
+        options);
+
+    QTRY_COMPARE_WITH_TIMEOUT(successes, 1, 1000);
+    QCOMPARE(attempts, 3);
+    QCOMPARE(failures, 0);
+}
+
+void ProviderTransportTest::transportDoesNotRetryClientErrors()
+{
+    HttpTransport transport;
+    int attempts = 0;
+    int failures = 0;
+    HttpRequestOptions options;
+    options.retryPolicy = RetryPolicy{3, 0, true};
+
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/missing"),
+        [&]() -> QNetworkReply * {
+            ++attempts;
+            return new FakeReply(requestFor(QStringLiteral("/missing")),
+                                 QNetworkReply::ContentNotFoundError,
+                                 404,
+                                 QByteArray(),
+                                 &transport);
+        },
+        [](QNetworkReply *) {},
+        [&](const NetworkError &) { ++failures; },
+        options);
+
+    QTRY_COMPARE_WITH_TIMEOUT(failures, 1, 1000);
+    QCOMPARE(attempts, 1);
+}
+
+void ProviderTransportTest::transportSuppressesCancellationCallbacks()
+{
+    HttpTransport transport;
+    int attempts = 0;
+    int failures = 0;
+    HttpRequestOptions options;
+    options.retryPolicy = RetryPolicy{3, 0, true};
+
+    QPointer<HttpRequestHandle> handle = transport.sendWithRetry(
+        this,
+        QStringLiteral("/cancel"),
+        [&]() -> QNetworkReply * {
+            ++attempts;
+            return new FakeReply(requestFor(QStringLiteral("/cancel")),
+                                 QNetworkReply::NoError,
+                                 200,
+                                 QByteArray(),
+                                 &transport);
+        },
+        [](QNetworkReply *) {},
+        [&](const NetworkError &) { ++failures; },
+        options);
+    handle->cancel();
+
+    QTRY_VERIFY_WITH_TIMEOUT(handle.isNull(), 1000);
+    QCOMPARE(failures, 0);
+    QCOMPARE(attempts, 1);
+}
+
+void ProviderTransportTest::transportEmitsUnauthorizedPolicy()
+{
+    HttpTransport transport;
+    QSignalSpy unauthorizedSpy(&transport, &HttpTransport::unauthorized);
+    int failures = 0;
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::DeferSessionExpiry;
+
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/Sessions"),
+        [&]() -> QNetworkReply * {
+            return new FakeReply(requestFor(QStringLiteral("/Sessions")),
+                                 QNetworkReply::AuthenticationRequiredError,
+                                 401,
+                                 QByteArray(),
+                                 &transport);
+        },
+        [](QNetworkReply *) {},
+        [&](const NetworkError &error) {
+            QCOMPARE(error.code, 401);
+            ++failures;
+        },
+        options);
+
+    QTRY_COMPARE_WITH_TIMEOUT(failures, 1, 1000);
+    QCOMPARE(unauthorizedSpy.count(), 1);
+    QCOMPARE(unauthorizedSpy.first().first().toBool(), true);
+}
+
+void ProviderTransportTest::cancellationIsNotClassifiedAsTransient()
+{
+    QVERIFY(!ErrorHandler::isTransientError(QNetworkReply::OperationCanceledError));
+}
+
+QTEST_MAIN(ProviderTransportTest)
+#include "ProviderTransportTest.moc"


### PR DESCRIPTION
## Summary
- add provider-neutral request-factory and authenticator interfaces with Jellyfin implementations
- centralize HTTP execution, retries, cancellation, redacted diagnostics, error mapping, and 401 policy in `HttpTransport`
- route authentication, catalog, playback, and remote-session traffic through the shared transport while preserving existing QML-facing service APIs
- confine Jellyfin `MediaBrowser` authorization-header construction to the Jellyfin provider boundary

Part of #75.

## Verification
- `./scripts/dev-build.sh`
- `nix build .#checks.x86_64-linux.tests --no-write-lock-file` (18/18 tests)
- `nix flake check --no-write-lock-file`
- `nix build --no-write-lock-file`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider transport boundaries with `HttpTransport`, `JellyfinRequestFactory`, and `JellyfinAuthenticator`
> - Introduces `HttpTransport` as a shared HTTP execution layer with centralized retry/backoff, 401 handling (`unauthorized` signal), and cancelable request handles via `HttpRequestHandle`.
> - Adds `IProviderRequestFactory` and `IProviderAuthenticator` interfaces with Jellyfin implementations (`JellyfinRequestFactory`, `JellyfinAuthenticator`) that own request header construction, URL redaction, and login/validation wire contracts.
> - Migrates `AuthenticationService`, `LibraryService`, `PlaybackService`, and `SessionService` from direct `QNetworkAccessManager` usage to `HttpTransport::sendWithRetry`, each with appropriate `UnauthorizedPolicy`.
> - Fixes several services (`LibraryService`) that previously emitted status-change signals on 401 responses by adding early-return checks via `checkForSessionExpiry`.
> - Fixes `OperationCanceledError` misclassification in `ErrorHandler::isTransientError` so canceled requests are no longer retried.
> - Adds `ProviderTransportTest` covering retry logic, cancellation suppression, unauthorized policy signaling, and Jellyfin provider contracts.
> - Risk: services receiving a null transport now fail fast with 'Network transport unavailable' rather than attempting requests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71b6842.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized network handling with retries, cancellation, error processing, and secure request logging.
  * Improved authentication and provider request handling, including token validation and session-expiry behavior.
  * Added Jellyfin request construction, authentication parsing, URL normalization, and sensitive-data redaction.

* **Bug Fixes**
  * Canceled requests and client errors are no longer retried.
  * Expired sessions are handled consistently across library, playback, and session operations.

* **Documentation**
  * Updated provider architecture, compatibility, service, and developer guidance.

* **Tests**
  * Added coverage for provider requests, authentication, retries, cancellation, authorization failures, and redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->