### PR TITLE
refactor(playback): finalize provider stream descriptors

### DIFF
--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -41,7 +41,7 @@ Existing list/detail/player flows are migrated in reviewable slices. During migr
 
 ## Playback boundary
 
-A `PlaybackDescriptor` is valid when it has a valid `MediaRef` and finalized `StreamRequest`. `PlayerController` may map canonical tracks to mpv runtime track IDs, but provider endpoints, query authentication, provider time units, and reporting DTOs belong outside the controller.
+A `PlaybackDescriptor` is valid when it has a valid `MediaRef` and finalized `StreamRequest`. `PlaybackService` obtains the selected adapter's `IPlaybackProvider`; `JellyfinPlaybackProvider` resolves relative PlaybackInfo URLs, adds current request authentication and track hints, converts timing, and identifies the canonical playback method. `PlayerController` consumes only the finalized descriptor and may map canonical tracks to mpv runtime track IDs. Provider endpoints, query authentication, provider time units, and reporting DTOs stay outside the controller.
 
 ## Tests
 
@@ -51,3 +51,4 @@ A `PlaybackDescriptor` is valid when it has a valid `MediaRef` and finalized `St
 - PascalCase Jellyfin item mapping to canonical camelCase values
 - token-free, round-trippable artwork cache keys
 - provider-neutral playback descriptor projections
+- Jellyfin stream finalization, canonical timing/tracks, and current credential injection at the playback-provider boundary

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -102,8 +102,9 @@ Key components
 - LinuxMpvBackend now includes basic `mpv_handle` lifecycle, property/event observation, and a Qt Quick `beforeRendering`-driven `mpv_render_context` render path (Linux runtime validation still pending).
 - MpvVideoItem / VideoSurface: minimal viewport plumbing for embedded backend integration.
 - PlayerProcessManager: manages external mpv process lifetime, sockets/pipes, scripts and config dir. Observes `time-pos`, `duration`, `pause`, `aid`, and `sid` properties.
-- PlayerController: state machine that handles play/pause/resume, listens for backend updates, manages track selection, and reports playback state to the Jellyfin server.
-- JellyfinClient: handles API communication for reporting playback events, track selections, and sessions.
+- PlayerController: provider-neutral state machine that handles play/pause/resume, listens for backend updates, manages track selection, and sends canonical playback state through `PlaybackService`.
+- `IPlaybackProvider` / `JellyfinPlaybackProvider`: finalize provider PlaybackInfo into Bloom `PlaybackDescriptor` values, including the authenticated stream request, canonical timing/tracks, playback method, and session identity.
+- PlaybackService: stable application façade for playback preparation and provider-specific reporting transport.
 - TrackPreferencesManager: persists explicit audio/subtitle user choices to a separate JSON file using a versioned schema.
 
 HDR and Dolby Vision policy
@@ -120,7 +121,7 @@ HDR and Dolby Vision policy
 Audio/Subtitle Track Selection
 - Call `JellyfinClient::getPlaybackInfo(itemId)` to fetch `PlaybackInfoResponse` containing `MediaSources` with all available streams.
 - Each `MediaSourceInfo` contains `mediaStreams` array with `MediaStreamInfo` objects describing video, audio, and subtitle tracks.
-- If PlaybackInfo provides `DirectStreamUrl` or `TranscodingUrl`, Bloom uses that Jellyfin-selected URL for playback and appends missing auth/media-source/track query parameters. The older constructed `/Videos/{itemId}/stream` URL remains the fallback when PlaybackInfo does not include a playback URL.
+- If PlaybackInfo provides `DirectStreamUrl` or `TranscodingUrl`, `JellyfinPlaybackProvider` finalizes that provider-selected URL and appends missing auth/media-source/track query parameters. The provider's constructed `/Videos/{itemId}/stream` endpoint remains its fallback when PlaybackInfo does not include a playback URL. `PlayerController` never constructs or parses these provider endpoints.
 - The server provides `defaultAudioStreamIndex` and `defaultSubtitleStreamIndex` which reflect the user's preferences set on the Jellyfin server.
 - Use `PlayerController::setSelectedAudioTrack(index)` and `setSelectedSubtitleTrack(index)` to change tracks during playback via mpv IPC (`aid`, `sid` properties).
 - Use `PlayerController::setSubtitleDelayMs(delayMs)`, `adjustSubtitleDelayMs(deltaMs)`, or `resetSubtitleDelay()` to retime primary subtitles during playback. Bloom stores delay in milliseconds, applies it to mpv's `sub-delay` property as fractional seconds, and accepts negative or positive offsets.

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -85,7 +85,7 @@ Provider conversion belongs inside provider adapters. `JellyfinModelMapper` is t
 
 ## Request, authentication, and transport boundaries
 
-`IProviderAdapter` bundles the provider implementation consumed by stable application façades. `JellyfinProviderAdapter` exposes the Jellyfin authenticator and request factory while identifying its provider/protocol mode; login, restore, browse, playback, and remote-session traffic therefore share one selected provider boundary without changing QML APIs.
+`IProviderAdapter` bundles the provider implementation consumed by stable application façades. `JellyfinProviderAdapter` exposes the Jellyfin authenticator, request factory, and playback provider while identifying its provider/protocol mode; login, restore, browse, playback, and remote-session traffic therefore share one selected provider boundary without changing QML APIs.
 
 `IProviderRequestFactory` owns provider-specific URL and authorization-header construction. `JellyfinRequestFactory` is the only production source of the `MediaBrowser` header and also redacts token-bearing query parameters before URLs reach logs.
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -15,6 +15,7 @@ Key services
 - `IProviderAdapter` / `JellyfinProviderAdapter` — Selected provider implementation bundle consumed by stable application façades.
 - `IProviderRequestFactory` / `JellyfinRequestFactory` — Provider-owned URL and authorization-header construction.
 - `IProviderAuthenticator` / `JellyfinAuthenticator` — Provider-owned login payload, response parsing, and validation routes.
+- `IPlaybackProvider` / `JellyfinPlaybackProvider` — Provider-owned finalization of canonical playback descriptors and authenticated stream requests.
 - `AuthenticationService` — Stable QML façade for login, logout, session persistence, and token validation; delegates provider wire details and HTTP execution.
 - `LibraryService` — Library views/items, series details, search, reusable chapter metadata, image/theme-song URLs.
 - `PlaybackService` — Playback reporting, stream info, media segments, trickplay URLs and info.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,9 @@ qt_add_executable(Bloom
     providers/jellyfin/JellyfinRequestFactory.cpp
     providers/jellyfin/JellyfinModelMapper.h
     providers/jellyfin/JellyfinModelMapper.cpp
+    providers/IPlaybackProvider.h
+    providers/jellyfin/JellyfinPlaybackProvider.h
+    providers/jellyfin/JellyfinPlaybackProvider.cpp
     providers/jellyfin/JellyfinProviderAdapter.h
     resources/fonts.qrc
     resources/sounds.qrc

--- a/src/models/MediaModels.cpp
+++ b/src/models/MediaModels.cpp
@@ -172,7 +172,11 @@ QVariantMap StreamRequest::toVariantMap() const
     return {
         {QStringLiteral("url"), url},
         {QStringLiteral("headers"), headers},
-        {QStringLiteral("method"), playbackMethodName(method)}
+        {QStringLiteral("method"), playbackMethodName(method)},
+        {QStringLiteral("pinsAudioTrack"), pinsAudioTrack},
+        {QStringLiteral("pinsSubtitleTrack"), pinsSubtitleTrack},
+        {QStringLiteral("pinnedAudioTrackId"), pinnedAudioTrackId},
+        {QStringLiteral("pinnedSubtitleTrackId"), pinnedSubtitleTrackId}
     };
 }
 

--- a/src/models/MediaModels.h
+++ b/src/models/MediaModels.h
@@ -88,6 +88,10 @@ struct StreamRequest {
     QUrl url;
     QVariantMap headers;
     PlaybackMethod method = PlaybackMethod::Unknown;
+    bool pinsAudioTrack = false;
+    bool pinsSubtitleTrack = false;
+    QString pinnedAudioTrackId;
+    QString pinnedSubtitleTrackId;
 
     bool isValid() const;
     QVariantMap toVariantMap() const;

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -61,6 +61,11 @@ AuthenticationService::~AuthenticationService()
     }
 }
 
+const IPlaybackProvider *AuthenticationService::playbackProvider() const
+{
+    return m_providerAdapter ? m_providerAdapter->playbackProvider() : nullptr;
+}
+
 QNetworkAccessManager *AuthenticationService::networkManager() const
 {
     return m_transport->networkManager();

--- a/src/network/AuthenticationService.h
+++ b/src/network/AuthenticationService.h
@@ -12,6 +12,7 @@
 #include "providers/ServerConnection.h"
 #include "security/CredentialStore.h"
 
+class IPlaybackProvider;
 class IProviderAdapter;
 class IProviderAuthenticator;
 class IProviderRequestFactory;
@@ -92,6 +93,7 @@ public:
     QString getUserId() const { return m_userId; }
     QString getAccessToken() const { return m_accessToken; }
     QString getUsername() const { return m_username; }
+    const IPlaybackProvider *playbackProvider() const;
     bool isAuthenticated() const { return !m_accessToken.isEmpty() && !m_userId.isEmpty(); }
     bool isRestoringSession() const { return m_isRestoringSession; }
     

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -2,6 +2,7 @@
 #include "AuthenticationService.h"
 #include "HttpTransport.h"
 #include "MediaSegmentProviderService.h"
+#include "providers/IPlaybackProvider.h"
 #include "../utils/ConfigManager.h"
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -12,9 +13,22 @@
 #include <QUrlQuery>
 #include <QLoggingCategory>
 #include <cmath>
+#include <optional>
 #include "../utils/BloomLogging.h"
 
 namespace {
+QString jellyfinPlayMethod(const QString &method)
+{
+    const QString normalized = method.trimmed().toLower();
+    if (normalized == QStringLiteral("transcode")) {
+        return QStringLiteral("Transcode");
+    }
+    if (normalized == QStringLiteral("directstream")) {
+        return QStringLiteral("DirectStream");
+    }
+    return QStringLiteral("DirectPlay");
+}
+
 QJsonObject buildPlaybackPayload(const QString &itemId, qint64 positionTicks,
                                  const QString &mediaSourceId,
                                  int audioStreamIndex, int subtitleStreamIndex,
@@ -32,7 +46,7 @@ QJsonObject buildPlaybackPayload(const QString &itemId, qint64 positionTicks,
     json["CanSeek"] = canSeek;
     json["IsPaused"] = isPaused;
     json["IsMuted"] = isMuted;
-    json["PlayMethod"] = playMethod.isEmpty() ? QStringLiteral("DirectPlay") : playMethod;
+    json["PlayMethod"] = jellyfinPlayMethod(playMethod);
     json["RepeatMode"] = repeatMode.isEmpty() ? QStringLiteral("RepeatNone") : repeatMode;
     json["PlaybackOrder"] = playbackOrder.isEmpty() ? QStringLiteral("Default") : playbackOrder;
 
@@ -54,8 +68,59 @@ PlaybackService::PlaybackService(AuthenticationService *authService,
     , m_transport(authService ? authService->transport() : nullptr)
     , m_configManager(configManager)
     , m_mediaSegmentProviderService(mediaSegmentProviderService)
+    , m_provider(authService ? authService->playbackProvider() : nullptr)
     , m_retryPolicy{3, 1000, true}
 {
+}
+
+PlaybackService::~PlaybackService() = default;
+
+Bloom::PlaybackDescriptor PlaybackService::createPlaybackDescriptor(
+    const QString &itemId,
+    const QVariantMap &providerSource,
+    int selectedAudioTrack,
+    int selectedSubtitleTrack,
+    qint64 startPositionMs,
+    const QString &playbackSessionId)
+{
+    if (!m_authService || !m_provider) {
+        NetworkError error;
+        error.code = -1;
+        error.endpoint = QStringLiteral("createPlaybackDescriptor");
+        error.userMessage = tr("Playback provider is unavailable.");
+        emitError(error);
+        return {};
+    }
+
+    Bloom::MediaRef media;
+    media.itemId = itemId;
+    ConfigManager *config = m_configManager
+        ? m_configManager
+        : (m_authService ? m_authService->configManager() : nullptr);
+    const auto connection = config ? config->getActiveConnection() : std::nullopt;
+    if (connection.has_value()) {
+        media.connectionId = connection->connectionId;
+    }
+    const PlaybackProviderContext context{
+        QUrl(m_authService->getServerUrl()),
+        m_authService->getAccessToken()
+    };
+    const Bloom::PlaybackDescriptor descriptor = m_provider->createDescriptor(
+        context,
+        media,
+        providerSource,
+        selectedAudioTrack,
+        selectedSubtitleTrack,
+        startPositionMs,
+        playbackSessionId);
+    if (!descriptor.isValid()) {
+        NetworkError error;
+        error.code = -2;
+        error.endpoint = QStringLiteral("createPlaybackDescriptor");
+        error.userMessage = tr("The playback provider returned an invalid stream request.");
+        emitError(error);
+    }
+    return descriptor;
 }
 
 // ============================================================================

--- a/src/network/PlaybackService.h
+++ b/src/network/PlaybackService.h
@@ -4,7 +4,8 @@
 #include <QObject>
 #include <QNetworkReply>
 #include <functional>
-#include "Types.h"  // For data structs (PlaybackInfoResponse, MediaSegmentInfo, TrickplayTileInfo, etc.)
+#include "Types.h"
+#include "models/MediaModels.h"  // For data structs (PlaybackInfoResponse, MediaSegmentInfo, TrickplayTileInfo, etc.)
 
 class AuthenticationService;
 class ConfigManager;
@@ -32,6 +33,15 @@ public:
                              ConfigManager *configManager = nullptr,
                              MediaSegmentProviderService *mediaSegmentProviderService = nullptr,
                              QObject *parent = nullptr);
+    ~PlaybackService() override;
+
+    virtual Bloom::PlaybackDescriptor createPlaybackDescriptor(
+        const QString &itemId,
+        const QVariantMap &providerSource,
+        int selectedAudioTrack,
+        int selectedSubtitleTrack,
+        qint64 startPositionMs = 0,
+        const QString &playbackSessionId = QString());
     
     // Playback Info - Get media streams and track information
     Q_INVOKABLE virtual void getPlaybackInfo(const QString &itemId);
@@ -123,6 +133,7 @@ private:
     HttpTransport *m_transport = nullptr;
     ConfigManager *m_configManager = nullptr;
     MediaSegmentProviderService *m_mediaSegmentProviderService = nullptr;
+    const class IPlaybackProvider *m_provider = nullptr;
     RetryPolicy m_retryPolicy;
     
     // Retry mechanism types  

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -24,7 +24,6 @@
 #include <QUuid>
 #include <QtGlobal>
 #include <QUrl>
-#include <QUrlQuery>
 #include <QSet>
 #include <QStringList>
 #include <QThread>
@@ -905,7 +904,16 @@ void PlayerController::enterIdleStateImmediate()
     m_contentFramerate = 0.0;
     m_contentIsHDR = false;
     m_contentShouldToneMapToSdr = false;
-    m_playMethod = QStringLiteral("DirectPlay");
+    m_playMethod = QStringLiteral("directPlay");
+    m_nextPlaybackMethod.clear();
+    m_streamPinsAudioTrack = false;
+    m_streamPinsSubtitleTrack = false;
+    m_nextStreamPinsAudioTrack = false;
+    m_nextStreamPinsSubtitleTrack = false;
+    m_pinnedAudioTrack = -1;
+    m_pinnedSubtitleTrack = -1;
+    m_nextPinnedAudioTrack = -1;
+    m_nextPinnedSubtitleTrack = -1;
     clearOverlayMetadata();
     clearPlaybackChapters();
     setBufferingProgress(0);
@@ -998,29 +1006,23 @@ void PlayerController::onEnterBufferingState()
     
     // Apply pending track selections now that the file is loaded
     // Use mpv track numbers (1-based, per-type) for mpv commands
-    QUrl pendingPlaybackUrl(m_pendingUrl);
-    QUrlQuery pendingPlaybackQuery(pendingPlaybackUrl);
-    const bool urlPinsAudioStream = pendingPlaybackQuery.hasQueryItem(QStringLiteral("AudioStreamIndex"));
-    const bool urlPinsSubtitleStream = pendingPlaybackQuery.hasQueryItem(QStringLiteral("SubtitleStreamIndex"));
-    const int pinnedAudioStreamIndex = pendingPlaybackQuery.queryItemValue(QStringLiteral("AudioStreamIndex")).toInt();
-    const int pinnedSubtitleStreamIndex = pendingPlaybackQuery.queryItemValue(QStringLiteral("SubtitleStreamIndex")).toInt();
-
-    const int desiredMpvAudioTrack = mpvAudioTrackForJellyfinIndex(m_selectedAudioTrack);
-    const int desiredMpvSubtitleTrack = mpvSubtitleTrackForJellyfinIndex(m_selectedSubtitleTrack);
-    const bool shouldOverridePinnedAudio = urlPinsAudioStream
+    const int desiredMpvAudioTrack = mpvAudioTrackForSourceIndex(m_selectedAudioTrack);
+    const int desiredMpvSubtitleTrack = mpvSubtitleTrackForSourceIndex(m_selectedSubtitleTrack);
+    const bool shouldOverridePinnedAudio = m_streamPinsAudioTrack
         && m_selectedAudioTrack >= 0
-        && m_selectedAudioTrack != pinnedAudioStreamIndex;
-    const bool shouldOverridePinnedSubtitle = urlPinsSubtitleStream
+        && m_selectedAudioTrack != m_pinnedAudioTrack;
+    const bool shouldOverridePinnedSubtitle = m_streamPinsSubtitleTrack
         && ((m_selectedSubtitleTrack == -1)
-            || (m_selectedSubtitleTrack >= 0 && m_selectedSubtitleTrack != pinnedSubtitleStreamIndex));
+            || (m_selectedSubtitleTrack >= 0
+                && m_selectedSubtitleTrack != m_pinnedSubtitleTrack));
 
     qCDebug(lcPlayback) << "Track startup selection:"
                         << "selectedAudio=" << m_selectedAudioTrack
                         << "selectedSubtitle=" << m_selectedSubtitleTrack
                         << "desiredMpvAudio=" << desiredMpvAudioTrack
                         << "desiredMpvSubtitle=" << desiredMpvSubtitleTrack
-                        << "urlPinsAudio=" << urlPinsAudioStream
-                        << "urlPinsSubtitle=" << urlPinsSubtitleStream
+                        << "streamPinsAudio=" << m_streamPinsAudioTrack
+                        << "streamPinsSubtitle=" << m_streamPinsSubtitleTrack
                         << "overridePinnedAudio=" << shouldOverridePinnedAudio
                         << "overridePinnedSubtitle=" << shouldOverridePinnedSubtitle;
 
@@ -1029,8 +1031,8 @@ void PlayerController::onEnterBufferingState()
     if (desiredMpvAudioTrack > 0) {
         qCDebug(lcPlayback) << "Applying startup audio track selection via aid:" << desiredMpvAudioTrack;
         m_playerBackend->sendVariantCommand({"set_property", "aid", desiredMpvAudioTrack});
-    } else if (urlPinsAudioStream && !shouldOverridePinnedAudio) {
-        qCDebug(lcPlayback) << "Keeping URL-pinned audio stream index:" << pinnedAudioStreamIndex;
+    } else if (m_streamPinsAudioTrack && !shouldOverridePinnedAudio) {
+        qCDebug(lcPlayback) << "Keeping provider-pinned audio track:" << m_pinnedAudioTrack;
     }
 
     if (m_selectedSubtitleTrack == -1) {
@@ -1039,8 +1041,8 @@ void PlayerController::onEnterBufferingState()
     } else if (desiredMpvSubtitleTrack > 0) {
         qCDebug(lcPlayback) << "Applying startup subtitle track selection via sid:" << desiredMpvSubtitleTrack;
         m_playerBackend->sendVariantCommand({"set_property", "sid", desiredMpvSubtitleTrack});
-    } else if (urlPinsSubtitleStream && !shouldOverridePinnedSubtitle) {
-        qCDebug(lcPlayback) << "Keeping URL-pinned subtitle stream index:" << pinnedSubtitleStreamIndex;
+    } else if (m_streamPinsSubtitleTrack && !shouldOverridePinnedSubtitle) {
+        qCDebug(lcPlayback) << "Keeping provider-pinned subtitle track:" << m_pinnedSubtitleTrack;
     }
     
     // If there was a pending seek for resume playback, execute it directly
@@ -2052,10 +2054,32 @@ void PlayerController::onPlaybackInfoLoaded(const QString &itemId, const Playbac
     const QString mediaSourceId = mediaSource.value(QStringLiteral("id")).toString();
     const QVariantList availableAudioTracks = buildAvailableTrackOptions(mediaSource, QStringLiteral("Audio"));
     const QVariantList availableSubtitleTracks = buildAvailableTrackOptions(mediaSource, QStringLiteral("Subtitle"));
-    const QString streamUrl = streamUrlForMediaSource(itemId,
-                                                      mediaSource,
-                                                      resolved.audioIndex,
-                                                      resolved.subtitleIndex);
+    const Bloom::PlaybackDescriptor descriptor = m_playbackService->createPlaybackDescriptor(
+        itemId,
+        mediaSource,
+        resolved.audioIndex,
+        resolved.subtitleIndex,
+        0,
+        playbackInfo.playSessionId);
+    QString streamUrl;
+    if (!descriptor.stream.isValid()) {
+        qCWarning(lcPlayback) << "Autoplay provider returned an invalid playback descriptor;"
+                                 " using the compatibility stream façade"
+                              << "itemId=" << itemId;
+        streamUrl = m_libraryService->getStreamUrl(itemId);
+        m_nextPlaybackMethod = QStringLiteral("DirectPlay");
+        m_nextStreamPinsAudioTrack = false;
+        m_nextStreamPinsSubtitleTrack = false;
+        m_nextPinnedAudioTrack = -1;
+        m_nextPinnedSubtitleTrack = -1;
+    } else {
+        streamUrl = descriptor.stream.url.toString();
+        m_nextPlaybackMethod = Bloom::playbackMethodName(descriptor.stream.method);
+        m_nextStreamPinsAudioTrack = descriptor.stream.pinsAudioTrack;
+        m_nextStreamPinsSubtitleTrack = descriptor.stream.pinsSubtitleTrack;
+        m_nextPinnedAudioTrack = descriptor.stream.pinnedAudioTrackId.toInt();
+        m_nextPinnedSubtitleTrack = descriptor.stream.pinnedSubtitleTrackId.toInt();
+    }
     const QString seriesId = m_pendingAutoplaySeriesId;
     const QString libraryId = m_pendingAutoplayLibraryId;
 
@@ -2401,6 +2425,24 @@ void PlayerController::launchResolvedPlaybackRequest(const QString &requestId)
                        request.overlayLogoUrl);
 
     const QVariantMap firstSegment = segments.first().toMap();
+    m_nextPlaybackMethod = firstSegment.value(QStringLiteral("playMethod")).toString();
+    m_nextStreamPinsAudioTrack = firstSegment.value(
+        QStringLiteral("pinsAudioTrack")).toBool();
+    m_nextStreamPinsSubtitleTrack = firstSegment.value(
+        QStringLiteral("pinsSubtitleTrack")).toBool();
+    m_nextPinnedAudioTrack = firstSegment.value(
+        QStringLiteral("pinnedAudioTrack"), -1).toInt();
+    m_nextPinnedSubtitleTrack = firstSegment.value(
+        QStringLiteral("pinnedSubtitleTrack"), -1).toInt();
+    m_nextPlaybackSegments = segments;
+    m_nextPlaylistAppendUrls.clear();
+    for (int index = 1; index < segments.size(); ++index) {
+        const QString segmentUrl = segments.at(index).toMap()
+                                       .value(QStringLiteral("url")).toString();
+        if (!segmentUrl.isEmpty()) {
+            m_nextPlaylistAppendUrls.append(segmentUrl);
+        }
+    }
     playUrlWithTracks(firstSegment.value(QStringLiteral("url")).toString(),
                       request.itemId,
                       request.startPositionTicks,
@@ -2417,30 +2459,6 @@ void PlayerController::launchResolvedPlaybackRequest(const QString &requestId)
                       firstSegment.value(QStringLiteral("framerate")).toDouble(),
                       firstSegment.value(QStringLiteral("isHDR")).toBool(),
                       firstSegment.value(QStringLiteral("toneMapToSdr")).toBool());
-
-    clearPlaybackSegments();
-    for (const QVariant &segment : segments) {
-        const QVariantMap segmentMap = segment.toMap();
-        m_playbackSegments.append(segmentMap);
-        m_aggregatePlaybackDuration += static_cast<double>(segmentMap.value(QStringLiteral("runTimeTicks")).toLongLong()) / 10000000.0;
-    }
-    if (m_aggregatePlaybackDuration > 0.0) {
-        m_duration = m_aggregatePlaybackDuration;
-        emit timelineChanged();
-    }
-    applyPlaybackSegment(0, false);
-
-    m_pendingPlaylistAppendUrls.clear();
-    for (int index = 1; index < segments.size(); ++index) {
-        const QString url = segments.at(index).toMap().value(QStringLiteral("url")).toString();
-        if (!url.isEmpty()) {
-            m_pendingPlaylistAppendUrls.append(url);
-        }
-    }
-    if (!m_pendingPlaylistAppendUrls.isEmpty() && m_playerBackend->isRunning()) {
-        m_playerBackend->appendUrlsToPlaylist(m_pendingPlaylistAppendUrls);
-        m_pendingPlaylistAppendUrls.clear();
-    }
 
     m_pendingPlaybackRequests.remove(requestId);
 }
@@ -2575,7 +2593,7 @@ QVariantMap PlayerController::resolveSegmentPlaybackContext(const QString &scope
 
 QVariantList PlayerController::buildMultipartSegments(const QVariantMap &request,
                                                       const QVariantMap &primarySource,
-                                                      const PlaybackInfoResponse &primaryPlaybackInfo) const
+                                                      const PlaybackInfoResponse &primaryPlaybackInfo)
 {
     QVariantList segments;
     const QString itemId = request.value(QStringLiteral("itemId")).toString();
@@ -2600,11 +2618,29 @@ QVariantList PlayerController::buildMultipartSegments(const QVariantMap &request
 
     QVariantMap primarySegment = primaryContext;
     primarySegment[QStringLiteral("itemId")] = itemId;
-    primarySegment[QStringLiteral("url")] = streamUrlForMediaSource(
+    const Bloom::PlaybackDescriptor primaryDescriptor = m_playbackService->createPlaybackDescriptor(
         itemId,
         primaryContext.value(QStringLiteral("mediaSource")).toMap(),
         primaryContext.value(QStringLiteral("audioIndex"), -1).toInt(),
-        primaryContext.value(QStringLiteral("subtitleIndex"), -1).toInt());
+        primaryContext.value(QStringLiteral("subtitleIndex"), -1).toInt(),
+        0,
+        primaryContext.value(QStringLiteral("playSessionId")).toString());
+    if (!primaryDescriptor.stream.isValid()) {
+        qCWarning(lcPlayback) << "Primary provider returned an invalid playback descriptor"
+                              << "itemId=" << itemId;
+        return {};
+    }
+    primarySegment[QStringLiteral("url")] = primaryDescriptor.stream.url.toString();
+    primarySegment[QStringLiteral("playMethod")] = Bloom::playbackMethodName(
+        primaryDescriptor.stream.method);
+    primarySegment[QStringLiteral("pinsAudioTrack")] =
+        primaryDescriptor.stream.pinsAudioTrack;
+    primarySegment[QStringLiteral("pinsSubtitleTrack")] =
+        primaryDescriptor.stream.pinsSubtitleTrack;
+    primarySegment[QStringLiteral("pinnedAudioTrack")] =
+        primaryDescriptor.stream.pinnedAudioTrackId.toInt();
+    primarySegment[QStringLiteral("pinnedSubtitleTrack")] =
+        primaryDescriptor.stream.pinnedSubtitleTrackId.toInt();
     segments.append(primarySegment);
 
     for (const PendingPlaybackRequest &pendingRequest : m_pendingPlaybackRequests) {
@@ -2638,11 +2674,29 @@ QVariantList PlayerController::buildMultipartSegments(const QVariantMap &request
 
             QVariantMap segment = partContext;
             segment[QStringLiteral("itemId")] = partId;
-            segment[QStringLiteral("url")] = streamUrlForMediaSource(
+            const Bloom::PlaybackDescriptor partDescriptor = m_playbackService->createPlaybackDescriptor(
                 partId,
                 partContext.value(QStringLiteral("mediaSource")).toMap(),
                 partContext.value(QStringLiteral("audioIndex"), -1).toInt(),
-                partContext.value(QStringLiteral("subtitleIndex"), -1).toInt());
+                partContext.value(QStringLiteral("subtitleIndex"), -1).toInt(),
+                0,
+                partContext.value(QStringLiteral("playSessionId")).toString());
+            if (!partDescriptor.stream.isValid()) {
+                qCWarning(lcPlayback) << "Skipping multipart item with invalid playback descriptor"
+                                      << "itemId=" << partId;
+                continue;
+            }
+            segment[QStringLiteral("url")] = partDescriptor.stream.url.toString();
+            segment[QStringLiteral("playMethod")] = Bloom::playbackMethodName(
+                partDescriptor.stream.method);
+            segment[QStringLiteral("pinsAudioTrack")] =
+                partDescriptor.stream.pinsAudioTrack;
+            segment[QStringLiteral("pinsSubtitleTrack")] =
+                partDescriptor.stream.pinsSubtitleTrack;
+            segment[QStringLiteral("pinnedAudioTrack")] =
+                partDescriptor.stream.pinnedAudioTrackId.toInt();
+            segment[QStringLiteral("pinnedSubtitleTrack")] =
+                partDescriptor.stream.pinnedSubtitleTrackId.toInt();
             segments.append(segment);
         }
         break;
@@ -2694,14 +2748,22 @@ void PlayerController::applyPlaybackSegment(int index, bool reportSegmentStart)
     const QVariantMap segment = m_playbackSegments.at(index);
     m_mediaSourceId = segment.value(QStringLiteral("mediaSourceId")).toString();
     m_playSessionId = segment.value(QStringLiteral("playSessionId")).toString();
+    const QString segmentPlayMethod = segment.value(QStringLiteral("playMethod")).toString();
+    if (!segmentPlayMethod.isEmpty()) {
+        m_playMethod = segmentPlayMethod;
+    }
+    m_streamPinsAudioTrack = segment.value(QStringLiteral("pinsAudioTrack")).toBool();
+    m_streamPinsSubtitleTrack = segment.value(QStringLiteral("pinsSubtitleTrack")).toBool();
+    m_pinnedAudioTrack = segment.value(QStringLiteral("pinnedAudioTrack"), -1).toInt();
+    m_pinnedSubtitleTrack = segment.value(QStringLiteral("pinnedSubtitleTrack"), -1).toInt();
     m_activeMediaSource = segment.value(QStringLiteral("mediaSource")).toMap();
     m_availableAudioTracks = segment.value(QStringLiteral("availableAudioTracks")).toList();
     m_availableSubtitleTracks = segment.value(QStringLiteral("availableSubtitleTracks")).toList();
     m_selectedAudioTrack = segment.value(QStringLiteral("audioIndex"), -1).toInt();
     m_selectedSubtitleTrack = segment.value(QStringLiteral("subtitleIndex"), -1).toInt();
     updateTrackMappings(m_activeMediaSource);
-    m_mpvAudioTrack = mpvAudioTrackForJellyfinIndex(m_selectedAudioTrack);
-    m_mpvSubtitleTrack = m_selectedSubtitleTrack >= 0 ? mpvSubtitleTrackForJellyfinIndex(m_selectedSubtitleTrack) : -1;
+    m_mpvAudioTrack = mpvAudioTrackForSourceIndex(m_selectedAudioTrack);
+    m_mpvSubtitleTrack = m_selectedSubtitleTrack >= 0 ? mpvSubtitleTrackForSourceIndex(m_selectedSubtitleTrack) : -1;
 
     emit mediaSourceIdChanged();
     emit playSessionIdChanged();
@@ -3097,7 +3159,7 @@ void PlayerController::playTestVideo()
         m_seekTargetWhileBuffering = -1;
         m_reportProgressOnNextPositionUpdate = false;
         m_startPositionTicks = 0;
-        m_playMethod = inferPlayMethod(m_testVideoUrl);
+        m_playMethod = QStringLiteral("directPlay");
         m_hasReportedStopForAttempt = false;
         m_hasEvaluatedCompletionForAttempt = false;
         cancelPendingDisplayRestore(true);
@@ -3172,6 +3234,7 @@ void PlayerController::playTestVideo()
 void PlayerController::playUrl(const QString &url, const QString &itemId, qint64 startPositionTicks, const QString &seriesId, const QString &seasonId, const QString &libraryId, double framerate, bool isHDR, bool toneMapToSdr)
 {
     m_playbackAttemptId = ++gPlaybackAttemptCounter;
+    const quint64 requestedPlaybackAttemptId = m_playbackAttemptId;
     m_reportProgressOnNextPositionUpdate = false;
     qCDebug(lcPlayback) << "PlayerController: playUrl called with itemId:" << itemId 
              << "startPositionTicks:" << startPositionTicks
@@ -3196,7 +3259,29 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
     clearPendingAutoplayContext();
     clearNextEpisodePrefetchState();
 
-    scheduleReplacementPlayback([this, url, itemId, startPositionTicks, seriesId, seasonId, libraryId, framerate, isHDR, toneMapToSdr]() {
+    const QString requestedPlayMethod = m_nextPlaybackMethod.isEmpty()
+        ? QStringLiteral("directPlay")
+        : m_nextPlaybackMethod;
+    const bool requestedPinsAudioTrack = m_nextStreamPinsAudioTrack;
+    const bool requestedPinsSubtitleTrack = m_nextStreamPinsSubtitleTrack;
+    const int requestedPinnedAudioTrack = m_nextPinnedAudioTrack;
+    const int requestedPinnedSubtitleTrack = m_nextPinnedSubtitleTrack;
+    const QVariantList requestedPlaybackSegments = m_nextPlaybackSegments;
+    const QStringList requestedPlaylistAppendUrls = m_nextPlaylistAppendUrls;
+    m_nextPlaybackMethod.clear();
+    m_nextStreamPinsAudioTrack = false;
+    m_nextStreamPinsSubtitleTrack = false;
+    m_nextPinnedAudioTrack = -1;
+    m_nextPinnedSubtitleTrack = -1;
+    m_nextPlaybackSegments.clear();
+    m_nextPlaylistAppendUrls.clear();
+
+    scheduleReplacementPlayback([this, url, itemId, startPositionTicks, seriesId, seasonId,
+                                 libraryId, framerate, isHDR, toneMapToSdr,
+                                 requestedPlayMethod, requestedPinsAudioTrack,
+                                 requestedPinsSubtitleTrack, requestedPinnedAudioTrack,
+                                 requestedPinnedSubtitleTrack, requestedPlaybackAttemptId,
+                                 requestedPlaybackSegments, requestedPlaylistAppendUrls]() {
         // Store pending playback info after the previous item has fully stopped.
         if (m_currentItemId != itemId) {
             m_currentItemId = itemId;
@@ -3221,11 +3306,39 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
         m_mpvDisplayFpsOverride = 0.0;
         m_contentIsHDR = isHDR;
         m_contentShouldToneMapToSdr = toneMapToSdr;
-        m_playMethod = inferPlayMethod(url);
+        m_playMethod = requestedPlayMethod;
+        m_streamPinsAudioTrack = requestedPinsAudioTrack;
+        m_streamPinsSubtitleTrack = requestedPinsSubtitleTrack;
+        m_pinnedAudioTrack = requestedPinnedAudioTrack;
+        m_pinnedSubtitleTrack = requestedPinnedSubtitleTrack;
         m_hasReportedStopForAttempt = false;
         m_hasEvaluatedCompletionForAttempt = false;
         cancelPendingDisplayRestore(true);
         clearPlaybackSegments();
+        for (const QVariant &segment : requestedPlaybackSegments) {
+            QVariantMap segmentMap = segment.toMap();
+            segmentMap[QStringLiteral("playbackAttemptId")] =
+                QVariant::fromValue(requestedPlaybackAttemptId);
+            m_playbackSegments.append(segmentMap);
+            m_aggregatePlaybackDuration += static_cast<double>(
+                segmentMap.value(QStringLiteral("runTimeTicks")).toLongLong()) / 10000000.0;
+        }
+        if (!m_playbackSegments.isEmpty()) {
+            if (m_aggregatePlaybackDuration > 0.0) {
+                m_duration = m_aggregatePlaybackDuration;
+                emit timelineChanged();
+            }
+            applyPlaybackSegment(0, false);
+            updateVersionAffinityFromMediaSource(m_activeMediaSource);
+            qCDebug(lcPlayback) << "Track mapping contract initialized:"
+                                << "audioMapEntries=" << m_audioTrackMap.size()
+                                << "subtitleMapEntries=" << m_subtitleTrackMap.size()
+                                << "selectedAudio=" << m_selectedAudioTrack
+                                << "selectedSubtitle=" << m_selectedSubtitleTrack
+                                << "selectedMpvAudio=" << m_mpvAudioTrack
+                                << "selectedMpvSubtitle=" << m_mpvSubtitleTrack;
+        }
+        m_pendingPlaylistAppendUrls = requestedPlaylistAppendUrls;
 
         // Clear previous OSC/trickplay state and request new data
         m_currentSegments.clear();
@@ -3535,12 +3648,12 @@ void PlayerController::setSelectedAudioTrack(int index)
     const int previousAudioTrack = m_selectedAudioTrack;
     m_selectedAudioTrack = index;
     qCDebug(lcPlayback) << "User audio track selection:"
-                        << "jellyfinIndex=" << index
+                        << "sourceIndex=" << index
                         << "previousJellyfinIndex=" << previousAudioTrack;
 
     if (m_playbackState == Playing || m_playbackState == Paused) {
         if (index >= 0) {
-            const int mpvTrackId = mpvAudioTrackForJellyfinIndex(index);
+            const int mpvTrackId = mpvAudioTrackForSourceIndex(index);
             if (mpvTrackId > 0) {
                 m_mpvAudioTrack = mpvTrackId;
                 qCDebug(lcPlayback) << "Applying audio track switch via aid:" << mpvTrackId;
@@ -3611,12 +3724,12 @@ void PlayerController::setSelectedSubtitleTrack(int index)
     const int previousSubtitleTrack = m_selectedSubtitleTrack;
     m_selectedSubtitleTrack = index;
     qCDebug(lcPlayback) << "User subtitle track selection:"
-                        << "jellyfinIndex=" << index
+                        << "sourceIndex=" << index
                         << "previousJellyfinIndex=" << previousSubtitleTrack;
 
     if (m_playbackState == Playing || m_playbackState == Paused) {
         if (index >= 0 || m_externalSubtitleTrackMap.contains(index)) {
-            const int mpvTrackId = m_externalSubtitleTrackMap.value(index, mpvSubtitleTrackForJellyfinIndex(index));
+            const int mpvTrackId = m_externalSubtitleTrackMap.value(index, mpvSubtitleTrackForSourceIndex(index));
             if (mpvTrackId > 0) {
                 m_mpvSubtitleTrack = mpvTrackId;
                 qCDebug(lcPlayback) << "Applying subtitle track switch via sid:" << mpvTrackId;
@@ -3649,7 +3762,7 @@ void PlayerController::setSelectedSubtitleTrack(int index)
 void PlayerController::addExternalSubtitleTrack(const QString &subtitleUrl,
                                                 const QString &displayTitle,
                                                 const QString &language,
-                                                int jellyfinStreamIndexHint)
+                                                int sourceStreamIndexHint)
 {
     const QString normalizedSubtitleUrl = subtitleUrl.trimmed();
     if (normalizedSubtitleUrl.isEmpty()) {
@@ -3663,8 +3776,8 @@ void PlayerController::addExternalSubtitleTrack(const QString &subtitleUrl,
     }
 
     int syntheticIndex = -1000 - m_externalSubtitleTrackMap.size();
-    if (jellyfinStreamIndexHint >= 0) {
-        syntheticIndex = jellyfinStreamIndexHint;
+    if (sourceStreamIndexHint >= 0) {
+        syntheticIndex = sourceStreamIndexHint;
     }
     const bool trackIndexAlreadyPresent = std::any_of(m_availableSubtitleTracks.cbegin(),
                                                       m_availableSubtitleTracks.cend(),
@@ -4074,53 +4187,38 @@ void PlayerController::playUrlWithTracks(const QString &url, const QString &item
     const QVariantList resolvedAvailableSubtitleTracks = availableSubtitleTracks.isEmpty()
         ? buildAvailableTrackOptions(mediaSource, QStringLiteral("Subtitle"))
         : availableSubtitleTracks;
+    const QString requestedPlayMethod = m_nextPlaybackMethod.isEmpty()
+        ? QStringLiteral("directPlay")
+        : m_nextPlaybackMethod;
+    const bool requestedPinsAudioTrack = m_nextStreamPinsAudioTrack;
+    const bool requestedPinsSubtitleTrack = m_nextStreamPinsSubtitleTrack;
+    const int requestedPinnedAudioTrack = m_nextPinnedAudioTrack;
+    const int requestedPinnedSubtitleTrack = m_nextPinnedSubtitleTrack;
 
-    playUrl(url, itemId, startPositionTicks, seriesId, seasonId, libraryId, framerate, isHDR, toneMapToSdr);
+    if (m_nextPlaybackSegments.isEmpty()) {
+        m_nextPlaybackSegments = {
+            QVariantMap{
+                {QStringLiteral("itemId"), itemId},
+                {QStringLiteral("mediaSourceId"), mediaSourceId},
+                {QStringLiteral("playSessionId"), playSessionId},
+                {QStringLiteral("mediaSource"), mediaSource},
+                {QStringLiteral("audioIndex"), audioStreamIndex},
+                {QStringLiteral("subtitleIndex"), subtitleStreamIndex},
+                {QStringLiteral("availableAudioTracks"), resolvedAvailableAudioTracks},
+                {QStringLiteral("availableSubtitleTracks"), resolvedAvailableSubtitleTracks},
+                {QStringLiteral("runTimeTicks"), mediaSource.value(QStringLiteral("runTimeTicks")).toLongLong()},
+                {QStringLiteral("playMethod"), requestedPlayMethod},
+                {QStringLiteral("pinsAudioTrack"), requestedPinsAudioTrack},
+                {QStringLiteral("pinsSubtitleTrack"), requestedPinsSubtitleTrack},
+                {QStringLiteral("pinnedAudioTrack"), requestedPinnedAudioTrack},
+                {QStringLiteral("pinnedSubtitleTrack"), requestedPinnedSubtitleTrack},
+                {QStringLiteral("url"), url}
+            }
+        };
+    }
 
-    m_mediaSourceId = mediaSourceId;
-    m_playSessionId = playSessionId;
-    m_activeMediaSource = mediaSource;
-    updateTrackMappings(mediaSource);
-
-    m_selectedAudioTrack = audioStreamIndex;
-    m_selectedSubtitleTrack = subtitleStreamIndex;
-    m_mpvAudioTrack = mpvAudioTrackForJellyfinIndex(audioStreamIndex);
-    m_mpvSubtitleTrack = subtitleStreamIndex >= 0 ? mpvSubtitleTrackForJellyfinIndex(subtitleStreamIndex) : -1;
-    m_availableAudioTracks = resolvedAvailableAudioTracks;
-    m_availableSubtitleTracks = resolvedAvailableSubtitleTracks;
-    m_playbackSegments = {
-        QVariantMap{
-            {QStringLiteral("itemId"), itemId},
-            {QStringLiteral("mediaSourceId"), mediaSourceId},
-            {QStringLiteral("playSessionId"), playSessionId},
-            {QStringLiteral("mediaSource"), mediaSource},
-            {QStringLiteral("audioIndex"), audioStreamIndex},
-            {QStringLiteral("subtitleIndex"), subtitleStreamIndex},
-            {QStringLiteral("availableAudioTracks"), resolvedAvailableAudioTracks},
-            {QStringLiteral("availableSubtitleTracks"), resolvedAvailableSubtitleTracks},
-            {QStringLiteral("runTimeTicks"), mediaSource.value(QStringLiteral("runTimeTicks")).toLongLong()},
-            {QStringLiteral("url"), url}
-        }
-    };
-    m_activePlaybackSegmentIndex = 0;
-    m_activePlaybackSegmentOffsetTicks = 0;
-    m_segmentRelativePosition = 0.0;
-    m_aggregatePlaybackDuration = static_cast<double>(mediaSource.value(QStringLiteral("runTimeTicks")).toLongLong()) / 10000000.0;
-    updateVersionAffinityFromMediaSource(mediaSource);
-
-    qCDebug(lcPlayback) << "Track mapping contract initialized:"
-                        << "audioMapEntries=" << m_audioTrackMap.size()
-                        << "subtitleMapEntries=" << m_subtitleTrackMap.size()
-                        << "selectedAudio=" << m_selectedAudioTrack
-                        << "selectedSubtitle=" << m_selectedSubtitleTrack
-                        << "selectedMpvAudio=" << m_mpvAudioTrack
-                        << "selectedMpvSubtitle=" << m_mpvSubtitleTrack;
-
-    emit mediaSourceIdChanged();
-    emit playSessionIdChanged();
-    emit selectedAudioTrackChanged();
-    emit selectedSubtitleTrackChanged();
-    emit availableTracksChanged();
+    playUrl(url, itemId, startPositionTicks, seriesId, seasonId, libraryId,
+            framerate, isHDR, toneMapToSdr);
 }
 
 void PlayerController::updateTrackMappings(const QVariantMap &mediaSource)
@@ -4135,39 +4233,39 @@ void PlayerController::updateTrackMappings(const QVariantMap &mediaSource)
     for (const QVariant &streamVariant : mediaStreams(mediaSource)) {
         const QVariantMap stream = streamVariant.toMap();
         const QString type = stream.value(QStringLiteral("type")).toString();
-        const int jellyfinIndex = stream.value(QStringLiteral("index"), -1).toInt();
-        if (jellyfinIndex < 0) {
+        const int sourceIndex = stream.value(QStringLiteral("index"), -1).toInt();
+        if (sourceIndex < 0) {
             continue;
         }
 
         if (type == QStringLiteral("Audio")) {
-            m_audioTrackMap.insert(jellyfinIndex, audioTrackId);
-            m_audioTrackReverseMap.insert(audioTrackId, jellyfinIndex);
+            m_audioTrackMap.insert(sourceIndex, audioTrackId);
+            m_audioTrackReverseMap.insert(audioTrackId, sourceIndex);
             ++audioTrackId;
         } else if (type == QStringLiteral("Subtitle")) {
-            m_subtitleTrackMap.insert(jellyfinIndex, subtitleTrackId);
-            m_subtitleTrackReverseMap.insert(subtitleTrackId, jellyfinIndex);
+            m_subtitleTrackMap.insert(sourceIndex, subtitleTrackId);
+            m_subtitleTrackReverseMap.insert(subtitleTrackId, sourceIndex);
             ++subtitleTrackId;
         }
     }
 }
 
-int PlayerController::mpvAudioTrackForJellyfinIndex(int jellyfinStreamIndex) const
+int PlayerController::mpvAudioTrackForSourceIndex(int sourceStreamIndex) const
 {
-    return jellyfinStreamIndex < 0 ? -1 : m_audioTrackMap.value(jellyfinStreamIndex, -1);
+    return sourceStreamIndex < 0 ? -1 : m_audioTrackMap.value(sourceStreamIndex, -1);
 }
 
-int PlayerController::jellyfinAudioTrackForMpvTrack(int mpvTrackId) const
+int PlayerController::sourceAudioTrackForMpvTrack(int mpvTrackId) const
 {
     return mpvTrackId < 0 ? -1 : m_audioTrackReverseMap.value(mpvTrackId, -1);
 }
 
-int PlayerController::mpvSubtitleTrackForJellyfinIndex(int jellyfinStreamIndex) const
+int PlayerController::mpvSubtitleTrackForSourceIndex(int sourceStreamIndex) const
 {
-    return jellyfinStreamIndex < 0 ? -1 : m_subtitleTrackMap.value(jellyfinStreamIndex, -1);
+    return sourceStreamIndex < 0 ? -1 : m_subtitleTrackMap.value(sourceStreamIndex, -1);
 }
 
-int PlayerController::jellyfinSubtitleTrackForMpvTrack(int mpvTrackId) const
+int PlayerController::sourceSubtitleTrackForMpvTrack(int mpvTrackId) const
 {
     return mpvTrackId < 0 ? -1 : m_subtitleTrackReverseMap.value(mpvTrackId, -1);
 }
@@ -4351,21 +4449,21 @@ void PlayerController::syncBackendAudioTrack(int mpvTrackId)
     }
 
     m_mpvAudioTrack = mpvTrackId;
-    const int jellyfinIndex = jellyfinAudioTrackForMpvTrack(mpvTrackId);
-    if (jellyfinIndex < 0) {
+    const int sourceIndex = sourceAudioTrackForMpvTrack(mpvTrackId);
+    if (sourceIndex < 0) {
         m_pendingAudioTrackPersistenceFromBackend = false;
         return;
     }
 
-    if (m_selectedAudioTrack != jellyfinIndex) {
-        m_selectedAudioTrack = jellyfinIndex;
+    if (m_selectedAudioTrack != sourceIndex) {
+        m_selectedAudioTrack = sourceIndex;
         if (m_activePlaybackSegmentIndex >= 0 && m_activePlaybackSegmentIndex < m_playbackSegments.size()) {
-            m_playbackSegments[m_activePlaybackSegmentIndex][QStringLiteral("audioIndex")] = jellyfinIndex;
+            m_playbackSegments[m_activePlaybackSegmentIndex][QStringLiteral("audioIndex")] = sourceIndex;
         }
         emit selectedAudioTrackChanged();
     }
     if (m_pendingAudioTrackPersistenceFromBackend) {
-        persistAudioPreferenceForCurrentScope(jellyfinIndex);
+        persistAudioPreferenceForCurrentScope(sourceIndex);
     }
     m_pendingAudioTrackPersistenceFromBackend = false;
 }
@@ -4415,21 +4513,21 @@ void PlayerController::syncBackendSubtitleTrack(int mpvTrackId)
             return;
         }
     }
-    const int jellyfinIndex = mpvTrackId < 0 ? -1 : jellyfinSubtitleTrackForMpvTrack(mpvTrackId);
-    if (mpvTrackId >= 0 && jellyfinIndex < 0) {
+    const int sourceIndex = mpvTrackId < 0 ? -1 : sourceSubtitleTrackForMpvTrack(mpvTrackId);
+    if (mpvTrackId >= 0 && sourceIndex < 0) {
         m_pendingSubtitleTrackPersistenceFromBackend = false;
         return;
     }
 
-    if (m_selectedSubtitleTrack != jellyfinIndex) {
-        m_selectedSubtitleTrack = jellyfinIndex;
+    if (m_selectedSubtitleTrack != sourceIndex) {
+        m_selectedSubtitleTrack = sourceIndex;
         if (m_activePlaybackSegmentIndex >= 0 && m_activePlaybackSegmentIndex < m_playbackSegments.size()) {
-            m_playbackSegments[m_activePlaybackSegmentIndex][QStringLiteral("subtitleIndex")] = jellyfinIndex;
+            m_playbackSegments[m_activePlaybackSegmentIndex][QStringLiteral("subtitleIndex")] = sourceIndex;
         }
         emit selectedSubtitleTrackChanged();
     }
     if (m_pendingSubtitleTrackPersistenceFromBackend) {
-        persistSubtitlePreferenceForCurrentScope(jellyfinIndex);
+        persistSubtitlePreferenceForCurrentScope(sourceIndex);
     }
     m_pendingSubtitleTrackPersistenceFromBackend = false;
 }
@@ -5194,14 +5292,15 @@ void PlayerController::setAwaitingNextEpisodeResolution(bool awaiting)
  */
 void PlayerController::startPlayback(const QString &url)
 {
-    qCDebug(lcPlayback) << "PlayerController: Starting playback of" << url;
+    const QString redactedUrl = QUrl(url).toString(QUrl::RemoveQuery | QUrl::RemoveUserInfo);
+    qCDebug(lcPlayback) << "PlayerController: Starting playback of" << redactedUrl;
     qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                             << "] start-playback"
                             << "contentIsHDR=" << m_contentIsHDR
                             << "toneMapToSdr=" << m_contentShouldToneMapToSdr
                             << "hdrOutputMode=" << m_config->getHDROutputMode()
                             << "contentFramerate=" << m_contentFramerate
-                            << "url=" << url;
+                            << "url=" << redactedUrl;
     
     // Cancel any pending deferred mpv start from previous playback
     m_startDelayTimer->stop();
@@ -5457,34 +5556,6 @@ QString PlayerController::eventToString(Event event)
     return QStringLiteral("Unknown");
 }
 
-QString PlayerController::inferPlayMethod(const QString &url)
-{
-    const QUrl parsedUrl(url);
-    const QString path = parsedUrl.path(QUrl::FullyDecoded).toLower();
-    const QStringList pathSegments = path.split(QLatin1Char('/'), Qt::SkipEmptyParts);
-
-    if (pathSegments.contains(QStringLiteral("transcode"))
-        || pathSegments.contains(QStringLiteral("hls"))
-        || path.endsWith(QStringLiteral("master.m3u8"))) {
-        return QStringLiteral("Transcode");
-    }
-    if (pathSegments.contains(QStringLiteral("stream"))) {
-        return QStringLiteral("DirectStream");
-    }
-
-    const QUrlQuery query(parsedUrl);
-    const auto queryItems = query.queryItems(QUrl::FullyDecoded);
-    for (const auto &item : queryItems) {
-        if (item.first.compare(QStringLiteral("static"), Qt::CaseInsensitive) == 0
-            && (item.second.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0
-                || item.second == QStringLiteral("1"))) {
-            return QStringLiteral("DirectPlay");
-        }
-    }
-
-    return QStringLiteral("DirectPlay");
-}
-
 bool PlayerController::isRecoverableBackendPlaybackError(const QString &error) const
 {
     const QString normalized = error.toLower();
@@ -5493,48 +5564,6 @@ bool PlayerController::isRecoverableBackendPlaybackError(const QString &error) c
         || normalized.contains(QStringLiteral("http error 5"))
         || normalized.contains(QStringLiteral("i/o error"))
         || normalized.contains(QStringLiteral("io error"));
-}
-
-QString PlayerController::streamUrlForMediaSource(const QString &itemId,
-                                                  const QVariantMap &mediaSource,
-                                                  int audioStreamIndex,
-                                                  int subtitleStreamIndex) const
-{
-    const QString mediaSourceId = mediaSource.value(QStringLiteral("id")).toString();
-    QString selectedUrl = mediaSource.value(QStringLiteral("directStreamUrl")).toString().trimmed();
-    if (selectedUrl.isEmpty()) {
-        selectedUrl = mediaSource.value(QStringLiteral("transcodingUrl")).toString().trimmed();
-    }
-    if (selectedUrl.isEmpty() || m_authService == nullptr) {
-        return m_libraryService->getStreamUrlWithTracks(itemId,
-                                                        mediaSourceId,
-                                                        audioStreamIndex,
-                                                        subtitleStreamIndex);
-    }
-
-    QUrl url(selectedUrl);
-    if (url.isRelative()) {
-        url = QUrl(m_authService->getServerUrl()).resolved(url);
-    }
-
-    QUrlQuery query(url);
-    if (!m_authService->getAccessToken().isEmpty()
-        && !query.hasQueryItem(QStringLiteral("api_key"))
-        && !query.hasQueryItem(QStringLiteral("X-Emby-Token"))) {
-        query.addQueryItem(QStringLiteral("api_key"), m_authService->getAccessToken());
-    }
-    if (!mediaSourceId.isEmpty() && !query.hasQueryItem(QStringLiteral("MediaSourceId"))) {
-        query.addQueryItem(QStringLiteral("MediaSourceId"), mediaSourceId);
-    }
-    if (audioStreamIndex >= 0 && !query.hasQueryItem(QStringLiteral("AudioStreamIndex"))) {
-        query.addQueryItem(QStringLiteral("AudioStreamIndex"), QString::number(audioStreamIndex));
-    }
-    if (subtitleStreamIndex >= 0 && !query.hasQueryItem(QStringLiteral("SubtitleStreamIndex"))) {
-        query.addQueryItem(QStringLiteral("SubtitleStreamIndex"), QString::number(subtitleStreamIndex));
-    }
-    url.setQuery(query);
-
-    return url.toString();
 }
 
 void PlayerController::updateSkipSegmentState()

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -287,7 +287,7 @@ public:
     Q_INVOKABLE void addExternalSubtitleTrack(const QString &subtitleUrl,
                                               const QString &displayTitle = QString(),
                                               const QString &language = QString(),
-                                              int jellyfinStreamIndexHint = -1);
+                                              int sourceStreamIndexHint = -1);
     Q_INVOKABLE void cycleAudioTrack();
     Q_INVOKABLE void cycleSubtitleTrack();
     Q_INVOKABLE void previousChapter();
@@ -636,18 +636,18 @@ private:
     void updateTrackMappings(const QVariantMap &mediaSource);
     /**
      * Map a Jellyfin audio stream index to the corresponding mpv audio track number.
-     * @param jellyfinStreamIndex Jellyfin audio stream index.
+     * @param sourceStreamIndex Jellyfin audio stream index.
      * @returns 1-based mpv audio track number, or -1 when auto/none is intended.
      */
-    int mpvAudioTrackForJellyfinIndex(int jellyfinStreamIndex) const;
-    int jellyfinAudioTrackForMpvTrack(int mpvTrackId) const;
+    int mpvAudioTrackForSourceIndex(int sourceStreamIndex) const;
+    int sourceAudioTrackForMpvTrack(int mpvTrackId) const;
     /**
      * Map a Jellyfin subtitle stream index to the corresponding mpv subtitle track number.
-     * @param jellyfinStreamIndex Jellyfin subtitle stream index.
+     * @param sourceStreamIndex Jellyfin subtitle stream index.
      * @returns 1-based mpv subtitle track number, or -1 when subtitles are disabled.
      */
-    int mpvSubtitleTrackForJellyfinIndex(int jellyfinStreamIndex) const;
-    int jellyfinSubtitleTrackForMpvTrack(int mpvTrackId) const;
+    int mpvSubtitleTrackForSourceIndex(int sourceStreamIndex) const;
+    int sourceSubtitleTrackForMpvTrack(int mpvTrackId) const;
     ResolvedTrackSelection resolveTrackSelection(const QVariantMap &mediaSource,
                                                  const ScopedTrackPreferences &preferences,
                                                  int preferredAudioIndex = -2,
@@ -680,12 +680,7 @@ private:
      * @returns A QString representation of `event`.
      */
     static QString eventToString(Event event);
-    static QString inferPlayMethod(const QString &url);
     [[nodiscard]] bool isRecoverableBackendPlaybackError(const QString &error) const;
-    [[nodiscard]] QString streamUrlForMediaSource(const QString &itemId,
-                                                  const QVariantMap &mediaSource,
-                                                  int audioStreamIndex,
-                                                  int subtitleStreamIndex) const;
     void fallbackToPendingAutoplayPlayback();
     [[nodiscard]] int pendingAutoplaySubtitleOverrideIndex() const;
     void stopAutoplayPlaybackInfoWait();
@@ -707,7 +702,7 @@ private:
                                               bool useAffinityFallback) const;
     QVariantList buildMultipartSegments(const QVariantMap &request,
                                         const QVariantMap &primarySource,
-                                        const PlaybackInfoResponse &primaryPlaybackInfo) const;
+                                        const PlaybackInfoResponse &primaryPlaybackInfo);
     QVariantMap activePlaybackSegment() const;
     QString activePlaybackSegmentItemId() const;
     void applyPlaybackSegment(int index, bool reportSegmentStart);
@@ -889,6 +884,8 @@ private:
     QHash<QString, QString> m_seriesLibraryIdCache;
     QSet<QString> m_seriesLibraryResolutionInFlight;
     QList<QVariantMap> m_playbackSegments;
+    QVariantList m_nextPlaybackSegments;
+    QStringList m_nextPlaylistAppendUrls;
     int m_activePlaybackSegmentIndex = -1;
     qint64 m_activePlaybackSegmentOffsetTicks = 0;
     double m_segmentRelativePosition = 0.0;
@@ -934,7 +931,16 @@ private:
     bool m_embeddedVideoShrinkEnabled = false;
     int m_volume = 100;
     bool m_muted = false;
-    QString m_playMethod = QStringLiteral("DirectPlay");
+    QString m_playMethod = QStringLiteral("directPlay");
+    QString m_nextPlaybackMethod;
+    bool m_streamPinsAudioTrack = false;
+    bool m_streamPinsSubtitleTrack = false;
+    bool m_nextStreamPinsAudioTrack = false;
+    bool m_nextStreamPinsSubtitleTrack = false;
+    int m_pinnedAudioTrack = -1;
+    int m_pinnedSubtitleTrack = -1;
+    int m_nextPinnedAudioTrack = -1;
+    int m_nextPinnedSubtitleTrack = -1;
     bool m_attemptedLinuxEmbeddedFallback = false;
     QString m_overlayTitle;
     QString m_overlaySubtitle;

--- a/src/providers/IPlaybackProvider.h
+++ b/src/providers/IPlaybackProvider.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "models/MediaModels.h"
+
+#include <QVariantMap>
+
+struct PlaybackProviderContext
+{
+    QUrl serverUrl;
+    QString accessToken;
+};
+
+/**
+ * @brief Provider boundary that finalizes player-facing playback descriptors.
+ *
+ * The providerSource map is opaque outside the selected provider adapter.
+ */
+class IPlaybackProvider
+{
+public:
+    virtual ~IPlaybackProvider() = default;
+
+    virtual Bloom::PlaybackDescriptor createDescriptor(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QVariantMap &providerSource,
+        int selectedAudioTrack,
+        int selectedSubtitleTrack,
+        qint64 startPositionMs,
+        const QString &playbackSessionId = QString()) const = 0;
+};

--- a/src/providers/IProviderAdapter.h
+++ b/src/providers/IProviderAdapter.h
@@ -2,6 +2,7 @@
 
 #include "providers/ServerConnection.h"
 
+class IPlaybackProvider;
 class IProviderAuthenticator;
 class IProviderRequestFactory;
 
@@ -20,4 +21,5 @@ public:
     virtual ProtocolMode protocolMode() const = 0;
     virtual const IProviderAuthenticator *authenticator() const = 0;
     virtual const IProviderRequestFactory *requestFactory() const = 0;
+    virtual const IPlaybackProvider *playbackProvider() const = 0;
 };

--- a/src/providers/jellyfin/JellyfinPlaybackProvider.cpp
+++ b/src/providers/jellyfin/JellyfinPlaybackProvider.cpp
@@ -1,0 +1,140 @@
+#include "JellyfinPlaybackProvider.h"
+
+#include "providers/jellyfin/JellyfinModelMapper.h"
+
+#include <QUrlQuery>
+
+namespace {
+
+QUrl resolveProviderUrl(const QUrl &serverUrl, const QString &providerUrl)
+{
+    QUrl url(providerUrl);
+    if (!url.isRelative()) {
+        return url;
+    }
+
+    QUrl base = serverUrl;
+    QString basePath = base.path();
+    if (!basePath.endsWith(QLatin1Char('/'))) {
+        basePath += QLatin1Char('/');
+        base.setPath(basePath);
+    }
+
+    QString relativePath = providerUrl;
+    if (relativePath.startsWith(QLatin1Char('/'))) {
+        const QString normalizedBasePath = basePath.chopped(1);
+        if (!normalizedBasePath.isEmpty()
+            && relativePath.startsWith(normalizedBasePath + QLatin1Char('/'))) {
+            QUrl origin = serverUrl;
+            origin.setPath(QStringLiteral("/"));
+            return origin.resolved(QUrl(relativePath.mid(1)));
+        }
+        relativePath.remove(0, 1);
+    }
+    return base.resolved(QUrl(relativePath));
+}
+
+Bloom::PlaybackTrack mapTrack(const QVariantMap &stream)
+{
+    Bloom::PlaybackTrack track;
+    track.trackId = QString::number(stream.value(QStringLiteral("index"), -1).toInt());
+    track.kind = stream.value(QStringLiteral("type")).toString().toLower();
+    track.language = stream.value(QStringLiteral("language")).toString();
+    track.codec = stream.value(QStringLiteral("codec")).toString();
+    track.displayTitle = stream.value(QStringLiteral("displayTitle")).toString();
+    track.isDefault = stream.value(QStringLiteral("isDefault")).toBool();
+    track.isForced = stream.value(QStringLiteral("isForced")).toBool();
+    track.isExternal = stream.value(QStringLiteral("isExternal")).toBool();
+    track.isHearingImpaired = stream.value(QStringLiteral("isHearingImpaired")).toBool();
+    return track;
+}
+
+} // namespace
+
+Bloom::PlaybackDescriptor JellyfinPlaybackProvider::createDescriptor(
+    const PlaybackProviderContext &context,
+    const Bloom::MediaRef &media,
+    const QVariantMap &providerSource,
+    int selectedAudioTrack,
+    int selectedSubtitleTrack,
+    qint64 startPositionMs,
+    const QString &playbackSessionId) const
+{
+    Bloom::PlaybackDescriptor descriptor;
+    descriptor.media = media;
+    descriptor.mediaVersionId = providerSource.value(QStringLiteral("id")).toString();
+    descriptor.playbackSessionId = playbackSessionId;
+    descriptor.durationMs = JellyfinModelMapper::ticksToMilliseconds(
+        providerSource.value(QStringLiteral("runTimeTicks")).toLongLong());
+    descriptor.startPositionMs = qMax<qint64>(0, startPositionMs);
+    descriptor.selectedAudioTrackId = selectedAudioTrack >= 0
+        ? QString::number(selectedAudioTrack) : QString();
+    descriptor.selectedSubtitleTrackId = selectedSubtitleTrack >= 0
+        ? QString::number(selectedSubtitleTrack) : QString();
+    descriptor.reporting = {true, true, true, true};
+
+    for (const QVariant &streamValue : providerSource.value(QStringLiteral("mediaStreams")).toList()) {
+        const Bloom::PlaybackTrack track = mapTrack(streamValue.toMap());
+        if (track.kind == QStringLiteral("audio")) {
+            descriptor.audioTracks.append(track);
+        } else if (track.kind == QStringLiteral("subtitle")) {
+            descriptor.subtitleTracks.append(track);
+        }
+    }
+
+    if (media.itemId.isEmpty()) {
+        return descriptor;
+    }
+
+    QString selectedUrl = providerSource.value(QStringLiteral("directStreamUrl")).toString().trimmed();
+    descriptor.stream.method = Bloom::PlaybackMethod::DirectStream;
+    if (selectedUrl.isEmpty()) {
+        selectedUrl = providerSource.value(QStringLiteral("transcodingUrl")).toString().trimmed();
+        descriptor.stream.method = Bloom::PlaybackMethod::Transcode;
+    }
+    if (selectedUrl.isEmpty()) {
+        selectedUrl = QStringLiteral("/Videos/%1/stream?Static=true").arg(media.itemId);
+        descriptor.stream.method = Bloom::PlaybackMethod::DirectPlay;
+    }
+
+    QUrl url(selectedUrl);
+    if (url.isRelative()) {
+        if (!context.serverUrl.isValid()) {
+            return descriptor;
+        }
+        url = resolveProviderUrl(context.serverUrl, selectedUrl);
+    }
+
+    QUrlQuery query(url);
+    const QString accessToken = context.accessToken;
+    if (!accessToken.isEmpty()
+        && !query.hasQueryItem(QStringLiteral("api_key"))
+        && !query.hasQueryItem(QStringLiteral("X-Emby-Token"))) {
+        query.addQueryItem(QStringLiteral("api_key"), accessToken);
+    }
+    if (!descriptor.mediaVersionId.isEmpty()
+        && !query.hasQueryItem(QStringLiteral("MediaSourceId"))) {
+        query.addQueryItem(QStringLiteral("MediaSourceId"), descriptor.mediaVersionId);
+    }
+    if (selectedAudioTrack >= 0
+        && !query.hasQueryItem(QStringLiteral("AudioStreamIndex"))) {
+        query.addQueryItem(QStringLiteral("AudioStreamIndex"),
+                           QString::number(selectedAudioTrack));
+    }
+    if (selectedSubtitleTrack >= 0
+        && !query.hasQueryItem(QStringLiteral("SubtitleStreamIndex"))) {
+        query.addQueryItem(QStringLiteral("SubtitleStreamIndex"),
+                           QString::number(selectedSubtitleTrack));
+    }
+    descriptor.stream.pinsAudioTrack = query.hasQueryItem(
+        QStringLiteral("AudioStreamIndex"));
+    descriptor.stream.pinsSubtitleTrack = query.hasQueryItem(
+        QStringLiteral("SubtitleStreamIndex"));
+    descriptor.stream.pinnedAudioTrackId = query.queryItemValue(
+        QStringLiteral("AudioStreamIndex"));
+    descriptor.stream.pinnedSubtitleTrackId = query.queryItemValue(
+        QStringLiteral("SubtitleStreamIndex"));
+    url.setQuery(query);
+    descriptor.stream.url = url;
+    return descriptor;
+}

--- a/src/providers/jellyfin/JellyfinPlaybackProvider.h
+++ b/src/providers/jellyfin/JellyfinPlaybackProvider.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "providers/IPlaybackProvider.h"
+
+class JellyfinPlaybackProvider final : public IPlaybackProvider
+{
+public:
+    Bloom::PlaybackDescriptor createDescriptor(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QVariantMap &providerSource,
+        int selectedAudioTrack,
+        int selectedSubtitleTrack,
+        qint64 startPositionMs,
+        const QString &playbackSessionId = QString()) const override;
+};

--- a/src/providers/jellyfin/JellyfinProviderAdapter.h
+++ b/src/providers/jellyfin/JellyfinProviderAdapter.h
@@ -2,6 +2,7 @@
 
 #include "providers/IProviderAdapter.h"
 #include "providers/jellyfin/JellyfinAuthenticator.h"
+#include "providers/jellyfin/JellyfinPlaybackProvider.h"
 #include "providers/jellyfin/JellyfinRequestFactory.h"
 
 class JellyfinProviderAdapter final : public IProviderAdapter
@@ -11,8 +12,10 @@ public:
     ProtocolMode protocolMode() const override { return ProtocolMode::Native; }
     const IProviderAuthenticator *authenticator() const override { return &m_authenticator; }
     const IProviderRequestFactory *requestFactory() const override { return &m_requestFactory; }
+    const IPlaybackProvider *playbackProvider() const override { return &m_playbackProvider; }
 
 private:
     JellyfinAuthenticator m_authenticator;
+    JellyfinPlaybackProvider m_playbackProvider;
     JellyfinRequestFactory m_requestFactory;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,9 @@ set(TEST_PROVIDER_BOUNDARY_SOURCES
     ${CMAKE_SOURCE_DIR}/src/models/MediaModels.cpp
     ${CMAKE_SOURCE_DIR}/src/network/HttpTransport.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinAuthenticator.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinArtworkProvider.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinModelMapper.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinPlaybackProvider.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinRequestFactory.cpp
 )
 
@@ -208,6 +211,7 @@ add_executable(CanonicalModelsTest
     CanonicalModelsTest.cpp
     ${CMAKE_SOURCE_DIR}/src/models/MediaModels.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinModelMapper.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinPlaybackProvider.cpp
 )
 
 target_include_directories(CanonicalModelsTest PRIVATE

--- a/tests/CanonicalModelsTest.cpp
+++ b/tests/CanonicalModelsTest.cpp
@@ -2,9 +2,11 @@
 
 #include "models/MediaModels.h"
 #include "providers/jellyfin/JellyfinModelMapper.h"
+#include "providers/jellyfin/JellyfinPlaybackProvider.h"
 
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QUrlQuery>
 #include <limits>
 
 class CanonicalModelsTest : public QObject
@@ -18,6 +20,7 @@ private slots:
     void artworkCacheKeyIsTokenFreeAndRoundTrips();
     void jellyfinArtworkEndpointContainsNoCredential();
     void playbackDescriptorExposesProviderNeutralShape();
+    void jellyfinPlaybackProviderFinalizesStreamAtBoundary();
 };
 
 void CanonicalModelsTest::jellyfinTimeConversionUsesMilliseconds()
@@ -138,6 +141,73 @@ void CanonicalModelsTest::jellyfinArtworkEndpointContainsNoCredential()
     QVERIFY(endpoint.contains(QStringLiteral("tag=chapter-tag")));
     QVERIFY(!endpoint.contains(QStringLiteral("api_key"), Qt::CaseInsensitive));
     QVERIFY(!endpoint.contains(QStringLiteral("token"), Qt::CaseInsensitive));
+}
+
+void CanonicalModelsTest::jellyfinPlaybackProviderFinalizesStreamAtBoundary()
+{
+    const PlaybackProviderContext context{
+        QUrl(QStringLiteral("https://media.example.test/base/")),
+        QStringLiteral("secret-token")
+    };
+    const Bloom::MediaRef media{
+        QStringLiteral("connection-1"),
+        QStringLiteral("movie-1")
+    };
+    const QVariantMap source{
+        {QStringLiteral("id"), QStringLiteral("source-1")},
+        {QStringLiteral("directStreamUrl"), QStringLiteral("/Videos/movie-1/stream")},
+        {QStringLiteral("runTimeTicks"), 20'000'000},
+        {QStringLiteral("mediaStreams"), QVariantList{
+             QVariantMap{
+                 {QStringLiteral("type"), QStringLiteral("Audio")},
+                 {QStringLiteral("index"), 2},
+                 {QStringLiteral("language"), QStringLiteral("eng")}
+             },
+             QVariantMap{
+                 {QStringLiteral("type"), QStringLiteral("Subtitle")},
+                 {QStringLiteral("index"), 4},
+                 {QStringLiteral("isExternal"), true}
+             }
+         }}
+    };
+
+    const JellyfinPlaybackProvider provider;
+    const Bloom::PlaybackDescriptor descriptor = provider.createDescriptor(
+        context, media, source, 2, 4, 500, QStringLiteral("session-1"));
+
+    QVERIFY(descriptor.isValid());
+    QCOMPARE(descriptor.durationMs, 2000);
+    QCOMPARE(descriptor.startPositionMs, 500);
+    QCOMPARE(descriptor.playbackSessionId, QStringLiteral("session-1"));
+    QCOMPARE(descriptor.audioTracks.size(), 1);
+    QCOMPARE(descriptor.subtitleTracks.size(), 1);
+    QCOMPARE(descriptor.stream.method, Bloom::PlaybackMethod::DirectStream);
+    QVERIFY(descriptor.stream.pinsAudioTrack);
+    QVERIFY(descriptor.stream.pinsSubtitleTrack);
+    QCOMPARE(descriptor.stream.pinnedAudioTrackId, QStringLiteral("2"));
+    QCOMPARE(descriptor.stream.pinnedSubtitleTrackId, QStringLiteral("4"));
+
+    const QUrlQuery query(descriptor.stream.url);
+    QCOMPARE(descriptor.stream.url.host(), QStringLiteral("media.example.test"));
+    QCOMPARE(descriptor.stream.url.path(), QStringLiteral("/base/Videos/movie-1/stream"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("api_key")), QStringLiteral("secret-token"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("MediaSourceId")), QStringLiteral("source-1"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("AudioStreamIndex")), QStringLiteral("2"));
+    QCOMPARE(query.queryItemValue(QStringLiteral("SubtitleStreamIndex")), QStringLiteral("4"));
+
+    QVariantMap fallbackSource = source;
+    fallbackSource.remove(QStringLiteral("directStreamUrl"));
+    const Bloom::PlaybackDescriptor fallback = provider.createDescriptor(
+        context, media, fallbackSource, -1, -1, 0);
+    QCOMPARE(fallback.stream.method, Bloom::PlaybackMethod::DirectPlay);
+    QCOMPARE(fallback.stream.url.path(), QStringLiteral("/base/Videos/movie-1/stream"));
+
+    QVariantMap prefixedSource = source;
+    prefixedSource[QStringLiteral("directStreamUrl")] =
+        QStringLiteral("/base/Videos/movie-1/stream");
+    const Bloom::PlaybackDescriptor prefixed = provider.createDescriptor(
+        context, media, prefixedSource, -1, -1, 0);
+    QCOMPARE(prefixed.stream.url.path(), QStringLiteral("/base/Videos/movie-1/stream"));
 }
 
 void CanonicalModelsTest::playbackDescriptorExposesProviderNeutralShape()

--- a/tests/PlayerControllerAutoplayContextTest.cpp
+++ b/tests/PlayerControllerAutoplayContextTest.cpp
@@ -12,6 +12,7 @@
 #include "network/AuthenticationService.h"
 #include "network/LibraryService.h"
 #include "network/PlaybackService.h"
+#include "providers/jellyfin/JellyfinPlaybackProvider.h"
 #include "utils/ConfigManager.h"
 #include "utils/DisplayManager.h"
 #include "utils/TrackPreferencesManager.h"
@@ -230,7 +231,49 @@ public:
 
     explicit FakePlaybackService(AuthenticationService *authService, QObject *parent = nullptr)
         : PlaybackService(authService, nullptr, nullptr, parent)
+        , m_authService(authService)
     {
+    }
+
+    Bloom::PlaybackDescriptor createPlaybackDescriptor(
+        const QString &itemId,
+        const QVariantMap &providerSource,
+        int selectedAudioTrack,
+        int selectedSubtitleTrack,
+        qint64 startPositionMs,
+        const QString &playbackSessionId) override
+    {
+        if (!providerSource.value(QStringLiteral("directStreamUrl")).toString().isEmpty()
+            || !providerSource.value(QStringLiteral("transcodingUrl")).toString().isEmpty()) {
+            JellyfinPlaybackProvider provider;
+            const PlaybackProviderContext context{
+                QUrl(m_authService ? m_authService->getServerUrl() : QString()),
+                m_authService ? m_authService->getAccessToken() : QString()
+            };
+            return provider.createDescriptor(
+                context,
+                Bloom::MediaRef{QStringLiteral("test-connection"), itemId},
+                providerSource,
+                selectedAudioTrack,
+                selectedSubtitleTrack,
+                startPositionMs,
+                playbackSessionId);
+        }
+
+        requestedDescriptorItemIds.append(itemId);
+        requestedDescriptorMediaSourceIds.append(
+            providerSource.value(QStringLiteral("id")).toString());
+        requestedDescriptorAudioIndexes.append(selectedAudioTrack);
+        requestedDescriptorSubtitleIndexes.append(selectedSubtitleTrack);
+
+        Bloom::PlaybackDescriptor descriptor;
+        descriptor.media = {QStringLiteral("test-connection"), itemId};
+        descriptor.mediaVersionId = providerSource.value(QStringLiteral("id")).toString();
+        descriptor.playbackSessionId = playbackSessionId;
+        descriptor.startPositionMs = startPositionMs;
+        descriptor.stream.url = QUrl(QStringLiteral("https://example.invalid/") + itemId);
+        descriptor.stream.method = Bloom::PlaybackMethod::DirectPlay;
+        return descriptor;
     }
 
     void getPlaybackInfo(const QString &itemId) override
@@ -295,6 +338,13 @@ public:
     QStringList requestedPlaybackInfoContexts;
     QStringList requestedAdditionalPartsItemIds;
     QStringList requestedAdditionalPartsContexts;
+    mutable QStringList requestedDescriptorItemIds;
+    mutable QStringList requestedDescriptorMediaSourceIds;
+    mutable QList<int> requestedDescriptorAudioIndexes;
+    mutable QList<int> requestedDescriptorSubtitleIndexes;
+
+private:
+    AuthenticationService *m_authService = nullptr;
 };
 
 static MediaSourceInfo buildMediaSourceInfo(const QString &id,
@@ -384,10 +434,12 @@ class PlayerControllerAutoplayContextTest : public QObject
 private slots:
     void initTestCase();
     void cleanupTestCase();
+    void playbackServiceReportsMissingProvider();
     void thresholdMetRequestsNextEpisodeDirectly();
     void userStopPastThresholdRequestsNextEpisode();
     void userStopBelowThresholdWaitsForBackendExit();
     void replacementPlaybackWaitsForQueuedTerminalFinalization();
+    void replacementPlaybackRetainsFinalizedStreamMetadata();
     void explicitStopReportsFinalProgressAndStoppedOnce();
     void explicitPausedStopReportsPausedState();
     void explicitMultipartStopReportsActiveSegmentContext();
@@ -500,6 +552,20 @@ void PlayerControllerAutoplayContextTest::cleanupTestCase()
     }
 #endif
     QStandardPaths::setTestModeEnabled(false);
+}
+
+void PlayerControllerAutoplayContextTest::playbackServiceReportsMissingProvider()
+{
+    PlaybackService playbackService(nullptr);
+    QSignalSpy errorSpy(&playbackService, &PlaybackService::errorOccurred);
+
+    const Bloom::PlaybackDescriptor descriptor = playbackService.createPlaybackDescriptor(
+        QStringLiteral("item-1"), QVariantMap{}, -1, -1);
+
+    QVERIFY(!descriptor.isValid());
+    QCOMPARE(errorSpy.count(), 1);
+    QCOMPARE(errorSpy.first().at(0).toString(), QStringLiteral("createPlaybackDescriptor"));
+    QVERIFY(!errorSpy.first().at(1).toString().isEmpty());
 }
 
 void PlayerControllerAutoplayContextTest::thresholdMetRequestsNextEpisodeDirectly()
@@ -679,6 +745,56 @@ void PlayerControllerAutoplayContextTest::replacementPlaybackWaitsForQueuedTermi
     QCOMPARE(controller.currentItemId(), QStringLiteral("item-2"));
     QCOMPARE(backend.lastStartUrl, QStringLiteral("https://example.invalid/item-2"));
     QVERIFY(!controller.m_terminalTransitionActive);
+}
+
+void PlayerControllerAutoplayContextTest::replacementPlaybackRetainsFinalizedStreamMetadata()
+{
+    ConfigManager config;
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+    backend.emitStopStateChangeSynchronously = false;
+    backend.setRunning(true);
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+    controller.m_currentItemId = QStringLiteral("item-1");
+    controller.m_playbackState = PlayerController::Playing;
+    controller.stop();
+
+    controller.m_nextPlaybackMethod = QStringLiteral("directStream");
+    controller.m_nextStreamPinsAudioTrack = true;
+    controller.m_nextPinnedAudioTrack = 4;
+    controller.playUrlWithTracks(QStringLiteral("https://example.invalid/item-2"),
+                                 QStringLiteral("item-2"),
+                                 0,
+                                 QString(),
+                                 QString(),
+                                 QString(),
+                                 QStringLiteral("source-2"),
+                                 QStringLiteral("session-2"),
+                                 QVariantMap{},
+                                 4,
+                                 -1);
+
+    QVERIFY(controller.m_playbackSegments.isEmpty());
+
+    backend.emitRunningState(false);
+    QCoreApplication::processEvents();
+
+    QCOMPARE(controller.m_playbackSegments.size(), 1);
+    QCOMPARE(controller.m_playMethod, QStringLiteral("directStream"));
+    QVERIFY(controller.m_streamPinsAudioTrack);
+    QCOMPARE(controller.m_pinnedAudioTrack, 4);
+    QCOMPARE(backend.lastStartUrl, QStringLiteral("https://example.invalid/item-2"));
 }
 
 void PlayerControllerAutoplayContextTest::explicitStopReportsFinalProgressAndStoppedOnce()
@@ -2592,7 +2708,7 @@ void PlayerControllerAutoplayContextTest::explicitPlaybackIgnoresUnscopedStalePl
     emit playbackService.playbackInfoLoaded(QStringLiteral("episode-1"), buildPlaybackInfo({staleSource}));
     emit playbackService.additionalPartsLoaded(QStringLiteral("episode-1"), QJsonArray{});
     QVERIFY(backend.lastStartUrl.isEmpty());
-    QVERIFY(libraryService.requestedStreamMediaSourceIds.isEmpty());
+    QVERIFY(playbackService.requestedDescriptorMediaSourceIds.isEmpty());
 
     emit playbackService.playbackInfoLoadedForRequest(QStringLiteral("episode-1"),
                                                       buildPlaybackInfo({freshSource}),
@@ -2600,7 +2716,8 @@ void PlayerControllerAutoplayContextTest::explicitPlaybackIgnoresUnscopedStalePl
     emit playbackService.additionalPartsLoadedForRequest(QStringLiteral("episode-1"), QJsonArray{}, requestId);
 
     QCOMPARE(backend.lastStartUrl, QStringLiteral("https://example.invalid/episode-1"));
-    QCOMPARE(libraryService.requestedStreamMediaSourceIds, QStringList{QStringLiteral("fresh-source")});
+    QCOMPARE(playbackService.requestedDescriptorMediaSourceIds,
+             QStringList{QStringLiteral("fresh-source")});
 }
 
 void PlayerControllerAutoplayContextTest::explicitPlaybackIgnoresCanceledRequestScopedPlaybackInfo()
@@ -2652,7 +2769,8 @@ void PlayerControllerAutoplayContextTest::explicitPlaybackIgnoresCanceledRequest
                                                       newRequestId);
     emit playbackService.additionalPartsLoadedForRequest(QStringLiteral("episode-1"), QJsonArray{}, newRequestId);
 
-    QCOMPARE(libraryService.requestedStreamMediaSourceIds, QStringList{QStringLiteral("fresh-source")});
+    QCOMPARE(playbackService.requestedDescriptorMediaSourceIds,
+             QStringList{QStringLiteral("fresh-source")});
 }
 
 void PlayerControllerAutoplayContextTest::primaryPlaybackInfoFailureDoesNotUseBasicStreamFallback()
@@ -2727,7 +2845,8 @@ void PlayerControllerAutoplayContextTest::additionalPartsFailureStillStartsPrima
                                                          requestId);
 
     QCOMPARE(backend.lastStartUrl, QStringLiteral("https://example.invalid/episode-1"));
-    QCOMPARE(libraryService.requestedStreamMediaSourceIds, QStringList{QStringLiteral("primary-source")});
+    QCOMPARE(playbackService.requestedDescriptorMediaSourceIds,
+             QStringList{QStringLiteral("primary-source")});
     QVERIFY(backend.appendedUrls.isEmpty());
 }
 
@@ -2771,7 +2890,8 @@ void PlayerControllerAutoplayContextTest::additionalPartPlaybackInfoFailureSkips
                                                       requestId);
 
     QCOMPARE(backend.lastStartUrl, QStringLiteral("https://example.invalid/episode-1"));
-    QCOMPARE(libraryService.requestedStreamMediaSourceIds, QStringList{QStringLiteral("primary-source")});
+    QCOMPARE(playbackService.requestedDescriptorMediaSourceIds,
+             QStringList{QStringLiteral("primary-source")});
     QVERIFY(backend.appendedUrls.isEmpty());
 }
 
@@ -2820,7 +2940,8 @@ void PlayerControllerAutoplayContextTest::retryRefreshesPlaybackInfoBeforeRestar
     emit playbackService.additionalPartsLoadedForRequest(QStringLiteral("episode-1"), QJsonArray{}, requestId);
 
     QCOMPARE(backend.lastStartUrl, QStringLiteral("https://example.invalid/episode-1"));
-    QCOMPARE(libraryService.requestedStreamMediaSourceIds, QStringList{QStringLiteral("fresh-source")});
+    QCOMPARE(playbackService.requestedDescriptorMediaSourceIds,
+             QStringList{QStringLiteral("fresh-source")});
     QCOMPARE(controller.m_startPositionTicks, 1200000000LL);
 }
 
@@ -3207,7 +3328,11 @@ void PlayerControllerAutoplayContextTest::startupTrackSelectionRespectsPinnedUrl
                                 &libraryService,
                                 &authService);
 
-    controller.m_pendingUrl = QStringLiteral("https://example.invalid/stream?AudioStreamIndex=4&SubtitleStreamIndex=8");
+    controller.m_pendingUrl = QStringLiteral("https://example.invalid/stream");
+    controller.m_streamPinsAudioTrack = true;
+    controller.m_streamPinsSubtitleTrack = true;
+    controller.m_pinnedAudioTrack = 4;
+    controller.m_pinnedSubtitleTrack = 8;
     controller.m_selectedAudioTrack = 4;
     controller.m_selectedSubtitleTrack = 8;
     controller.updateTrackMappings(buildMediaSource({


### PR DESCRIPTION
## Summary
- add `IPlaybackProvider` and `JellyfinPlaybackProvider` to the selected provider adapter
- finalize authenticated stream URLs, canonical timing/tracks, method, and pin metadata before the player
- remove provider endpoint/query parsing and `api_key` mutation from `PlayerController`
- preserve deferred replacement and multipart playback metadata safely
- redact playback URL queries from logs

## Scope
Third stacked slice of Bloom issue #76. Catalog/UI canonicalization remains upstack, so this PR is Draft.

## Verification
- `./scripts/dev-build.sh`
- 19/19 Nix tests
- `nix flake check --no-write-lock-file`

Part of #76

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Introduce `IPlaybackProvider` and `JellyfinPlaybackProvider` to finalize stream descriptors at the provider boundary
> - Adds `IPlaybackProvider` interface and `JellyfinPlaybackProvider` implementation that resolve stream URLs, inject authentication, normalize playback method, map audio/subtitle tracks, and set track-pinning state into a `PlaybackDescriptor`.
> - `PlaybackService` gains a `createPlaybackDescriptor` method that delegates to the provider and emits errors when the provider is missing or returns an invalid descriptor.
> - `PlayerController` drops `streamUrlForMediaSource` and `inferPlayMethod` and instead consumes pre-built descriptors; play method is normalized to lowercase (e.g. `"directPlay"`) throughout.
> - Track mapping methods are renamed from `jellyfinAudioTrackForMpvTrack`/`mpvAudioTrackForJellyfinIndex` style to `sourceAudioTrackForMpvTrack`/`mpvAudioTrackForSourceIndex` to remove provider-specific naming.
> - New controller state fields (`m_streamPinsAudioTrack`, `m_pinnedAudioTrack`, `m_next*` variants) carry pinning decisions through deferred segment application in `playUrl`.
> - Risk: `m_playMethod` default changes from `"DirectPlay"` to `"directPlay"`; callers that compare this string case-sensitively will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b2eeee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->