### PR TITLE
feat(profiles): add multi-connection workspace schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ See also:
 - docs/playback.md  — mpv and playback/reporting integration
 - docs/provider-compatibility.md — provider-neutral server contract matrix, reproducible Jellyfin/Silo pins, and native API assumptions
 - docs/provider-architecture.md — connection identity, credential migration, and incremental provider adapter boundaries
+- docs/profiles.md — Bloom profiles (workspace memberships distinct from provider profiles)
 - docs/canonical-models.md — Bloom-owned media, artwork, and playback model contracts
 - docs/media-segments.md — External intro/recap/credits provider integration and precedence
 - docs/hero-banner.md — Home hero sources, settings, focus behavior, and backdrop synchronization

--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -8,6 +8,7 @@ Bloom-owned canonical models separate UI/player code from provider wire formats.
 - Durations, positions, chapter starts, and media segments use milliseconds.
 - Provider time conversion occurs only in the provider adapter.
 - `MediaRef` combines `connectionId` and `itemId`; a remote item ID is never globally unique by itself.
+- Bloom profile `memberId` is request/source context only and must not be added to `MediaRef`, artwork cache keys, or library disk caches. See [profiles](profiles.md).
 - `ArtworkRef` is token-free and identifies artwork by connection, item, kind, index, tag, and requested width.
 - Artwork fetch URLs, headers, and expiring provider representations are transport details and must not become cache identities.
 - `PlaybackDescriptor` owns the finalized stream request, normalized tracks, session identity, canonical timing, chapters, and reporting capabilities consumed by the player.

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,8 +23,9 @@ mpv config directory
 
 Session management
 - Config v28 stores versioned provider-neutral records under `settings.connections`; see [provider architecture](provider-architecture.md).
+- Config v30 stores Bloom workspaces under `settings.bloom_profiles` schema `1`; see [profiles](profiles.md). `getBloomProfilesConfig` / `setBloomProfilesConfig` are raw accessors — `BloomProfileRepository` owns validation and CRUD.
 - `setJellyfinSession()`, `getJellyfinSession()`, and `clearJellyfinSession()` are temporary compatibility façades over the active connection.
-- Credentials are stored by `CredentialStore`, never in a connection or new `app.json` writes. Legacy `settings.jellyfin` metadata remains only until its secure-store migration is verified.
+- Credentials are stored by `CredentialStore`, never in a connection, Bloom profile, or new `app.json` writes. Legacy `settings.jellyfin` metadata remains only until its secure-store migration is verified.
 - Handle 401 errors by emitting `sessionExpired()` and invoking logout/clear sessions.
 
 Config API sample (high level)
@@ -56,6 +57,7 @@ MPV profile management
 - Config v27 adds `settings.input_bindings` with schema `1`, empty keyboard overrides, and empty gamepad overrides.
 - Config v28 adds `settings.connections` schema `1`, migrates valid Jellyfin session metadata to a stable connection ID, and retains the legacy record only until credential migration succeeds.
 - Config v29 adds `settings.connection_state` schema `1` and migrates MPV library/series assignments plus library startup-buffering overrides into the active connection scope so identical remote IDs cannot collide.
+- Config v30 adds `settings.bloom_profiles` schema `1`. Migration creates one default `single` Bloom profile for the active connection (or sole saved connection), or an empty block when no connections exist. Deterministic UUIDv5 IDs keep retries idempotent. `settings.connections.active` is unchanged.
 - Built-in profile behavior: `Low Quality` uses mpv `--profile=fast`; `Medium Quality` uses `--profile=high-quality`; `High Quality` uses `--profile=high-quality` plus bundled FSRCNNX, KrigBilateral, and SSimDownscaler GLSL shaders loaded from `~~/shaders/...`. The ArtCNN/nnedi3 profiles use `--profile=high-quality`, `--hwdec=no`, a single selected bundled shader, Gandhi Sans Bold subtitle styling from `~~/fonts`, and optional mpv deband tuning for the `-Deband` variants.
 - Settings > MPV > Edit Profiles > Import Config creates a new profile from an existing `mpv.conf`. v1 imports only global top-level options before the first `[profile]` section and stores them as normalized `extra_args` entries (`--option=value` or `--option`) in `settings.mpv_profiles`; it never overwrites an existing profile.
 - MPV profile import/save/load normalizes one surrounding quote pair from `--option=value` and stores common shader aliases (`--glsl-shader`, `--glsl-shader-append`, `--glsl-shaders`, `--glsl-shaders-append`) as ordered `--glsl-shaders-append=...` entries. On playback, Bloom emits a single `--glsl-shaders-clr` before the profile shader appends so multiple shaders load in profile order while replacing any inherited shader list.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,0 +1,122 @@
+# Bloom profiles
+
+Bloom profiles are Bloom-owned workspaces for switching and (later) merging independent server connections. They are distinct from provider household profiles (for example Silo or Jellyfin user profiles).
+
+This page documents the schema/repository slice (issue #91). Merged catalog reads, picker UI, and service fan-out are not implemented yet.
+
+## Terminology
+
+| Term | Meaning |
+| --- | --- |
+| **Connection** | One `ServerConnection` identity: server + account + provider profile + credential reference. |
+| **Provider profile** | Server-owned user/household profile selected within a connection. |
+| **Bloom profile** | User-named, ordered set of independent connection memberships. |
+| **Membership** | One connection attached to a Bloom profile (`memberId` + `connectionId`). |
+| **Single mode** | Exactly one membership; preserves today’s single-connection browsing behavior. |
+| **Merged mode** | Multiple memberships; aggregation comes in a later slice. |
+
+## Identity rules
+
+- `connectionId` is one server + account + provider-profile credential identity. The same physical server may appear as multiple connections when users/accounts differ; those connections have distinct `connectionId`s.
+- Within one Bloom profile, at most one membership per `connectionId` so `MediaRef{connectionId,itemId}` stays unambiguous.
+- Never dedupe or key memberships by `serverId`, `baseUrl`, or account alone.
+- Membership identity belongs in request/source context, not in `MediaRef` or cache keys. `memberId` must not be copied into media identity or disk caches.
+- Profile JSON stores only Bloom profile fields and `connection_id` references. No URLs, accounts, provider profile IDs, usernames, or credentials.
+
+## Persistence (`settings.bloom_profiles`)
+
+Config app version 30 introduces schema version 1:
+
+```json
+{
+  "version": 1,
+  "active_profile_id": "…",
+  "items": [
+    {
+      "id": "…",
+      "name": "Default",
+      "mode": "single",
+      "members": [
+        {
+          "member_id": "…",
+          "connection_id": "…",
+          "enabled": true,
+          "priority": 0,
+          "label_override": "optional"
+        }
+      ],
+      "default_member_id": "…",
+      "created_at": "2026-07-21T18:00:00Z",
+      "updated_at": "2026-07-21T18:00:00Z"
+    }
+  ]
+}
+```
+
+- Member order is the ordered `members` array; `priority` is normalized to `0..n-1` deterministically.
+- `ConfigManager::getBloomProfilesConfig` / `setBloomProfilesConfig` are raw read/write accessors (setter saves). Validation and CRUD live in `BloomProfileRepository`.
+
+## Migration (config v29 → v30)
+
+- Preserve prior single-connection behavior by creating **one** default `single` Bloom profile containing **only** the current active connection, or the sole saved connection when none is active.
+- Do **not** put every saved connection into the migrated profile.
+- Zero connections → empty v1 block (`active_profile_id` empty, `items` empty).
+- Profile IDs use deterministic UUIDv5 values derived from `connectionId`; member IDs derive from the Bloom profile plus `connectionId`, so retries are idempotent without conflating memberships across profiles.
+- `settings.connections.active` and existing connection behavior stay unchanged in this slice.
+- Default config ships an empty v1 block.
+
+## Repository API
+
+`BloomProfileRepository` (`src/profiles/BloomProfileRepository.*`) is a provider-neutral `QObject` registered in `ServiceLocator` after `ConfigManager` (production and test).
+
+Public surface:
+
+- `profiles()`, `activeProfile()`, `profile(id)`
+- `upsertProfile`, `removeProfile`, `setActiveProfile` (`upsertProfile` takes a reference and writes back assigned IDs/timestamps)
+- `addMember`, `removeMember`, `reorderMembers`, `setDefaultMember`
+- Immutable `BloomProfileRequestContext` snapshots: `bloomProfileId`, `memberId`, `connectionId`, `generation`
+- `generation()`, `activeRequestContext()`, `requestContext(profileId, memberId)`, `isCurrent(context)`
+
+### Validation and repair
+
+On load (and when connections change), the repository:
+
+- Drops members whose `connectionId` is missing from `ConfigManager::getConnections`
+- Dedupes only identical `connectionId` (keeps the first)
+- Regenerates empty member IDs deterministically from the Bloom profile plus `connectionId`; regenerates duplicate member IDs with a new UUID
+- Repairs `default_member_id` to the first enabled member, else the first member
+- Repairs `active_profile_id` to the first valid profile when needed
+- Drops empty profiles; an empty repository is valid
+- Persists repairs idempotently
+
+**Single mode:** must resolve through exactly one membership. If an upsert supplies more than one member, the repository deterministically retains the default member when present, otherwise the first, and drops the rest. `addMember` rejects a second membership in Single mode.
+
+**Merged mode:** may include multiple distinct `connectionId`s.
+
+### Request context epoch
+
+Switching the active profile, default member, or membership-affecting mutations increments `generation`. Callers keep a `BloomProfileRequestContext` and use `isCurrent` to ignore stale async results.
+
+This layer does **not** secretly change `ConfigManager`’s active connection. Context is foundation-only until later service-routing slices.
+
+## Types
+
+- `BloomProfileMode { Single, Merged }`
+- `BloomProfileMember` — `memberId`, `connectionId`, `enabled`, `priority`, optional `labelOverride`
+- `BloomProfile` — stable UUID `id`, `name`, `mode`, ordered `members`, `defaultMemberId`, timestamps
+- `BloomProfileRequestContext` — profile/member/connection + generation
+
+Snake_case JSON; C++ API uses camelCase fields.
+
+## Out of scope (later slices)
+
+- Bloom profile picker / settings QML
+- Merged Home/Library/Search coordinators
+- Binding services to explicit request context instead of the global active connection
+- Cross-server metadata deduplication
+
+## Tests
+
+`BloomProfileRepositoryTest` covers JSON round-trip, multi-server plus two users on one physical server (shared `baseUrl`, distinct `connectionId`s), duplicate-connection dedupe, migration seeding (active-only, sole connection, empty), dangling repair, ordering/default repair, Single-mode multi-member retention, CRUD persistence, context epoch stale guards, and absence of credential/server identity fields in profile JSON.
+
+See also: [provider architecture](provider-architecture.md), [canonical models](canonical-models.md), [config](config.md), [services](services.md).

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -51,6 +51,10 @@ Config schema version 28 stores connections under `settings.connections`:
 
 `ConfigManager` provides connection persistence and active-connection access. Connection removal is intentionally deferred until an account-session service can delete credentials before dropping metadata. Its Jellyfin session methods remain temporary compatibility façades while existing callers move to provider-neutral services.
 
+## Bloom profiles
+
+Bloom profiles (`src/profiles/*`, documented in [`profiles.md`](profiles.md)) are Bloom-owned workspaces, not provider household profiles. A membership references a `connectionId` only. The same physical server may appear multiple times via distinct connections (different accounts/users); memberships are never keyed by `serverId` or `baseUrl`. Within one Bloom profile, at most one membership per `connectionId` so `MediaRef{connectionId,itemId}` remains unambiguous. Membership identity lives in request/source context (`BloomProfileRequestContext`), not in `MediaRef` or caches. Config v30 persists `settings.bloom_profiles`; migration seeds one default `single` profile from the active (or sole) connection without changing `settings.connections.active`.
+
 ## Credential storage and migration
 
 `CredentialStore` (`src/security/CredentialStore.*`) centralizes credential key generation over the platform `ISecretStore` implementation.

--- a/docs/services.md
+++ b/docs/services.md
@@ -6,6 +6,7 @@ Overview
 
 Key services
 - `ConfigManager` — Configuration, QML bindings, and provider-neutral connection metadata persistence.
+- `BloomProfileRepository` — Bloom workspace profiles/memberships and request-context generation; depends on ConfigManager raw `settings.bloom_profiles` accessors. See [profiles](profiles.md).
 - `CredentialStore` — Provider-neutral platform-keychain names, access/refresh/profile token storage, and verified legacy Jellyfin credential migration.
 - `TrackPreferencesManager` — Versioned, connection-scoped persistence for explicit season/movie audio and subtitle preferences.
 - `IPlayerBackend` — Playback backend abstraction registered in `ServiceLocator`.
@@ -31,6 +32,7 @@ Key services
 
 Initialization order (recommended)
 1. ConfigManager — loads configs, path info, and active `ServerConnection` metadata.
+1.1. BloomProfileRepository — loads/repairs `settings.bloom_profiles` after ConfigManager.
 2. IPlayerBackend — created by `PlayerBackendFactory` (`win-libmpv` on Windows; platform-selected backend elsewhere).
 3. HttpTransport and `JellyfinProviderAdapter` — own shared HTTP execution and the selected provider wire implementation.
 4. AuthenticationService — stable session façade; depends on `CredentialStore`, `HttpTransport`, and `IProviderAdapter`.

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation {
       LoggingConfigTest \
       ConfigManagerThemeTest \
       ConnectionPersistenceTest \
+      BloomProfileRepositoryTest \
       ProviderTransportTest \
       CanonicalModelsTest \
       InputBindingManagerTest \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,10 @@ qt_add_executable(Bloom
     core/ServiceLocator.cpp
     providers/ServerConnection.h
     providers/ServerConnection.cpp
+    profiles/BloomProfile.h
+    profiles/BloomProfile.cpp
+    profiles/BloomProfileRepository.h
+    profiles/BloomProfileRepository.cpp
     providers/IProviderAdapter.h
     providers/IArtworkProvider.h
     providers/IProviderAuthenticator.h

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -1,6 +1,7 @@
 #include "ApplicationInitializer.h"
 #include "ServiceLocator.h"
 #include "utils/ConfigManager.h"
+#include "profiles/BloomProfileRepository.h"
 #include "utils/DisplayManager.h"
 #include "ui/ResponsiveLayoutManager.h"
 #include "utils/TrackPreferencesManager.h"
@@ -129,6 +130,10 @@ void ApplicationInitializer::registerServices()
 
     // Load configuration early so logging and downstream services can read settings
     m_configManager->load();
+
+    // 1.1 BloomProfileRepository - Depends on ConfigManager (loads after config)
+    m_bloomProfileRepository = std::make_unique<BloomProfileRepository>(m_configManager.get());
+    ServiceLocator::registerService<BloomProfileRepository>(m_bloomProfileRepository.get());
 
     LoggingConfig::apply(
         LoggingConfig::levelFromString(m_configManager->getLogLevel()),

--- a/src/core/ApplicationInitializer.h
+++ b/src/core/ApplicationInitializer.h
@@ -5,6 +5,7 @@
 
 class QGuiApplication;
 class ConfigManager;
+class BloomProfileRepository;
 class DisplayManager;
 class ResponsiveLayoutManager;
 class TrackPreferencesManager;
@@ -100,6 +101,7 @@ private:
     
     // Service ownership
     std::unique_ptr<ConfigManager> m_configManager;
+    std::unique_ptr<BloomProfileRepository> m_bloomProfileRepository;
     std::unique_ptr<DisplayManager> m_displayManager;
     std::unique_ptr<TrackPreferencesManager> m_trackPreferencesManager;
     std::unique_ptr<IPlayerBackend> m_playerBackend;

--- a/src/core/ServiceLocator.h
+++ b/src/core/ServiceLocator.h
@@ -24,6 +24,7 @@
  * Services must be registered in the following order due to dependencies:
  * 
  * 1. **ConfigManager** - No dependencies, loads configuration
+ * 1.1. **BloomProfileRepository** - Depends on: ConfigManager (Bloom profile store)
  * 2. **IPlayerBackend** - No dependencies, active playback backend implementation
  * 3. **AuthenticationService** - No dependencies, handles authentication/session
  * 4. **LibraryService** - Depends on: AuthenticationService (library/data APIs)

--- a/src/profiles/BloomProfile.cpp
+++ b/src/profiles/BloomProfile.cpp
@@ -1,0 +1,166 @@
+#include "BloomProfile.h"
+
+#include <QJsonArray>
+#include <QUuid>
+
+namespace {
+
+const QUuid &bloomProfileNamespace()
+{
+    static const QUuid ns(QStringLiteral("{a3f7c2e1-9b4d-5e8a-b1c6-2d4f8a0e7b93}"));
+    return ns;
+}
+
+QString formatTimestamp(const QDateTime &value)
+{
+    if (!value.isValid()) {
+        return {};
+    }
+    return value.toUTC().toString(Qt::ISODate);
+}
+
+QDateTime parseTimestamp(const QString &value)
+{
+    if (value.trimmed().isEmpty()) {
+        return {};
+    }
+    QDateTime parsed = QDateTime::fromString(value, Qt::ISODate);
+    if (!parsed.isValid()) {
+        parsed = QDateTime::fromString(value, Qt::ISODateWithMs);
+    }
+    if (!parsed.isValid()) {
+        return {};
+    }
+    return parsed.toUTC();
+}
+
+} // namespace
+
+bool BloomProfileMember::isValid() const
+{
+    return !memberId.trimmed().isEmpty() && !connectionId.trimmed().isEmpty();
+}
+
+QJsonObject BloomProfileMember::toJson() const
+{
+    QJsonObject json;
+    json[QStringLiteral("member_id")] = memberId;
+    json[QStringLiteral("connection_id")] = connectionId;
+    json[QStringLiteral("enabled")] = enabled;
+    json[QStringLiteral("priority")] = priority;
+    if (!labelOverride.trimmed().isEmpty()) {
+        json[QStringLiteral("label_override")] = labelOverride;
+    }
+    return json;
+}
+
+BloomProfileMember BloomProfileMember::fromJson(const QJsonObject &json)
+{
+    BloomProfileMember member;
+    member.memberId = json.value(QStringLiteral("member_id")).toString().trimmed();
+    member.connectionId = json.value(QStringLiteral("connection_id")).toString().trimmed();
+    member.enabled = json.value(QStringLiteral("enabled")).toBool(true);
+    member.priority = json.value(QStringLiteral("priority")).toInt(0);
+    member.labelOverride = json.value(QStringLiteral("label_override")).toString();
+    return member;
+}
+
+bool BloomProfile::isValid() const
+{
+    return !id.trimmed().isEmpty()
+        && !name.trimmed().isEmpty()
+        && !members.isEmpty();
+}
+
+QJsonObject BloomProfile::toJson() const
+{
+    QJsonObject json;
+    json[QStringLiteral("id")] = id;
+    json[QStringLiteral("name")] = name;
+    json[QStringLiteral("mode")] = modeName(mode);
+    QJsonArray membersJson;
+    for (const BloomProfileMember &member : members) {
+        membersJson.append(member.toJson());
+    }
+    json[QStringLiteral("members")] = membersJson;
+    json[QStringLiteral("default_member_id")] = defaultMemberId;
+    json[QStringLiteral("created_at")] = formatTimestamp(createdAt);
+    json[QStringLiteral("updated_at")] = formatTimestamp(updatedAt);
+    return json;
+}
+
+BloomProfile BloomProfile::fromJson(const QJsonObject &json)
+{
+    BloomProfile profile;
+    profile.id = json.value(QStringLiteral("id")).toString().trimmed();
+    profile.name = json.value(QStringLiteral("name")).toString().trimmed();
+    profile.mode = modeFromName(json.value(QStringLiteral("mode")).toString());
+    profile.defaultMemberId = json.value(QStringLiteral("default_member_id")).toString().trimmed();
+    profile.createdAt = parseTimestamp(json.value(QStringLiteral("created_at")).toString());
+    profile.updatedAt = parseTimestamp(json.value(QStringLiteral("updated_at")).toString());
+
+    const QJsonArray membersJson = json.value(QStringLiteral("members")).toArray();
+    for (const QJsonValue &value : membersJson) {
+        if (!value.isObject()) {
+            continue;
+        }
+        profile.members.append(BloomProfileMember::fromJson(value.toObject()));
+    }
+    return profile;
+}
+
+QString BloomProfile::modeName(BloomProfileMode mode)
+{
+    switch (mode) {
+    case BloomProfileMode::Merged:
+        return QStringLiteral("merged");
+    case BloomProfileMode::Single:
+        return QStringLiteral("single");
+    }
+    return QStringLiteral("single");
+}
+
+BloomProfileMode BloomProfile::modeFromName(const QString &name)
+{
+    return name.trimmed().compare(QStringLiteral("merged"), Qt::CaseInsensitive) == 0
+        ? BloomProfileMode::Merged
+        : BloomProfileMode::Single;
+}
+
+QString BloomProfile::createProfileId()
+{
+    return QUuid::createUuid().toString(QUuid::WithoutBraces);
+}
+
+QString BloomProfile::createMemberId()
+{
+    return QUuid::createUuid().toString(QUuid::WithoutBraces);
+}
+
+QString BloomProfile::createDeterministicProfileId(const QString &connectionId)
+{
+    const QByteArray identity =
+        QStringLiteral("bloom-profile\n%1").arg(connectionId.trimmed()).toUtf8();
+    return QUuid::createUuidV5(bloomProfileNamespace(), identity).toString(QUuid::WithoutBraces);
+}
+
+QString BloomProfile::createDeterministicMemberId(const QString &profileId,
+                                                  const QString &connectionId)
+{
+    const QByteArray identity = QStringLiteral("bloom-member\n%1\n%2")
+                                    .arg(profileId.trimmed(), connectionId.trimmed())
+                                    .toUtf8();
+    return QUuid::createUuidV5(bloomProfileNamespace(), identity).toString(QUuid::WithoutBraces);
+}
+
+bool BloomProfileRequestContext::isValid() const
+{
+    return !bloomProfileId.trimmed().isEmpty()
+        && !memberId.trimmed().isEmpty()
+        && !connectionId.trimmed().isEmpty();
+}
+
+bool BloomProfileRequestContext::isCurrent(quint64 currentGeneration) const
+{
+    return isValid() && generation == currentGeneration;
+}

--- a/src/profiles/BloomProfile.h
+++ b/src/profiles/BloomProfile.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <QDateTime>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QList>
+#include <QMetaType>
+#include <QString>
+
+/**
+ * @brief Workspace composition mode for a Bloom profile.
+ *
+ * Single resolves through exactly one membership. Merged may include multiple
+ * independent connection memberships (no cross-server deduplication in MVP).
+ */
+enum class BloomProfileMode {
+    Single,
+    Merged
+};
+
+/**
+ * @brief One ServerConnection membership inside a Bloom profile.
+ *
+ * Identity is memberId + connectionId. Never keyed by serverId, baseUrl, or
+ * provider profile alone — the same physical server may appear via distinct
+ * connectionIds (different accounts/users).
+ */
+struct BloomProfileMember {
+    QString memberId;
+    QString connectionId;
+    bool enabled = true;
+    int priority = 0;
+    QString labelOverride;
+
+    bool isValid() const;
+    QJsonObject toJson() const;
+    static BloomProfileMember fromJson(const QJsonObject &json);
+};
+
+/**
+ * @brief Bloom-owned workspace grouping independent connection memberships.
+ *
+ * Distinct from provider household profiles. Credentials, base URLs, accounts,
+ * and provider profile IDs are never stored here — only connectionId references.
+ */
+struct BloomProfile {
+    QString id;
+    QString name;
+    BloomProfileMode mode = BloomProfileMode::Single;
+    QList<BloomProfileMember> members;
+    QString defaultMemberId;
+    QDateTime createdAt;
+    QDateTime updatedAt;
+
+    bool isValid() const;
+    QJsonObject toJson() const;
+    static BloomProfile fromJson(const QJsonObject &json);
+
+    static QString modeName(BloomProfileMode mode);
+    static BloomProfileMode modeFromName(const QString &name);
+
+    static QString createProfileId();
+    static QString createMemberId();
+    /// Deterministic UUIDv5 from connectionId (migration / repair idempotency).
+    static QString createDeterministicProfileId(const QString &connectionId);
+    static QString createDeterministicMemberId(const QString &profileId,
+                                               const QString &connectionId);
+};
+
+/**
+ * @brief Immutable request/source context for a membership-scoped operation.
+ *
+ * memberId stays out of MediaRef and caches. generation/epoch lets callers
+ * detect stale contexts after active profile, default member, or membership
+ * context switches. This does not change ConfigManager's active connection.
+ */
+struct BloomProfileRequestContext {
+    QString bloomProfileId;
+    QString memberId;
+    QString connectionId;
+    quint64 generation = 0;
+
+    bool isValid() const;
+    bool isCurrent(quint64 currentGeneration) const;
+};
+
+Q_DECLARE_METATYPE(BloomProfileMode)
+Q_DECLARE_METATYPE(BloomProfileMember)
+Q_DECLARE_METATYPE(BloomProfile)
+Q_DECLARE_METATYPE(BloomProfileRequestContext)
+Q_DECLARE_METATYPE(QList<BloomProfileMember>)
+Q_DECLARE_METATYPE(QList<BloomProfile>)

--- a/src/profiles/BloomProfileRepository.cpp
+++ b/src/profiles/BloomProfileRepository.cpp
@@ -1,0 +1,692 @@
+#include "BloomProfileRepository.h"
+
+#include "utils/ConfigManager.h"
+
+#include <QDateTime>
+#include <QHash>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QUuid>
+#include <algorithm>
+#include <utility>
+
+#include "providers/ServerConnection.h"
+
+BloomProfileRepository::BloomProfileRepository(ConfigManager *configManager, QObject *parent)
+    : QObject(parent)
+    , m_configManager(configManager)
+{
+    if (m_configManager) {
+        connect(m_configManager, &ConfigManager::connectionsChanged,
+                this, &BloomProfileRepository::reload);
+    }
+    reload();
+}
+
+QList<BloomProfile> BloomProfileRepository::profiles() const
+{
+    return m_store.items;
+}
+
+std::optional<BloomProfile> BloomProfileRepository::activeProfile() const
+{
+    return profile(m_store.activeProfileId);
+}
+
+std::optional<BloomProfile> BloomProfileRepository::profile(const QString &id) const
+{
+    const QString normalized = id.trimmed();
+    if (normalized.isEmpty()) {
+        return std::nullopt;
+    }
+    for (const BloomProfile &item : m_store.items) {
+        if (item.id == normalized) {
+            return item;
+        }
+    }
+    return std::nullopt;
+}
+
+bool BloomProfileRepository::upsertProfile(BloomProfile &profile)
+{
+    if (!m_configManager) {
+        return false;
+    }
+
+    const QString previousActiveProfileId = m_store.activeProfileId;
+    profile.id = profile.id.trimmed();
+    profile.name = profile.name.trimmed();
+    if (profile.id.isEmpty()) {
+        profile.id = BloomProfile::createProfileId();
+    }
+    if (profile.name.isEmpty()) {
+        return false;
+    }
+
+    bool changed = false;
+    profile = sanitizeProfile(profile, knownConnectionIds(), &changed);
+    if (!profile.isValid()) {
+        return false;
+    }
+
+    const QDateTime now = QDateTime::currentDateTimeUtc();
+    bool found = false;
+    for (BloomProfile &existing : m_store.items) {
+        if (existing.id != profile.id) {
+            continue;
+        }
+        profile.createdAt = existing.createdAt.isValid() ? existing.createdAt : now;
+        profile.updatedAt = now;
+        existing = profile;
+        found = true;
+        break;
+    }
+    if (!found) {
+        if (!profile.createdAt.isValid()) {
+            profile.createdAt = now;
+        }
+        profile.updatedAt = now;
+        m_store.items.append(profile);
+    }
+
+    if (m_store.activeProfileId.trimmed().isEmpty()) {
+        m_store.activeProfileId = profile.id;
+    }
+
+    persistStore(m_store);
+    const bool activeProfileIdChanged = previousActiveProfileId != m_store.activeProfileId;
+    const bool activeProfileUpdated = !previousActiveProfileId.isEmpty()
+        && profile.id == previousActiveProfileId;
+    if (activeProfileIdChanged || activeProfileUpdated) {
+        bumpGeneration();
+    }
+    emit profilesChanged();
+    if (activeProfileIdChanged) {
+        emit activeProfileChanged();
+    }
+    return true;
+}
+
+bool BloomProfileRepository::removeProfile(const QString &id)
+{
+    const QString normalized = id.trimmed();
+    if (normalized.isEmpty() || !m_configManager) {
+        return false;
+    }
+
+    const QString previousActiveProfileId = m_store.activeProfileId;
+    const auto before = m_store.items.size();
+    m_store.items.removeIf([&](const BloomProfile &item) { return item.id == normalized; });
+    if (m_store.items.size() == before) {
+        return false;
+    }
+
+    if (m_store.activeProfileId == normalized) {
+        m_store.activeProfileId = m_store.items.isEmpty() ? QString() : m_store.items.first().id;
+    }
+
+    persistStore(m_store);
+    const bool activeProfileIdChanged = previousActiveProfileId != m_store.activeProfileId;
+    if (activeProfileIdChanged) {
+        bumpGeneration();
+    }
+    emit profilesChanged();
+    if (activeProfileIdChanged) {
+        emit activeProfileChanged();
+    }
+    return true;
+}
+
+bool BloomProfileRepository::setActiveProfile(const QString &id)
+{
+    const QString normalized = id.trimmed();
+    if (!m_configManager || !profile(normalized).has_value()) {
+        return false;
+    }
+    if (m_store.activeProfileId == normalized) {
+        return true;
+    }
+
+    m_store.activeProfileId = normalized;
+    persistStore(m_store);
+    bumpGeneration();
+    emit activeProfileChanged();
+    emit profilesChanged();
+    return true;
+}
+
+bool BloomProfileRepository::addMember(const QString &profileId, BloomProfileMember member)
+{
+    auto existing = profile(profileId);
+    if (!existing.has_value() || !m_configManager) {
+        return false;
+    }
+
+    BloomProfile updated = *existing;
+    if (updated.mode == BloomProfileMode::Single && !updated.members.isEmpty()) {
+        return false;
+    }
+
+    member.memberId = member.memberId.trimmed();
+    member.connectionId = member.connectionId.trimmed();
+    if (member.connectionId.isEmpty()) {
+        return false;
+    }
+    if (!knownConnectionIds().contains(member.connectionId)) {
+        return false;
+    }
+    for (const BloomProfileMember &current : updated.members) {
+        if (current.connectionId == member.connectionId) {
+            return false;
+        }
+    }
+    if (member.memberId.isEmpty()) {
+        member.memberId = BloomProfile::createDeterministicMemberId(updated.id,
+                                                                    member.connectionId);
+    }
+
+    updated.members.append(member);
+    if (updated.defaultMemberId.trimmed().isEmpty()) {
+        updated.defaultMemberId = member.memberId;
+    }
+    return upsertProfile(updated);
+}
+
+bool BloomProfileRepository::removeMember(const QString &profileId, const QString &memberId)
+{
+    auto existing = profile(profileId);
+    if (!existing.has_value() || !m_configManager) {
+        return false;
+    }
+
+    BloomProfile updated = *existing;
+    const QString normalizedMember = memberId.trimmed();
+    const auto before = updated.members.size();
+    updated.members.removeIf([&](const BloomProfileMember &member) {
+        return member.memberId == normalizedMember;
+    });
+    if (updated.members.size() == before) {
+        return false;
+    }
+    if (updated.members.isEmpty()) {
+        return false;
+    }
+    if (updated.defaultMemberId == normalizedMember) {
+        updated.defaultMemberId.clear();
+    }
+    return upsertProfile(updated);
+}
+
+bool BloomProfileRepository::reorderMembers(const QString &profileId,
+                                            const QStringList &orderedMemberIds)
+{
+    auto existing = profile(profileId);
+    if (!existing.has_value() || !m_configManager) {
+        return false;
+    }
+
+    BloomProfile updated = *existing;
+    QHash<QString, BloomProfileMember> byId;
+    for (const BloomProfileMember &member : updated.members) {
+        byId.insert(member.memberId, member);
+    }
+    if (byId.size() != orderedMemberIds.size()) {
+        return false;
+    }
+
+    QList<BloomProfileMember> reordered;
+    QSet<QString> seen;
+    for (const QString &memberId : orderedMemberIds) {
+        const QString normalized = memberId.trimmed();
+        if (!byId.contains(normalized) || seen.contains(normalized)) {
+            return false;
+        }
+        seen.insert(normalized);
+        reordered.append(byId.value(normalized));
+    }
+    if (reordered.size() != updated.members.size()) {
+        return false;
+    }
+
+    updated.members = reordered;
+    normalizeMemberPriorities(updated.members);
+    return upsertProfile(updated);
+}
+
+bool BloomProfileRepository::setDefaultMember(const QString &profileId, const QString &memberId)
+{
+    auto existing = profile(profileId);
+    if (!existing.has_value() || !m_configManager) {
+        return false;
+    }
+
+    BloomProfile updated = *existing;
+    const QString normalized = memberId.trimmed();
+    const auto member = findMember(updated, normalized);
+    if (!member.has_value() || !member->enabled) {
+        return false;
+    }
+    if (updated.defaultMemberId == normalized) {
+        return true;
+    }
+    updated.defaultMemberId = normalized;
+    return upsertProfile(updated);
+}
+
+quint64 BloomProfileRepository::generation() const
+{
+    return m_generation;
+}
+
+BloomProfileRequestContext BloomProfileRepository::activeRequestContext() const
+{
+    const auto active = activeProfile();
+    if (!active.has_value() || active->members.isEmpty()) {
+        return {};
+    }
+
+    QString memberId = active->defaultMemberId.trimmed();
+    auto member = findMember(*active, memberId);
+    if (!member.has_value() || !member->enabled) {
+        member.reset();
+        for (const BloomProfileMember &candidate : active->members) {
+            if (candidate.enabled) {
+                member = candidate;
+                break;
+            }
+        }
+    }
+    if (!member.has_value()) {
+        return {};
+    }
+
+    BloomProfileRequestContext context;
+    context.bloomProfileId = active->id;
+    context.memberId = member->memberId;
+    context.connectionId = member->connectionId;
+    context.generation = m_generation;
+    return context;
+}
+
+BloomProfileRequestContext BloomProfileRepository::requestContext(const QString &profileId,
+                                                                  const QString &memberId) const
+{
+    const auto existing = profile(profileId);
+    if (!existing.has_value()) {
+        return {};
+    }
+    const auto member = findMember(*existing, memberId);
+    if (!member.has_value() || !member->enabled) {
+        return {};
+    }
+
+    BloomProfileRequestContext context;
+    context.bloomProfileId = existing->id;
+    context.memberId = member->memberId;
+    context.connectionId = member->connectionId;
+    context.generation = m_generation;
+    return context;
+}
+
+bool BloomProfileRepository::isCurrent(const BloomProfileRequestContext &context) const
+{
+    if (!context.isCurrent(m_generation)) {
+        return false;
+    }
+    const auto existing = profile(context.bloomProfileId);
+    if (!existing.has_value()) {
+        return false;
+    }
+    const auto member = findMember(*existing, context.memberId);
+    return member.has_value()
+        && member->enabled
+        && member->connectionId == context.connectionId;
+}
+
+void BloomProfileRepository::reload()
+{
+    if (!m_configManager) {
+        m_store = {};
+        return;
+    }
+
+    const QString previousActiveProfileId = m_store.activeProfileId;
+    const auto previousActiveProfile = activeProfile();
+    const QJsonObject previousStore = storeToJson(m_store);
+    bool normalized = false;
+    Store loaded = loadStore(&normalized);
+    bool repaired = false;
+    Store sanitized = sanitizeStore(std::move(loaded), &repaired);
+    const bool needsPersistence = normalized || repaired;
+    const bool storeChanged = previousStore != storeToJson(sanitized);
+    m_store = std::move(sanitized);
+    if (needsPersistence) {
+        persistStore(m_store);
+    }
+    if (storeChanged) {
+        const auto currentActiveProfile = activeProfile();
+        const bool activeProfileIdChanged = previousActiveProfileId != m_store.activeProfileId;
+        const bool activeProfileContentChanged = previousActiveProfile.has_value()
+            != currentActiveProfile.has_value()
+            || (previousActiveProfile.has_value() && currentActiveProfile.has_value()
+                && previousActiveProfile->toJson() != currentActiveProfile->toJson());
+        if (activeProfileIdChanged || activeProfileContentChanged) {
+            bumpGeneration();
+        }
+        emit profilesChanged();
+        if (activeProfileIdChanged || activeProfileContentChanged) {
+            emit activeProfileChanged();
+        }
+    }
+}
+
+BloomProfileRepository::Store BloomProfileRepository::loadStore(bool *normalized) const
+{
+    Store store;
+    if (normalized) {
+        *normalized = false;
+    }
+    if (!m_configManager) {
+        return store;
+    }
+
+    const QJsonObject root = m_configManager->getBloomProfilesConfig();
+    const QString storedActiveProfileId =
+        root.value(QStringLiteral("active_profile_id")).toString();
+    store.activeProfileId = storedActiveProfileId.trimmed();
+    if (normalized && store.activeProfileId != storedActiveProfileId) {
+        *normalized = true;
+    }
+
+    const QJsonArray items = root.value(QStringLiteral("items")).toArray();
+    for (const QJsonValue &value : items) {
+        if (!value.isObject()) {
+            if (normalized) {
+                *normalized = true;
+            }
+            continue;
+        }
+        const QJsonObject storedProfile = value.toObject();
+        const BloomProfile profile = BloomProfile::fromJson(storedProfile);
+        if (normalized
+            && (storedProfile.value(QStringLiteral("id")).toString() != profile.id
+                || storedProfile.value(QStringLiteral("name")).toString() != profile.name
+                || storedProfile.value(QStringLiteral("default_member_id")).toString()
+                    != profile.defaultMemberId)) {
+            *normalized = true;
+        }
+
+        const QJsonArray storedMembers = storedProfile.value(QStringLiteral("members")).toArray();
+        for (qsizetype index = 0;
+             normalized && index < storedMembers.size() && index < profile.members.size();
+             ++index) {
+            const QJsonObject storedMember = storedMembers.at(index).toObject();
+            const BloomProfileMember &member = profile.members.at(index);
+            if (storedMember.value(QStringLiteral("member_id")).toString() != member.memberId
+                || storedMember.value(QStringLiteral("connection_id")).toString()
+                    != member.connectionId) {
+                *normalized = true;
+            }
+        }
+        store.items.append(profile);
+    }
+    return store;
+}
+
+QJsonObject BloomProfileRepository::storeToJson(const Store &store) const
+{
+    QJsonObject root;
+    root[QStringLiteral("version")] = 1;
+    root[QStringLiteral("active_profile_id")] = store.activeProfileId;
+    QJsonArray items;
+    for (const BloomProfile &profile : store.items) {
+        items.append(profile.toJson());
+    }
+    root[QStringLiteral("items")] = items;
+    return root;
+}
+
+void BloomProfileRepository::persistStore(const Store &store)
+{
+    if (!m_configManager) {
+        return;
+    }
+    m_configManager->setBloomProfilesConfig(storeToJson(store));
+}
+
+BloomProfileRepository::Store BloomProfileRepository::sanitizeStore(Store store, bool *changed) const
+{
+    if (changed) {
+        *changed = false;
+    }
+
+    const QSet<QString> validConnections = knownConnectionIds();
+    QList<BloomProfile> sanitizedItems;
+    QSet<QString> seenProfileIds;
+
+    for (BloomProfile profile : store.items) {
+        bool profileChanged = false;
+        profile = sanitizeProfile(profile, validConnections, &profileChanged);
+        if (!profile.isValid()) {
+            if (changed) {
+                *changed = true;
+            }
+            continue;
+        }
+        if (seenProfileIds.contains(profile.id)) {
+            if (changed) {
+                *changed = true;
+            }
+            continue;
+        }
+        seenProfileIds.insert(profile.id);
+        if (profileChanged && changed) {
+            *changed = true;
+        }
+        sanitizedItems.append(profile);
+    }
+
+    if (sanitizedItems.size() != store.items.size() && changed) {
+        *changed = true;
+    }
+    store.items = sanitizedItems;
+
+    bool activeValid = false;
+    for (const BloomProfile &profile : store.items) {
+        if (profile.id == store.activeProfileId) {
+            activeValid = true;
+            break;
+        }
+    }
+    if (!activeValid) {
+        const QString repaired = store.items.isEmpty() ? QString() : store.items.first().id;
+        if (repaired != store.activeProfileId && changed) {
+            *changed = true;
+        }
+        store.activeProfileId = repaired;
+    }
+
+    return store;
+}
+
+BloomProfile BloomProfileRepository::sanitizeProfile(BloomProfile profile,
+                                                     const QSet<QString> &validConnectionIds,
+                                                     bool *changed) const
+{
+    if (changed) {
+        *changed = false;
+    }
+
+    profile.id = profile.id.trimmed();
+    profile.name = profile.name.trimmed();
+    profile.defaultMemberId = profile.defaultMemberId.trimmed();
+    if (profile.id.isEmpty()) {
+        profile.id = BloomProfile::createProfileId();
+        if (changed) {
+            *changed = true;
+        }
+    }
+    if (profile.name.isEmpty()) {
+        profile.name = QStringLiteral("Profile");
+        if (changed) {
+            *changed = true;
+        }
+    }
+
+    QList<BloomProfileMember> sanitizedMembers;
+    QSet<QString> seenConnectionIds;
+    QSet<QString> seenMemberIds;
+
+    for (BloomProfileMember member : profile.members) {
+        member.connectionId = member.connectionId.trimmed();
+        member.memberId = member.memberId.trimmed();
+        if (member.connectionId.isEmpty() || !validConnectionIds.contains(member.connectionId)) {
+            if (changed) {
+                *changed = true;
+            }
+            continue;
+        }
+        if (seenConnectionIds.contains(member.connectionId)) {
+            if (changed) {
+                *changed = true;
+            }
+            continue;
+        }
+        seenConnectionIds.insert(member.connectionId);
+
+        if (member.memberId.isEmpty()) {
+            member.memberId = BloomProfile::createDeterministicMemberId(profile.id,
+                                                                        member.connectionId);
+            if (changed) {
+                *changed = true;
+            }
+        }
+        if (seenMemberIds.contains(member.memberId)) {
+            member.memberId = BloomProfile::createMemberId();
+            if (changed) {
+                *changed = true;
+            }
+        }
+        seenMemberIds.insert(member.memberId);
+        sanitizedMembers.append(member);
+    }
+
+    if (profile.mode == BloomProfileMode::Single && sanitizedMembers.size() > 1) {
+        BloomProfileMember retained = sanitizedMembers.first();
+        for (const BloomProfileMember &member : sanitizedMembers) {
+            if (member.memberId == profile.defaultMemberId) {
+                retained = member;
+                break;
+            }
+        }
+        sanitizedMembers = {retained};
+        if (changed) {
+            *changed = true;
+        }
+    }
+
+    if (sanitizedMembers.isEmpty()) {
+        profile.members.clear();
+        profile.defaultMemberId.clear();
+        if (changed) {
+            *changed = true;
+        }
+        return profile;
+    }
+
+    bool priorityChanged = false;
+    for (qsizetype index = 0; index < sanitizedMembers.size(); ++index) {
+        if (sanitizedMembers[index].priority != static_cast<int>(index)) {
+            priorityChanged = true;
+        }
+        sanitizedMembers[index].priority = static_cast<int>(index);
+    }
+    if (priorityChanged && changed) {
+        *changed = true;
+    }
+
+    const bool hasEnabledMember = std::any_of(
+        sanitizedMembers.cbegin(), sanitizedMembers.cend(),
+        [](const BloomProfileMember &member) { return member.enabled; });
+    bool defaultValid = false;
+    for (const BloomProfileMember &member : sanitizedMembers) {
+        if (member.memberId == profile.defaultMemberId
+            && (member.enabled || !hasEnabledMember)) {
+            defaultValid = true;
+            break;
+        }
+    }
+    if (!defaultValid) {
+        QString repaired;
+        for (const BloomProfileMember &member : sanitizedMembers) {
+            if (member.enabled) {
+                repaired = member.memberId;
+                break;
+            }
+        }
+        if (repaired.isEmpty()) {
+            repaired = sanitizedMembers.first().memberId;
+        }
+        if (repaired != profile.defaultMemberId && changed) {
+            *changed = true;
+        }
+        profile.defaultMemberId = repaired;
+    }
+
+    profile.members = sanitizedMembers;
+    if (!profile.createdAt.isValid()) {
+        profile.createdAt = QDateTime::currentDateTimeUtc();
+        if (changed) {
+            *changed = true;
+        }
+    }
+    if (!profile.updatedAt.isValid()) {
+        profile.updatedAt = profile.createdAt;
+        if (changed) {
+            *changed = true;
+        }
+    }
+    return profile;
+}
+
+void BloomProfileRepository::normalizeMemberPriorities(QList<BloomProfileMember> &members) const
+{
+    for (qsizetype index = 0; index < members.size(); ++index) {
+        members[index].priority = static_cast<int>(index);
+    }
+}
+
+void BloomProfileRepository::bumpGeneration()
+{
+    ++m_generation;
+    emit generationChanged(m_generation);
+}
+
+QSet<QString> BloomProfileRepository::knownConnectionIds() const
+{
+    QSet<QString> ids;
+    if (!m_configManager) {
+        return ids;
+    }
+    for (const ServerConnection &connection : m_configManager->getConnections()) {
+        if (!connection.connectionId.trimmed().isEmpty()) {
+            ids.insert(connection.connectionId);
+        }
+    }
+    return ids;
+}
+
+std::optional<BloomProfileMember> BloomProfileRepository::findMember(const BloomProfile &profile,
+                                                                     const QString &memberId) const
+{
+    const QString normalized = memberId.trimmed();
+    if (normalized.isEmpty()) {
+        return std::nullopt;
+    }
+    for (const BloomProfileMember &member : profile.members) {
+        if (member.memberId == normalized) {
+            return member;
+        }
+    }
+    return std::nullopt;
+}

--- a/src/profiles/BloomProfileRepository.h
+++ b/src/profiles/BloomProfileRepository.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "BloomProfile.h"
+
+#include <QObject>
+#include <QSet>
+#include <QStringList>
+#include <optional>
+
+class ConfigManager;
+
+/**
+ * @brief Provider-neutral repository for Bloom profile persistence and request context.
+ *
+ * Uses ConfigManager only for raw settings.bloom_profiles accessors. Owns validation,
+ * repair, and CRUD. Does not implement merged catalog reads or change the active
+ * ServerConnection — request context is the foundation for later service routing.
+ */
+class BloomProfileRepository : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit BloomProfileRepository(ConfigManager *configManager, QObject *parent = nullptr);
+
+    QList<BloomProfile> profiles() const;
+    std::optional<BloomProfile> activeProfile() const;
+    std::optional<BloomProfile> profile(const QString &id) const;
+
+    bool upsertProfile(BloomProfile &profile);
+    bool removeProfile(const QString &id);
+    bool setActiveProfile(const QString &id);
+
+    bool addMember(const QString &profileId, BloomProfileMember member);
+    bool removeMember(const QString &profileId, const QString &memberId);
+    bool reorderMembers(const QString &profileId, const QStringList &orderedMemberIds);
+    bool setDefaultMember(const QString &profileId, const QString &memberId);
+
+    quint64 generation() const;
+    BloomProfileRequestContext activeRequestContext() const;
+    BloomProfileRequestContext requestContext(const QString &profileId,
+                                              const QString &memberId) const;
+    bool isCurrent(const BloomProfileRequestContext &context) const;
+
+    /// Reloads from ConfigManager, repairs, and persists when changed.
+    void reload();
+
+signals:
+    void profilesChanged();
+    void activeProfileChanged();
+    void generationChanged(quint64 generation);
+
+private:
+    struct Store {
+        QString activeProfileId;
+        QList<BloomProfile> items;
+    };
+
+    Store loadStore(bool *normalized) const;
+    QJsonObject storeToJson(const Store &store) const;
+    void persistStore(const Store &store);
+    Store sanitizeStore(Store store, bool *changed) const;
+    BloomProfile sanitizeProfile(BloomProfile profile,
+                                 const QSet<QString> &validConnectionIds,
+                                 bool *changed) const;
+    void normalizeMemberPriorities(QList<BloomProfileMember> &members) const;
+    void bumpGeneration();
+    QSet<QString> knownConnectionIds() const;
+    std::optional<BloomProfileMember> findMember(const BloomProfile &profile,
+                                                 const QString &memberId) const;
+
+    ConfigManager *m_configManager = nullptr;
+    Store m_store;
+    quint64 m_generation = 1;
+};

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -2,6 +2,7 @@
 #include "BloomLogging.h"
 #include "LoggingConfig.h"
 #include "MpvArgFilter.h"
+#include "profiles/BloomProfile.h"
 #include <QFile>
 #include <QJsonDocument>
 #include <QStandardPaths>
@@ -828,6 +829,7 @@ void ConfigManager::load()
     }
 
     m_config = doc.object();
+    const QJsonObject loadedConfig = m_config;
 
     // Run migrations, ensure config is at the current version
     if (!migrateConfig()) {
@@ -850,6 +852,9 @@ void ConfigManager::load()
         return;
     }
 
+    if (m_config != loadedConfig) {
+        save();
+    }
     qDebug() << "Loaded config from" << path;
 }
 
@@ -1035,6 +1040,31 @@ void ConfigManager::finalizeLegacyJellyfinMigration()
     m_config[QStringLiteral("settings")] = settings;
     save();
     emit connectionsChanged();
+}
+
+QJsonObject ConfigManager::getBloomProfilesConfig() const
+{
+    return m_config.value(QStringLiteral("settings")).toObject()
+        .value(QStringLiteral("bloom_profiles")).toObject();
+}
+
+void ConfigManager::setBloomProfilesConfig(const QJsonObject &config)
+{
+    QJsonObject settings = m_config.value(QStringLiteral("settings")).toObject();
+    QJsonObject normalized = config;
+    if (normalized.value(QStringLiteral("version")).toInt() != 1) {
+        normalized[QStringLiteral("version")] = 1;
+    }
+    if (!normalized.contains(QStringLiteral("active_profile_id"))
+        || !normalized.value(QStringLiteral("active_profile_id")).isString()) {
+        normalized[QStringLiteral("active_profile_id")] = QString();
+    }
+    if (!normalized.value(QStringLiteral("items")).isArray()) {
+        normalized[QStringLiteral("items")] = QJsonArray();
+    }
+    settings[QStringLiteral("bloom_profiles")] = normalized;
+    m_config[QStringLiteral("settings")] = settings;
+    save();
 }
 
 void ConfigManager::setJellyfinSession(const QString &serverUrl,
@@ -4063,6 +4093,71 @@ public:
         newConfig[QStringLiteral("settings")] = settings;
         return newConfig;
     }
+
+    static QJsonObject emptyBloomProfilesBlock()
+    {
+        QJsonObject bloomProfiles;
+        bloomProfiles[QStringLiteral("version")] = 1;
+        bloomProfiles[QStringLiteral("active_profile_id")] = QString();
+        bloomProfiles[QStringLiteral("items")] = QJsonArray();
+        return bloomProfiles;
+    }
+
+    static QJsonObject migrateV29ToV30(const QJsonObject &oldConfig)
+    {
+        QJsonObject newConfig = oldConfig;
+        newConfig[QStringLiteral("version")] = 30;
+
+        QJsonObject settings = newConfig.value(QStringLiteral("settings")).toObject();
+        const QJsonObject connections = settings.value(QStringLiteral("connections")).toObject();
+        const QJsonArray connectionItems = connections.value(QStringLiteral("items")).toArray();
+        const QString activeConnectionId =
+            connections.value(QStringLiteral("active")).toString().trimmed();
+
+        QString seedConnectionId;
+        QSet<QString> knownIds;
+        for (const QJsonValue &value : connectionItems) {
+            const QString id = value.toObject().value(QStringLiteral("id")).toString().trimmed();
+            if (!id.isEmpty()) {
+                knownIds.insert(id);
+            }
+        }
+        if (!activeConnectionId.isEmpty() && knownIds.contains(activeConnectionId)) {
+            seedConnectionId = activeConnectionId;
+        } else if (knownIds.size() == 1) {
+            seedConnectionId = *knownIds.constBegin();
+        }
+
+        QJsonObject bloomProfiles = emptyBloomProfilesBlock();
+        if (!seedConnectionId.isEmpty()) {
+            const QString profileId = BloomProfile::createDeterministicProfileId(seedConnectionId);
+            const QString memberId = BloomProfile::createDeterministicMemberId(profileId,
+                                                                                 seedConnectionId);
+            const QString now = QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
+
+            QJsonObject member;
+            member[QStringLiteral("member_id")] = memberId;
+            member[QStringLiteral("connection_id")] = seedConnectionId;
+            member[QStringLiteral("enabled")] = true;
+            member[QStringLiteral("priority")] = 0;
+
+            QJsonObject profile;
+            profile[QStringLiteral("id")] = profileId;
+            profile[QStringLiteral("name")] = QStringLiteral("Default");
+            profile[QStringLiteral("mode")] = QStringLiteral("single");
+            profile[QStringLiteral("members")] = QJsonArray{member};
+            profile[QStringLiteral("default_member_id")] = memberId;
+            profile[QStringLiteral("created_at")] = now;
+            profile[QStringLiteral("updated_at")] = now;
+
+            bloomProfiles[QStringLiteral("active_profile_id")] = profileId;
+            bloomProfiles[QStringLiteral("items")] = QJsonArray{profile};
+        }
+        settings[QStringLiteral("bloom_profiles")] = bloomProfiles;
+
+        newConfig[QStringLiteral("settings")] = settings;
+        return newConfig;
+    }
 };
 }
 
@@ -4315,6 +4410,14 @@ bool ConfigManager::migrateConfig()
                 qWarning() << "Migration produced invalid config (no version)";
                 return false;
             }
+        } else if (version == 29) {
+            m_config = ConfigMigrator::migrateV29ToV30(m_config);
+            if (m_config.contains("version") && m_config["version"].isDouble()) {
+                version = m_config["version"].toInt();
+            } else {
+                qWarning() << "Migration produced invalid config (no version)";
+                return false;
+            }
         } else {
             qWarning() << "Unknown config version during migration:" << version;
             return false;
@@ -4368,6 +4471,14 @@ bool ConfigManager::validateConfig(const QJsonObject &cfg)
             return false;
         }
     }
+    if (version >= 30) {
+        const QJsonObject bloomProfiles = settings.value(QStringLiteral("bloom_profiles")).toObject();
+        if (bloomProfiles.value(QStringLiteral("version")).toInt() != 1
+            || !bloomProfiles.value(QStringLiteral("items")).isArray()
+            || !bloomProfiles.value(QStringLiteral("active_profile_id")).isString()) {
+            return false;
+        }
+    }
     return true;
 }
 
@@ -4397,6 +4508,12 @@ QJsonObject ConfigManager::defaultConfig() const
     connections[QStringLiteral("active")] = QString();
     connections[QStringLiteral("items")] = QJsonArray();
     settings[QStringLiteral("connections")] = connections;
+
+    QJsonObject bloomProfiles;
+    bloomProfiles[QStringLiteral("version")] = 1;
+    bloomProfiles[QStringLiteral("active_profile_id")] = QString();
+    bloomProfiles[QStringLiteral("items")] = QJsonArray();
+    settings[QStringLiteral("bloom_profiles")] = bloomProfiles;
 
     QJsonObject playback;
     playback["completion_threshold"] = 90;

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -199,6 +199,11 @@ public:
     bool hasPendingLegacyJellyfinMigration() const;
     void finalizeLegacyJellyfinMigration();
 
+    // Raw Bloom profile store (settings.bloom_profiles). Validation/CRUD owned by
+    // BloomProfileRepository — these accessors only read/write the JSON block.
+    QJsonObject getBloomProfilesConfig() const;
+    void setBloomProfilesConfig(const QJsonObject &config);
+
     // Temporary Jellyfin-compatible session façade
     /**
      * @brief Persists a Jellyfin session after a successful login.
@@ -629,6 +634,6 @@ private:
 
     QJsonObject m_config;
 
-    static constexpr int kCurrentConfigVersion = 29;
+    static constexpr int kCurrentConfigVersion = 30;
     QJsonObject defaultConfig() const;
 };

--- a/tests/BloomProfileRepositoryTest.cpp
+++ b/tests/BloomProfileRepositoryTest.cpp
@@ -1,0 +1,949 @@
+#include <QtTest/QtTest>
+
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSet>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include "profiles/BloomProfile.h"
+#include "profiles/BloomProfileRepository.h"
+#include "providers/ServerConnection.h"
+#include "utils/ConfigManager.h"
+
+namespace {
+
+class ScopedConfigIsolation
+{
+public:
+    explicit ScopedConfigIsolation(const QString &path)
+        : m_previousConfigHome(qgetenv("XDG_CONFIG_HOME"))
+        , m_previousAppData(qgetenv("APPDATA"))
+        , m_previousHome(qgetenv("HOME"))
+        , m_hadPreviousConfigHome(!m_previousConfigHome.isNull())
+        , m_hadPreviousAppData(!m_previousAppData.isNull())
+        , m_hadPreviousHome(!m_previousHome.isNull())
+    {
+        QStandardPaths::setTestModeEnabled(true);
+        qputenv("XDG_CONFIG_HOME", path.toUtf8());
+        qputenv("APPDATA", path.toUtf8());
+        qputenv("HOME", path.toUtf8());
+        QDir().mkpath(path + QStringLiteral("/Library/Preferences"));
+    }
+
+    ~ScopedConfigIsolation()
+    {
+        restore("XDG_CONFIG_HOME", m_previousConfigHome, m_hadPreviousConfigHome);
+        restore("APPDATA", m_previousAppData, m_hadPreviousAppData);
+        restore("HOME", m_previousHome, m_hadPreviousHome);
+        QStandardPaths::setTestModeEnabled(false);
+    }
+
+private:
+    static void restore(const char *name, const QByteArray &value, bool hadPrevious)
+    {
+        if (hadPrevious) {
+            qputenv(name, value);
+        } else {
+            qunsetenv(name);
+        }
+    }
+
+    QByteArray m_previousConfigHome;
+    QByteArray m_previousAppData;
+    QByteArray m_previousHome;
+    bool m_hadPreviousConfigHome;
+    bool m_hadPreviousAppData;
+    bool m_hadPreviousHome;
+};
+
+ServerConnection makeConnection(const QString &connectionId,
+                                const QString &baseUrl,
+                                const QString &accountId,
+                                const QString &username)
+{
+    ServerConnection connection;
+    connection.connectionId = connectionId;
+    connection.providerKind = ProviderKind::Jellyfin;
+    connection.protocolMode = ProtocolMode::Native;
+    connection.baseUrl = baseUrl;
+    connection.accountId = accountId;
+    connection.profileId = accountId;
+    connection.username = username;
+    connection.displayName = username;
+    connection.credentialReference = ServerConnection::createCredentialReference(connectionId);
+    return connection;
+}
+
+QJsonObject minimalV29Config()
+{
+    QJsonObject connections;
+    connections[QStringLiteral("version")] = 1;
+    connections[QStringLiteral("active")] = QString();
+    connections[QStringLiteral("items")] = QJsonArray();
+
+    QJsonObject connectionState;
+    connectionState[QStringLiteral("version")] = 1;
+    connectionState[QStringLiteral("scopes")] = QJsonObject();
+
+    QJsonObject settings;
+    settings[QStringLiteral("playback")] = QJsonObject{{QStringLiteral("completion_threshold"), 90}};
+    settings[QStringLiteral("connections")] = connections;
+    settings[QStringLiteral("connection_state")] = connectionState;
+
+    QJsonObject config;
+    config[QStringLiteral("version")] = 29;
+    config[QStringLiteral("settings")] = settings;
+    return config;
+}
+
+void writeConfig(const QJsonObject &config)
+{
+    QVERIFY(QDir().mkpath(ConfigManager::getConfigDir()));
+    QFile file(ConfigManager::getConfigPath());
+    QVERIFY(file.open(QIODevice::WriteOnly | QIODevice::Truncate));
+    file.write(QJsonDocument(config).toJson(QJsonDocument::Indented));
+}
+
+QJsonObject readPersistedRoot()
+{
+    QFile file(ConfigManager::getConfigPath());
+    if (!file.open(QIODevice::ReadOnly)) {
+        return {};
+    }
+    return QJsonDocument::fromJson(file.readAll()).object();
+}
+
+bool jsonContainsForbiddenSecretFields(const QJsonValue &value)
+{
+    static const QSet<QString> forbiddenKeys = {
+        QStringLiteral("base_url"),
+        QStringLiteral("server_url"),
+        QStringLiteral("server_id"),
+        QStringLiteral("server_name"),
+        QStringLiteral("account_id"),
+        QStringLiteral("username"),
+        QStringLiteral("display_name"),
+        QStringLiteral("profile_id"),
+        QStringLiteral("credential_reference"),
+        QStringLiteral("access_token"),
+        QStringLiteral("refresh_token"),
+        QStringLiteral("password"),
+        QStringLiteral("api_key"),
+    };
+
+    if (value.isObject()) {
+        const QJsonObject object = value.toObject();
+        for (auto it = object.begin(); it != object.end(); ++it) {
+            if (forbiddenKeys.contains(it.key())) {
+                return true;
+            }
+            if (jsonContainsForbiddenSecretFields(it.value())) {
+                return true;
+            }
+        }
+    } else if (value.isArray()) {
+        for (const QJsonValue &entry : value.toArray()) {
+            if (jsonContainsForbiddenSecretFields(entry)) {
+                return true;
+            }
+        }
+    } else if (value.isString()) {
+        const QString text = value.toString();
+        if (text.contains(QStringLiteral("https://"), Qt::CaseInsensitive)
+            || text.contains(QStringLiteral("http://"), Qt::CaseInsensitive)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+class BloomProfileRepositoryTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void defaultConfigHasEmptyBloomProfilesBlock();
+    void jsonRoundTripPreservesOrderedMembers();
+    void multiServerAndTwoUsersOnSamePhysicalServer();
+    void duplicateSameConnectionIsDeduped();
+    void migrationSeedsOnlyActiveConnectionWithDeterministicIds();
+    void migrationUsesSoleConnectionWhenNoActive();
+    void migrationWritesEmptyBlockWithZeroConnections();
+    void danglingMembersAreRepairedAndPersistedIdempotently();
+    void whitespaceNormalizationIsPersisted();
+    void malformedEntriesArePersistentlyRemoved();
+    void orderingAndDefaultMemberRepair();
+    void singleModeUpsertRetainsDefaultOrFirstMember();
+    void crudPersistsAcrossReload();
+    void requestContextGenerationStaleGuard();
+    void validExternalReloadEmitsAndInvalidatesActiveContext();
+    void disabledDefaultCannotBecomeRequestTarget();
+    void inactiveProfileMutationDoesNotChangeActiveGeneration();
+    void profileJsonExcludesCredentialAndServerIdentity();
+};
+
+void BloomProfileRepositoryTest::defaultConfigHasEmptyBloomProfilesBlock()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+
+    const QJsonObject bloom = config.getBloomProfilesConfig();
+    QCOMPARE(bloom.value(QStringLiteral("version")).toInt(), 1);
+    QCOMPARE(bloom.value(QStringLiteral("active_profile_id")).toString(), QString());
+    QVERIFY(bloom.value(QStringLiteral("items")).toArray().isEmpty());
+
+    BloomProfileRepository repo(&config);
+    QVERIFY(repo.profiles().isEmpty());
+    QVERIFY(!repo.activeProfile().has_value());
+}
+
+void BloomProfileRepositoryTest::jsonRoundTripPreservesOrderedMembers()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-a"),
+                                           QStringLiteral("https://a.example.test"),
+                                           QStringLiteral("a"),
+                                           QStringLiteral("A")),
+                            false);
+    config.upsertConnection(makeConnection(QStringLiteral("conn-b"),
+                                           QStringLiteral("https://b.example.test"),
+                                           QStringLiteral("b"),
+                                           QStringLiteral("B")),
+                            false);
+
+    BloomProfileRepository repo(&config);
+    BloomProfile profile;
+    profile.name = QStringLiteral("Merged Home");
+    profile.mode = BloomProfileMode::Merged;
+    BloomProfileMember first;
+    first.memberId = QStringLiteral("member-1");
+    first.connectionId = QStringLiteral("conn-b");
+    first.enabled = true;
+    first.labelOverride = QStringLiteral("Kids");
+    BloomProfileMember second;
+    second.memberId = QStringLiteral("member-2");
+    second.connectionId = QStringLiteral("conn-a");
+    second.enabled = false;
+    profile.members = {first, second};
+    profile.defaultMemberId = QStringLiteral("member-1");
+    QVERIFY(repo.upsertProfile(profile));
+
+    BloomProfileRepository reloaded(&config);
+    QCOMPARE(reloaded.profiles().size(), 1);
+    const BloomProfile stored = reloaded.profiles().first();
+    QCOMPARE(stored.mode, BloomProfileMode::Merged);
+    QCOMPARE(stored.members.size(), 2);
+    QCOMPARE(stored.members.at(0).connectionId, QStringLiteral("conn-b"));
+    QCOMPARE(stored.members.at(0).priority, 0);
+    QCOMPARE(stored.members.at(0).labelOverride, QStringLiteral("Kids"));
+    QCOMPARE(stored.members.at(1).connectionId, QStringLiteral("conn-a"));
+    QCOMPARE(stored.members.at(1).priority, 1);
+    QCOMPARE(stored.defaultMemberId, QStringLiteral("member-1"));
+    QVERIFY(BloomProfile::createDeterministicMemberId(QStringLiteral("profile-a"),
+                                                      QStringLiteral("conn-a"))
+            != BloomProfile::createDeterministicMemberId(QStringLiteral("profile-b"),
+                                                         QStringLiteral("conn-a")));
+}
+
+void BloomProfileRepositoryTest::multiServerAndTwoUsersOnSamePhysicalServer()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    const QString sharedUrl = QStringLiteral("https://shared.example.test");
+    config.upsertConnection(makeConnection(QStringLiteral("conn-alice"),
+                                           sharedUrl,
+                                           QStringLiteral("alice"),
+                                           QStringLiteral("Alice")),
+                            true);
+    config.upsertConnection(makeConnection(QStringLiteral("conn-bob"),
+                                           sharedUrl,
+                                           QStringLiteral("bob"),
+                                           QStringLiteral("Bob")),
+                            false);
+    config.upsertConnection(makeConnection(QStringLiteral("conn-other"),
+                                           QStringLiteral("https://other.example.test"),
+                                           QStringLiteral("other"),
+                                           QStringLiteral("Other")),
+                            false);
+
+    BloomProfileRepository repo(&config);
+    BloomProfile profile;
+    profile.name = QStringLiteral("Family");
+    profile.mode = BloomProfileMode::Merged;
+    for (const QString &connectionId : {QStringLiteral("conn-alice"),
+                                        QStringLiteral("conn-bob"),
+                                        QStringLiteral("conn-other")}) {
+        BloomProfileMember member;
+        member.connectionId = connectionId;
+        profile.members.append(member);
+    }
+    profile.defaultMemberId = profile.members.first().memberId;
+    QVERIFY(repo.upsertProfile(profile));
+
+    const auto stored = repo.activeProfile();
+    QVERIFY(stored.has_value());
+    QCOMPARE(stored->members.size(), 3);
+    QCOMPARE(stored->members.at(0).connectionId, QStringLiteral("conn-alice"));
+    QCOMPARE(stored->members.at(1).connectionId, QStringLiteral("conn-bob"));
+    QCOMPARE(stored->members.at(2).connectionId, QStringLiteral("conn-other"));
+}
+
+void BloomProfileRepositoryTest::duplicateSameConnectionIsDeduped()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-1"),
+                                           QStringLiteral("https://media.example.test"),
+                                           QStringLiteral("user"),
+                                           QStringLiteral("User")),
+                            true);
+
+    QJsonObject bloom;
+    bloom[QStringLiteral("version")] = 1;
+    QJsonObject memberA;
+    memberA[QStringLiteral("member_id")] = QStringLiteral("m-a");
+    memberA[QStringLiteral("connection_id")] = QStringLiteral("conn-1");
+    memberA[QStringLiteral("enabled")] = true;
+    memberA[QStringLiteral("priority")] = 0;
+    QJsonObject memberB;
+    memberB[QStringLiteral("member_id")] = QStringLiteral("m-b");
+    memberB[QStringLiteral("connection_id")] = QStringLiteral("conn-1");
+    memberB[QStringLiteral("enabled")] = true;
+    memberB[QStringLiteral("priority")] = 1;
+    QJsonObject profile;
+    profile[QStringLiteral("id")] = QStringLiteral("profile-1");
+    profile[QStringLiteral("name")] = QStringLiteral("Dup");
+    profile[QStringLiteral("mode")] = QStringLiteral("merged");
+    profile[QStringLiteral("members")] = QJsonArray{memberA, memberB};
+    profile[QStringLiteral("default_member_id")] = QStringLiteral("m-a");
+    bloom[QStringLiteral("active_profile_id")] = QStringLiteral("profile-1");
+    bloom[QStringLiteral("items")] = QJsonArray{profile};
+    config.setBloomProfilesConfig(bloom);
+
+    BloomProfileRepository repo(&config);
+    QCOMPARE(repo.profiles().size(), 1);
+    QCOMPARE(repo.profiles().first().members.size(), 1);
+    QCOMPARE(repo.profiles().first().members.first().memberId, QStringLiteral("m-a"));
+
+    BloomProfileRepository again(&config);
+    QCOMPARE(again.profiles().first().members.size(), 1);
+}
+
+void BloomProfileRepositoryTest::migrationSeedsOnlyActiveConnectionWithDeterministicIds()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    QJsonObject config = minimalV29Config();
+    QJsonObject settings = config.value(QStringLiteral("settings")).toObject();
+    QJsonObject connections = settings.value(QStringLiteral("connections")).toObject();
+    const ServerConnection active = makeConnection(QStringLiteral("conn-active"),
+                                                   QStringLiteral("https://active.example.test"),
+                                                   QStringLiteral("active"),
+                                                   QStringLiteral("Active"));
+    const ServerConnection other = makeConnection(QStringLiteral("conn-other"),
+                                                  QStringLiteral("https://other.example.test"),
+                                                  QStringLiteral("other"),
+                                                  QStringLiteral("Other"));
+    connections[QStringLiteral("active")] = active.connectionId;
+    connections[QStringLiteral("items")] = QJsonArray{active.toJson(), other.toJson()};
+    settings[QStringLiteral("connections")] = connections;
+    config[QStringLiteral("settings")] = settings;
+    writeConfig(config);
+
+    ConfigManager first;
+    first.load();
+    const QJsonObject persistedAfterMigration = readPersistedRoot();
+    QCOMPARE(persistedAfterMigration.value(QStringLiteral("version")).toInt(), 30);
+    QCOMPARE(persistedAfterMigration.value(QStringLiteral("settings")).toObject()
+                 .value(QStringLiteral("bloom_profiles")).toObject()
+                 .value(QStringLiteral("items")).toArray().size(),
+             1);
+    ConfigManager second;
+    second.load();
+
+    const QJsonObject bloom = first.getBloomProfilesConfig();
+    QCOMPARE(bloom.value(QStringLiteral("version")).toInt(), 1);
+    QCOMPARE(bloom.value(QStringLiteral("items")).toArray().size(), 1);
+    const QJsonObject profile = bloom.value(QStringLiteral("items")).toArray().at(0).toObject();
+    QCOMPARE(profile.value(QStringLiteral("mode")).toString(), QStringLiteral("single"));
+    QCOMPARE(profile.value(QStringLiteral("members")).toArray().size(), 1);
+    QCOMPARE(profile.value(QStringLiteral("members")).toArray().at(0).toObject()
+                 .value(QStringLiteral("connection_id")).toString(),
+             QStringLiteral("conn-active"));
+    const QString expectedProfileId =
+        BloomProfile::createDeterministicProfileId(QStringLiteral("conn-active"));
+    QCOMPARE(profile.value(QStringLiteral("id")).toString(), expectedProfileId);
+    QCOMPARE(profile.value(QStringLiteral("members")).toArray().at(0).toObject()
+                 .value(QStringLiteral("member_id")).toString(),
+             BloomProfile::createDeterministicMemberId(expectedProfileId,
+                                                       QStringLiteral("conn-active")));
+    QCOMPARE(second.getBloomProfilesConfig().value(QStringLiteral("items")).toArray().at(0).toObject()
+                 .value(QStringLiteral("id")).toString(),
+             profile.value(QStringLiteral("id")).toString());
+    QCOMPARE(first.getActiveConnection()->connectionId, QStringLiteral("conn-active"));
+}
+
+void BloomProfileRepositoryTest::migrationUsesSoleConnectionWhenNoActive()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    QJsonObject config = minimalV29Config();
+    QJsonObject settings = config.value(QStringLiteral("settings")).toObject();
+    QJsonObject connections = settings.value(QStringLiteral("connections")).toObject();
+    const ServerConnection sole = makeConnection(QStringLiteral("conn-sole"),
+                                                 QStringLiteral("https://sole.example.test"),
+                                                 QStringLiteral("sole"),
+                                                 QStringLiteral("Sole"));
+    connections[QStringLiteral("active")] = QString();
+    connections[QStringLiteral("items")] = QJsonArray{sole.toJson()};
+    settings[QStringLiteral("connections")] = connections;
+    config[QStringLiteral("settings")] = settings;
+    writeConfig(config);
+
+    ConfigManager manager;
+    manager.load();
+    const QJsonObject profile = manager.getBloomProfilesConfig()
+                                    .value(QStringLiteral("items")).toArray().at(0).toObject();
+    QCOMPARE(profile.value(QStringLiteral("members")).toArray().at(0).toObject()
+                 .value(QStringLiteral("connection_id")).toString(),
+             QStringLiteral("conn-sole"));
+}
+
+void BloomProfileRepositoryTest::migrationWritesEmptyBlockWithZeroConnections()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+    writeConfig(minimalV29Config());
+
+    ConfigManager manager;
+    manager.load();
+    const QJsonObject bloom = manager.getBloomProfilesConfig();
+    QCOMPARE(bloom.value(QStringLiteral("version")).toInt(), 1);
+    QVERIFY(bloom.value(QStringLiteral("items")).toArray().isEmpty());
+    manager.save();
+    QCOMPARE(readPersistedRoot().value(QStringLiteral("version")).toInt(), 30);
+}
+
+void BloomProfileRepositoryTest::danglingMembersAreRepairedAndPersistedIdempotently()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-live"),
+                                           QStringLiteral("https://live.example.test"),
+                                           QStringLiteral("live"),
+                                           QStringLiteral("Live")),
+                            true);
+
+    QJsonObject bloom;
+    bloom[QStringLiteral("version")] = 1;
+    QJsonObject live;
+    live[QStringLiteral("member_id")] = QStringLiteral("m-live");
+    live[QStringLiteral("connection_id")] = QStringLiteral("conn-live");
+    live[QStringLiteral("enabled")] = true;
+    live[QStringLiteral("priority")] = 0;
+    QJsonObject dangling;
+    dangling[QStringLiteral("member_id")] = QStringLiteral("m-gone");
+    dangling[QStringLiteral("connection_id")] = QStringLiteral("conn-gone");
+    dangling[QStringLiteral("enabled")] = true;
+    dangling[QStringLiteral("priority")] = 1;
+    QJsonObject profile;
+    profile[QStringLiteral("id")] = QStringLiteral("profile-1");
+    profile[QStringLiteral("name")] = QStringLiteral("Repair");
+    profile[QStringLiteral("mode")] = QStringLiteral("merged");
+    profile[QStringLiteral("members")] = QJsonArray{live, dangling};
+    profile[QStringLiteral("default_member_id")] = QStringLiteral("m-gone");
+    bloom[QStringLiteral("active_profile_id")] = QStringLiteral("profile-1");
+    bloom[QStringLiteral("items")] = QJsonArray{profile};
+    config.setBloomProfilesConfig(bloom);
+
+    BloomProfileRepository first(&config);
+    QCOMPARE(first.profiles().first().members.size(), 1);
+    QCOMPARE(first.profiles().first().defaultMemberId, QStringLiteral("m-live"));
+
+    const QJsonObject persisted = config.getBloomProfilesConfig();
+    BloomProfileRepository second(&config);
+    QCOMPARE(second.profiles().first().members.size(), 1);
+    QCOMPARE(config.getBloomProfilesConfig(), persisted);
+}
+
+void BloomProfileRepositoryTest::whitespaceNormalizationIsPersisted()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-1"),
+                                           QStringLiteral("https://one.example.test"),
+                                           QStringLiteral("one"),
+                                           QStringLiteral("One")),
+                            true);
+
+    QJsonObject member{
+        {QStringLiteral("member_id"), QStringLiteral("  member-1  ")},
+        {QStringLiteral("connection_id"), QStringLiteral("  conn-1  ")},
+        {QStringLiteral("enabled"), true},
+        {QStringLiteral("priority"), 0}
+    };
+    QJsonObject profile{
+        {QStringLiteral("id"), QStringLiteral("  profile-1  ")},
+        {QStringLiteral("name"), QStringLiteral("  Profile One  ")},
+        {QStringLiteral("mode"), QStringLiteral("single")},
+        {QStringLiteral("members"), QJsonArray{member}},
+        {QStringLiteral("default_member_id"), QStringLiteral("  member-1  ")}
+    };
+    config.setBloomProfilesConfig(QJsonObject{
+        {QStringLiteral("version"), 1},
+        {QStringLiteral("active_profile_id"), QStringLiteral("  profile-1  ")},
+        {QStringLiteral("items"), QJsonArray{profile, QStringLiteral("malformed")}}
+    });
+
+    BloomProfileRepository repo(&config);
+    QCOMPARE(repo.activeProfile()->id, QStringLiteral("profile-1"));
+    QCOMPARE(repo.activeProfile()->name, QStringLiteral("Profile One"));
+    QCOMPARE(repo.activeProfile()->members.first().memberId, QStringLiteral("member-1"));
+    QCOMPARE(repo.activeProfile()->members.first().connectionId, QStringLiteral("conn-1"));
+
+    const QJsonObject persisted = config.getBloomProfilesConfig();
+    QCOMPARE(persisted.value(QStringLiteral("active_profile_id")).toString(),
+             QStringLiteral("profile-1"));
+    const QJsonArray persistedItems = persisted.value(QStringLiteral("items")).toArray();
+    QCOMPARE(persistedItems.size(), 1);
+    const QJsonObject persistedProfile = persistedItems.first().toObject();
+    QCOMPARE(persistedProfile.value(QStringLiteral("id")).toString(),
+             QStringLiteral("profile-1"));
+    QCOMPARE(persistedProfile.value(QStringLiteral("name")).toString(),
+             QStringLiteral("Profile One"));
+    const QJsonObject persistedMember = persistedProfile.value(QStringLiteral("members"))
+                                            .toArray().first().toObject();
+    QCOMPARE(persistedMember.value(QStringLiteral("member_id")).toString(),
+             QStringLiteral("member-1"));
+    QCOMPARE(persistedMember.value(QStringLiteral("connection_id")).toString(),
+             QStringLiteral("conn-1"));
+}
+
+void BloomProfileRepositoryTest::malformedEntriesArePersistentlyRemoved()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-1"),
+                                           QStringLiteral("https://one.example.test"),
+                                           QStringLiteral("one"),
+                                           QStringLiteral("One")),
+                            true);
+
+    BloomProfileMember member;
+    member.memberId = QStringLiteral("member-1");
+    member.connectionId = QStringLiteral("conn-1");
+
+    BloomProfile profile;
+    profile.id = QStringLiteral("profile-1");
+    profile.name = QStringLiteral("Profile One");
+    profile.members = {member};
+    profile.defaultMemberId = member.memberId;
+    profile.createdAt = QDateTime::currentDateTimeUtc();
+    profile.updatedAt = profile.createdAt;
+
+    config.setBloomProfilesConfig(QJsonObject{
+        {QStringLiteral("version"), 1},
+        {QStringLiteral("active_profile_id"), profile.id},
+        {QStringLiteral("items"), QJsonArray{profile.toJson(), QStringLiteral("malformed")}}
+    });
+
+    BloomProfileRepository repo(&config);
+    QCOMPARE(repo.profiles().size(), 1);
+    const QJsonArray persistedItems = config.getBloomProfilesConfig()
+                                          .value(QStringLiteral("items")).toArray();
+    QCOMPARE(persistedItems.size(), 1);
+    QCOMPARE(persistedItems.first().toObject().value(QStringLiteral("id")).toString(),
+             profile.id);
+}
+
+void BloomProfileRepositoryTest::orderingAndDefaultMemberRepair()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-1"),
+                                           QStringLiteral("https://one.example.test"),
+                                           QStringLiteral("one"),
+                                           QStringLiteral("One")),
+                            false);
+    config.upsertConnection(makeConnection(QStringLiteral("conn-2"),
+                                           QStringLiteral("https://two.example.test"),
+                                           QStringLiteral("two"),
+                                           QStringLiteral("Two")),
+                            false);
+
+    BloomProfileRepository repo(&config);
+    BloomProfile profile;
+    profile.name = QStringLiteral("Ordered");
+    profile.mode = BloomProfileMode::Merged;
+    BloomProfileMember disabled;
+    disabled.memberId = QStringLiteral("m-1");
+    disabled.connectionId = QStringLiteral("conn-1");
+    disabled.enabled = false;
+    disabled.priority = 99;
+    BloomProfileMember enabled;
+    enabled.memberId = QStringLiteral("m-2");
+    enabled.connectionId = QStringLiteral("conn-2");
+    enabled.enabled = true;
+    enabled.priority = 5;
+    profile.members = {disabled, enabled};
+    profile.defaultMemberId = QStringLiteral("missing");
+    QVERIFY(repo.upsertProfile(profile));
+
+    const BloomProfile stored = repo.profiles().first();
+    QCOMPARE(stored.members.at(0).priority, 0);
+    QCOMPARE(stored.members.at(1).priority, 1);
+    QCOMPARE(stored.defaultMemberId, QStringLiteral("m-2"));
+
+    QVERIFY(repo.reorderMembers(stored.id, {QStringLiteral("m-2"), QStringLiteral("m-1")}));
+    const BloomProfile reordered = repo.profile(stored.id).value();
+    QCOMPARE(reordered.members.at(0).memberId, QStringLiteral("m-2"));
+    QCOMPARE(reordered.members.at(0).priority, 0);
+    QCOMPARE(reordered.members.at(1).memberId, QStringLiteral("m-1"));
+    QCOMPARE(reordered.members.at(1).priority, 1);
+}
+
+void BloomProfileRepositoryTest::singleModeUpsertRetainsDefaultOrFirstMember()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-1"),
+                                           QStringLiteral("https://one.example.test"),
+                                           QStringLiteral("one"),
+                                           QStringLiteral("One")),
+                            false);
+    config.upsertConnection(makeConnection(QStringLiteral("conn-2"),
+                                           QStringLiteral("https://two.example.test"),
+                                           QStringLiteral("two"),
+                                           QStringLiteral("Two")),
+                            false);
+
+    BloomProfileRepository repo(&config);
+    BloomProfile profile;
+    profile.name = QStringLiteral("Single");
+    profile.mode = BloomProfileMode::Single;
+    BloomProfileMember first;
+    first.memberId = QStringLiteral("m-1");
+    first.connectionId = QStringLiteral("conn-1");
+    BloomProfileMember second;
+    second.memberId = QStringLiteral("m-2");
+    second.connectionId = QStringLiteral("conn-2");
+    profile.members = {first, second};
+    profile.defaultMemberId = QStringLiteral("m-2");
+    QVERIFY(repo.upsertProfile(profile));
+
+    const BloomProfile stored = repo.profiles().first();
+    QCOMPARE(stored.mode, BloomProfileMode::Single);
+    QCOMPARE(stored.members.size(), 1);
+    QCOMPARE(stored.members.first().memberId, QStringLiteral("m-2"));
+    QCOMPARE(stored.defaultMemberId, QStringLiteral("m-2"));
+}
+
+void BloomProfileRepositoryTest::crudPersistsAcrossReload()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-1"),
+                                           QStringLiteral("https://one.example.test"),
+                                           QStringLiteral("one"),
+                                           QStringLiteral("One")),
+                            true);
+    config.upsertConnection(makeConnection(QStringLiteral("conn-2"),
+                                           QStringLiteral("https://two.example.test"),
+                                           QStringLiteral("two"),
+                                           QStringLiteral("Two")),
+                            false);
+
+    BloomProfileRepository repo(&config);
+    BloomProfile first;
+    first.name = QStringLiteral("Alpha");
+    first.mode = BloomProfileMode::Single;
+    BloomProfileMember member;
+    member.connectionId = QStringLiteral("conn-1");
+    first.members = {member};
+    QVERIFY(repo.upsertProfile(first));
+
+    BloomProfile second;
+    second.name = QStringLiteral("Beta");
+    second.mode = BloomProfileMode::Merged;
+    BloomProfileMember betaMember = member;
+    betaMember.memberId.clear();
+    BloomProfileMember extra;
+    extra.connectionId = QStringLiteral("conn-2");
+    second.members = {betaMember, extra};
+    QVERIFY(repo.upsertProfile(second));
+    QVERIFY(repo.setActiveProfile(second.id));
+    QVERIFY(repo.removeProfile(first.id));
+
+    BloomProfileRepository reloaded(&config);
+    QCOMPARE(reloaded.profiles().size(), 1);
+    QCOMPARE(reloaded.activeProfile()->name, QStringLiteral("Beta"));
+    QCOMPARE(reloaded.activeProfile()->members.size(), 2);
+}
+
+void BloomProfileRepositoryTest::requestContextGenerationStaleGuard()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-1"),
+                                           QStringLiteral("https://one.example.test"),
+                                           QStringLiteral("one"),
+                                           QStringLiteral("One")),
+                            true);
+    config.upsertConnection(makeConnection(QStringLiteral("conn-2"),
+                                           QStringLiteral("https://two.example.test"),
+                                           QStringLiteral("two"),
+                                           QStringLiteral("Two")),
+                            false);
+
+    BloomProfileRepository repo(&config);
+    BloomProfile profile;
+    profile.name = QStringLiteral("Ctx");
+    profile.mode = BloomProfileMode::Merged;
+    BloomProfileMember one;
+    one.memberId = QStringLiteral("m-1");
+    one.connectionId = QStringLiteral("conn-1");
+    BloomProfileMember two;
+    two.memberId = QStringLiteral("m-2");
+    two.connectionId = QStringLiteral("conn-2");
+    profile.members = {one, two};
+    profile.defaultMemberId = QStringLiteral("m-1");
+    QVERIFY(repo.upsertProfile(profile));
+
+    const BloomProfileRequestContext before = repo.activeRequestContext();
+    QVERIFY(before.isValid());
+    QVERIFY(repo.isCurrent(before));
+    QCOMPARE(before.connectionId, QStringLiteral("conn-1"));
+    QVERIFY(!before.memberId.isEmpty());
+
+    const quint64 generationBefore = repo.generation();
+    QVERIFY(repo.setDefaultMember(profile.id, QStringLiteral("m-2")));
+    QVERIFY(repo.generation() > generationBefore);
+    QVERIFY(!before.isCurrent(repo.generation()));
+    QVERIFY(!repo.isCurrent(before));
+
+    const BloomProfileRequestContext after = repo.activeRequestContext();
+    QVERIFY(repo.isCurrent(after));
+    QCOMPARE(after.connectionId, QStringLiteral("conn-2"));
+    QCOMPARE(config.getActiveConnection()->connectionId, QStringLiteral("conn-1"));
+}
+
+void BloomProfileRepositoryTest::disabledDefaultCannotBecomeRequestTarget()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-disabled"),
+                                           QStringLiteral("https://shared.example.test"),
+                                           QStringLiteral("disabled"),
+                                           QStringLiteral("Disabled")),
+                            true);
+    config.upsertConnection(makeConnection(QStringLiteral("conn-enabled"),
+                                           QStringLiteral("https://shared.example.test"),
+                                           QStringLiteral("enabled"),
+                                           QStringLiteral("Enabled")),
+                            false);
+
+    BloomProfileRepository repo(&config);
+    BloomProfile profile;
+    profile.name = QStringLiteral("Enabled routing");
+    profile.mode = BloomProfileMode::Merged;
+    BloomProfileMember disabled;
+    disabled.memberId = QStringLiteral("member-disabled");
+    disabled.connectionId = QStringLiteral("conn-disabled");
+    disabled.enabled = false;
+    BloomProfileMember enabled;
+    enabled.memberId = QStringLiteral("member-enabled");
+    enabled.connectionId = QStringLiteral("conn-enabled");
+    enabled.enabled = true;
+    profile.members = {disabled, enabled};
+    profile.defaultMemberId = disabled.memberId;
+    QVERIFY(repo.upsertProfile(profile));
+
+    QCOMPARE(profile.defaultMemberId, enabled.memberId);
+    QCOMPARE(repo.activeRequestContext().memberId, enabled.memberId);
+    QVERIFY(!repo.requestContext(profile.id, disabled.memberId).isValid());
+    QVERIFY(!repo.setDefaultMember(profile.id, disabled.memberId));
+}
+
+void BloomProfileRepositoryTest::validExternalReloadEmitsAndInvalidatesActiveContext()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-1"),
+                                           QStringLiteral("https://one.example.test"),
+                                           QStringLiteral("one"),
+                                           QStringLiteral("One")),
+                            true);
+    config.upsertConnection(makeConnection(QStringLiteral("conn-2"),
+                                           QStringLiteral("https://two.example.test"),
+                                           QStringLiteral("two"),
+                                           QStringLiteral("Two")),
+                            false);
+
+    BloomProfileRepository repo(&config);
+    BloomProfile first;
+    first.name = QStringLiteral("First");
+    first.members = {BloomProfileMember{QString(), QStringLiteral("conn-1")}};
+    QVERIFY(repo.upsertProfile(first));
+
+    BloomProfile second;
+    second.name = QStringLiteral("Second");
+    second.members = {BloomProfileMember{QString(), QStringLiteral("conn-2")}};
+    QVERIFY(repo.upsertProfile(second));
+    QVERIFY(repo.setActiveProfile(first.id));
+
+    const BloomProfileRequestContext staleContext = repo.activeRequestContext();
+    QVERIFY(staleContext.isValid());
+    const quint64 previousGeneration = repo.generation();
+    QSignalSpy profilesChangedSpy(&repo, &BloomProfileRepository::profilesChanged);
+    QSignalSpy activeChangedSpy(&repo, &BloomProfileRepository::activeProfileChanged);
+
+    QJsonObject externalStore = config.getBloomProfilesConfig();
+    externalStore[QStringLiteral("active_profile_id")] = second.id;
+    config.setBloomProfilesConfig(externalStore);
+    repo.reload();
+
+    QCOMPARE(repo.activeProfile()->id, second.id);
+    QVERIFY(repo.generation() > previousGeneration);
+    QVERIFY(!repo.isCurrent(staleContext));
+    QCOMPARE(profilesChangedSpy.count(), 1);
+    QCOMPARE(activeChangedSpy.count(), 1);
+}
+
+void BloomProfileRepositoryTest::inactiveProfileMutationDoesNotChangeActiveGeneration()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-active"),
+                                           QStringLiteral("https://active.example.test"),
+                                           QStringLiteral("active"),
+                                           QStringLiteral("Active")),
+                            true);
+    config.upsertConnection(makeConnection(QStringLiteral("conn-inactive"),
+                                           QStringLiteral("https://inactive.example.test"),
+                                           QStringLiteral("inactive"),
+                                           QStringLiteral("Inactive")),
+                            false);
+
+    BloomProfileRepository repo(&config);
+    BloomProfile active;
+    active.name = QStringLiteral("Active");
+    active.members = {BloomProfileMember{QString(), QStringLiteral("conn-active")}};
+    QVERIFY(repo.upsertProfile(active));
+
+    BloomProfile inactive;
+    inactive.name = QStringLiteral("Inactive");
+    inactive.members = {BloomProfileMember{QString(), QStringLiteral("conn-inactive")}};
+    QVERIFY(repo.upsertProfile(inactive));
+
+    const quint64 generationBefore = repo.generation();
+    QSignalSpy activeChangedSpy(&repo, &BloomProfileRepository::activeProfileChanged);
+    inactive.name = QStringLiteral("Renamed inactive");
+    QVERIFY(repo.upsertProfile(inactive));
+    QCOMPARE(repo.generation(), generationBefore);
+    QCOMPARE(activeChangedSpy.count(), 0);
+}
+
+void BloomProfileRepositoryTest::profileJsonExcludesCredentialAndServerIdentity()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.upsertConnection(makeConnection(QStringLiteral("conn-1"),
+                                           QStringLiteral("https://secret.example.test"),
+                                           QStringLiteral("account-1"),
+                                           QStringLiteral("SecretUser")),
+                            true);
+
+    BloomProfileRepository repo(&config);
+    BloomProfile profile;
+    profile.name = QStringLiteral("Safe");
+    profile.mode = BloomProfileMode::Single;
+    BloomProfileMember member;
+    member.memberId = QStringLiteral("m-1");
+    member.connectionId = QStringLiteral("conn-1");
+    profile.members = {member};
+    profile.defaultMemberId = member.memberId;
+    QVERIFY(repo.upsertProfile(profile));
+
+    const QJsonObject bloom = config.getBloomProfilesConfig();
+    QVERIFY(!jsonContainsForbiddenSecretFields(bloom));
+    const QByteArray serialized = QJsonDocument(bloom).toJson(QJsonDocument::Compact);
+    QVERIFY(!serialized.contains("https://"));
+    QVERIFY(!serialized.contains("SecretUser"));
+    QVERIFY(!serialized.contains("account-1"));
+    QVERIFY(!serialized.contains("credential"));
+}
+
+QTEST_MAIN(BloomProfileRepositoryTest)
+#include "BloomProfileRepositoryTest.moc"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(TEST_PROVIDER_BOUNDARY_SOURCES
 
 set(TEST_CONFIG_SOURCES
     ${CMAKE_SOURCE_DIR}/src/providers/ServerConnection.cpp
+    ${CMAKE_SOURCE_DIR}/src/profiles/BloomProfile.cpp
     ${CMAKE_SOURCE_DIR}/src/security/CredentialStore.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/ConfigManager.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/MpvArgFilter.cpp
@@ -214,6 +215,26 @@ target_link_libraries(ConnectionPersistenceTest
 )
 
 add_test(NAME ConnectionPersistenceTest COMMAND ConnectionPersistenceTest)
+
+add_executable(BloomProfileRepositoryTest
+    BloomProfileRepositoryTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/profiles/BloomProfileRepository.cpp
+    ${TEST_CONFIG_SOURCES}
+    ${CMAKE_SOURCE_DIR}/src/resources/mpv-shaders.qrc
+)
+
+target_include_directories(BloomProfileRepositoryTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+target_link_libraries(BloomProfileRepositoryTest
+    PRIVATE
+        Qt6::Core
+        Qt6::Test
+)
+
+add_test(NAME BloomProfileRepositoryTest COMMAND BloomProfileRepositoryTest)
 
 add_executable(ProviderTransportTest
     ProviderTransportTest.cpp
@@ -589,6 +610,7 @@ qt_add_executable(VisualRegressionTest
     ${CMAKE_SOURCE_DIR}/src/utils/SystemPowerController.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/CacheMigrator.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/DetailViewCache.cpp
+    ${CMAKE_SOURCE_DIR}/src/profiles/BloomProfileRepository.cpp
     ${TEST_CONFIG_SOURCES}
     # Network sources
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp

--- a/tests/ConfigManagerThemeTest.cpp
+++ b/tests/ConfigManagerThemeTest.cpp
@@ -416,7 +416,7 @@ void ConfigManagerThemeTest::v19MigrationAddsThemeVariantSettings()
     QFile migratedFile(ConfigManager::getConfigPath());
     QVERIFY(migratedFile.open(QIODevice::ReadOnly));
     const QJsonObject migrated = QJsonDocument::fromJson(migratedFile.readAll()).object();
-    QCOMPARE(migrated.value(QStringLiteral("version")).toInt(), 29);
+    QCOMPARE(migrated.value(QStringLiteral("version")).toInt(), 30);
     const QJsonObject ui = migrated.value(QStringLiteral("settings")).toObject().value(QStringLiteral("ui")).toObject();
     QVERIFY(ui.contains(QStringLiteral("theme_flavor")));
     QCOMPARE(ui.value(QStringLiteral("theme_color_scheme")).toString(), QStringLiteral("blue"));
@@ -741,7 +741,7 @@ void ConfigManagerThemeTest::v24MigrationAddsScreensaverSettings()
     QFile migratedFile(ConfigManager::getConfigPath());
     QVERIFY(migratedFile.open(QIODevice::ReadOnly));
     const QJsonObject migrated = QJsonDocument::fromJson(migratedFile.readAll()).object();
-    QCOMPARE(migrated.value(QStringLiteral("version")).toInt(), 29);
+    QCOMPARE(migrated.value(QStringLiteral("version")).toInt(), 30);
     const QJsonObject ui = migrated.value(QStringLiteral("settings")).toObject().value(QStringLiteral("ui")).toObject();
     const QJsonObject screensaver = ui.value(QStringLiteral("screensaver")).toObject();
     QCOMPARE(screensaver.value(QStringLiteral("enabled")).toBool(), false);
@@ -781,7 +781,7 @@ void ConfigManagerThemeTest::v25MigrationAddsHeroEpisodeSynopsisSetting()
     QFile migratedFile(ConfigManager::getConfigPath());
     QVERIFY(migratedFile.open(QIODevice::ReadOnly));
     const QJsonObject migrated = QJsonDocument::fromJson(migratedFile.readAll()).object();
-    QCOMPARE(migrated.value(QStringLiteral("version")).toInt(), 29);
+    QCOMPARE(migrated.value(QStringLiteral("version")).toInt(), 30);
     const QJsonObject heroBanner = migrated.value(QStringLiteral("settings")).toObject()
                                        .value(QStringLiteral("ui")).toObject()
                                        .value(QStringLiteral("hero_banner")).toObject();
@@ -814,7 +814,7 @@ void ConfigManagerThemeTest::v26MigrationAddsInputBindings()
     QFile migratedFile(ConfigManager::getConfigPath());
     QVERIFY(migratedFile.open(QIODevice::ReadOnly));
     const QJsonObject migrated = QJsonDocument::fromJson(migratedFile.readAll()).object();
-    QCOMPARE(migrated.value(QStringLiteral("version")).toInt(), 29);
+    QCOMPARE(migrated.value(QStringLiteral("version")).toInt(), 30);
     const QJsonObject settings = migrated.value(QStringLiteral("settings")).toObject();
     const QJsonObject storedBindings = settings.value(QStringLiteral("input_bindings")).toObject();
     QCOMPARE(storedBindings.value(QStringLiteral("schema")).toInt(), 1);

--- a/tests/ConnectionPersistenceTest.cpp
+++ b/tests/ConnectionPersistenceTest.cpp
@@ -322,7 +322,7 @@ void ConnectionPersistenceTest::finalizeMigrationRemovesLegacyMetadataAndConfigT
     const QByteArray persisted = file.readAll();
     QVERIFY(!persisted.contains("legacy-config-token"));
     const QJsonObject root = QJsonDocument::fromJson(persisted).object();
-    QCOMPARE(root.value(QStringLiteral("version")).toInt(), 29);
+    QCOMPARE(root.value(QStringLiteral("version")).toInt(), 30);
     QVERIFY(!root.value(QStringLiteral("settings")).toObject().contains(QStringLiteral("jellyfin")));
 }
 


### PR DESCRIPTION
## Summary
- add versioned Bloom profile and ordered membership models that support multiple servers and multiple users on one physical server through independent connection identities
- add a provider-neutral repository with validation, CRUD, active profile/default member selection, and generation-guarded request/source contexts
- migrate existing users to one behavior-preserving single profile, keep credentials and server/account details out of profile JSON, and register the repository as an application service
- document identity, cache, migration, and future merged-read rules

## Validation
- `./scripts/dev-build.sh`
- `BloomProfileRepositoryTest` (17/17)
- `ConnectionPersistenceTest` (29/29)
- `ConfigManagerThemeTest` (39/39)
- independent profile schema review: PASS
- `git diff --check`

Implements the schema/repository foundation for #91. Merged reads and the keyboard/gamepad profile picker remain follow-up slices.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add multi-connection workspace profiles with config v30 migration
> - Introduces `BloomProfile` and `BloomProfileRepository` to manage named workspaces that group one or more server connections, supporting `single` and `merged` composition modes.
> - Adds `ConfigManager` v29→v30 migration that creates a default single-mode Bloom profile seeded from the existing active (or sole) connection using deterministic UUIDv5 IDs.
> - `BloomProfileRepository` handles CRUD, member ordering, active profile selection, and request context generation; it reacts to connection list changes and self-repairs invalid/dangling members on reload.
> - New `getBloomProfilesConfig`/`setBloomProfilesConfig` accessors on `ConfigManager` expose the raw `settings.bloom_profiles` block; `setBloomProfilesConfig` normalizes and immediately persists.
> - `ConfigManager.load()` now auto-saves if any migration or validation step modifies the in-memory config.
> - Behavioral Change: config version bumps to 30; existing v29 configs are migrated on first load and written back to disk automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d92d78f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bloom profiles for managing single or merged workspaces across saved connections.
  * Profiles support member selection, labels, ordering, enabled states, and default members.
  * Added persistence and automatic profile setup when upgrading existing configurations.
  * Added validation and repair for invalid or outdated profile data.
* **Documentation**
  * Added comprehensive Bloom profile documentation, configuration details, and usage guidance.
* **Tests**
  * Added coverage for profile creation, migration, persistence, ordering, repair, and context validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->