### PR TITLE
refactor(movie): consume canonical detail models

### DIFF
--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -33,7 +33,18 @@ The types expose temporary `QVariantMap` projections so existing QML-facing faç
 
 `JellyfinModelMapper` converts Jellyfin item, user-state, person, artwork, chapter, and tick fields into Bloom canonical values. Jellyfin ticks are converted to milliseconds there and must not be introduced into new model or QML APIs.
 
+`LibraryService` asks the selected `IProviderAdapter` to map item and similar-item wire DTOs exactly once (scoped with `activeConnectionId()`), then emits:
+
+- raw compatibility signals (`itemLoaded`, `similarItemsLoaded`) for unmigrated flows
+- parallel canonical signals (`canonicalItemLoaded`, `canonicalSimilarItemsLoaded`) for migrated consumers
+
+Raw signals are transitional and remain until Home, Library, Series, and remaining detail flows finish migrating. New code must connect to the canonical signals and must not fall back to PascalCase wire keys.
+
 Existing list/detail/player flows are migrated in reviewable slices. During migration, compatibility façades may retain old methods, but canonical consumers must not fall back to PascalCase wire keys.
+
+## Migrated surfaces
+
+- **Movie Details**: `MovieDetailsViewModel` and `MovieDetailsView.qml` consume only canonical item/similar-item payloads. Cached movie and similar JSON is canonical (`*_details_canonical.json` / `*_similar_items_canonical.json`); wire-shaped disk caches are rejected. Artwork resolves through `ArtworkRef` maps and `LibraryService::getCachedArtworkUrl`. Display timing uses `durationMs` / `positionMs`. Playback request payloads still convert resume position to ticks at the QML→player compatibility boundary until the playback request contract is migrated.
 
 ## Artwork identity
 
@@ -48,7 +59,9 @@ A `PlaybackDescriptor` is valid when it has a valid `MediaRef` and finalized `St
 `CanonicalModelsTest` covers:
 
 - Jellyfin tick/millisecond conversion
-- PascalCase Jellyfin item mapping to canonical camelCase values
+- PascalCase Jellyfin item mapping to canonical camelCase values used by Movie Details (identity, timing, ratings, genres, people, provider IDs, artwork refs)
 - token-free, round-trippable artwork cache keys
 - provider-neutral playback descriptor projections
 - Jellyfin stream finalization, canonical timing/tracks, and current credential injection at the playback-provider boundary
+
+`SimilarItemsRetryTest` also asserts Movie Details similar-item shelves keep the canonical `itemId` / `primaryArtwork` shape and ignore wire-only entries.

--- a/docs/viewmodels.md
+++ b/docs/viewmodels.md
@@ -68,16 +68,16 @@ private:
 ViewModel for the series-style movie details screen.
 
 ### Purpose
-Acts as the data source for `MovieDetailsView.qml`. It aggregates Jellyfin movie metadata, playback progress, chapters, cast, similar-library recommendations, and external ratings from MDBList (IMDb, TMDB, Rotten Tomatoes, etc.) plus AniList when available.
+Acts as the data source for `MovieDetailsView.qml`. It aggregates canonical movie metadata, playback progress, chapters, cast, similar-library recommendations, and external ratings from MDBList (IMDb, TMDB, Rotten Tomatoes, etc.) plus AniList when available. It consumes `LibraryService::canonicalItemLoaded` / `canonicalSimilarItemsLoaded` only; raw Jellyfin DTO signals remain for unmigrated flows.
 
 ### Public API
 - **Key Properties**:
   - `title`, `overview`, `logoUrl`, `posterUrl`, `backdropUrl`: UI-ready metadata and artwork.
-  - `officialRating`, `runtimeTicks`, `communityRating`, `premiereDate`, `genres`: movie metadata used by the hero chips and synopsis area.
-  - `isWatched`, `playbackPositionTicks`: sync with Jellyfin `UserData` and drive `Play` vs `Resume` UI.
-  - `people`: cast/crew entries used by the lower cast shelf.
+  - `officialRating`, `durationMs`, `communityRating`, `premiereDate`, `genres`: movie metadata used by the hero chips and synopsis area.
+  - `isWatched`, `positionMs`: sync with canonical user state and drive `Play` vs `Resume` UI.
+  - `people`: cast/crew entries used by the lower cast shelf (canonical person maps).
   - `chapters`, `chaptersLoading`: normalized movie chapter cards plus the rail loading state.
-  - `similarItems`, `similarItemsLoading`: recommendation shelf data and loading state for similar titles.
+  - `similarItems`, `similarItemsLoading`: recommendation shelf data and loading state for similar titles (`itemId`, `primaryArtwork`, camelCase fields).
   - `mdbListRatings`: `QVariantMap` containing normalized external ratings, including AniList when merged in.
 - **Methods**:
   - `loadMovieDetails(QString movieId)`: hydrates from cache when possible, then refreshes metadata and similar items from the library service.
@@ -96,7 +96,7 @@ Acts as the data source for `MovieDetailsView.qml`. It aggregates Jellyfin movie
 - **Config**: Reads `ConfigManager` for API keys and cache storage paths.
 
 ### Lifecycle & Side Effects
-- **Caching**: Uses separate in-memory and disk caches for movie details and similar items. Disk cache resides in `<configDir>/cache/movies/` with a 1-hour TTL. Movie chapters keep a small in-memory per-movie cache so returning to a movie does not immediately re-show loading skeletons.
+- **Caching**: Uses separate in-memory and disk caches for canonical movie details and similar items. Disk cache resides under `<configDir>/cache/connections/<scope>/movies/` with `*_details_canonical.json` / `*_similar_items_canonical.json` filenames and a 1-hour TTL; wire-shaped caches are rejected. Movie chapters keep a small in-memory per-movie cache so returning to a movie does not immediately re-show loading skeletons.
 - **Rating Fetching**: Automatically triggers external rating lookups after metadata loads when provider IDs (IMDb/TMDB) are present.
 - **Recommendation Fetching**: Requests similar items after details load, while still allowing cached empty recommendation results to short-circuit redundant network fetches.
 - **State Cleanup**: `clear()` should be called when navigating away from the view to prevent stale shelves or metadata from lingering.

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -66,6 +66,22 @@ const IPlaybackProvider *AuthenticationService::playbackProvider() const
     return m_providerAdapter ? m_providerAdapter->playbackProvider() : nullptr;
 }
 
+QVariantMap AuthenticationService::mapMediaItem(const QJsonObject &wireItem,
+                                                 const QString &connectionId) const
+{
+    return m_providerAdapter
+        ? m_providerAdapter->mapMediaItem(wireItem, connectionId)
+        : QVariantMap{};
+}
+
+QVariantList AuthenticationService::mapMediaItems(const QJsonArray &wireItems,
+                                                   const QString &connectionId) const
+{
+    return m_providerAdapter
+        ? m_providerAdapter->mapMediaItems(wireItems, connectionId)
+        : QVariantList{};
+}
+
 QNetworkAccessManager *AuthenticationService::networkManager() const
 {
     return m_transport->networkManager();

--- a/src/network/AuthenticationService.h
+++ b/src/network/AuthenticationService.h
@@ -3,7 +3,11 @@
 #include <QObject>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <QJsonArray>
+#include <QJsonObject>
 #include <QString>
+#include <QVariantList>
+#include <QVariantMap>
 #include <functional>
 #include <memory>
 #include <QFutureWatcher>
@@ -94,6 +98,10 @@ public:
     QString getAccessToken() const { return m_accessToken; }
     QString getUsername() const { return m_username; }
     const IPlaybackProvider *playbackProvider() const;
+    QVariantMap mapMediaItem(const QJsonObject &wireItem,
+                             const QString &connectionId) const;
+    QVariantList mapMediaItems(const QJsonArray &wireItems,
+                               const QString &connectionId) const;
     bool isAuthenticated() const { return !m_accessToken.isEmpty() && !m_userId.isEmpty(); }
     bool isRestoringSession() const { return m_isRestoringSession; }
     

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -904,6 +904,7 @@ void LibraryService::getItem(const QString &itemId, const QString &requestContex
         return;
     }
 
+    const QString connectionId = activeConnectionId(m_authService);
     const QString endpoint = buildItemEndpoint(m_authService->getUserId(), itemId);
     
     sendRequestWithRetry(endpoint,
@@ -917,7 +918,7 @@ void LibraryService::getItem(const QString &itemId, const QString &requestContex
             }
             return m_authService->networkManager()->get(request);
         },
-        [this, itemId, endpoint, requestContext](QNetworkReply *reply) {
+        [this, itemId, endpoint, requestContext, connectionId](QNetworkReply *reply) {
             QByteArray data = reply->readAll();
             int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
             if (httpStatus == 304) {
@@ -945,8 +946,14 @@ void LibraryService::getItem(const QString &itemId, const QString &requestContex
                 emitError(error);
                 return;
             }
-            emit itemLoaded(itemId, doc.object(), requestContext);
-            emit itemLoaded(itemId, doc.object());
+            const QJsonObject wireItem = doc.object();
+            const QVariantMap canonicalItem = m_authService
+                ? m_authService->mapMediaItem(wireItem, connectionId)
+                : QVariantMap{};
+            emit itemLoaded(itemId, wireItem, requestContext);
+            emit itemLoaded(itemId, wireItem);
+            emit canonicalItemLoaded(itemId, canonicalItem, requestContext);
+            emit canonicalItemLoaded(itemId, canonicalItem);
         },
         [this, itemId, requestContext](const NetworkError &error) {
             emit itemFailed(itemId, error.userMessage, requestContext);
@@ -1181,6 +1188,7 @@ void LibraryService::getSimilarItems(const QString &itemId, int limit)
         "ChildCount"
     };
 
+    const QString connectionId = activeConnectionId(m_authService);
     QString endpoint = QString("/Items/%1/Similar?UserId=%2&Limit=%3&Fields=%4&EnableImageTypes=Primary")
                            .arg(itemId, m_authService->getUserId())
                            .arg(qMax(1, limit))
@@ -1191,7 +1199,7 @@ void LibraryService::getSimilarItems(const QString &itemId, int limit)
             QNetworkRequest request = m_authService->createRequest(endpoint);
             return m_authService->networkManager()->get(request);
         },
-        [this, itemId](QNetworkReply *reply) {
+        [this, itemId, connectionId](QNetworkReply *reply) {
             const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
             if (!doc.isObject()) {
                 NetworkError error;
@@ -1212,7 +1220,12 @@ void LibraryService::getSimilarItems(const QString &itemId, int limit)
                 return;
             }
 
-            emit similarItemsLoaded(itemId, root.value("Items").toArray());
+            const QJsonArray wireItems = root.value("Items").toArray();
+            const QVariantList canonicalItems = m_authService
+                ? m_authService->mapMediaItems(wireItems, connectionId)
+                : QVariantList{};
+            emit similarItemsLoaded(itemId, wireItems);
+            emit canonicalSimilarItemsLoaded(itemId, canonicalItems);
         },
         [this, itemId](const NetworkError &error) {
             emit similarItemsFailed(itemId, error.userMessage);

--- a/src/network/LibraryService.h
+++ b/src/network/LibraryService.h
@@ -11,6 +11,8 @@
 #include <QHash>
 #include <QSet>
 #include <QDate>
+#include <QVariantList>
+#include <QVariantMap>
 #include <functional>
 #include "Types.h"  // Shared data structs and error helpers
 
@@ -162,6 +164,10 @@ signals:
     // Generic Item Signals
     void itemLoaded(const QString &itemId, const QJsonObject &data);
     void itemLoaded(const QString &itemId, const QJsonObject &data, const QString &requestContext);
+    // Provider-neutral camelCase item projections (mapped once at the service boundary).
+    // Raw itemLoaded signals remain for unmigrated callers during the catalog migration.
+    void canonicalItemLoaded(const QString &itemId, const QVariantMap &item);
+    void canonicalItemLoaded(const QString &itemId, const QVariantMap &item, const QString &requestContext);
     void itemLibraryResolved(const QString &itemId, const QString &libraryId);
     void itemLibraryResolutionFailed(const QString &itemId, const QString &error);
     void itemNotModified(const QString &itemId);
@@ -178,6 +184,7 @@ signals:
     void seriesDetailsLoaded(const QString &seriesId, const QJsonObject &seriesData);
     void seriesDetailsNotModified(const QString &seriesId);
     void similarItemsLoaded(const QString &itemId, const QJsonArray &items);
+    void canonicalSimilarItemsLoaded(const QString &itemId, const QVariantList &items);
     void similarItemsFailed(const QString &itemId, const QString &error);
     void nextUnplayedEpisodeLoaded(const QString &seriesId,
                                    const QJsonObject &episodeData,

--- a/src/providers/IProviderAdapter.h
+++ b/src/providers/IProviderAdapter.h
@@ -2,6 +2,11 @@
 
 #include "providers/ServerConnection.h"
 
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QVariantList>
+#include <QVariantMap>
+
 class IPlaybackProvider;
 class IProviderAuthenticator;
 class IProviderRequestFactory;
@@ -22,4 +27,8 @@ public:
     virtual const IProviderAuthenticator *authenticator() const = 0;
     virtual const IProviderRequestFactory *requestFactory() const = 0;
     virtual const IPlaybackProvider *playbackProvider() const = 0;
+    virtual QVariantMap mapMediaItem(const QJsonObject &wireItem,
+                                     const QString &connectionId) const = 0;
+    virtual QVariantList mapMediaItems(const QJsonArray &wireItems,
+                                       const QString &connectionId) const = 0;
 };

--- a/src/providers/jellyfin/JellyfinProviderAdapter.h
+++ b/src/providers/jellyfin/JellyfinProviderAdapter.h
@@ -2,6 +2,7 @@
 
 #include "providers/IProviderAdapter.h"
 #include "providers/jellyfin/JellyfinAuthenticator.h"
+#include "providers/jellyfin/JellyfinModelMapper.h"
 #include "providers/jellyfin/JellyfinPlaybackProvider.h"
 #include "providers/jellyfin/JellyfinRequestFactory.h"
 
@@ -13,6 +14,16 @@ public:
     const IProviderAuthenticator *authenticator() const override { return &m_authenticator; }
     const IProviderRequestFactory *requestFactory() const override { return &m_requestFactory; }
     const IPlaybackProvider *playbackProvider() const override { return &m_playbackProvider; }
+    QVariantMap mapMediaItem(const QJsonObject &wireItem,
+                             const QString &connectionId) const override
+    {
+        return JellyfinModelMapper::mediaItem(wireItem, connectionId);
+    }
+    QVariantList mapMediaItems(const QJsonArray &wireItems,
+                               const QString &connectionId) const override
+    {
+        return JellyfinModelMapper::mediaItems(wireItems, connectionId);
+    }
 
 private:
     JellyfinAuthenticator m_authenticator;

--- a/src/test/MockLibraryService.cpp
+++ b/src/test/MockLibraryService.cpp
@@ -1,6 +1,7 @@
 #include "MockLibraryService.h"
 #include "TestModeController.h"
 #include "../network/NextEpisodeResolver.h"
+#include "providers/jellyfin/JellyfinModelMapper.h"
 #include <QUrl>
 #include <QDebug>
 #include <algorithm>
@@ -341,8 +342,12 @@ void MockLibraryService::getItem(const QString &itemId, const QString &requestCo
     QJsonObject item = findItemById(itemId);
     if (!item.isEmpty()) {
         qCDebug(lcTest) << "MockLibraryService::getItem(" << itemId << ") -> found";
+        const QVariantMap canonicalItem = JellyfinModelMapper::mediaItem(
+            item, QStringLiteral("mock-connection"));
         emit itemLoaded(itemId, item, requestContext);
         emit itemLoaded(itemId, item);
+        emit canonicalItemLoaded(itemId, canonicalItem, requestContext);
+        emit canonicalItemLoaded(itemId, canonicalItem);
     } else {
         qCWarning(lcTest) << "MockLibraryService::getItem(" << itemId << ") -> not found";
         emit itemFailed(itemId, "Item not found: " + itemId, requestContext);

--- a/src/ui/LibraryScreen.qml
+++ b/src/ui/LibraryScreen.qml
@@ -764,7 +764,9 @@ FocusScope {
         id: movieDetailsComponent
         
         MovieDetailsView {
-            movieId: root.currentMovieData ? root.currentMovieData.Id : ""
+            movieId: root.currentMovieData
+                     ? (root.currentMovieData.itemId || root.currentMovieData.Id || "")
+                     : ""
             pendingReturnState: root._movieDetailsReturnState
             restorePendingReturnState: root._restoreMovieDetailsReturnState
              
@@ -1998,16 +2000,18 @@ FocusScope {
     }
 
     function handleSelection(item) {
+        const mediaType = item ? (item.Type || item.mediaType || "") : ""
+        const remoteId = item ? (item.Id || item.itemId || "") : ""
         console.log("[Library] handleSelection",
-                    "itemType:", item && item.Type,
-                    "itemId:", item && item.Id,
+                    "itemType:", mediaType,
+                    "itemId:", remoteId,
                     "currentParentId:", currentParentId,
                     "currentSeriesId:", currentSeriesId)
         
         // Clear pending restore state when navigating forward
         clearPendingRestoreState()
         
-        if (item.Type === "Series") {
+        if (mediaType === "Series") {
             // Show series details view
             // Capture current grid position for restoration
             var gridRef = contentLoader.item ? contentLoader.item.grid : null
@@ -2032,8 +2036,8 @@ FocusScope {
                         JSON.stringify(previousContext),
                         "stackSize:", navigationStack.length)
             
-            currentSeriesId = item.Id
-            currentParentId = item.Id
+            currentSeriesId = remoteId
+            currentParentId = remoteId
             showSeriesDetails = true
             showSeasonView = false
             
@@ -2130,10 +2134,10 @@ FocusScope {
             currentParentId = item.Id
             showSeriesDetails = false
             showSeasonView = false
-        } else if (item.Type === "Movie") {
+        } else if (mediaType === "Movie") {
             // Show movie details view
             showMovieDetailsView(item)
-        } else if (item.Type === "Episode") {
+        } else if (mediaType === "Episode") {
             // Show episode view
             showEpisodeDetails(item)
         }
@@ -2593,27 +2597,54 @@ FocusScope {
         }
 
         // 1. Item's own backdrops
+        if (item.backdropArtwork && item.backdropArtwork.itemId) {
+            const backdropArt = item.backdropArtwork
+            const canonicalBackdrop = LibraryService.getCachedArtworkUrl(
+                        backdropArt.itemId,
+                        backdropArt.kind || "backdrop",
+                        backdropArt.index || 0,
+                        backdropArt.tag || "",
+                        1920)
+            if (canonicalBackdrop && candidates.indexOf(canonicalBackdrop) === -1) {
+                candidates.push(canonicalBackdrop)
+            }
+        }
         if (item.BackdropImageTags && item.BackdropImageTags.length > 0) {
-            appendBackdropSet(item.Id, item.BackdropImageTags)
+            appendBackdropSet(item.Id || item.itemId, item.BackdropImageTags)
         }
 
         // 2. Parent/Season backdrops
         if (item.ParentBackdropImageTags && item.ParentBackdropImageTags.length > 0) {
-            var parentId = item.ParentBackdropItemId || item.ParentBackdropImageItemId || item.ParentId
+            const parentId = item.ParentBackdropItemId || item.ParentBackdropImageItemId || item.ParentId || item.parentId
             appendBackdropSet(parentId, item.ParentBackdropImageTags)
         }
 
         // 3. Fallback: Series Backdrop (Blind URL)
         // Always add this as a last resort if we have a SeriesId.
         // Try both "Backdrop/0" and "Backdrop" (no index) to be safe.
-        if (item.SeriesId) {
-            appendUrl(item.SeriesId, "Backdrop/0", 1920, "")
-            appendUrl(item.SeriesId, "Backdrop", 1920, "")
-        } else if (item.ParentId && (item.Type === "Season" || item.Type === "Episode")) {
+        const seriesId = item.SeriesId || item.seriesId || ""
+        if (seriesId) {
+            appendUrl(seriesId, "Backdrop/0", 1920, "")
+            appendUrl(seriesId, "Backdrop", 1920, "")
+        } else if ((item.ParentId || item.parentId) && ((item.Type || item.mediaType) === "Season" || (item.Type || item.mediaType) === "Episode")) {
             // For Season, Parent is Series. For Episode, Parent is Season.
             // If SeriesId is missing, try ParentId if we are a Season.
-            if (item.Type === "Season") {
-                appendUrl(item.ParentId, "Backdrop/0", 1920, "")
+            if ((item.Type || item.mediaType) === "Season") {
+                appendUrl(item.ParentId || item.parentId, "Backdrop/0", 1920, "")
+            }
+        }
+
+        // 4. Canonical primary artwork fallback for migrated recommendation payloads
+        if (candidates.length === 0 && item.primaryArtwork && item.primaryArtwork.itemId) {
+            const primaryArt = item.primaryArtwork
+            const primaryUrl = LibraryService.getCachedArtworkUrl(
+                        primaryArt.itemId,
+                        primaryArt.kind || "primary",
+                        primaryArt.index || 0,
+                        primaryArt.tag || "",
+                        1920)
+            if (primaryUrl) {
+                candidates.push(primaryUrl)
             }
         }
         

--- a/src/ui/MovieDetailsView.qml
+++ b/src/ui/MovieDetailsView.qml
@@ -19,12 +19,12 @@ FocusScope {
 
     readonly property string movieName: MovieDetailsViewModel.title
     readonly property string movieOverview: MovieDetailsViewModel.overview
-    readonly property var runtimeTicks: MovieDetailsViewModel.runtimeTicks
+    readonly property double durationMs: MovieDetailsViewModel.durationMs
     readonly property var communityRating: MovieDetailsViewModel.communityRating
     readonly property string premiereDate: MovieDetailsViewModel.premiereDate
     readonly property int productionYear: MovieDetailsViewModel.productionYear
     readonly property bool isPlayed: MovieDetailsViewModel.isWatched
-    readonly property var playbackPositionTicks: MovieDetailsViewModel.playbackPositionTicks
+    readonly property double positionMs: MovieDetailsViewModel.positionMs
     readonly property string officialRating: MovieDetailsViewModel.officialRating
     readonly property var genres: MovieDetailsViewModel.genres
     readonly property var castAndCrew: MovieDetailsViewModel.people || []
@@ -64,22 +64,32 @@ FocusScope {
     signal backRequested()
     signal returnStateConsumed()
 
+    function artworkUrlFromRef(artwork, width) {
+        if (!artwork || !artwork.itemId) {
+            return ""
+        }
+        return LibraryService.getCachedArtworkUrl(
+                    artwork.itemId,
+                    artwork.kind || "primary",
+                    artwork.index || 0,
+                    artwork.tag || "",
+                    width || 420)
+    }
+
     component RecommendationPosterCard: Item {
         id: recommendationCard
 
         required property var itemData
         property bool isFocused: false
         property bool isHovered: InputModeManager.pointerActive && recommendationMouseArea.containsMouse
-        readonly property string posterSource: itemData.Id
-                                              ? LibraryService.getCachedImageUrlWithWidth(itemData.Id, "Primary", 420)
-                                              : ""
-        readonly property string title: itemData.Name || ""
+        readonly property string posterSource: root.artworkUrlFromRef(itemData.primaryArtwork, 420)
+        readonly property string title: itemData.name || ""
         readonly property string subtitle: {
-            if (itemData.ProductionYear) {
-                return String(itemData.ProductionYear)
+            if (itemData.productionYear) {
+                return String(itemData.productionYear)
             }
-            if (itemData.PremiereDate) {
-                const date = new Date(itemData.PremiereDate)
+            if (itemData.premiereDate) {
+                const date = new Date(itemData.premiereDate)
                 if (!isNaN(date.getTime())) {
                     return String(date.getFullYear())
                 }
@@ -148,7 +158,7 @@ FocusScope {
 
                     Text {
                         anchors.centerIn: parent
-                        text: recommendationCard.itemData.Type === "Series" ? Icons.tvShows : Icons.movie
+                        text: recommendationCard.itemData.mediaType === "Series" ? Icons.tvShows : Icons.movie
                         font.family: Theme.fontIcon
                         font.pixelSize: Math.round(56 * Theme.layoutScale)
                         color: Theme.textSecondary
@@ -378,9 +388,10 @@ FocusScope {
 
         return {
             itemId: movieId,
+            // Playback stack still expects ticks; convert from canonical milliseconds at the boundary.
             startPositionTicks: startPositionOverride !== undefined && startPositionOverride !== null
                                 ? startPositionOverride
-                                : (playbackPositionTicks || 0),
+                                : Math.round((positionMs || 0) * 10000),
             seriesId: "",
             seasonId: "",
             overlayTitle: movieName || qsTr("Now Playing"),
@@ -419,9 +430,9 @@ FocusScope {
         root.playRequested(buildPlaybackRequest(startPositionTicks, lastPlaybackRestoreFocusTarget))
     }
 
-    function formatRuntime(ticks) {
-        if (!ticks || ticks === 0) return ""
-        var totalMinutes = Math.round(ticks / 600000000)
+    function formatRuntime(ms) {
+        if (!ms || ms === 0) return ""
+        var totalMinutes = Math.round(ms / 60000)
         var hours = Math.floor(totalMinutes / 60)
         var minutes = totalMinutes % 60
         if (hours > 0) {
@@ -440,11 +451,10 @@ FocusScope {
                          : minutes + ":" + pad(remainder)
     }
 
-    function calculateEndTime(ticks) {
-        if (!ticks || ticks === 0) return ""
+    function calculateEndTime(ms) {
+        if (!ms || ms === 0) return ""
         var now = new Date()
-        var runtimeMs = ticks / 10000
-        var endTime = new Date(now.getTime() + runtimeMs)
+        var endTime = new Date(now.getTime() + ms)
         return qsTr("Ends %1").arg(endTime.toLocaleTimeString(Qt.locale(), "h:mm AP"))
     }
 
@@ -454,11 +464,11 @@ FocusScope {
     }
 
     function watchedMinutes() {
-        return Math.round((playbackPositionTicks || 0) / 600000000)
+        return Math.round((positionMs || 0) / 60000)
     }
 
     function totalMinutes() {
-        return Math.round((runtimeTicks || 0) / 600000000)
+        return Math.round((durationMs || 0) / 60000)
     }
 
     function remainingMinutes() {
@@ -1053,8 +1063,8 @@ FocusScope {
 
                             MetadataChip { text: productionYear > 0 ? String(productionYear) : "" }
                             MetadataChip { text: officialRating }
-                            MetadataChip { text: formatRuntime(runtimeTicks) }
-                            MetadataChip { text: calculateEndTime(runtimeTicks) }
+                            MetadataChip { text: formatRuntime(durationMs) }
+                            MetadataChip { text: calculateEndTime(durationMs) }
                             MetadataChip { text: formatCommunityRating() }
 
                             Repeater {
@@ -1187,7 +1197,7 @@ FocusScope {
 
                             Button {
                                 id: playButton
-                                text: playbackPositionTicks > 0 ? qsTr("Resume") : qsTr("Play")
+                                text: positionMs > 0 ? qsTr("Resume") : qsTr("Play")
                                 enabled: movieId !== ""
                                 Layout.preferredHeight: Theme.buttonHeightLarge
                                 Layout.preferredWidth: Theme.buttonHeightLarge
@@ -1352,7 +1362,7 @@ FocusScope {
                         }
 
                         ColumnLayout {
-                            visible: playbackPositionTicks > 0 && !isPlayed
+                            visible: positionMs > 0 && !isPlayed
                             Layout.fillWidth: true
                             spacing: Math.round(4 * Theme.layoutScale)
 
@@ -1386,7 +1396,7 @@ FocusScope {
                                     anchors.left: parent.left
                                     anchors.top: parent.top
                                     anchors.bottom: parent.bottom
-                                    width: runtimeTicks > 0 ? parent.width * Math.min(1, playbackPositionTicks / runtimeTicks) : 0
+                                    width: durationMs > 0 ? parent.width * Math.min(1, positionMs / durationMs) : 0
                                     radius: 3
                                     color: Theme.accentPrimary
                                 }

--- a/src/ui/PersonCard.qml
+++ b/src/ui/PersonCard.qml
@@ -34,9 +34,21 @@ FocusScope {
             Image {
                 id: personImage
                 anchors.fill: parent
-                source: personCard.itemData.Id && personCard.itemData.PrimaryImageTag
-                        ? LibraryService.getCachedImageUrlWithWidth(personCard.itemData.Id, "Primary", 360)
-                        : ""
+                source: {
+                    const artwork = personCard.itemData.artwork
+                    if (artwork && artwork.itemId) {
+                        return LibraryService.getCachedArtworkUrl(
+                                    artwork.itemId,
+                                    artwork.kind || "primary",
+                                    artwork.index || 0,
+                                    artwork.tag || "",
+                                    360)
+                    }
+                    if (personCard.itemData.Id && personCard.itemData.PrimaryImageTag) {
+                        return LibraryService.getCachedImageUrlWithWidth(personCard.itemData.Id, "Primary", 360)
+                    }
+                    return ""
+                }
                 fillMode: Image.PreserveAspectCrop
                 horizontalAlignment: Image.AlignHCenter
                 verticalAlignment: Image.AlignBottom
@@ -96,7 +108,7 @@ FocusScope {
             ScrollingCardLabel {
                 id: castNameLabel
                 anchors.fill: parent
-                text: personCard.itemData.Name || ""
+                text: personCard.itemData.name || personCard.itemData.Name || ""
                 fontPixelSize: Theme.fontSizeSmall
                 fontWeight: Font.DemiBold
                 textColor: Theme.textPrimary
@@ -112,7 +124,11 @@ FocusScope {
             ScrollingCardLabel {
                 id: castSubtitleLabel
                 anchors.fill: parent
-                text: personCard.itemData.Subtitle || ""
+                text: personCard.itemData.subtitle
+                      || personCard.itemData.Subtitle
+                      || personCard.itemData.role
+                      || personCard.itemData.kind
+                      || ""
                 fontPixelSize: Theme.fontSizeSmall
                 fontWeight: Font.Normal
                 textColor: Theme.textSecondary

--- a/src/viewmodels/MovieDetailsViewModel.cpp
+++ b/src/viewmodels/MovieDetailsViewModel.cpp
@@ -1,10 +1,9 @@
 #include "MovieDetailsViewModel.h"
 #include "../core/ServiceLocator.h"
 #include "../network/LibraryService.h"
+#include "../models/MediaModels.h"
 #include "../utils/ConfigManager.h"
 #include "../utils/DetailViewCache.h"
-#include "../utils/DetailListHelper.h"
-#include "../utils/DetailMetadataHelper.h"
 #include "../utils/ExternalRatingsHelper.h"
 #include <QDateTime>
 #include <QDir>
@@ -50,7 +49,68 @@ QString scopedCacheKey(const QString &remoteId)
     }
     return scope + QLatin1Char('\n') + remoteId;
 }
+
+bool isCanonicalMovieCache(const QJsonObject &movieData)
+{
+    return movieData.contains(QStringLiteral("itemId"))
+        && !movieData.contains(QStringLiteral("Id"))
+        && !movieData.contains(QStringLiteral("RunTimeTicks"))
+        && !movieData.contains(QStringLiteral("UserData"))
+        && !movieData.contains(QStringLiteral("ImageTags"))
+        && !movieData.contains(QStringLiteral("BackdropImageTags"))
+        && !movieData.contains(QStringLiteral("ProviderIds"));
 }
+
+bool isCanonicalSimilarItemsCache(const QJsonArray &items)
+{
+    if (items.isEmpty()) {
+        return true;
+    }
+    const QJsonObject first = items.at(0).toObject();
+    return first.contains(QStringLiteral("itemId"))
+        && !first.contains(QStringLiteral("Id"))
+        && !first.contains(QStringLiteral("ImageTags"));
+}
+
+QJsonArray variantListToJsonArray(const QVariantList &items)
+{
+    QJsonArray array;
+    for (const QVariant &value : items) {
+        if (!value.canConvert<QVariantMap>()) {
+            continue;
+        }
+        array.append(QJsonObject::fromVariantMap(value.toMap()));
+    }
+    return array;
+}
+
+QVariantList jsonArrayToVariantList(const QJsonArray &items)
+{
+    QVariantList mapped;
+    mapped.reserve(items.size());
+    for (const QJsonValue &value : items) {
+        if (value.isObject()) {
+            mapped.append(value.toObject().toVariantMap());
+        }
+    }
+    return mapped;
+}
+
+QStringList genresFromCanonical(const QVariant &genresValue)
+{
+    QStringList genres;
+    const QVariantList list = genresValue.toList();
+    genres.reserve(list.size());
+    for (const QVariant &value : list) {
+        const QString genre = value.toString();
+        if (!genre.isEmpty()) {
+            genres.append(genre);
+        }
+    }
+    return genres;
+}
+
+} // namespace
 
 MovieDetailsViewModel::MovieDetailsViewModel(QObject *parent)
     : BaseViewModel(parent)
@@ -59,15 +119,13 @@ MovieDetailsViewModel::MovieDetailsViewModel(QObject *parent)
     m_networkManager = new QNetworkAccessManager(this);
     
     if (m_libraryService) {
-        // Connect to generalized item loading signals or specific movie signals if available
-        // LibraryService emits itemLoaded for individual items
         connect(m_libraryService,
-                qOverload<const QString &, const QJsonObject &>(&LibraryService::itemLoaded),
+                qOverload<const QString &, const QVariantMap &>(&LibraryService::canonicalItemLoaded),
                 this, &MovieDetailsViewModel::onMovieDetailsLoaded);
         connect(m_libraryService,
                 qOverload<const QString &>(&LibraryService::itemNotModified),
                 this, &MovieDetailsViewModel::onMovieDetailsNotModified);
-        connect(m_libraryService, &LibraryService::similarItemsLoaded,
+        connect(m_libraryService, &LibraryService::canonicalSimilarItemsLoaded,
                 this, &MovieDetailsViewModel::onSimilarItemsLoaded);
         connect(m_libraryService, &LibraryService::similarItemsFailed,
                 this, &MovieDetailsViewModel::onSimilarItemsFailed);
@@ -77,21 +135,18 @@ MovieDetailsViewModel::MovieDetailsViewModel(QObject *parent)
                 this, &MovieDetailsViewModel::onMovieChaptersFailed);
         connect(m_libraryService, &LibraryService::errorOccurred,
                 this, &MovieDetailsViewModel::onErrorOccurred);
-        // Map generic itemPlayedStatusChanged to internal logic if needed,
-        // or rely on next refresh. But here we can bind to itemUserDataChanged if we implement it.
-        // For now, let's just listen to itemLoaded which contains UserData.
-        // Also listen to itemPlayedStatusChanged to update local state.
-         connect(m_libraryService, &LibraryService::itemPlayedStatusChanged,
+        connect(m_libraryService, &LibraryService::itemPlayedStatusChanged,
                 this, [this](const QString &itemId, bool played) {
-                    if (itemId == m_movieId) {
-                        m_isWatched = played;
-                        emit isWatchedChanged();
-                        // Also update internal QJson object if possible
-                        QJsonObject userData = m_movieData["UserData"].toObject();
-                        userData["Played"] = played;
-                        m_movieData["UserData"] = userData;
-                        storeMovieCache(m_movieId, m_movieData);
+                    if (itemId != m_movieId) {
+                        return;
                     }
+                    m_isWatched = played;
+                    emit isWatchedChanged();
+                    m_movieData.insert(QStringLiteral("watched"), played);
+                    QJsonObject userState = m_movieData.value(QStringLiteral("userState")).toObject();
+                    userState.insert(QStringLiteral("watched"), played);
+                    m_movieData.insert(QStringLiteral("userState"), userState);
+                    storeMovieCache(m_movieId, m_movieData);
                 });
     } else {
         qCWarning(lcViewModels) << "MovieDetailsViewModel: LibraryService not available in ServiceLocator";
@@ -115,7 +170,7 @@ QString MovieDetailsViewModel::movieCachePath(const QString &movieId) const
     if (movieId.isEmpty()) return QString();
     QDir dir(cacheDir());
     dir.mkpath(".");
-    return dir.filePath(DetailViewCache::sanitizeCacheKey(movieId) + "_details.json");
+    return dir.filePath(DetailViewCache::sanitizeCacheKey(movieId) + "_details_canonical.json");
 }
 
 QString MovieDetailsViewModel::similarItemsCachePath(const QString &movieId) const
@@ -123,34 +178,51 @@ QString MovieDetailsViewModel::similarItemsCachePath(const QString &movieId) con
     if (movieId.isEmpty()) return QString();
     QDir dir(cacheDir());
     dir.mkpath(".");
-    return dir.filePath(DetailViewCache::sanitizeCacheKey(movieId) + "_similar_items.json");
+    return dir.filePath(DetailViewCache::sanitizeCacheKey(movieId) + "_similar_items_canonical.json");
 }
 
 bool MovieDetailsViewModel::loadMovieFromCache(const QString &movieId, QJsonObject &movieData, bool requireFresh) const
 {
-    return DetailViewCache::loadObjectCache(s_movieCache,
-                                            scopedCacheKey(movieId),
-                                            movieCachePath(movieId),
-                                            kMovieMemoryTtlMs,
-                                            kMovieDiskTtlMs,
-                                            movieData,
-                                            requireFresh);
+    if (!DetailViewCache::loadObjectCache(s_movieCache,
+                                          scopedCacheKey(movieId),
+                                          movieCachePath(movieId),
+                                          kMovieMemoryTtlMs,
+                                          kMovieDiskTtlMs,
+                                          movieData,
+                                          requireFresh)) {
+        return false;
+    }
+    if (!isCanonicalMovieCache(movieData)) {
+        movieData = QJsonObject();
+        return false;
+    }
+    return true;
 }
 
 bool MovieDetailsViewModel::loadSimilarItemsFromCache(const QString &movieId, QJsonArray &items, bool requireFresh) const
 {
-    return DetailViewCache::loadArrayCache(s_similarItemsCache,
-                                           scopedCacheKey(movieId),
-                                           similarItemsCachePath(movieId),
-                                           kSimilarMemoryTtlMs,
-                                           kSimilarDiskTtlMs,
-                                           items,
-                                           requireFresh,
-                                           true);
+    if (!DetailViewCache::loadArrayCache(s_similarItemsCache,
+                                         scopedCacheKey(movieId),
+                                         similarItemsCachePath(movieId),
+                                         kSimilarMemoryTtlMs,
+                                         kSimilarDiskTtlMs,
+                                         items,
+                                         requireFresh,
+                                         true)) {
+        return false;
+    }
+    if (!isCanonicalSimilarItemsCache(items)) {
+        items = QJsonArray();
+        return false;
+    }
+    return true;
 }
 
 void MovieDetailsViewModel::storeMovieCache(const QString &movieId, const QJsonObject &movieData) const
 {
+    if (!isCanonicalMovieCache(movieData)) {
+        return;
+    }
     DetailViewCache::storeObjectCache(s_movieCache,
                                       scopedCacheKey(movieId),
                                       movieCachePath(movieId),
@@ -159,6 +231,9 @@ void MovieDetailsViewModel::storeMovieCache(const QString &movieId, const QJsonO
 
 void MovieDetailsViewModel::storeSimilarItemsCache(const QString &movieId, const QJsonArray &items) const
 {
+    if (!isCanonicalSimilarItemsCache(items)) {
+        return;
+    }
     DetailViewCache::storeArrayCache(s_similarItemsCache,
                                      scopedCacheKey(movieId),
                                      similarItemsCachePath(movieId),
@@ -203,23 +278,14 @@ void MovieDetailsViewModel::loadMovieDetails(const QString &movieId)
         qCDebug(lcViewModels) << "MovieDetailsViewModel: Serving movie details from cache"
                  << (hasFresh ? "FRESH" : "STALE");
         m_movieData = cachedMovie;
-        updateMovieMetadata(cachedMovie);
+        updateMovieMetadata(cachedMovie.toVariantMap());
     }
 
     if (hasAnySimilarItems) {
         qCDebug(lcViewModels) << "MovieDetailsViewModel: Serving similar items from cache"
                  << (hasFreshSimilarItems ? "FRESH" : "STALE")
                  << "count:" << cachedSimilarItems.size();
-        QVariantList mappedItems;
-        mappedItems.reserve(cachedSimilarItems.size());
-        for (const auto &value : cachedSimilarItems) {
-            const QJsonObject item = value.toObject();
-            if (item.isEmpty()) {
-                continue;
-            }
-            mappedItems.append(item.toVariantMap());
-        }
-        m_similarItems = mappedItems;
+        m_similarItems = normalizeSimilarItems(jsonArrayToVariantList(cachedSimilarItems));
         m_similarItemsAttempted = hasFreshSimilarItems;
         m_similarItemsLoading = false;
         emit similarItemsChanged();
@@ -232,8 +298,6 @@ void MovieDetailsViewModel::loadMovieDetails(const QString &movieId)
 
     qCDebug(lcViewModels) << "MovieDetailsViewModel::loadMovieDetails" << movieId;
     
-    // Fetch from server
-    // Request typical fields for details view
     m_libraryService->getItem(movieId);
     loadMovieChapters(movieId);
 }
@@ -271,7 +335,8 @@ void MovieDetailsViewModel::clear(bool preserveArtwork)
     m_productionYear = 0;
     m_isWatched = false;
     m_officialRating.clear();
-    m_runtimeTicks = 0;
+    m_durationMs = 0;
+    m_positionMs = 0;
     m_communityRating = 0.0;
     m_people.clear();
     m_chapters.clear();
@@ -282,13 +347,11 @@ void MovieDetailsViewModel::clear(bool preserveArtwork)
     m_similarItems.clear();
     m_similarItemsAttempted = false;
     m_similarItemsLoading = false;
-    m_playbackPositionTicks = 0;
     m_premiereDate = QDateTime();
     
     m_movieData = QJsonObject();
 
     if (!preserveArtwork) {
-        // Clear ratings data
         m_mdbListRatings.clear();
         m_rawMdbListRatings.clear();
         m_currentAniListImdbId.clear();
@@ -312,7 +375,8 @@ void MovieDetailsViewModel::clear(bool preserveArtwork)
     emit productionYearChanged();
     emit isWatchedChanged();
     emit officialRatingChanged();
-    emit runtimeTicksChanged();
+    emit durationMsChanged();
+    emit positionMsChanged();
     emit communityRatingChanged();
     emit peopleChanged();
     emit chaptersChanged();
@@ -321,7 +385,6 @@ void MovieDetailsViewModel::clear(bool preserveArtwork)
     emit similarItemsChanged();
     emit similarItemsLoadingChanged();
     emit premiereDateChanged();
-    emit playbackPositionTicksChanged();
     if (!preserveArtwork) {
         emit mdbListRatingsChanged();
     }
@@ -369,16 +432,16 @@ QVariantMap MovieDetailsViewModel::getMovieData() const
     return m_movieData.toVariantMap();
 }
 
-void MovieDetailsViewModel::onMovieDetailsLoaded(const QString &itemId, const QJsonObject &data)
+void MovieDetailsViewModel::onMovieDetailsLoaded(const QString &itemId, const QVariantMap &data)
 {
     if (itemId != m_movieId) return;
     
     m_loadingMovie = false;
     setLoading(false);
     
-    m_movieData = data;
+    m_movieData = QJsonObject::fromVariantMap(data);
     updateMovieMetadata(data);
-    storeMovieCache(itemId, data);
+    storeMovieCache(itemId, m_movieData);
 
     if (!m_similarItemsAttempted && !m_similarItemsLoading && m_libraryService) {
         m_similarItemsAttempted = true;
@@ -406,16 +469,16 @@ void MovieDetailsViewModel::onMovieDetailsNotModified(const QString &itemId)
     }
 }
 
-void MovieDetailsViewModel::onSimilarItemsLoaded(const QString &itemId, const QJsonArray &items)
+void MovieDetailsViewModel::onSimilarItemsLoaded(const QString &itemId, const QVariantList &items)
 {
     if (itemId != m_movieId) {
         return;
     }
 
-    m_similarItems = DetailListHelper::mapSimilarItems(items);
+    m_similarItems = normalizeSimilarItems(items);
     m_similarItemsAttempted = true;
     m_similarItemsLoading = false;
-    storeSimilarItemsCache(itemId, items);
+    storeSimilarItemsCache(itemId, variantListToJsonArray(m_similarItems));
     emit similarItemsChanged();
     emit similarItemsLoadingChanged();
 }
@@ -477,7 +540,7 @@ void MovieDetailsViewModel::onMovieChaptersFailed(const QString &itemId, const Q
 
 void MovieDetailsViewModel::onErrorOccurred(const QString &endpoint, const QString &error)
 {
-    // Simple heuristic to check if this error relates to our current loading
+    Q_UNUSED(endpoint)
     if (m_loadingMovie) {
         m_loadingMovie = false;
         setLoading(false);
@@ -486,64 +549,113 @@ void MovieDetailsViewModel::onErrorOccurred(const QString &endpoint, const QStri
     }
 }
 
-
-
-void MovieDetailsViewModel::updateMovieMetadata(const QJsonObject &data)
+QString MovieDetailsViewModel::cachedArtworkUrl(const QVariantMap &artwork, int width) const
 {
-    const auto common = DetailMetadataHelper::extractCommonMetadata(
-        data,
-        m_movieId,
-        [this](const QString &itemId, const QString &imageType, int width) {
-            return m_libraryService ? m_libraryService->getCachedImageUrlWithWidth(itemId, imageType, width)
-                                    : QString();
-        },
-        QString(),
-        true);
+    if (!m_libraryService || artwork.isEmpty()) {
+        return {};
+    }
+    const Bloom::ArtworkRef ref = Bloom::ArtworkRef::fromVariantMap(artwork);
+    if (ref.itemId.isEmpty() || ref.kind == Bloom::ArtworkKind::Unknown) {
+        return {};
+    }
+    return m_libraryService->getCachedArtworkUrl(ref.itemId,
+                                                  Bloom::artworkKindName(ref.kind),
+                                                  ref.index,
+                                                  ref.tag,
+                                                  width);
+}
 
-    m_title = common.title;
-    m_overview = common.overview;
-    m_productionYear = common.productionYear;
-    m_officialRating = common.officialRating;
-    m_runtimeTicks = data.value("RunTimeTicks").toVariant().toLongLong();
-    m_communityRating = data.value("CommunityRating").toDouble();
+QVariantList MovieDetailsViewModel::mapCanonicalPeople(const QVariantList &people) const
+{
+    QVariantList mappedPeople;
+    mappedPeople.reserve(qMin(people.size(), qsizetype(18)));
 
-    if (data.contains("PremiereDate")) {
-        m_premiereDate = QDateTime::fromString(data.value("PremiereDate").toString(), Qt::ISODate);
+    for (const QVariant &value : people) {
+        QVariantMap person = value.toMap();
+        const QString name = person.value(QStringLiteral("name")).toString();
+        if (name.isEmpty()) {
+            continue;
+        }
+
+        QString subtitle = person.value(QStringLiteral("role")).toString();
+        if (subtitle.isEmpty()) {
+            subtitle = person.value(QStringLiteral("kind")).toString();
+        }
+        person.insert(QStringLiteral("subtitle"), subtitle);
+        mappedPeople.append(person);
+
+        if (mappedPeople.size() >= 18) {
+            break;
+        }
     }
 
-    m_genres = common.genres;
-    m_isWatched = common.isWatched;
-    m_playbackPositionTicks = common.playbackPositionTicks;
-    m_people = common.people;
-    m_logoUrl = common.logoUrl;
-    m_posterUrl = common.posterUrl;
-    m_backdropUrl = common.backdropUrl;
+    return mappedPeople;
+}
+
+QVariantList MovieDetailsViewModel::normalizeSimilarItems(const QVariantList &items) const
+{
+    QVariantList mappedItems;
+    mappedItems.reserve(items.size());
+    for (const QVariant &value : items) {
+        const QVariantMap item = value.toMap();
+        if (item.value(QStringLiteral("itemId")).toString().isEmpty()) {
+            continue;
+        }
+        mappedItems.append(item);
+    }
+    return mappedItems;
+}
+
+void MovieDetailsViewModel::updateMovieMetadata(const QVariantMap &data)
+{
+    m_title = data.value(QStringLiteral("name")).toString();
+    m_overview = data.value(QStringLiteral("overview")).toString();
+    m_productionYear = data.value(QStringLiteral("productionYear")).toInt();
+    m_officialRating = data.value(QStringLiteral("officialRating")).toString();
+    m_durationMs = data.value(QStringLiteral("durationMs")).toLongLong();
+    m_communityRating = data.value(QStringLiteral("communityRating")).toDouble();
+    m_positionMs = data.value(QStringLiteral("positionMs")).toLongLong();
+    m_isWatched = data.value(QStringLiteral("watched")).toBool();
+    m_genres = genresFromCanonical(data.value(QStringLiteral("genres")));
+    m_people = mapCanonicalPeople(data.value(QStringLiteral("people")).toList());
+
+    const QString premiereDate = data.value(QStringLiteral("premiereDate")).toString();
+    if (!premiereDate.isEmpty()) {
+        m_premiereDate = QDateTime::fromString(premiereDate, Qt::ISODate);
+    } else {
+        m_premiereDate = QDateTime();
+    }
+
+    m_logoUrl = cachedArtworkUrl(data.value(QStringLiteral("logoArtwork")).toMap(), 2000);
+    m_posterUrl = cachedArtworkUrl(data.value(QStringLiteral("primaryArtwork")).toMap(), 400);
+    m_backdropUrl = cachedArtworkUrl(data.value(QStringLiteral("backdropArtwork")).toMap(), 1920);
+    if (m_backdropUrl.isEmpty()) {
+        m_backdropUrl = m_posterUrl;
+    }
 
     emit titleChanged();
     emit overviewChanged();
     emit productionYearChanged();
     emit officialRatingChanged();
-    emit runtimeTicksChanged();
+    emit durationMsChanged();
     emit communityRatingChanged();
     emit peopleChanged();
     emit genresChanged();
     emit premiereDateChanged();
     emit isWatchedChanged();
-    emit playbackPositionTicksChanged();
+    emit positionMsChanged();
     emit logoUrlChanged();
     emit posterUrlChanged();
     emit backdropUrlChanged();
     
-    // Fetch External Ratings
-    // Get external IDs
-    QString imdbId = data.value("ProviderIds").toObject().value("Imdb").toString();
-    QString tmdbId = data.value("ProviderIds").toObject().value("Tmdb").toString();
+    const QVariantMap providerIds = data.value(QStringLiteral("providerIds")).toMap();
+    const QString imdbId = providerIds.value(QStringLiteral("Imdb")).toString();
+    const QString tmdbId = providerIds.value(QStringLiteral("Tmdb")).toString();
     
     if (!imdbId.isEmpty() || !tmdbId.isEmpty()) {
         fetchMdbListRatings(imdbId, tmdbId, "movie");
     }
     
-    // Try to fetch AniList ratings if it's an anime
     bool isAnime = false;
     for (const auto &genre : m_genres) {
         if (genre.compare("Anime", Qt::CaseInsensitive) == 0 || 
@@ -557,10 +669,6 @@ void MovieDetailsViewModel::updateMovieMetadata(const QJsonObject &data)
         fetchAniListRating(imdbId, m_title, m_productionYear);
     }
 }
-
-// ============================================================
-// External Ratings Logic (Ported from SeriesDetailsViewModel)
-// ============================================================
 
 void MovieDetailsViewModel::fetchMdbListRatings(const QString &imdbId, const QString &tmdbId, const QString &type)
 {
@@ -611,20 +719,16 @@ void MovieDetailsViewModel::fetchAniListRating(const QString &imdbId, const QStr
 {
     if (imdbId.isEmpty()) return;
     
-    // Prevent re-querying if we already looked up this ID
     if (m_currentAniListImdbId == imdbId) return;
     m_currentAniListImdbId = imdbId;
-    m_aniListRating.clear(); // Clear old data
+    m_aniListRating.clear();
 
-    // First try mapping via Wikidata
     fetchAniListIdFromWikidata(imdbId, [this, title, year](const QString &foundId) {
+        Q_UNUSED(year)
         if (!foundId.isEmpty()) {
             qCDebug(lcViewModels) << "Found AniList ID via Wikidata:" << foundId;
             queryAniListById(foundId);
         } else {
-            // Fallback: Search by title if Wikidata fails
-            // NOTE: Implementing just the Wikidata path first as it's cleaner. 
-            // Title search can be fuzzy.
             qCWarning(lcViewModels) << "No AniList ID found in Wikidata for" << title;
         }
     });

--- a/src/viewmodels/MovieDetailsViewModel.h
+++ b/src/viewmodels/MovieDetailsViewModel.h
@@ -8,6 +8,8 @@
 #include <QSet>
 #include <QHash>
 #include <QNetworkAccessManager>
+#include <QVariantList>
+#include <QVariantMap>
 #include <functional>
 
 class LibraryService;
@@ -18,6 +20,8 @@ struct ChapterInfo;
  *
  * This class provides movie metadata (title, overview, logo, etc.) and
  * handles fetching external ratings from MDBList and AniList.
+ * Movie details and similar items are consumed as Bloom canonical camelCase
+ * models with millisecond timing.
  */
 class MovieDetailsViewModel : public BaseViewModel
 {
@@ -36,7 +40,8 @@ class MovieDetailsViewModel : public BaseViewModel
     Q_PROPERTY(bool isWatched READ isWatched NOTIFY isWatchedChanged)
     
     Q_PROPERTY(QString officialRating READ officialRating NOTIFY officialRatingChanged)
-    Q_PROPERTY(qint64 runtimeTicks READ runtimeTicks NOTIFY runtimeTicksChanged)
+    Q_PROPERTY(qint64 durationMs READ durationMs NOTIFY durationMsChanged)
+    Q_PROPERTY(qint64 positionMs READ positionMs NOTIFY positionMsChanged)
     Q_PROPERTY(double communityRating READ communityRating NOTIFY communityRatingChanged)
     Q_PROPERTY(QVariantList people READ people NOTIFY peopleChanged)
     Q_PROPERTY(QVariantList chapters READ chapters NOTIFY chaptersChanged)
@@ -45,7 +50,6 @@ class MovieDetailsViewModel : public BaseViewModel
     Q_PROPERTY(QVariantList similarItems READ similarItems NOTIFY similarItemsChanged)
     Q_PROPERTY(bool similarItemsLoading READ similarItemsLoading NOTIFY similarItemsLoadingChanged)
     Q_PROPERTY(QDateTime premiereDate READ premiereDate NOTIFY premiereDateChanged)
-    Q_PROPERTY(qint64 playbackPositionTicks READ playbackPositionTicks NOTIFY playbackPositionTicksChanged)
 
     // MDBList Ratings
     Q_PROPERTY(QVariantMap mdbListRatings READ mdbListRatings NOTIFY mdbListRatingsChanged)
@@ -65,7 +69,8 @@ public:
     bool isWatched() const { return m_isWatched; }
     
     QString officialRating() const { return m_officialRating; }
-    qint64 runtimeTicks() const { return m_runtimeTicks; }
+    qint64 durationMs() const { return m_durationMs; }
+    qint64 positionMs() const { return m_positionMs; }
     double communityRating() const { return m_communityRating; }
     QVariantList people() const { return m_people; }
     QVariantList chapters() const { return m_chapters; }
@@ -74,7 +79,6 @@ public:
     QVariantList similarItems() const { return m_similarItems; }
     bool similarItemsLoading() const { return m_similarItemsLoading; }
     QDateTime premiereDate() const { return m_premiereDate; }
-    qint64 playbackPositionTicks() const { return m_playbackPositionTicks; }
 
     // Property accessors - MDBList
     QVariantMap mdbListRatings() const { return m_mdbListRatings; }
@@ -141,7 +145,8 @@ signals:
     void isWatchedChanged();
     
     void officialRatingChanged();
-    void runtimeTicksChanged();
+    void durationMsChanged();
+    void positionMsChanged();
     void communityRatingChanged();
     void peopleChanged();
     void chaptersChanged();
@@ -150,23 +155,25 @@ signals:
     void similarItemsChanged();
     void similarItemsLoadingChanged();
     void premiereDateChanged();
-    void playbackPositionTicksChanged();
     void mdbListRatingsChanged();
 
     void movieLoaded();
     void loadError(const QString &error);
 
 private slots:
-    void onMovieDetailsLoaded(const QString &itemId, const QJsonObject &data);
+    void onMovieDetailsLoaded(const QString &itemId, const QVariantMap &data);
     void onMovieDetailsNotModified(const QString &itemId);
-    void onSimilarItemsLoaded(const QString &itemId, const QJsonArray &items);
+    void onSimilarItemsLoaded(const QString &itemId, const QVariantList &items);
     void onSimilarItemsFailed(const QString &itemId, const QString &error);
     void onMovieChaptersLoaded(const QString &itemId, const QList<ChapterInfo> &chapters);
     void onMovieChaptersFailed(const QString &itemId, const QString &error);
     void onErrorOccurred(const QString &endpoint, const QString &error);
 
 private:
-    void updateMovieMetadata(const QJsonObject &data);
+    void updateMovieMetadata(const QVariantMap &data);
+    QString cachedArtworkUrl(const QVariantMap &artwork, int width) const;
+    QVariantList mapCanonicalPeople(const QVariantList &people) const;
+    QVariantList normalizeSimilarItems(const QVariantList &items) const;
     void compileRatings();
     void applyMovieChapters(const QString &movieId, const QVariantList &chapters);
     void setMovieChaptersLoading(bool loading);
@@ -185,7 +192,8 @@ private:
     bool m_isWatched = false;
     
     QString m_officialRating;
-    qint64 m_runtimeTicks = 0;
+    qint64 m_durationMs = 0;
+    qint64 m_positionMs = 0;
     double m_communityRating = 0.0;
     QVariantList m_people;
     QVariantList m_chapters;
@@ -195,7 +203,6 @@ private:
     bool m_similarItemsAttempted = false;
     bool m_similarItemsLoading = false;
     QDateTime m_premiereDate;
-    qint64 m_playbackPositionTicks = 0;
 
     QJsonObject m_movieData;
     

--- a/tests/CanonicalModelsTest.cpp
+++ b/tests/CanonicalModelsTest.cpp
@@ -39,13 +39,31 @@ void CanonicalModelsTest::jellyfinItemMapsToCanonicalCamelCase()
         {QStringLiteral("Id"), QStringLiteral("movie-1")},
         {QStringLiteral("Name"), QStringLiteral("Example")},
         {QStringLiteral("Type"), QStringLiteral("Movie")},
+        {QStringLiteral("Overview"), QStringLiteral("A sample overview")},
+        {QStringLiteral("ProductionYear"), 2024},
+        {QStringLiteral("PremiereDate"), QStringLiteral("2024-01-15T00:00:00.000Z")},
+        {QStringLiteral("OfficialRating"), QStringLiteral("PG-13")},
+        {QStringLiteral("CommunityRating"), 8.5},
         {QStringLiteral("RunTimeTicks"), 72'000'000'000.0},
+        {QStringLiteral("Genres"), QJsonArray{QStringLiteral("Action"), QStringLiteral("Sci-Fi")}},
         {QStringLiteral("ImageTags"), QJsonObject{
              {QStringLiteral("Primary"), QStringLiteral("primary-tag")},
              {QStringLiteral("Logo"), QStringLiteral("logo-tag")}
          }},
         {QStringLiteral("BackdropImageTags"), QJsonArray{QStringLiteral("backdrop-tag")}},
-        {QStringLiteral("ProviderIds"), QJsonObject{{QStringLiteral("Tmdb"), QStringLiteral("42")}}},
+        {QStringLiteral("ProviderIds"), QJsonObject{
+             {QStringLiteral("Imdb"), QStringLiteral("tt123")},
+             {QStringLiteral("Tmdb"), QStringLiteral("42")}
+         }},
+        {QStringLiteral("People"), QJsonArray{
+             QJsonObject{
+                 {QStringLiteral("Id"), QStringLiteral("person-1")},
+                 {QStringLiteral("Name"), QStringLiteral("Ada")},
+                 {QStringLiteral("Role"), QStringLiteral("Director")},
+                 {QStringLiteral("Type"), QStringLiteral("Director")},
+                 {QStringLiteral("PrimaryImageTag"), QStringLiteral("person-tag")}
+             }
+         }},
         {QStringLiteral("UserData"), QJsonObject{
              {QStringLiteral("Played"), true},
              {QStringLiteral("IsFavorite"), true},
@@ -61,10 +79,21 @@ void CanonicalModelsTest::jellyfinItemMapsToCanonicalCamelCase()
     QCOMPARE(item.value(QStringLiteral("itemId")).toString(), QStringLiteral("movie-1"));
     QCOMPARE(item.value(QStringLiteral("name")).toString(), QStringLiteral("Example"));
     QCOMPARE(item.value(QStringLiteral("mediaType")).toString(), QStringLiteral("Movie"));
+    QCOMPARE(item.value(QStringLiteral("overview")).toString(), QStringLiteral("A sample overview"));
+    QCOMPARE(item.value(QStringLiteral("productionYear")).toInt(), 2024);
+    QCOMPARE(item.value(QStringLiteral("premiereDate")).toString(),
+             QStringLiteral("2024-01-15T00:00:00.000Z"));
+    QCOMPARE(item.value(QStringLiteral("officialRating")).toString(), QStringLiteral("PG-13"));
+    QCOMPARE(item.value(QStringLiteral("communityRating")).toDouble(), 8.5);
     QCOMPARE(item.value(QStringLiteral("durationMs")).toLongLong(), 7'200'000);
     QCOMPARE(item.value(QStringLiteral("positionMs")).toLongLong(), 1500);
     QVERIFY(item.value(QStringLiteral("watched")).toBool());
     QVERIFY(item.value(QStringLiteral("favorite")).toBool());
+    QCOMPARE(item.value(QStringLiteral("genres")).toList().size(), 2);
+    QCOMPARE(item.value(QStringLiteral("genres")).toList().at(0).toString(),
+             QStringLiteral("Action"));
+    QCOMPARE(item.value(QStringLiteral("providerIds")).toMap()
+                 .value(QStringLiteral("Imdb")).toString(), QStringLiteral("tt123"));
     QCOMPARE(item.value(QStringLiteral("providerIds")).toMap()
                  .value(QStringLiteral("Tmdb")).toString(), QStringLiteral("42"));
 
@@ -73,13 +102,33 @@ void CanonicalModelsTest::jellyfinItemMapsToCanonicalCamelCase()
              QStringLiteral("RunTimeTicks"),
              QStringLiteral("ImageTags"),
              QStringLiteral("BackdropImageTags"),
-             QStringLiteral("UserData")}) {
+             QStringLiteral("UserData"),
+             QStringLiteral("ProviderIds")}) {
         QVERIFY2(!item.contains(wireKey), qPrintable(wireKey));
     }
 
     const QVariantMap primary = item.value(QStringLiteral("primaryArtwork")).toMap();
     QCOMPARE(primary.value(QStringLiteral("kind")).toString(), QStringLiteral("primary"));
     QCOMPARE(primary.value(QStringLiteral("tag")).toString(), QStringLiteral("primary-tag"));
+    QCOMPARE(item.value(QStringLiteral("logoArtwork")).toMap()
+                 .value(QStringLiteral("tag")).toString(), QStringLiteral("logo-tag"));
+    QCOMPARE(item.value(QStringLiteral("backdropArtwork")).toMap()
+                 .value(QStringLiteral("tag")).toString(), QStringLiteral("backdrop-tag"));
+
+    const QVariantList people = item.value(QStringLiteral("people")).toList();
+    QCOMPARE(people.size(), 1);
+    const QVariantMap person = people.first().toMap();
+    QCOMPARE(person.value(QStringLiteral("name")).toString(), QStringLiteral("Ada"));
+    QCOMPARE(person.value(QStringLiteral("role")).toString(), QStringLiteral("Director"));
+    QCOMPARE(person.value(QStringLiteral("personId")).toString(), QStringLiteral("person-1"));
+    QCOMPARE(person.value(QStringLiteral("artwork")).toMap()
+                 .value(QStringLiteral("kind")).toString(), QStringLiteral("person"));
+
+    const QVariantList similar = JellyfinModelMapper::mediaItems(
+        QJsonArray{wire}, QStringLiteral("connection-1"));
+    QCOMPARE(similar.size(), 1);
+    QCOMPARE(similar.first().toMap().value(QStringLiteral("itemId")).toString(),
+             QStringLiteral("movie-1"));
 }
 
 void CanonicalModelsTest::jellyfinParentBackdropUsesImageItemId()

--- a/tests/SimilarItemsRetryTest.cpp
+++ b/tests/SimilarItemsRetryTest.cpp
@@ -29,6 +29,17 @@ public:
         return QString("image://%1/%2/%3").arg(itemId, imageType).arg(width);
     }
 
+    QString getCachedArtworkUrl(const QString &itemId,
+                                const QString &imageType,
+                                int imageIndex,
+                                const QString &imageTag,
+                                int width) override
+    {
+        Q_UNUSED(imageIndex)
+        Q_UNUSED(imageTag)
+        return QStringLiteral("artwork://%1/%2/%3").arg(itemId, imageType).arg(width);
+    }
+
     QStringList requestedIds;
 };
 
@@ -115,6 +126,7 @@ private slots:
     void init();
     void cleanup();
     void movieSimilarItemsFailureAllowsRetry();
+    void movieCanonicalSimilarItemsReplaceWireShape();
     void seriesSimilarItemsFailureAllowsRetry();
     void seriesEpisodeDetailsFailureIsTargeted();
     void seriesEpisodeDetailsNotModifiedRetriesOnce();
@@ -159,6 +171,45 @@ void SimilarItemsRetryTest::movieSimilarItemsFailureAllowsRetry()
     vm.onMovieDetailsNotModified(QStringLiteral("movie-1"));
     QCOMPARE(m_libraryService->requestedIds.size(), 1);
     QCOMPARE(m_libraryService->requestedIds.first(), QStringLiteral("movie-1"));
+}
+
+void SimilarItemsRetryTest::movieCanonicalSimilarItemsReplaceWireShape()
+{
+    MovieDetailsViewModel vm;
+    vm.m_movieId = QStringLiteral("movie-1");
+    vm.m_similarItemsLoading = true;
+
+    const QVariantList canonicalItems{
+        QVariantMap{
+            {QStringLiteral("itemId"), QStringLiteral("movie-2")},
+            {QStringLiteral("name"), QStringLiteral("Similar")},
+            {QStringLiteral("mediaType"), QStringLiteral("Movie")},
+            {QStringLiteral("productionYear"), 2023},
+            {QStringLiteral("primaryArtwork"), QVariantMap{
+                 {QStringLiteral("connectionId"), QStringLiteral("connection-1")},
+                 {QStringLiteral("itemId"), QStringLiteral("movie-2")},
+                 {QStringLiteral("kind"), QStringLiteral("primary")},
+                 {QStringLiteral("index"), 0},
+                 {QStringLiteral("tag"), QStringLiteral("poster-tag")},
+                 {QStringLiteral("requestedWidth"), 0}
+             }}
+        },
+        QVariantMap{
+            {QStringLiteral("Id"), QStringLiteral("legacy-wire")},
+            {QStringLiteral("Name"), QStringLiteral("Should Be Ignored")}
+        }
+    };
+
+    vm.onSimilarItemsLoaded(QStringLiteral("movie-1"), canonicalItems);
+
+    QCOMPARE(vm.similarItems().size(), 1);
+    const QVariantMap item = vm.similarItems().first().toMap();
+    QCOMPARE(item.value(QStringLiteral("itemId")).toString(), QStringLiteral("movie-2"));
+    QCOMPARE(item.value(QStringLiteral("name")).toString(), QStringLiteral("Similar"));
+    QVERIFY(item.contains(QStringLiteral("primaryArtwork")));
+    QVERIFY(!item.contains(QStringLiteral("Id")));
+    QCOMPARE(vm.similarItemsLoading(), false);
+    QCOMPARE(vm.m_similarItemsAttempted, true);
 }
 
 void SimilarItemsRetryTest::seriesSimilarItemsFailureAllowsRetry()


### PR DESCRIPTION
## Summary
- map item and similar-item payloads through the active provider adapter while retaining temporary raw compatibility signals
- migrate Movie Details state, cache files, timing, artwork, people, provider IDs, and recommendations to canonical camelCase contracts
- update Movie Details and recommendation QML consumers and add canonical mapper/cache regression coverage

## Validation
- `./scripts/dev-build.sh`
- `nix build '.#checks.x86_64-linux.tests' --no-write-lock-file -L` (19/19 tests)
- deterministic QML lint plus six focused QML reviews
- independent canonical Movie Details review: PASS
- `git diff --check`

Part of #76.

Draft while the stacked canonical migration continues.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor MovieDetailsViewModel to consume canonical detail models
> - `MovieDetailsViewModel` now connects to `LibraryService::canonicalItemLoaded` and `canonicalSimilarItemsLoaded` signals instead of wire signals, reading all display fields (name, overview, timing, artwork, people) from canonical `QVariantMap`/`QVariantList` payloads.
> - `LibraryService` maps wire responses to canonical form via `AuthenticationService::mapMediaItem`/`mapMediaItems` (delegating to `IProviderAdapter`) and emits both wire and canonical signals in parallel, preserving backward compatibility.
> - `MovieDetailsView.qml` and `LibraryScreen.qml` updated to use canonical fields (`durationMs`/`positionMs`, `primaryArtwork`, `mediaType`, `itemId`), converting ms→ticks only when issuing playback requests.
> - Disk cache filenames changed from wire-shaped JSON to `*_details_canonical.json` / `*_similar_items_canonical.json`; old wire caches are rejected on load.
> - `PersonCard.qml` prefers canonical artwork and name fields with fallback to wire fields.
> - Behavioral Change: `durationMs`/`positionMs` replace `runtimeTicks`/`playbackPositionTicks` in the public QML API of `MovieDetailsViewModel`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 392c022.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Movie details now use canonical metadata, artwork, recommendations, and millisecond-based playback timing.
  * Added improved artwork resolution and fallback handling across movie, library, cast, and recommendation views.
  * Similar items now consistently display canonical identifiers and details.

* **Bug Fixes**
  * Improved navigation and selection handling across movies, series, and episodes.
  * Invalid or outdated cached movie data is rejected and refreshed.

* **Documentation**
  * Updated canonical data contracts, Movie Details behavior, caching rules, and testing expectations.

* **Tests**
  * Expanded coverage for metadata mapping, artwork caching, playback details, and similar-item handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->