### PR TITLE
refactor(providers): bundle Jellyfin adapter boundaries

### DIFF
--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -79,13 +79,15 @@ Config v29 stores server-owned preferences under `settings.connection_state.scop
 
 ## Request, authentication, and transport boundaries
 
+`IProviderAdapter` bundles the provider implementation consumed by stable application façades. `JellyfinProviderAdapter` exposes the Jellyfin authenticator and request factory while identifying its provider/protocol mode; login, restore, browse, playback, and remote-session traffic therefore share one selected provider boundary without changing QML APIs.
+
 `IProviderRequestFactory` owns provider-specific URL and authorization-header construction. `JellyfinRequestFactory` is the only production source of the `MediaBrowser` header and also redacts token-bearing query parameters before URLs reach logs.
 
 `IProviderAuthenticator` owns provider login payloads, response parsing, and validation routes. `JellyfinAuthenticator` implements the existing AuthenticateByName flow while `AuthenticationService` remains the stable QML-facing session façade.
 
 `HttpTransport` owns the shared `QNetworkAccessManager` and centralizes retry/backoff, cancellation, error mapping, redacted request logging, and unauthorized policy. Catalog and remote-session `401` responses expire immediately; playback reads can defer expiry until playback stops. Canceled work is never retried. `SessionService` uses the shared transport instead of a private network manager.
 
-The remaining issue #75 work is extracting provider route/JSON behavior behind catalog/playback/session adapter interfaces. QML must not select protocol routes, construct provider headers, or read credentials. Native Silo authentication remains deferred until its adapter can own access, refresh, and profile-token behavior.
+`LibraryService`, `PlaybackService`, and `SessionService` remain the stable Jellyfin catalog/playback/remote-session adapters for their existing QML signals while all of their HTTP requests flow through the selected provider request factory and transport. Canonical JSON/model conversion continues with the provider model work without changing those façade contracts. QML must not select protocol routes, construct provider headers, or read credentials. Native Silo authentication remains deferred until its adapter can own access, refresh, and profile-token behavior.
 
 ## Verification
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -12,6 +12,7 @@ Key services
 - `ExternalMpvBackend` — External mpv process/IPC backend adapter (primary rollback path on Linux/non-Windows).
 - `PlayerProcessManager` — Manages external mpv process & IPC (used by `ExternalMpvBackend`).
 - `HttpTransport` — Owns the shared `QNetworkAccessManager` and central retry, cancellation, error, redaction, and unauthorized-response policy.
+- `IProviderAdapter` / `JellyfinProviderAdapter` — Selected provider implementation bundle consumed by stable application façades.
 - `IProviderRequestFactory` / `JellyfinRequestFactory` — Provider-owned URL and authorization-header construction.
 - `IProviderAuthenticator` / `JellyfinAuthenticator` — Provider-owned login payload, response parsing, and validation routes.
 - `AuthenticationService` — Stable QML façade for login, logout, session persistence, and token validation; delegates provider wire details and HTTP execution.
@@ -30,8 +31,8 @@ Key services
 Initialization order (recommended)
 1. ConfigManager — loads configs, path info, and active `ServerConnection` metadata.
 2. IPlayerBackend — created by `PlayerBackendFactory` (`win-libmpv` on Windows; platform-selected backend elsewhere).
-3. HttpTransport and provider request/authentication implementations — own shared HTTP execution and Jellyfin wire construction.
-4. AuthenticationService — stable session façade; depends on `CredentialStore`, `HttpTransport`, `IProviderRequestFactory`, and `IProviderAuthenticator`.
+3. HttpTransport and `JellyfinProviderAdapter` — own shared HTTP execution and the selected provider wire implementation.
+4. AuthenticationService — stable session façade; depends on `CredentialStore`, `HttpTransport`, and `IProviderAdapter`.
 4.1. LibraryService — depends on AuthenticationService and uses its shared transport.
 5. InputModeManager — depends on QGuiApplication.
 5.1. InputBindingManager — depends on QGuiApplication + ConfigManager.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,12 +13,14 @@ qt_add_executable(Bloom
     core/ServiceLocator.cpp
     providers/ServerConnection.h
     providers/ServerConnection.cpp
+    providers/IProviderAdapter.h
     providers/IProviderAuthenticator.h
     providers/IProviderRequestFactory.h
     providers/jellyfin/JellyfinAuthenticator.h
     providers/jellyfin/JellyfinAuthenticator.cpp
     providers/jellyfin/JellyfinRequestFactory.h
     providers/jellyfin/JellyfinRequestFactory.cpp
+    providers/jellyfin/JellyfinProviderAdapter.h
     resources/fonts.qrc
     resources/sounds.qrc
     resources/images.qrc

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -32,10 +32,8 @@
 #include "utils/BloomLogging.h"
 #include "network/SessionManager.h"
 #include "network/SessionService.h"
-#include "providers/IProviderAuthenticator.h"
-#include "providers/IProviderRequestFactory.h"
-#include "providers/jellyfin/JellyfinAuthenticator.h"
-#include "providers/jellyfin/JellyfinRequestFactory.h"
+#include "providers/IProviderAdapter.h"
+#include "providers/jellyfin/JellyfinProviderAdapter.h"
 #include "updates/UpdateService.h"
 #include "test/TestModeController.h"
 #include "test/MockAuthenticationService.h"
@@ -217,15 +215,13 @@ void ApplicationInitializer::registerServices()
         
         // 3. Provider-neutral transport and Jellyfin wire adapters
         m_httpTransport = std::make_unique<HttpTransport>();
-        m_providerRequestFactory = std::make_unique<JellyfinRequestFactory>();
-        m_providerAuthenticator = std::make_unique<JellyfinAuthenticator>();
+        m_providerAdapter = std::make_unique<JellyfinProviderAdapter>();
 
         // 3.1 AuthenticationService - stable façade over provider boundaries
         m_authService = std::make_unique<AuthenticationService>(
             m_secretStore.get(),
             m_httpTransport.get(),
-            m_providerRequestFactory.get(),
-            m_providerAuthenticator.get());
+            m_providerAdapter.get());
         ServiceLocator::registerService<AuthenticationService>(m_authService.get());
         
         // 3.2 LibraryService - Depends on AuthenticationService

--- a/src/core/ApplicationInitializer.h
+++ b/src/core/ApplicationInitializer.h
@@ -23,8 +23,7 @@ class LibraryViewModel;
 class SeriesDetailsViewModel;
 class MovieDetailsViewModel;
 class UpNextRecommendationsViewModel;
-class IProviderAuthenticator;
-class IProviderRequestFactory;
+class IProviderAdapter;
 class ISecretStore;
 class HttpTransport;
 class SidebarSettings;
@@ -107,8 +106,7 @@ private:
     // ISecretStore — owned here, raw pointer passed to AuthenticationService
     std::unique_ptr<ISecretStore> m_secretStore;
     std::unique_ptr<HttpTransport> m_httpTransport;
-    std::unique_ptr<IProviderRequestFactory> m_providerRequestFactory;
-    std::unique_ptr<IProviderAuthenticator> m_providerAuthenticator;
+    std::unique_ptr<IProviderAdapter> m_providerAdapter;
 
     std::unique_ptr<AuthenticationService> m_authService;
     std::unique_ptr<LibraryService> m_libraryService;

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -2,10 +2,10 @@
 #include "HttpTransport.h"
 #include "../security/ISecretStore.h"
 #include "../utils/ConfigManager.h"
+#include "providers/IProviderAdapter.h"
 #include "providers/IProviderAuthenticator.h"
 #include "providers/IProviderRequestFactory.h"
-#include "providers/jellyfin/JellyfinAuthenticator.h"
-#include "providers/jellyfin/JellyfinRequestFactory.h"
+#include "providers/jellyfin/JellyfinProviderAdapter.h"
 #include <QNetworkRequest>
 #include <QUrl>
 #include <QJsonDocument>
@@ -18,11 +18,11 @@
 AuthenticationService::AuthenticationService(ISecretStore *secretStore, QObject *parent)
     : QObject(parent)
     , m_ownedTransport(std::make_unique<HttpTransport>())
-    , m_ownedRequestFactory(std::make_unique<JellyfinRequestFactory>())
-    , m_ownedProviderAuthenticator(std::make_unique<JellyfinAuthenticator>())
+    , m_ownedProviderAdapter(std::make_unique<JellyfinProviderAdapter>())
     , m_transport(m_ownedTransport.get())
-    , m_requestFactory(m_ownedRequestFactory.get())
-    , m_providerAuthenticator(m_ownedProviderAuthenticator.get())
+    , m_providerAdapter(m_ownedProviderAdapter.get())
+    , m_requestFactory(m_providerAdapter->requestFactory())
+    , m_providerAuthenticator(m_providerAdapter->authenticator())
     , m_secretStore(secretStore)
 {
     m_transport->setUrlRedactor([this](const QUrl &url) {
@@ -34,16 +34,17 @@ AuthenticationService::AuthenticationService(ISecretStore *secretStore, QObject 
 
 AuthenticationService::AuthenticationService(ISecretStore *secretStore,
                                                HttpTransport *transport,
-                                               IProviderRequestFactory *requestFactory,
-                                               IProviderAuthenticator *providerAuthenticator,
+                                               IProviderAdapter *providerAdapter,
                                                QObject *parent)
     : QObject(parent)
     , m_transport(transport)
-    , m_requestFactory(requestFactory)
-    , m_providerAuthenticator(providerAuthenticator)
+    , m_providerAdapter(providerAdapter)
+    , m_requestFactory(providerAdapter ? providerAdapter->requestFactory() : nullptr)
+    , m_providerAuthenticator(providerAdapter ? providerAdapter->authenticator() : nullptr)
     , m_secretStore(secretStore)
 {
     Q_ASSERT(m_transport);
+    Q_ASSERT(m_providerAdapter);
     Q_ASSERT(m_requestFactory);
     Q_ASSERT(m_providerAuthenticator);
     m_transport->setUrlRedactor([this](const QUrl &url) {

--- a/src/network/AuthenticationService.h
+++ b/src/network/AuthenticationService.h
@@ -12,6 +12,7 @@
 #include "providers/ServerConnection.h"
 #include "security/CredentialStore.h"
 
+class IProviderAdapter;
 class IProviderAuthenticator;
 class IProviderRequestFactory;
 class ISecretStore;
@@ -41,8 +42,7 @@ public:
     explicit AuthenticationService(ISecretStore *secretStore = nullptr, QObject *parent = nullptr);
     AuthenticationService(ISecretStore *secretStore,
                           HttpTransport *transport,
-                          IProviderRequestFactory *requestFactory,
-                          IProviderAuthenticator *providerAuthenticator,
+                          IProviderAdapter *providerAdapter,
                           QObject *parent = nullptr);
     virtual ~AuthenticationService();
     
@@ -141,11 +141,11 @@ private slots:
 
 private:
     std::unique_ptr<HttpTransport> m_ownedTransport;
-    std::unique_ptr<IProviderRequestFactory> m_ownedRequestFactory;
-    std::unique_ptr<IProviderAuthenticator> m_ownedProviderAuthenticator;
+    std::unique_ptr<IProviderAdapter> m_ownedProviderAdapter;
     HttpTransport *m_transport = nullptr;
-    IProviderRequestFactory *m_requestFactory = nullptr;
-    IProviderAuthenticator *m_providerAuthenticator = nullptr;
+    IProviderAdapter *m_providerAdapter = nullptr;
+    const IProviderRequestFactory *m_requestFactory = nullptr;
+    const IProviderAuthenticator *m_providerAuthenticator = nullptr;
     QString m_serverUrl;
     QString m_accessToken;
     QString m_userId;

--- a/src/providers/IProviderAdapter.h
+++ b/src/providers/IProviderAdapter.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "providers/ServerConnection.h"
+
+class IProviderAuthenticator;
+class IProviderRequestFactory;
+
+/**
+ * @brief Provider implementation bundle consumed by stable application façades.
+ *
+ * The adapter owns provider wire behavior while Bloom's QML-facing services own
+ * UI-compatible state and signals.
+ */
+class IProviderAdapter
+{
+public:
+    virtual ~IProviderAdapter() = default;
+
+    virtual ProviderKind providerKind() const = 0;
+    virtual ProtocolMode protocolMode() const = 0;
+    virtual const IProviderAuthenticator *authenticator() const = 0;
+    virtual const IProviderRequestFactory *requestFactory() const = 0;
+};

--- a/src/providers/jellyfin/JellyfinProviderAdapter.h
+++ b/src/providers/jellyfin/JellyfinProviderAdapter.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "providers/IProviderAdapter.h"
+#include "providers/jellyfin/JellyfinAuthenticator.h"
+#include "providers/jellyfin/JellyfinRequestFactory.h"
+
+class JellyfinProviderAdapter final : public IProviderAdapter
+{
+public:
+    ProviderKind providerKind() const override { return ProviderKind::Jellyfin; }
+    ProtocolMode protocolMode() const override { return ProtocolMode::Native; }
+    const IProviderAuthenticator *authenticator() const override { return &m_authenticator; }
+    const IProviderRequestFactory *requestFactory() const override { return &m_requestFactory; }
+
+private:
+    JellyfinAuthenticator m_authenticator;
+    JellyfinRequestFactory m_requestFactory;
+};

--- a/tests/ProviderTransportTest.cpp
+++ b/tests/ProviderTransportTest.cpp
@@ -12,6 +12,7 @@
 #include "providers/IProviderAuthenticator.h"
 #include "providers/IProviderRequestFactory.h"
 #include "providers/jellyfin/JellyfinAuthenticator.h"
+#include "providers/jellyfin/JellyfinProviderAdapter.h"
 #include "providers/jellyfin/JellyfinRequestFactory.h"
 
 namespace {
@@ -92,6 +93,7 @@ class ProviderTransportTest : public QObject
     Q_OBJECT
 
 private slots:
+    void jellyfinAdapterExposesProviderBoundaries();
     void jellyfinRequestFactoryBuildsHeaderWithAndWithoutToken();
     void jellyfinRequestFactoryNormalizesUrlAndRedactsSecrets();
     void jellyfinAuthenticatorOwnsLoginAndValidationWireContract();
@@ -101,6 +103,15 @@ private slots:
     void transportEmitsUnauthorizedPolicy();
     void cancellationIsNotClassifiedAsTransient();
 };
+
+void ProviderTransportTest::jellyfinAdapterExposesProviderBoundaries()
+{
+    JellyfinProviderAdapter adapter;
+    QCOMPARE(adapter.providerKind(), ProviderKind::Jellyfin);
+    QCOMPARE(adapter.protocolMode(), ProtocolMode::Native);
+    QVERIFY(adapter.authenticator());
+    QVERIFY(adapter.requestFactory());
+}
 
 void ProviderTransportTest::jellyfinRequestFactoryBuildsHeaderWithAndWithoutToken()
 {


### PR DESCRIPTION
## Summary
- add `IProviderAdapter` as the provider implementation bundle consumed by Bloom's stable application façades
- add `JellyfinProviderAdapter` to own and expose Jellyfin request and authentication boundaries
- wire application initialization and authentication through the selected provider adapter without changing QML APIs
- document the final provider boundary and add adapter coverage

Closes #75.

## Verification
- `./scripts/dev-build.sh`
- `nix build .#checks.x86_64-linux.tests --no-write-lock-file` (18/18 tests)
- `nix flake check --no-write-lock-file`
- `nix build --no-write-lock-file`
- final full-stack subagent review: PASS

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle Jellyfin adapter boundaries behind a single `IProviderAdapter` interface
> - Introduces [`IProviderAdapter`](https://github.com/crowquillx/Bloom/pull/86/files#diff-c34079421f414b380879c82c371fe5f1c2a6c3312d1753fc2c8b18e47aa536b4) as a new interface that bundles `providerKind()`, `protocolMode()`, `authenticator()`, and `requestFactory()` into a single object.
> - Adds [`JellyfinProviderAdapter`](https://github.com/crowquillx/Bloom/pull/86/files#diff-243e126875eafb9db8a508f1c9dfaf2045c6066de6ce20a19c371c5ea663b468) as the concrete implementation, owning both `JellyfinAuthenticator` and `JellyfinRequestFactory` internally.
> - Replaces separate `m_providerRequestFactory` and `m_providerAuthenticator` members in `ApplicationInitializer` and `AuthenticationService` with a single `IProviderAdapter` pointer.
> - Behavioral Change: `AuthenticationService`'s external constructor now accepts `IProviderAdapter*` instead of separate factory and authenticator pointers, changing its public API.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 070bd4e. 26 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->