### PR TITLE
refactor(models): add canonical media contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ See also:
 - docs/playback.md  — mpv and playback/reporting integration
 - docs/provider-compatibility.md — provider-neutral server contract matrix, reproducible Jellyfin/Silo pins, and native API assumptions
 - docs/provider-architecture.md — connection identity, credential migration, and incremental provider adapter boundaries
+- docs/canonical-models.md — Bloom-owned media, artwork, and playback model contracts
 - docs/media-segments.md — External intro/recap/credits provider integration and precedence
 - docs/hero-banner.md — Home hero sources, settings, focus behavior, and backdrop synchronization
 - docs/theme.md     — Theme.qml tokens and design system

--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -1,0 +1,53 @@
+# Canonical media models
+
+Bloom-owned canonical models separate UI/player code from provider wire formats. Their implementation starts in `src/models/MediaModels.*`; provider conversion belongs under the provider adapter, such as `src/providers/jellyfin/JellyfinModelMapper.*`.
+
+## Rules
+
+- Canonical map keys use `camelCase`.
+- Durations, positions, chapter starts, and media segments use milliseconds.
+- Provider time conversion occurs only in the provider adapter.
+- `MediaRef` combines `connectionId` and `itemId`; a remote item ID is never globally unique by itself.
+- `ArtworkRef` is token-free and identifies artwork by connection, item, kind, index, tag, and requested width.
+- Artwork fetch URLs, headers, and expiring provider representations are transport details and must not become cache identities.
+- `PlaybackDescriptor` owns the finalized stream request, normalized tracks, session identity, canonical timing, chapters, and reporting capabilities consumed by the player.
+- New QML must not inspect provider DTO field names.
+
+## Foundation types
+
+`MediaModels` currently defines:
+
+- `MediaRef`
+- `ArtworkRef`
+- `UserMediaState`
+- `Person`
+- `Chapter`
+- `StreamRequest`
+- `PlaybackTrack`
+- `PlaybackReportingCapabilities`
+- `PlaybackDescriptor`
+
+The types expose temporary `QVariantMap` projections so existing QML-facing façades can migrate incrementally without making provider JSON the public contract.
+
+## Jellyfin conversion
+
+`JellyfinModelMapper` converts Jellyfin item, user-state, person, artwork, chapter, and tick fields into Bloom canonical values. Jellyfin ticks are converted to milliseconds there and must not be introduced into new model or QML APIs.
+
+Existing list/detail/player flows are migrated in reviewable slices. During migration, compatibility façades may retain old methods, but canonical consumers must not fall back to PascalCase wire keys.
+
+## Artwork identity
+
+`ArtworkRef::cacheKey()` serializes only token-free canonical fields. Token rotation or a refreshed presigned URL must not change the cache key. The image provider resolves the current authenticated fetch request on a cache miss rather than persisting that request URL.
+
+## Playback boundary
+
+A `PlaybackDescriptor` is valid when it has a valid `MediaRef` and finalized `StreamRequest`. `PlayerController` may map canonical tracks to mpv runtime track IDs, but provider endpoints, query authentication, provider time units, and reporting DTOs belong outside the controller.
+
+## Tests
+
+`CanonicalModelsTest` covers:
+
+- Jellyfin tick/millisecond conversion
+- PascalCase Jellyfin item mapping to canonical camelCase values
+- token-free, round-trippable artwork cache keys
+- provider-neutral playback descriptor projections

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -77,6 +77,12 @@ Config v29 stores server-owned preferences under `settings.connection_state.scop
 
 `track_preferences.json` schema v4 groups season/movie preferences by connection scope and applies the same pending-activation rule. Library SQLite caches and series/movie detail caches use SHA-256 connection-scope directory keys, while static in-memory cache keys include the connection ID and are cleared when the active scope changes. `LibraryViewModel` reopens its cache and clears displayed account state when the active connection changes. Logout cancels transport operations and clears library validation, remote-session, and detail-view state without deleting another connection's persisted preferences.
 
+## Canonical model boundary
+
+Bloom-owned media contracts live in `src/models/MediaModels.*` and are documented in [`canonical-models.md`](canonical-models.md). `MediaRef` always combines connection and remote item identity; canonical times use milliseconds; `ArtworkRef` cache identities contain no credentials; and `PlaybackDescriptor` carries a finalized provider-neutral stream request. Temporary `QVariantMap` projections use Bloom-defined camelCase fields.
+
+Provider conversion belongs inside provider adapters. `JellyfinModelMapper` is the initial Jellyfin DTO boundary and owns tick-to-millisecond conversion for mapped items and chapters. Existing catalog, artwork, and player consumers migrate to these contracts in focused slices while stable QML-facing façade names remain available.
+
 ## Request, authentication, and transport boundaries
 
 `IProviderAdapter` bundles the provider implementation consumed by stable application façades. `JellyfinProviderAdapter` exposes the Jellyfin authenticator and request factory while identifying its provider/protocol mode; login, restore, browse, playback, and remote-session traffic therefore share one selected provider boundary without changing QML APIs.

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation {
       ConfigManagerThemeTest \
       ConnectionPersistenceTest \
       ProviderTransportTest \
+      CanonicalModelsTest \
       InputBindingManagerTest \
       PlayerBackendFactoryTest \
       PlayerControllerAutoplayContextTest \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,8 @@ qt_add_executable(Bloom
     providers/jellyfin/JellyfinAuthenticator.cpp
     providers/jellyfin/JellyfinRequestFactory.h
     providers/jellyfin/JellyfinRequestFactory.cpp
+    providers/jellyfin/JellyfinModelMapper.h
+    providers/jellyfin/JellyfinModelMapper.cpp
     providers/jellyfin/JellyfinProviderAdapter.h
     resources/fonts.qrc
     resources/sounds.qrc
@@ -55,6 +57,8 @@ qt_add_executable(Bloom
     network/SeerrService.cpp
     network/Types.h
     network/Types.cpp
+    models/MediaModels.h
+    models/MediaModels.cpp
     network/SessionManager.h
     network/SessionManager.cpp
     network/SessionService.h

--- a/src/models/MediaModels.cpp
+++ b/src/models/MediaModels.cpp
@@ -1,0 +1,240 @@
+#include "MediaModels.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <string>
+
+namespace Bloom {
+
+QString artworkKindName(ArtworkKind kind)
+{
+    switch (kind) {
+    case ArtworkKind::Primary: return QStringLiteral("primary");
+    case ArtworkKind::Thumb: return QStringLiteral("thumb");
+    case ArtworkKind::Backdrop: return QStringLiteral("backdrop");
+    case ArtworkKind::Logo: return QStringLiteral("logo");
+    case ArtworkKind::Chapter: return QStringLiteral("chapter");
+    case ArtworkKind::Person: return QStringLiteral("person");
+    case ArtworkKind::Unknown: return QStringLiteral("unknown");
+    }
+    return QStringLiteral("unknown");
+}
+
+ArtworkKind artworkKindFromName(const QString &name)
+{
+    const QString normalized = name.trimmed().toLower();
+    if (normalized == QStringLiteral("primary")) return ArtworkKind::Primary;
+    if (normalized == QStringLiteral("thumb")) return ArtworkKind::Thumb;
+    if (normalized == QStringLiteral("backdrop")) return ArtworkKind::Backdrop;
+    if (normalized == QStringLiteral("logo")) return ArtworkKind::Logo;
+    if (normalized == QStringLiteral("chapter")) return ArtworkKind::Chapter;
+    if (normalized == QStringLiteral("person")) return ArtworkKind::Person;
+    return ArtworkKind::Unknown;
+}
+
+bool MediaRef::isValid() const
+{
+    return !connectionId.trimmed().isEmpty() && !itemId.trimmed().isEmpty();
+}
+
+QVariantMap MediaRef::toVariantMap() const
+{
+    return {
+        {QStringLiteral("connectionId"), connectionId},
+        {QStringLiteral("itemId"), itemId}
+    };
+}
+
+bool ArtworkRef::isValid() const
+{
+    return !connectionId.trimmed().isEmpty()
+        && !itemId.trimmed().isEmpty()
+        && kind != ArtworkKind::Unknown
+        && index >= 0
+        && requestedWidth >= 0;
+}
+
+QString ArtworkRef::cacheKey() const
+{
+    const QJsonObject object{
+        {QStringLiteral("connectionId"), connectionId},
+        {QStringLiteral("itemId"), itemId},
+        {QStringLiteral("kind"), artworkKindName(kind)},
+        {QStringLiteral("index"), index},
+        {QStringLiteral("tag"), tag},
+        {QStringLiteral("requestedWidth"), requestedWidth}
+    };
+    const QByteArray payload = QJsonDocument(object).toJson(QJsonDocument::Compact)
+                                   .toBase64(QByteArray::Base64UrlEncoding
+                                             | QByteArray::OmitTrailingEquals);
+    return QStringLiteral("artwork:") + QString::fromLatin1(payload);
+}
+
+QVariantMap ArtworkRef::toVariantMap() const
+{
+    return {
+        {QStringLiteral("connectionId"), connectionId},
+        {QStringLiteral("itemId"), itemId},
+        {QStringLiteral("kind"), artworkKindName(kind)},
+        {QStringLiteral("index"), index},
+        {QStringLiteral("tag"), tag},
+        {QStringLiteral("requestedWidth"), requestedWidth},
+        {QStringLiteral("cacheKey"), cacheKey()}
+    };
+}
+
+ArtworkRef ArtworkRef::fromCacheKey(const QString &key)
+{
+    constexpr auto prefix = "artwork:";
+    if (!key.startsWith(QString::fromLatin1(prefix))) {
+        return {};
+    }
+    const QByteArray encoded = key.mid(static_cast<qsizetype>(std::char_traits<char>::length(prefix)))
+                                   .toLatin1();
+    const QByteArray payload = QByteArray::fromBase64(encoded, QByteArray::Base64UrlEncoding);
+    const QJsonDocument document = QJsonDocument::fromJson(payload);
+    if (!document.isObject()) {
+        return {};
+    }
+    return fromVariantMap(document.object().toVariantMap());
+}
+
+ArtworkRef ArtworkRef::fromVariantMap(const QVariantMap &map)
+{
+    ArtworkRef ref;
+    ref.connectionId = map.value(QStringLiteral("connectionId")).toString();
+    ref.itemId = map.value(QStringLiteral("itemId")).toString();
+    ref.kind = artworkKindFromName(map.value(QStringLiteral("kind")).toString());
+    ref.index = map.value(QStringLiteral("index"), 0).toInt();
+    ref.tag = map.value(QStringLiteral("tag")).toString();
+    ref.requestedWidth = map.value(QStringLiteral("requestedWidth"), 0).toInt();
+    return ref;
+}
+
+QVariantMap UserMediaState::toVariantMap() const
+{
+    return {
+        {QStringLiteral("watched"), watched},
+        {QStringLiteral("favorite"), favorite},
+        {QStringLiteral("positionMs"), positionMs},
+        {QStringLiteral("unplayedItemCount"), unplayedItemCount},
+        {QStringLiteral("lastPlayedAt"), lastPlayedAt}
+    };
+}
+
+QVariantMap Person::toVariantMap() const
+{
+    QVariantMap map{
+        {QStringLiteral("media"), media.toVariantMap()},
+        {QStringLiteral("personId"), media.itemId},
+        {QStringLiteral("name"), name},
+        {QStringLiteral("role"), role},
+        {QStringLiteral("kind"), kind}
+    };
+    if (artwork.isValid()) {
+        map[QStringLiteral("artwork")] = artwork.toVariantMap();
+    }
+    return map;
+}
+
+QVariantMap Chapter::toVariantMap() const
+{
+    QVariantMap map{
+        {QStringLiteral("name"), name},
+        {QStringLiteral("startMs"), startMs}
+    };
+    if (artwork.isValid()) {
+        map[QStringLiteral("artwork")] = artwork.toVariantMap();
+    }
+    return map;
+}
+
+QString playbackMethodName(PlaybackMethod method)
+{
+    switch (method) {
+    case PlaybackMethod::DirectPlay: return QStringLiteral("directPlay");
+    case PlaybackMethod::DirectStream: return QStringLiteral("directStream");
+    case PlaybackMethod::Transcode: return QStringLiteral("transcode");
+    case PlaybackMethod::Unknown: return QStringLiteral("unknown");
+    }
+    return QStringLiteral("unknown");
+}
+
+bool StreamRequest::isValid() const
+{
+    return url.isValid()
+        && !url.isEmpty()
+        && method != PlaybackMethod::Unknown;
+}
+
+QVariantMap StreamRequest::toVariantMap() const
+{
+    return {
+        {QStringLiteral("url"), url},
+        {QStringLiteral("headers"), headers},
+        {QStringLiteral("method"), playbackMethodName(method)}
+    };
+}
+
+QVariantMap PlaybackTrack::toVariantMap() const
+{
+    return {
+        {QStringLiteral("trackId"), trackId},
+        {QStringLiteral("kind"), kind},
+        {QStringLiteral("language"), language},
+        {QStringLiteral("codec"), codec},
+        {QStringLiteral("displayTitle"), displayTitle},
+        {QStringLiteral("isDefault"), isDefault},
+        {QStringLiteral("isForced"), isForced},
+        {QStringLiteral("isExternal"), isExternal},
+        {QStringLiteral("isHearingImpaired"), isHearingImpaired}
+    };
+}
+
+QVariantMap PlaybackReportingCapabilities::toVariantMap() const
+{
+    return {
+        {QStringLiteral("start"), start},
+        {QStringLiteral("progress"), progress},
+        {QStringLiteral("pause"), pause},
+        {QStringLiteral("stop"), stop}
+    };
+}
+
+bool PlaybackDescriptor::isValid() const
+{
+    return media.isValid() && stream.isValid();
+}
+
+QVariantMap PlaybackDescriptor::toVariantMap() const
+{
+    QVariantList audio;
+    for (const PlaybackTrack &track : audioTracks) {
+        audio.append(track.toVariantMap());
+    }
+    QVariantList subtitles;
+    for (const PlaybackTrack &track : subtitleTracks) {
+        subtitles.append(track.toVariantMap());
+    }
+    QVariantList chapterMaps;
+    for (const Chapter &chapter : chapters) {
+        chapterMaps.append(chapter.toVariantMap());
+    }
+
+    return {
+        {QStringLiteral("media"), media.toVariantMap()},
+        {QStringLiteral("stream"), stream.toVariantMap()},
+        {QStringLiteral("mediaVersionId"), mediaVersionId},
+        {QStringLiteral("playbackSessionId"), playbackSessionId},
+        {QStringLiteral("durationMs"), durationMs},
+        {QStringLiteral("startPositionMs"), startPositionMs},
+        {QStringLiteral("audioTracks"), audio},
+        {QStringLiteral("subtitleTracks"), subtitles},
+        {QStringLiteral("selectedAudioTrackId"), selectedAudioTrackId},
+        {QStringLiteral("selectedSubtitleTrackId"), selectedSubtitleTrackId},
+        {QStringLiteral("chapters"), chapterMaps},
+        {QStringLiteral("reporting"), reporting.toVariantMap()}
+    };
+}
+
+} // namespace Bloom

--- a/src/models/MediaModels.h
+++ b/src/models/MediaModels.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include <QByteArray>
+#include <QList>
+#include <QMetaType>
+#include <QString>
+#include <QUrl>
+#include <QVariantList>
+#include <QVariantMap>
+
+namespace Bloom {
+
+enum class ArtworkKind {
+    Primary,
+    Thumb,
+    Backdrop,
+    Logo,
+    Chapter,
+    Person,
+    Unknown
+};
+
+QString artworkKindName(ArtworkKind kind);
+ArtworkKind artworkKindFromName(const QString &name);
+
+struct MediaRef {
+    QString connectionId;
+    QString itemId;
+
+    bool isValid() const;
+    QVariantMap toVariantMap() const;
+};
+
+struct ArtworkRef {
+    QString connectionId;
+    QString itemId;
+    ArtworkKind kind = ArtworkKind::Unknown;
+    int index = 0;
+    QString tag;
+    int requestedWidth = 0;
+
+    bool isValid() const;
+    QString cacheKey() const;
+    QVariantMap toVariantMap() const;
+
+    static ArtworkRef fromCacheKey(const QString &key);
+    static ArtworkRef fromVariantMap(const QVariantMap &map);
+};
+
+struct UserMediaState {
+    bool watched = false;
+    bool favorite = false;
+    qint64 positionMs = 0;
+    int unplayedItemCount = 0;
+    QString lastPlayedAt;
+
+    QVariantMap toVariantMap() const;
+};
+
+struct Person {
+    MediaRef media;
+    QString name;
+    QString role;
+    QString kind;
+    ArtworkRef artwork;
+
+    QVariantMap toVariantMap() const;
+};
+
+struct Chapter {
+    QString name;
+    qint64 startMs = 0;
+    ArtworkRef artwork;
+
+    QVariantMap toVariantMap() const;
+};
+
+enum class PlaybackMethod {
+    Unknown,
+    DirectPlay,
+    DirectStream,
+    Transcode
+};
+
+QString playbackMethodName(PlaybackMethod method);
+
+struct StreamRequest {
+    QUrl url;
+    QVariantMap headers;
+    PlaybackMethod method = PlaybackMethod::Unknown;
+
+    bool isValid() const;
+    QVariantMap toVariantMap() const;
+};
+
+struct PlaybackTrack {
+    QString trackId;
+    QString kind;
+    QString language;
+    QString codec;
+    QString displayTitle;
+    bool isDefault = false;
+    bool isForced = false;
+    bool isExternal = false;
+    bool isHearingImpaired = false;
+
+    QVariantMap toVariantMap() const;
+};
+
+struct PlaybackReportingCapabilities {
+    bool start = false;
+    bool progress = false;
+    bool pause = false;
+    bool stop = false;
+
+    QVariantMap toVariantMap() const;
+};
+
+struct PlaybackDescriptor {
+    MediaRef media;
+    StreamRequest stream;
+    QString mediaVersionId;
+    QString playbackSessionId;
+    qint64 durationMs = 0;
+    qint64 startPositionMs = 0;
+    QList<PlaybackTrack> audioTracks;
+    QList<PlaybackTrack> subtitleTracks;
+    QString selectedAudioTrackId;
+    QString selectedSubtitleTrackId;
+    QList<Chapter> chapters;
+    PlaybackReportingCapabilities reporting;
+
+    bool isValid() const;
+    QVariantMap toVariantMap() const;
+};
+
+} // namespace Bloom
+
+Q_DECLARE_METATYPE(Bloom::MediaRef)
+Q_DECLARE_METATYPE(Bloom::ArtworkRef)
+Q_DECLARE_METATYPE(Bloom::PlaybackDescriptor)

--- a/src/providers/jellyfin/JellyfinModelMapper.cpp
+++ b/src/providers/jellyfin/JellyfinModelMapper.cpp
@@ -1,0 +1,223 @@
+#include "JellyfinModelMapper.h"
+
+#include <QDateTime>
+#include <QJsonValue>
+#include <limits>
+
+namespace {
+
+QVariantList stringList(const QJsonArray &values)
+{
+    QVariantList result;
+    result.reserve(values.size());
+    for (const QJsonValue &value : values) {
+        if (value.isString()) {
+            result.append(value.toString());
+        } else if (value.isObject()) {
+            const QString name = value.toObject().value(QStringLiteral("Name")).toString();
+            if (!name.isEmpty()) {
+                result.append(name);
+            }
+        }
+    }
+    return result;
+}
+
+void appendArtwork(QVariantList &artwork,
+                   QVariantMap &item,
+                   const QString &property,
+                   const QString &connectionId,
+                   const QString &itemId,
+                   Bloom::ArtworkKind kind,
+                   const QString &tag,
+                   int index = 0)
+{
+    if (connectionId.isEmpty() || itemId.isEmpty() || tag.isEmpty()) {
+        return;
+    }
+    Bloom::ArtworkRef ref;
+    ref.connectionId = connectionId;
+    ref.itemId = itemId;
+    ref.kind = kind;
+    ref.index = index;
+    ref.tag = tag;
+    const QVariantMap map = ref.toVariantMap();
+    artwork.append(map);
+    if (!property.isEmpty() && !item.contains(property)) {
+        item[property] = map;
+    }
+}
+
+QVariantList people(const QJsonArray &wirePeople, const QString &connectionId)
+{
+    QVariantList result;
+    result.reserve(wirePeople.size());
+    for (const QJsonValue &value : wirePeople) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const QJsonObject wirePerson = value.toObject();
+        Bloom::Person person;
+        person.media.connectionId = connectionId;
+        person.media.itemId = wirePerson.value(QStringLiteral("Id")).toString();
+        person.name = wirePerson.value(QStringLiteral("Name")).toString();
+        person.role = wirePerson.value(QStringLiteral("Role")).toString();
+        person.kind = wirePerson.value(QStringLiteral("Type")).toString();
+        const QString imageTag = wirePerson.value(QStringLiteral("PrimaryImageTag")).toString();
+        if (!person.media.itemId.isEmpty() && !imageTag.isEmpty()) {
+            person.artwork.connectionId = connectionId;
+            person.artwork.itemId = person.media.itemId;
+            person.artwork.kind = Bloom::ArtworkKind::Person;
+            person.artwork.tag = imageTag;
+        }
+        result.append(person.toVariantMap());
+    }
+    return result;
+}
+
+} // namespace
+
+qint64 JellyfinModelMapper::ticksToMilliseconds(qint64 ticks)
+{
+    return ticks <= 0 ? 0 : ticks / 10000;
+}
+
+qint64 JellyfinModelMapper::millisecondsToTicks(qint64 milliseconds)
+{
+    if (milliseconds <= 0) {
+        return 0;
+    }
+    constexpr qint64 multiplier = 10000;
+    if (milliseconds > std::numeric_limits<qint64>::max() / multiplier) {
+        return std::numeric_limits<qint64>::max();
+    }
+    return milliseconds * multiplier;
+}
+
+QVariantMap JellyfinModelMapper::mediaItem(const QJsonObject &wireItem,
+                                           const QString &connectionId)
+{
+    const QString itemId = wireItem.value(QStringLiteral("Id")).toString();
+    const QJsonObject userData = wireItem.value(QStringLiteral("UserData")).toObject();
+
+    Bloom::UserMediaState state;
+    state.watched = userData.value(QStringLiteral("Played")).toBool();
+    state.favorite = userData.value(QStringLiteral("IsFavorite")).toBool();
+    state.positionMs = ticksToMilliseconds(
+        userData.value(QStringLiteral("PlaybackPositionTicks")).toVariant().toLongLong());
+    state.unplayedItemCount = userData.value(QStringLiteral("UnplayedItemCount")).toInt();
+    state.lastPlayedAt = userData.value(QStringLiteral("LastPlayedDate")).toString();
+
+    QVariantMap item{
+        {QStringLiteral("media"), Bloom::MediaRef{connectionId, itemId}.toVariantMap()},
+        {QStringLiteral("connectionId"), connectionId},
+        {QStringLiteral("itemId"), itemId},
+        {QStringLiteral("name"), wireItem.value(QStringLiteral("Name")).toString()},
+        {QStringLiteral("mediaType"), wireItem.value(QStringLiteral("Type")).toString()},
+        {QStringLiteral("collectionType"), wireItem.value(QStringLiteral("CollectionType")).toString()},
+        {QStringLiteral("parentId"), wireItem.value(QStringLiteral("ParentId")).toString()},
+        {QStringLiteral("seriesId"), wireItem.value(QStringLiteral("SeriesId")).toString()},
+        {QStringLiteral("seasonId"), wireItem.value(QStringLiteral("SeasonId")).toString()},
+        {QStringLiteral("seriesName"), wireItem.value(QStringLiteral("SeriesName")).toString()},
+        {QStringLiteral("indexNumber"), wireItem.value(QStringLiteral("IndexNumber")).toInt(-1)},
+        {QStringLiteral("parentIndexNumber"), wireItem.value(QStringLiteral("ParentIndexNumber")).toInt(-1)},
+        {QStringLiteral("overview"), wireItem.value(QStringLiteral("Overview")).toString()},
+        {QStringLiteral("productionYear"), wireItem.value(QStringLiteral("ProductionYear")).toInt()},
+        {QStringLiteral("premiereDate"), wireItem.value(QStringLiteral("PremiereDate")).toString()},
+        {QStringLiteral("endDate"), wireItem.value(QStringLiteral("EndDate")).toString()},
+        {QStringLiteral("officialRating"), wireItem.value(QStringLiteral("OfficialRating")).toString()},
+        {QStringLiteral("communityRating"), wireItem.value(QStringLiteral("CommunityRating")).toDouble()},
+        {QStringLiteral("durationMs"), ticksToMilliseconds(
+             wireItem.value(QStringLiteral("RunTimeTicks")).toVariant().toLongLong())},
+        {QStringLiteral("childCount"), wireItem.value(QStringLiteral("ChildCount")).toInt()},
+        {QStringLiteral("status"), wireItem.value(QStringLiteral("Status")).toString()},
+        {QStringLiteral("locationType"), wireItem.value(QStringLiteral("LocationType")).toString()},
+        {QStringLiteral("path"), wireItem.value(QStringLiteral("Path")).toString()},
+        {QStringLiteral("genres"), stringList(wireItem.value(QStringLiteral("Genres")).toArray())},
+        {QStringLiteral("studios"), stringList(wireItem.value(QStringLiteral("Studios")).toArray())},
+        {QStringLiteral("tags"), stringList(wireItem.value(QStringLiteral("Tags")).toArray())},
+        {QStringLiteral("providerIds"), wireItem.value(QStringLiteral("ProviderIds")).toObject().toVariantMap()},
+        {QStringLiteral("userState"), state.toVariantMap()},
+        {QStringLiteral("watched"), state.watched},
+        {QStringLiteral("favorite"), state.favorite},
+        {QStringLiteral("positionMs"), state.positionMs},
+        {QStringLiteral("unplayedItemCount"), state.unplayedItemCount},
+        {QStringLiteral("people"), people(wireItem.value(QStringLiteral("People")).toArray(), connectionId)}
+    };
+
+    QVariantList artwork;
+    const QJsonObject imageTags = wireItem.value(QStringLiteral("ImageTags")).toObject();
+    appendArtwork(artwork, item, QStringLiteral("primaryArtwork"), connectionId, itemId,
+                  Bloom::ArtworkKind::Primary,
+                  imageTags.value(QStringLiteral("Primary")).toString());
+    appendArtwork(artwork, item, QStringLiteral("thumbArtwork"), connectionId, itemId,
+                  Bloom::ArtworkKind::Thumb,
+                  imageTags.value(QStringLiteral("Thumb")).toString());
+    appendArtwork(artwork, item, QStringLiteral("logoArtwork"), connectionId, itemId,
+                  Bloom::ArtworkKind::Logo,
+                  imageTags.value(QStringLiteral("Logo")).toString());
+
+    const QJsonArray backdropTags = wireItem.value(QStringLiteral("BackdropImageTags")).toArray();
+    for (qsizetype index = 0; index < backdropTags.size(); ++index) {
+        appendArtwork(artwork, item, QStringLiteral("backdropArtwork"), connectionId, itemId,
+                      Bloom::ArtworkKind::Backdrop, backdropTags.at(index).toString(),
+                      static_cast<int>(index));
+    }
+    if (!item.contains(QStringLiteral("backdropArtwork"))) {
+        appendArtwork(artwork, item, QStringLiteral("backdropArtwork"), connectionId, itemId,
+                      Bloom::ArtworkKind::Backdrop,
+                      imageTags.value(QStringLiteral("Backdrop")).toString());
+    }
+
+    const QJsonArray parentBackdropTags =
+        wireItem.value(QStringLiteral("ParentBackdropImageTags")).toArray();
+    QString parentBackdropItemId =
+        wireItem.value(QStringLiteral("ParentBackdropItemId")).toString();
+    if (parentBackdropItemId.isEmpty()) {
+        parentBackdropItemId =
+            wireItem.value(QStringLiteral("ParentBackdropImageItemId")).toString();
+    }
+    if (parentBackdropItemId.isEmpty()) {
+        parentBackdropItemId = wireItem.value(QStringLiteral("SeriesId")).toString();
+    }
+    for (qsizetype index = 0; index < parentBackdropTags.size(); ++index) {
+        appendArtwork(artwork, item, QStringLiteral("backdropArtwork"), connectionId,
+                      parentBackdropItemId, Bloom::ArtworkKind::Backdrop,
+                      parentBackdropTags.at(index).toString(), static_cast<int>(index));
+    }
+    item[QStringLiteral("artwork")] = artwork;
+    return item;
+}
+
+QVariantList JellyfinModelMapper::mediaItems(const QJsonArray &wireItems,
+                                             const QString &connectionId)
+{
+    QVariantList items;
+    items.reserve(wireItems.size());
+    for (const QJsonValue &value : wireItems) {
+        if (value.isObject()) {
+            items.append(mediaItem(value.toObject(), connectionId));
+        }
+    }
+    return items;
+}
+
+Bloom::Chapter JellyfinModelMapper::chapter(const QJsonObject &wireChapter,
+                                            const QString &connectionId,
+                                            const QString &itemId,
+                                            int chapterIndex)
+{
+    Bloom::Chapter chapter;
+    chapter.name = wireChapter.value(QStringLiteral("Name")).toString();
+    chapter.startMs = ticksToMilliseconds(
+        wireChapter.value(QStringLiteral("StartPositionTicks")).toVariant().toLongLong());
+    const QString imageTag = wireChapter.value(QStringLiteral("ImageTag")).toString();
+    if (!imageTag.isEmpty()) {
+        chapter.artwork.connectionId = connectionId;
+        chapter.artwork.itemId = itemId;
+        chapter.artwork.kind = Bloom::ArtworkKind::Chapter;
+        chapter.artwork.index = qMax(0, chapterIndex);
+        chapter.artwork.tag = imageTag;
+    }
+    return chapter;
+}

--- a/src/providers/jellyfin/JellyfinModelMapper.h
+++ b/src/providers/jellyfin/JellyfinModelMapper.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "models/MediaModels.h"
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QVariantList>
+#include <QVariantMap>
+
+class JellyfinModelMapper
+{
+public:
+    static qint64 ticksToMilliseconds(qint64 ticks);
+    static qint64 millisecondsToTicks(qint64 milliseconds);
+
+    static QVariantMap mediaItem(const QJsonObject &wireItem,
+                                 const QString &connectionId);
+    static QVariantList mediaItems(const QJsonArray &wireItems,
+                                   const QString &connectionId);
+    static Bloom::Chapter chapter(const QJsonObject &wireChapter,
+                                  const QString &connectionId,
+                                  const QString &itemId,
+                                  int chapterIndex);
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -203,6 +203,25 @@ target_link_libraries(ProviderTransportTest
 
 add_test(NAME ProviderTransportTest COMMAND ProviderTransportTest)
 
+add_executable(CanonicalModelsTest
+    CanonicalModelsTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/models/MediaModels.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinModelMapper.cpp
+)
+
+target_include_directories(CanonicalModelsTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+target_link_libraries(CanonicalModelsTest
+    PRIVATE
+        Qt6::Core
+        Qt6::Test
+)
+
+add_test(NAME CanonicalModelsTest COMMAND CanonicalModelsTest)
+
 add_executable(InputBindingManagerTest
     InputBindingManagerTest.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/InputBindingManager.cpp

--- a/tests/CanonicalModelsTest.cpp
+++ b/tests/CanonicalModelsTest.cpp
@@ -1,0 +1,149 @@
+#include <QtTest/QtTest>
+
+#include "models/MediaModels.h"
+#include "providers/jellyfin/JellyfinModelMapper.h"
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <limits>
+
+class CanonicalModelsTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void jellyfinTimeConversionUsesMilliseconds();
+    void jellyfinItemMapsToCanonicalCamelCase();
+    void jellyfinParentBackdropUsesImageItemId();
+    void artworkCacheKeyIsTokenFreeAndRoundTrips();
+    void playbackDescriptorExposesProviderNeutralShape();
+};
+
+void CanonicalModelsTest::jellyfinTimeConversionUsesMilliseconds()
+{
+    QCOMPARE(JellyfinModelMapper::ticksToMilliseconds(10'000'000), 1000);
+    QCOMPARE(JellyfinModelMapper::ticksToMilliseconds(-1), 0);
+    QCOMPARE(JellyfinModelMapper::millisecondsToTicks(1000), 10'000'000);
+    QCOMPARE(JellyfinModelMapper::millisecondsToTicks(-1), 0);
+    QCOMPARE(JellyfinModelMapper::millisecondsToTicks(std::numeric_limits<qint64>::max()),
+             std::numeric_limits<qint64>::max());
+}
+
+void CanonicalModelsTest::jellyfinItemMapsToCanonicalCamelCase()
+{
+    const QJsonObject wire{
+        {QStringLiteral("Id"), QStringLiteral("movie-1")},
+        {QStringLiteral("Name"), QStringLiteral("Example")},
+        {QStringLiteral("Type"), QStringLiteral("Movie")},
+        {QStringLiteral("RunTimeTicks"), 72'000'000'000.0},
+        {QStringLiteral("ImageTags"), QJsonObject{
+             {QStringLiteral("Primary"), QStringLiteral("primary-tag")},
+             {QStringLiteral("Logo"), QStringLiteral("logo-tag")}
+         }},
+        {QStringLiteral("BackdropImageTags"), QJsonArray{QStringLiteral("backdrop-tag")}},
+        {QStringLiteral("ProviderIds"), QJsonObject{{QStringLiteral("Tmdb"), QStringLiteral("42")}}},
+        {QStringLiteral("UserData"), QJsonObject{
+             {QStringLiteral("Played"), true},
+             {QStringLiteral("IsFavorite"), true},
+             {QStringLiteral("PlaybackPositionTicks"), 15'000'000.0}
+         }}
+    };
+
+    const QVariantMap item = JellyfinModelMapper::mediaItem(
+        wire, QStringLiteral("connection-1"));
+
+    QCOMPARE(item.value(QStringLiteral("connectionId")).toString(),
+             QStringLiteral("connection-1"));
+    QCOMPARE(item.value(QStringLiteral("itemId")).toString(), QStringLiteral("movie-1"));
+    QCOMPARE(item.value(QStringLiteral("name")).toString(), QStringLiteral("Example"));
+    QCOMPARE(item.value(QStringLiteral("mediaType")).toString(), QStringLiteral("Movie"));
+    QCOMPARE(item.value(QStringLiteral("durationMs")).toLongLong(), 7'200'000);
+    QCOMPARE(item.value(QStringLiteral("positionMs")).toLongLong(), 1500);
+    QVERIFY(item.value(QStringLiteral("watched")).toBool());
+    QVERIFY(item.value(QStringLiteral("favorite")).toBool());
+    QCOMPARE(item.value(QStringLiteral("providerIds")).toMap()
+                 .value(QStringLiteral("Tmdb")).toString(), QStringLiteral("42"));
+
+    for (const QString &wireKey : {
+             QStringLiteral("Id"),
+             QStringLiteral("RunTimeTicks"),
+             QStringLiteral("ImageTags"),
+             QStringLiteral("BackdropImageTags"),
+             QStringLiteral("UserData")}) {
+        QVERIFY2(!item.contains(wireKey), qPrintable(wireKey));
+    }
+
+    const QVariantMap primary = item.value(QStringLiteral("primaryArtwork")).toMap();
+    QCOMPARE(primary.value(QStringLiteral("kind")).toString(), QStringLiteral("primary"));
+    QCOMPARE(primary.value(QStringLiteral("tag")).toString(), QStringLiteral("primary-tag"));
+}
+
+void CanonicalModelsTest::jellyfinParentBackdropUsesImageItemId()
+{
+    const QVariantMap item = JellyfinModelMapper::mediaItem(
+        QJsonObject{
+            {QStringLiteral("Id"), QStringLiteral("episode-1")},
+            {QStringLiteral("ParentBackdropItemId"), QString()},
+            {QStringLiteral("ParentBackdropImageItemId"), QStringLiteral("series-1")},
+            {QStringLiteral("ParentBackdropImageTags"),
+             QJsonArray{QStringLiteral("series-backdrop-tag")}}
+        },
+        QStringLiteral("connection-1"));
+
+    const QVariantMap artwork = item.value(QStringLiteral("backdropArtwork")).toMap();
+    QCOMPARE(artwork.value(QStringLiteral("itemId")).toString(),
+             QStringLiteral("series-1"));
+    QCOMPARE(artwork.value(QStringLiteral("tag")).toString(),
+             QStringLiteral("series-backdrop-tag"));
+}
+
+void CanonicalModelsTest::artworkCacheKeyIsTokenFreeAndRoundTrips()
+{
+    Bloom::ArtworkRef ref;
+    ref.connectionId = QStringLiteral("connection-1");
+    ref.itemId = QStringLiteral("movie-1");
+    ref.kind = Bloom::ArtworkKind::Backdrop;
+    ref.index = 2;
+    ref.tag = QStringLiteral("tag-1");
+    ref.requestedWidth = 1920;
+
+    const QString key = ref.cacheKey();
+    QVERIFY(key.startsWith(QStringLiteral("artwork:")));
+    QVERIFY(!key.contains(QStringLiteral("api_key"), Qt::CaseInsensitive));
+    QVERIFY(!key.contains(QStringLiteral("secret-token")));
+
+    const Bloom::ArtworkRef decoded = Bloom::ArtworkRef::fromCacheKey(key);
+    QCOMPARE(decoded.connectionId, ref.connectionId);
+    QCOMPARE(decoded.itemId, ref.itemId);
+    QCOMPARE(static_cast<int>(decoded.kind), static_cast<int>(ref.kind));
+    QCOMPARE(decoded.index, ref.index);
+    QCOMPARE(decoded.tag, ref.tag);
+    QCOMPARE(decoded.requestedWidth, ref.requestedWidth);
+}
+
+void CanonicalModelsTest::playbackDescriptorExposesProviderNeutralShape()
+{
+    Bloom::PlaybackDescriptor descriptor;
+    descriptor.media = {QStringLiteral("connection-1"), QStringLiteral("movie-1")};
+    descriptor.stream.url = QUrl(QStringLiteral("https://media.example.test/stream"));
+    descriptor.stream.headers = {
+        {QStringLiteral("Authorization"), QStringLiteral("opaque")}
+    };
+    QVERIFY(!descriptor.isValid());
+    descriptor.stream.method = Bloom::PlaybackMethod::DirectPlay;
+    descriptor.durationMs = 7'200'000;
+    descriptor.startPositionMs = 30'000;
+    descriptor.reporting = {true, true, true, true};
+
+    QVERIFY(descriptor.isValid());
+    const QVariantMap map = descriptor.toVariantMap();
+    QCOMPARE(map.value(QStringLiteral("durationMs")).toLongLong(), 7'200'000);
+    QCOMPARE(map.value(QStringLiteral("startPositionMs")).toLongLong(), 30'000);
+    QCOMPARE(map.value(QStringLiteral("stream")).toMap()
+                 .value(QStringLiteral("method")).toString(), QStringLiteral("directPlay"));
+    QVERIFY(!map.contains(QStringLiteral("RunTimeTicks")));
+    QVERIFY(!map.contains(QStringLiteral("MediaSourceId")));
+}
+
+QTEST_MAIN(CanonicalModelsTest)
+#include "CanonicalModelsTest.moc"


### PR DESCRIPTION
## Summary
- add Bloom-owned canonical media, artwork, chapter, track, and playback descriptor contracts
- add Jellyfin adapter mapping for camelCase fields and millisecond time units
- add canonical model regression coverage and architecture documentation

## Scope
First stacked slice of Bloom issue #76. This PR establishes contracts only; catalog/UI migration continues upstack.

## Verification
- `./scripts/dev-build.sh`
- `nix flake check --no-write-lock-file`

Part of #76

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add canonical media models and Jellyfin model mapper to Bloom
> - Introduces canonical C++ media types in [`src/models/MediaModels.h`](https://github.com/crowquillx/Bloom/pull/88/files#diff-1ea33207ab3189f18c1603fc803f4e8e16647b9ea755ee7465e565f65e53b52e) and [`MediaModels.cpp`](https://github.com/crowquillx/Bloom/pull/88/files#diff-4a960341bd11f20c5003f30d76100eb2283819a9f2f069fcd2125a9a035d0e2d): `MediaRef`, `ArtworkRef`, `PlaybackDescriptor`, and related structs/enums with `toVariantMap()` serialization for QML consumers.
> - Adds [`JellyfinModelMapper`](https://github.com/crowquillx/Bloom/pull/88/files#diff-dd0b5b05e26d0093c7aaa842b37bf3c26cece8eb2e45bf809652a37054a7580d) to convert Jellyfin wire JSON into canonical camelCase `QVariantMap`s, including tick-to-millisecond conversion, token-free `ArtworkRef` cache keys, user state, people, chapters, and backdrop resolution.
> - All field names use camelCase, timing uses milliseconds, and token-free artwork identities are base64url-encoded — provider conversion is contained within the Jellyfin adapter.
> - Adds `CanonicalModelsTest` covering tick conversion, field naming, backdrop fallback, `ArtworkRef` round-trip, and `PlaybackDescriptor` validity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19eb962.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canonical media and playback models with consistent metadata, artwork, timing, and serialization.
  * Added Jellyfin media and chapter mapping, including artwork handling and time conversion.
  * Added secure, token-free artwork cache identifiers.

* **Documentation**
  * Documented canonical model contracts and provider architecture boundaries.

* **Tests**
  * Added coverage for model serialization, Jellyfin mapping, artwork caching, and playback descriptors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->