### PR TITLE
refactor(artwork): use token-free cache identities

### DIFF
--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -37,7 +37,7 @@ Existing list/detail/player flows are migrated in reviewable slices. During migr
 
 ## Artwork identity
 
-`ArtworkRef::cacheKey()` serializes only token-free canonical fields. Token rotation or a refreshed presigned URL must not change the cache key. The image provider resolves the current authenticated fetch request on a cache miss rather than persisting that request URL.
+`ArtworkRef::cacheKey()` serializes only token-free canonical fields. Token rotation or a refreshed provider representation does not change the cache key. `ImageCacheProvider` delegates cache misses to `IArtworkProvider`; `JellyfinArtworkProvider` resolves the current authenticated request with an authorization header and no query token. The resolved request URL is never persisted or logged.
 
 ## Playback boundary
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -8,10 +8,12 @@ Hybrid mode prefers cached pre-rounded PNGs, falls back to the shader path, and 
 - Env overrides: `BLOOM_ROUNDED_IMAGE_MODE`, `BLOOM_ROUNDED_PREPROCESS` / `BLOOM_ROUNDED_IMAGE_PREPROCESS` (`0/1` or `true/false`).
 
 ## Pre-rounded path (ImageCacheProvider)
-- Rounded variants are stored beside originals in the image cache, keyed by URL + radius + size.
+- Provider artwork is identified by a token-free `ArtworkRef` cache key (`connectionId`, item, kind/index/tag, and requested width). Authenticated URLs and headers are resolved only on a cache miss and are never persisted or logged.
+- Rounded variants are stored beside originals and keyed by the `ArtworkRef` identity + radius + size.
 - Generation triggers after cache hits/misses when preprocessing is enabled; emits `roundedImageReady(url, fileUrl)` once written.
 - Defaults: radius `Theme.imageRadius`, size `640x960` (poster). Callers may pass custom radius/size to `requestRoundedImage(url, radius, w, h)`.
-- Invalidation: radius/size are part of the cache key; `ConfigManager.clearCache()` removes originals and rounded variants together.
+- Invalidation: artwork tag, radius, and size are part of the cache key; `ConfigManager.clearCache()` removes originals and rounded variants together.
+- Migration: image-cache schema v2 clears legacy URL-keyed rows and vacuums SQLite so query credentials from older releases do not remain in cache metadata.
 
 ## Shader fallback
 - GLSL source: `src/resources/shaders/rounded_image.frag`; compiled via `qt6_add_shaders` to `qrc:/shaders/rounded_image.frag.qsb`.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,10 +14,13 @@ qt_add_executable(Bloom
     providers/ServerConnection.h
     providers/ServerConnection.cpp
     providers/IProviderAdapter.h
+    providers/IArtworkProvider.h
     providers/IProviderAuthenticator.h
     providers/IProviderRequestFactory.h
     providers/jellyfin/JellyfinAuthenticator.h
     providers/jellyfin/JellyfinAuthenticator.cpp
+    providers/jellyfin/JellyfinArtworkProvider.h
+    providers/jellyfin/JellyfinArtworkProvider.cpp
     providers/jellyfin/JellyfinRequestFactory.h
     providers/jellyfin/JellyfinRequestFactory.cpp
     providers/jellyfin/JellyfinModelMapper.h

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -2,6 +2,8 @@
 #include "AuthenticationService.h"
 #include "HttpTransport.h"
 #include "NextEpisodeResolver.h"
+#include "models/MediaModels.h"
+#include "utils/ConfigManager.h"
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QTimer>
@@ -11,6 +13,7 @@
 #include <algorithm>
 #include <QLoggingCategory>
 #include <memory>
+#include <optional>
 #include "../utils/BloomLogging.h"
 
 namespace {
@@ -32,6 +35,22 @@ QString buildChaptersEndpoint(const QString &userId, const QString &itemId)
 {
     return QString("/Users/%1/Items/%2?Fields=Chapters&EnableImages=true&EnableImageTypes=Chapter&ImageTypeLimit=100")
         .arg(userId, itemId);
+}
+
+QString activeConnectionId(const AuthenticationService *authService)
+{
+    ConfigManager *config = authService ? authService->configManager() : nullptr;
+    const auto connection = config ? config->getActiveConnection() : std::nullopt;
+    return connection.has_value() ? connection->connectionId : QString();
+}
+
+QString cachedArtworkSource(const Bloom::ArtworkRef &artwork)
+{
+    if (!artwork.isValid()) {
+        return {};
+    }
+    return QStringLiteral("image://cached/%1").arg(
+        QString::fromUtf8(QUrl::toPercentEncoding(artwork.cacheKey())));
 }
 
 QStringList sortedList(QStringList values)
@@ -842,11 +861,14 @@ void LibraryService::getScreensaverItems(int limit)
                     continue;
                 }
 
-                QString backdropUrl = getCachedImageUrlWithWidth(itemId, QStringLiteral("Backdrop"), 1920);
+                const QString backdropUrl = getCachedArtworkUrl(itemId,
+                                                                  QStringLiteral("Backdrop"),
+                                                                  0,
+                                                                  tag,
+                                                                  1920);
                 if (backdropUrl.isEmpty()) {
                     continue;
                 }
-                backdropUrl += QStringLiteral("?tag=") + tag;
                 item.insert(QStringLiteral("BackdropUrl"), backdropUrl);
 
                 if (item.value("ImageTags").toObject().contains(QStringLiteral("Logo"))) {
@@ -1743,27 +1765,38 @@ QString LibraryService::getStreamUrlWithTracks(const QString &itemId, const QStr
 
 QString LibraryService::getImageUrl(const QString &itemId, const QString &imageType)
 {
-    return QString("%1/Items/%2/Images/%3?quality=90&fillWidth=400&api_key=%4")
-        .arg(m_authService->getServerUrl(), itemId, imageType, m_authService->getAccessToken());
+    return getCachedArtworkUrl(itemId, imageType, 0, QString(), 400);
 }
 
 QString LibraryService::getImageUrlWithWidth(const QString &itemId, const QString &imageType, int width)
 {
-    if (width <= 0) width = 1920;
-    return QString("%1/Items/%2/Images/%3?quality=95&fillWidth=%4&api_key=%5")
-        .arg(m_authService->getServerUrl(), itemId, imageType, QString::number(width), m_authService->getAccessToken());
+    return getCachedArtworkUrl(itemId, imageType, 0, QString(), width);
 }
 
 QString LibraryService::getCachedImageUrl(const QString &itemId, const QString &imageType)
 {
-    QString originalUrl = getImageUrl(itemId, imageType);
-    return QString("image://cached/%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(originalUrl)));
+    return getCachedArtworkUrl(itemId, imageType, 0, QString(), 400);
 }
 
 QString LibraryService::getCachedImageUrlWithWidth(const QString &itemId, const QString &imageType, int width)
 {
-    QString originalUrl = getImageUrlWithWidth(itemId, imageType, width);
-    return QString("image://cached/%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(originalUrl)));
+    return getCachedArtworkUrl(itemId, imageType, 0, QString(), width);
+}
+
+QString LibraryService::getCachedArtworkUrl(const QString &itemId,
+                                            const QString &imageType,
+                                            int imageIndex,
+                                            const QString &imageTag,
+                                            int width)
+{
+    Bloom::ArtworkRef artwork;
+    artwork.connectionId = activeConnectionId(m_authService);
+    artwork.itemId = itemId;
+    artwork.kind = Bloom::artworkKindFromName(imageType);
+    artwork.index = qMax(0, imageIndex);
+    artwork.tag = imageTag.trimmed();
+    artwork.requestedWidth = width > 0 ? width : 1920;
+    return cachedArtworkSource(artwork);
 }
 
 QString LibraryService::getCachedChapterThumbnailUrl(const QString &itemId, int chapterIndex, const QString &imageTag, const QString &imagePath, int width)
@@ -1782,16 +1815,11 @@ QString LibraryService::getCachedChapterThumbnailUrl(const QString &itemId, int 
         width = 480;
     }
 
-    QString originalUrl = QString("%1/Items/%2/Images/Chapter/%3?maxWidth=%4&api_key=%5")
-        .arg(m_authService->getServerUrl(),
-             itemId,
-             QString::number(chapterIndex),
-             QString::number(width),
-             m_authService->getAccessToken());
-    if (!imageTag.trimmed().isEmpty()) {
-        originalUrl += QString("&tag=%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(imageTag)));
-    }
-    const QString cachedUrl = QString("image://cached/%1").arg(QString::fromUtf8(QUrl::toPercentEncoding(originalUrl)));
+    const QString cachedUrl = getCachedArtworkUrl(itemId,
+                                                   QStringLiteral("chapter"),
+                                                   chapterIndex,
+                                                   imageTag,
+                                                   width);
     qCInfo(lcLibrary) << "LibraryService: Chapter thumbnail request"
             << "item" << itemId
             << "index" << chapterIndex

--- a/src/network/LibraryService.h
+++ b/src/network/LibraryService.h
@@ -138,6 +138,11 @@ public:
     Q_INVOKABLE virtual QString getImageUrlWithWidth(const QString &itemId, const QString &imageType, int width);
     Q_INVOKABLE virtual QString getCachedImageUrl(const QString &itemId, const QString &imageType);
     Q_INVOKABLE virtual QString getCachedImageUrlWithWidth(const QString &itemId, const QString &imageType, int width);
+    Q_INVOKABLE virtual QString getCachedArtworkUrl(const QString &itemId,
+                                                     const QString &imageType,
+                                                     int imageIndex,
+                                                     const QString &imageTag,
+                                                     int width);
     Q_INVOKABLE virtual QString getCachedChapterThumbnailUrl(const QString &itemId, int chapterIndex, const QString &imageTag, const QString &imagePath = QString(), int width = 480);
 
     QNetworkReply* pingServer();

--- a/src/providers/IArtworkProvider.h
+++ b/src/providers/IArtworkProvider.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "models/MediaModels.h"
+
+#include <QNetworkRequest>
+#include <optional>
+
+/**
+ * @brief Resolves a token-free artwork identity into an authenticated fetch.
+ *
+ * Implementations must not use the resolved URL as a persistent cache key.
+ */
+class IArtworkProvider
+{
+public:
+    virtual ~IArtworkProvider() = default;
+
+    virtual std::optional<QNetworkRequest> resolveArtwork(
+        const Bloom::ArtworkRef &artwork) const = 0;
+};

--- a/src/providers/jellyfin/JellyfinArtworkProvider.cpp
+++ b/src/providers/jellyfin/JellyfinArtworkProvider.cpp
@@ -1,0 +1,31 @@
+#include "JellyfinArtworkProvider.h"
+
+#include "network/AuthenticationService.h"
+#include "providers/jellyfin/JellyfinModelMapper.h"
+#include "utils/ConfigManager.h"
+
+JellyfinArtworkProvider::JellyfinArtworkProvider(AuthenticationService *authService)
+    : m_authService(authService)
+{
+}
+
+std::optional<QNetworkRequest> JellyfinArtworkProvider::resolveArtwork(
+    const Bloom::ArtworkRef &artwork) const
+{
+    if (!m_authService || !artwork.isValid() || !m_authService->isAuthenticated()) {
+        return std::nullopt;
+    }
+
+    ConfigManager *config = m_authService->configManager();
+    const auto connection = config ? config->getActiveConnection() : std::nullopt;
+    if (!connection.has_value() || connection->connectionId != artwork.connectionId
+        || connection->providerKind != ProviderKind::Jellyfin) {
+        return std::nullopt;
+    }
+
+    const QString endpoint = JellyfinModelMapper::artworkEndpoint(artwork);
+    if (endpoint.isEmpty()) {
+        return std::nullopt;
+    }
+    return m_authService->createRequest(endpoint);
+}

--- a/src/providers/jellyfin/JellyfinArtworkProvider.h
+++ b/src/providers/jellyfin/JellyfinArtworkProvider.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "providers/IArtworkProvider.h"
+
+class AuthenticationService;
+
+class JellyfinArtworkProvider final : public IArtworkProvider
+{
+public:
+    explicit JellyfinArtworkProvider(AuthenticationService *authService);
+
+    std::optional<QNetworkRequest> resolveArtwork(
+        const Bloom::ArtworkRef &artwork) const override;
+
+private:
+    AuthenticationService *m_authService = nullptr;
+};

--- a/src/providers/jellyfin/JellyfinModelMapper.cpp
+++ b/src/providers/jellyfin/JellyfinModelMapper.cpp
@@ -2,6 +2,7 @@
 
 #include <QDateTime>
 #include <QJsonValue>
+#include <QUrlQuery>
 #include <limits>
 
 namespace {
@@ -220,4 +221,61 @@ Bloom::Chapter JellyfinModelMapper::chapter(const QJsonObject &wireChapter,
         chapter.artwork.tag = imageTag;
     }
     return chapter;
+}
+
+QString JellyfinModelMapper::artworkEndpoint(const Bloom::ArtworkRef &artwork)
+{
+    if (!artwork.isValid()) {
+        return {};
+    }
+
+    QString imageType;
+    switch (artwork.kind) {
+    case Bloom::ArtworkKind::Primary:
+    case Bloom::ArtworkKind::Person:
+        imageType = QStringLiteral("Primary");
+        break;
+    case Bloom::ArtworkKind::Thumb:
+        imageType = QStringLiteral("Thumb");
+        break;
+    case Bloom::ArtworkKind::Backdrop:
+        imageType = QStringLiteral("Backdrop");
+        break;
+    case Bloom::ArtworkKind::Logo:
+        imageType = QStringLiteral("Logo");
+        break;
+    case Bloom::ArtworkKind::Chapter:
+        imageType = QStringLiteral("Chapter");
+        break;
+    case Bloom::ArtworkKind::Unknown:
+        return {};
+    }
+
+    QString endpoint;
+    if (artwork.kind == Bloom::ArtworkKind::Chapter) {
+        endpoint = QStringLiteral("/Items/%1/Images/Chapter/%2")
+                       .arg(artwork.itemId, QString::number(artwork.index));
+    } else if (artwork.kind == Bloom::ArtworkKind::Backdrop && artwork.index > 0) {
+        endpoint = QStringLiteral("/Items/%1/Images/%2/%3")
+                       .arg(artwork.itemId, imageType, QString::number(artwork.index));
+    } else {
+        endpoint = QStringLiteral("/Items/%1/Images/%2")
+                       .arg(artwork.itemId, imageType);
+    }
+
+    QUrlQuery query;
+    if (artwork.requestedWidth > 0) {
+        query.addQueryItem(artwork.kind == Bloom::ArtworkKind::Chapter
+                               ? QStringLiteral("maxWidth")
+                               : QStringLiteral("fillWidth"),
+                           QString::number(artwork.requestedWidth));
+    }
+    query.addQueryItem(QStringLiteral("quality"), QStringLiteral("95"));
+    if (!artwork.tag.isEmpty()) {
+        query.addQueryItem(QStringLiteral("tag"), artwork.tag);
+    }
+    if (!query.isEmpty()) {
+        endpoint += QLatin1Char('?') + query.toString(QUrl::FullyEncoded);
+    }
+    return endpoint;
 }

--- a/src/providers/jellyfin/JellyfinModelMapper.h
+++ b/src/providers/jellyfin/JellyfinModelMapper.h
@@ -21,4 +21,5 @@ public:
                                   const QString &connectionId,
                                   const QString &itemId,
                                   int chapterIndex);
+    static QString artworkEndpoint(const Bloom::ArtworkRef &artwork);
 };

--- a/src/test/MockLibraryService.cpp
+++ b/src/test/MockLibraryService.cpp
@@ -313,8 +313,11 @@ void MockLibraryService::getScreensaverItems(int limit)
             continue;
         }
         item.insert(QStringLiteral("BackdropUrl"),
-                    getCachedImageUrlWithWidth(itemId, QStringLiteral("Backdrop"), 1920)
-                        + QStringLiteral("?tag=") + tag);
+                    getCachedArtworkUrl(itemId,
+                                        QStringLiteral("Backdrop"),
+                                        0,
+                                        tag,
+                                        1920));
         if (item.value("ImageTags").toObject().contains(QStringLiteral("Logo"))) {
             item.insert(QStringLiteral("LogoUrl"),
                         getCachedImageUrlWithWidth(item.value("Id").toString(),
@@ -607,6 +610,17 @@ QString MockLibraryService::getCachedImageUrl(const QString &itemId, const QStri
 
 QString MockLibraryService::getCachedImageUrlWithWidth(const QString &itemId, const QString &imageType, int width)
 {
+    return getImageUrlWithWidth(itemId, imageType, width);
+}
+
+QString MockLibraryService::getCachedArtworkUrl(const QString &itemId,
+                                                const QString &imageType,
+                                                int imageIndex,
+                                                const QString &imageTag,
+                                                int width)
+{
+    Q_UNUSED(imageIndex)
+    Q_UNUSED(imageTag)
     return getImageUrlWithWidth(itemId, imageType, width);
 }
 

--- a/src/test/MockLibraryService.h
+++ b/src/test/MockLibraryService.h
@@ -82,6 +82,11 @@ public:
     Q_INVOKABLE QString getImageUrlWithWidth(const QString &itemId, const QString &imageType, int width) override;
     Q_INVOKABLE QString getCachedImageUrl(const QString &itemId, const QString &imageType) override;
     Q_INVOKABLE QString getCachedImageUrlWithWidth(const QString &itemId, const QString &imageType, int width) override;
+    Q_INVOKABLE QString getCachedArtworkUrl(const QString &itemId,
+                                             const QString &imageType,
+                                             int imageIndex,
+                                             const QString &imageTag,
+                                             int width) override;
 
 private:
     QJsonObject m_fixture;

--- a/src/ui/HomeScreen.qml
+++ b/src/ui/HomeScreen.qml
@@ -476,10 +476,11 @@ FocusScope {
         var candidate = backdropCandidates[candidateIndex]
         
         // Construct backdrop URL
-        var url = LibraryService.getCachedImageUrlWithWidth(candidate.itemId, "Backdrop", 1920)
-        if (url && candidate.backdropTag) {
-            url += "?tag=" + candidate.backdropTag
-        }
+        var url = LibraryService.getCachedArtworkUrl(candidate.itemId,
+                                                     "Backdrop",
+                                                     0,
+                                                     candidate.backdropTag || "",
+                                                     1920)
         
         currentBackdropUrl = url
     }

--- a/src/ui/ImageCacheProvider.cpp
+++ b/src/ui/ImageCacheProvider.cpp
@@ -1,4 +1,5 @@
 #include "ImageCacheProvider.h"
+#include "providers/IArtworkProvider.h"
 #include <QStandardPaths>
 #include <QDir>
 #include <QFile>
@@ -17,17 +18,22 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QImageWriter>
+#include <utility>
 #include "../utils/BloomLogging.h"
 
 // ============================================================================
 // CachedImageResponse Implementation
 // ============================================================================
 
-CachedImageResponse::CachedImageResponse(const QString &url, const QSize &requestedSize,
-                             ImageCacheProvider *provider)
+CachedImageResponse::CachedImageResponse(
+    const QString &url,
+    const QSize &requestedSize,
+    ImageCacheProvider *provider,
+    std::optional<QNetworkRequest> resolvedRequest)
     : m_url(url)
     , m_requestedSize(requestedSize)
     , m_provider(provider)
+    , m_resolvedRequest(std::move(resolvedRequest))
 {
     setAutoDelete(false);
 }
@@ -106,7 +112,8 @@ void CachedImageResponse::loadFromCache()
         QImage image = reader.read();
         
         if (!image.isNull()) {
-            qCDebug(lcImageCache) << "Cache hit:" << m_url;
+            qCDebug(lcImageCache) << "Cache hit:"
+                                  << m_provider->safeCacheLabel(m_url);
             
             // Update access time in database
             m_provider->touchCacheEntry(m_url);
@@ -135,7 +142,8 @@ void CachedImageResponse::loadFromCache()
     }
     
     // Not in cache, fetch from network
-    qCDebug(lcImageCache) << "Cache miss, fetching:" << m_url;
+    qCDebug(lcImageCache) << "Cache miss, fetching:"
+                          << m_provider->safeCacheLabel(m_url);
     fetchFromNetwork();
 }
 
@@ -147,13 +155,12 @@ void CachedImageResponse::fetchFromNetwork()
         return;
     }
     
-    QUrl url(m_url);
-    if (!url.isValid()) {
-        finishWithError("Invalid URL: " + m_url);
+    if (!m_resolvedRequest.has_value()) {
+        finishWithError("Unable to resolve image request");
         return;
     }
-    
-    QNetworkRequest request(url);
+
+    QNetworkRequest request = *m_resolvedRequest;
     request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, 
                         QNetworkRequest::PreferNetwork);
     request.setHeader(QNetworkRequest::UserAgentHeader, "Bloom/1.0");
@@ -257,7 +264,8 @@ void CachedImageResponse::finishWithImage(const QImage &image)
 void CachedImageResponse::finishWithError(const QString &error)
 {
     m_errorString = error;
-    qCWarning(lcImageCache) << "Image load failed:" << m_url << "-" << error;
+    qCWarning(lcImageCache) << "Image load failed:"
+                            << m_provider->safeCacheLabel(m_url) << "-" << error;
     emit finished();
 }
 
@@ -265,9 +273,11 @@ void CachedImageResponse::finishWithError(const QString &error)
 // ImageCacheProvider Implementation
 // ============================================================================
 
-ImageCacheProvider::ImageCacheProvider(qint64 maxCacheSizeMB)
+ImageCacheProvider::ImageCacheProvider(qint64 maxCacheSizeMB,
+                                       IArtworkProvider *artworkProvider)
     : QQuickAsyncImageProvider()
     , m_maxCacheSize(maxCacheSizeMB * 1024 * 1024)  // Convert MB to bytes
+    , m_artworkProvider(artworkProvider)
     , m_memoryCache(50 * 1024 * 1024)  // 50MB memory cache
 {
     // Set up cache directory
@@ -352,7 +362,28 @@ void ImageCacheProvider::initDatabase()
     
     // Create index for LRU queries
     query.exec("CREATE INDEX IF NOT EXISTS idx_last_accessed ON cache_entries(last_accessed)");
-    
+
+    query.exec(QStringLiteral("PRAGMA user_version"));
+    const int schemaVersion = query.next() ? query.value(0).toInt() : 0;
+    query.finish();
+    if (schemaVersion < 2) {
+        QSqlQuery oldEntries(m_db);
+        oldEntries.exec(QStringLiteral("SELECT filename FROM cache_entries"));
+        QStringList oldFiles;
+        while (oldEntries.next()) {
+            oldFiles.append(m_cacheDir + QLatin1Char('/') + oldEntries.value(0).toString());
+        }
+        oldEntries.finish();
+        QSqlQuery reset(m_db);
+        reset.exec(QStringLiteral("DELETE FROM cache_entries"));
+        reset.exec(QStringLiteral("VACUUM"));
+        reset.exec(QStringLiteral("PRAGMA user_version = 2"));
+        for (const QString &file : oldFiles) {
+            QFile::remove(file);
+        }
+        qCInfo(lcImageCache) << "Cleared legacy URL-keyed image cache entries";
+    }
+
     // Calculate current cache size
     query.exec("SELECT COALESCE(SUM(size), 0) FROM cache_entries");
     if (query.next()) {
@@ -373,12 +404,15 @@ QQuickImageResponse *ImageCacheProvider::requestImageResponse(const QString &id,
     
     if (url.isEmpty()) {
         qCWarning(lcImageCache) << "Empty image URL requested";
-        auto *response = new CachedImageResponse("", requestedSize, this);
+        auto *response = new CachedImageResponse("", requestedSize, this, std::nullopt);
         response->finishWithError("Empty URL");
         return response;
     }
     
-    auto *response = new CachedImageResponse(url, requestedSize, this);
+    auto *response = new CachedImageResponse(url,
+                                             requestedSize,
+                                             this,
+                                             resolveRequest(url));
     m_threadPool.start(response);
     return response;
 }
@@ -393,7 +427,10 @@ void ImageCacheProvider::prefetch(const QStringList &urls)
         }
         
         // Create a prefetch response (no size requirement)
-        auto *response = new CachedImageResponse(url, QSize(), this);
+        auto *response = new CachedImageResponse(url,
+                                                 QSize(),
+                                                 this,
+                                                 resolveRequest(url));
         QObject::connect(response, &QQuickImageResponse::finished, 
                          response, &QObject::deleteLater);
         m_threadPool.start(response);
@@ -494,7 +531,8 @@ QString ImageCacheProvider::saveDataForKey(const QString &urlKey, const QByteArr
         m_currentCacheSize += data.size();
     }
     
-    qCDebug(lcImageCache) << "Cached:" << urlKey << "size:" << data.size();
+    qCDebug(lcImageCache) << "Cached:" << safeCacheLabel(urlKey)
+                          << "size:" << data.size();
     
     // Check if eviction is needed
     evictIfNeeded();
@@ -599,6 +637,41 @@ QString ImageCacheProvider::hashUrl(const QString &url) const
     QByteArray hash = QCryptographicHash::hash(url.toUtf8(), 
                                                 QCryptographicHash::Sha256);
     return hash.toHex().left(32);  // Use first 32 chars of SHA256
+}
+
+QString ImageCacheProvider::safeCacheLabel(const QString &cacheKey) const
+{
+    return QStringLiteral("cache:%1").arg(hashUrl(cacheKey));
+}
+
+std::optional<QNetworkRequest> ImageCacheProvider::resolveRequest(const QString &cacheKey) const
+{
+    if (QThread::currentThread() != thread()) {
+        std::optional<QNetworkRequest> resolved;
+        QMetaObject::invokeMethod(const_cast<ImageCacheProvider *>(this),
+                                  [this, &resolved, cacheKey]() {
+                                      resolved = resolveRequest(cacheKey);
+                                  },
+                                  Qt::BlockingQueuedConnection);
+        return resolved;
+    }
+
+    if (cacheKey.startsWith(QStringLiteral("artwork:"))) {
+        if (!m_artworkProvider) {
+            return std::nullopt;
+        }
+        const Bloom::ArtworkRef artwork = Bloom::ArtworkRef::fromCacheKey(cacheKey);
+        if (!artwork.isValid()) {
+            return std::nullopt;
+        }
+        return m_artworkProvider->resolveArtwork(artwork);
+    }
+
+    const QUrl url(cacheKey);
+    if (!url.isValid() || url.isEmpty()) {
+        return std::nullopt;
+    }
+    return QNetworkRequest(url);
 }
 
 QString ImageCacheProvider::roundedKey(const QString &url, int radiusPx, const QSize &targetSize) const

--- a/src/ui/ImageCacheProvider.h
+++ b/src/ui/ImageCacheProvider.h
@@ -6,6 +6,7 @@
 #include <QThreadPool>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <QNetworkRequest>
 #include <QMutex>
 #include <QSqlDatabase>
 #include <QCache>
@@ -16,7 +17,9 @@
 #include <QList>
 #include <QHash>
 #include <QPair>
+#include <optional>
 
+class IArtworkProvider;
 class ImageCacheProvider;
 
 /**
@@ -30,8 +33,10 @@ class CachedImageResponse : public QQuickImageResponse, public QRunnable
     Q_OBJECT
     
 public:
-    CachedImageResponse(const QString &url, const QSize &requestedSize,
-                  ImageCacheProvider *provider);
+    CachedImageResponse(const QString &url,
+                        const QSize &requestedSize,
+                        ImageCacheProvider *provider,
+                        std::optional<QNetworkRequest> resolvedRequest);
     ~CachedImageResponse() override;
     
     QQuickTextureFactory *textureFactory() const override;
@@ -64,6 +69,7 @@ private:
     QString m_errorString;
     bool m_cancelled = false;
     QNetworkReply *m_reply = nullptr;
+    std::optional<QNetworkRequest> m_resolvedRequest;
     QMutex m_mutex;
 };
 
@@ -94,7 +100,8 @@ public:
      * @brief Construct image cache provider
      * @param maxCacheSizeMB Maximum disk cache size in megabytes (default 500MB)
      */
-    explicit ImageCacheProvider(qint64 maxCacheSizeMB = 500);
+    explicit ImageCacheProvider(qint64 maxCacheSizeMB = 500,
+                                IArtworkProvider *artworkProvider = nullptr);
     ~ImageCacheProvider() override;
     
     QQuickImageResponse *requestImageResponse(const QString &id, 
@@ -209,6 +216,8 @@ private:
      * @brief Generate cache file name from URL
      */
     QString hashUrl(const QString &url) const;
+    QString safeCacheLabel(const QString &cacheKey) const;
+    std::optional<QNetworkRequest> resolveRequest(const QString &cacheKey) const;
     
     /**
      * @brief Construct a stable key for a rounded variant.
@@ -249,6 +258,7 @@ private:
     int m_defaultRoundedRadius = 16;
     QSize m_defaultRoundedSize = QSize(640, 960);
     bool m_enableRoundedPreprocess = true;
+    IArtworkProvider *m_artworkProvider = nullptr;
     
     // SQLite database for cache metadata
     QSqlDatabase m_db;

--- a/src/ui/LibraryScreen.qml
+++ b/src/ui/LibraryScreen.qml
@@ -2567,11 +2567,19 @@ FocusScope {
         function appendUrl(id, type, width, tag) {
             if (!id || !type)
                 return
-            var url = LibraryService.getCachedImageUrlWithWidth(id, type, width || 1920)
-            if (tag && tag.length > 0) {
-                url += (url.indexOf("?") >= 0 ? "&" : "?") + "tag=" + tag
+            let kind = type
+            let index = 0
+            const separator = type.indexOf("/")
+            if (separator >= 0) {
+                kind = type.substring(0, separator)
+                index = Number(type.substring(separator + 1)) || 0
             }
-            if (candidates.indexOf(url) === -1) {
+            const url = LibraryService.getCachedArtworkUrl(id,
+                                                          kind,
+                                                          index,
+                                                          tag || "",
+                                                          width || 1920)
+            if (url && candidates.indexOf(url) === -1) {
                 candidates.push(url)
             }
         }

--- a/src/ui/SettingsScreen.qml
+++ b/src/ui/SettingsScreen.qml
@@ -236,8 +236,11 @@ FocusScope {
         if (backdropCandidates.length === 0) { currentBackdropUrl = ""; return }
         var randomIndex = Math.floor(Math.random() * backdropCandidates.length)
         var candidate = backdropCandidates[randomIndex]
-        var url = LibraryService.getCachedImageUrlWithWidth(candidate.itemId, "Backdrop", 1920)
-        if (url && candidate.backdropTag) url += "?tag=" + candidate.backdropTag
+        var url = LibraryService.getCachedArtworkUrl(candidate.itemId,
+                                                     "Backdrop",
+                                                     0,
+                                                     candidate.backdropTag || "",
+                                                     1920)
         currentBackdropUrl = url
     }
 

--- a/src/ui/WindowManager.cpp
+++ b/src/ui/WindowManager.cpp
@@ -18,6 +18,8 @@
 #include "viewmodels/MovieDetailsViewModel.h"
 #include "viewmodels/UpNextRecommendationsViewModel.h"
 #include "network/AuthenticationService.h"
+#include "providers/IArtworkProvider.h"
+#include "providers/jellyfin/JellyfinArtworkProvider.h"
 #include "network/LibraryService.h"
 #include "network/PlaybackService.h"
 #include "network/SeerrService.h"
@@ -65,7 +67,10 @@ WindowManager::~WindowManager()
 void WindowManager::setup(ConfigManager* configManager)
 {
     // ImageCacheProvider
-    m_imageCacheProvider = new ImageCacheProvider(configManager->getImageCacheSizeMB());
+    m_artworkProvider = std::make_unique<JellyfinArtworkProvider>(
+        ServiceLocator::get<AuthenticationService>());
+    m_imageCacheProvider = new ImageCacheProvider(configManager->getImageCacheSizeMB(),
+                                                   m_artworkProvider.get());
     const QString roundedMode = configManager->getRoundedImageMode();
     const bool roundedPreprocessEnabled = configManager->getRoundedImagePreprocessEnabled()
         && roundedMode != "shader";

--- a/src/ui/WindowManager.h
+++ b/src/ui/WindowManager.h
@@ -4,9 +4,11 @@
 #include <QQmlApplicationEngine>
 #include <QQuickWindow>
 #include <QGuiApplication>
+#include <memory>
 
 class ApplicationInitializer;
 class ConfigManager;
+class IArtworkProvider;
 class ImageCacheProvider;
 class GpuMemoryTrimmer;
 
@@ -25,6 +27,7 @@ public:
 
 private:
     QGuiApplication* m_app;
+    std::unique_ptr<IArtworkProvider> m_artworkProvider;
     QQmlApplicationEngine m_engine;
     ImageCacheProvider* m_imageCacheProvider = nullptr;
     GpuMemoryTrimmer* m_gpuMemoryTrimmer = nullptr;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TEST_LOGGING_SOURCES
 )
 
 set(TEST_PROVIDER_BOUNDARY_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/models/MediaModels.cpp
     ${CMAKE_SOURCE_DIR}/src/network/HttpTransport.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinAuthenticator.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinRequestFactory.cpp

--- a/tests/CanonicalModelsTest.cpp
+++ b/tests/CanonicalModelsTest.cpp
@@ -16,6 +16,7 @@ private slots:
     void jellyfinItemMapsToCanonicalCamelCase();
     void jellyfinParentBackdropUsesImageItemId();
     void artworkCacheKeyIsTokenFreeAndRoundTrips();
+    void jellyfinArtworkEndpointContainsNoCredential();
     void playbackDescriptorExposesProviderNeutralShape();
 };
 
@@ -119,6 +120,24 @@ void CanonicalModelsTest::artworkCacheKeyIsTokenFreeAndRoundTrips()
     QCOMPARE(decoded.index, ref.index);
     QCOMPARE(decoded.tag, ref.tag);
     QCOMPARE(decoded.requestedWidth, ref.requestedWidth);
+}
+
+void CanonicalModelsTest::jellyfinArtworkEndpointContainsNoCredential()
+{
+    Bloom::ArtworkRef artwork;
+    artwork.connectionId = QStringLiteral("connection-1");
+    artwork.itemId = QStringLiteral("episode-1");
+    artwork.kind = Bloom::ArtworkKind::Chapter;
+    artwork.index = 3;
+    artwork.tag = QStringLiteral("chapter-tag");
+    artwork.requestedWidth = 480;
+
+    const QString endpoint = JellyfinModelMapper::artworkEndpoint(artwork);
+    QVERIFY(endpoint.startsWith(QStringLiteral("/Items/episode-1/Images/Chapter/3?")));
+    QVERIFY(endpoint.contains(QStringLiteral("maxWidth=480")));
+    QVERIFY(endpoint.contains(QStringLiteral("tag=chapter-tag")));
+    QVERIFY(!endpoint.contains(QStringLiteral("api_key"), Qt::CaseInsensitive));
+    QVERIFY(!endpoint.contains(QStringLiteral("token"), Qt::CaseInsensitive));
 }
 
 void CanonicalModelsTest::playbackDescriptorExposesProviderNeutralShape()


### PR DESCRIPTION
## Summary
- add provider-owned artwork request resolution
- replace authenticated URL cache identities with token-free `ArtworkRef` keys
- resolve credentials only on cache misses and clean legacy cache metadata
- migrate backdrop callers, mocks, tests, security docs, and image docs

## Scope
Second stacked slice of Bloom issue #76, on the canonical model foundation.

## Verification
- `./scripts/dev-build.sh`
- `nix flake check --no-write-lock-file`

Part of #76

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace raw authenticated URLs with token-free artwork cache keys across image providers
> - Introduces `IArtworkProvider` and `JellyfinArtworkProvider` to resolve token-free `ArtworkRef` identities into authenticated `QNetworkRequest`s (using auth headers, not query tokens) at fetch time.
> - Adds `JellyfinModelMapper::artworkEndpoint` to build credential-free endpoint paths from an `ArtworkRef`.
> - Rewrites `LibraryService` URL helpers (`getImageUrl`, `getCachedImageUrl`, `getCachedArtworkUrl`, etc.) to return `image://cached/` keys derived from `ArtworkRef::cacheKey()` instead of direct HTTP URLs with API key query params.
> - `ImageCacheProvider` gains a schema v2 migration that purges legacy URL-keyed cache entries and vacuums the SQLite DB on first run, and uses `resolveRequest` to translate artwork keys to authenticated requests on cache miss.
> - Risk: the schema v2 migration clears all existing cached image rows on upgrade, requiring images to be re-fetched.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb0f9e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->