### PR TITLE
refactor(playback): serialize reports in provider adapters

### DIFF
--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -53,7 +53,7 @@ Existing list/detail/player flows are migrated in reviewable slices. During migr
 
 ## Playback boundary
 
-A `PlaybackDescriptor` is valid when it has a valid `MediaRef` and finalized `StreamRequest`. `PlaybackService` obtains the selected adapter's `IPlaybackProvider`; `JellyfinPlaybackProvider` resolves relative PlaybackInfo URLs, adds current request authentication and track hints, converts timing, and identifies the canonical playback method. `PlayerController` consumes only the finalized descriptor and may map canonical tracks to mpv runtime track IDs. Provider endpoints, query authentication, provider time units, and reporting DTOs stay outside the controller.
+A `PlaybackDescriptor` is valid when it has a valid `MediaRef` and finalized `StreamRequest`. `PlaybackService` obtains the selected adapter's `IPlaybackProvider`; `JellyfinPlaybackProvider` resolves relative PlaybackInfo URLs, adds current request authentication and track hints, converts timing, and identifies the canonical playback method. `PlayerController` consumes only the finalized descriptor and may map canonical tracks to mpv runtime track IDs. Playback positions and multipart durations remain milliseconds through the controller and service façade. The provider serializes report endpoints and payloads, including Jellyfin's final millisecond-to-tick conversion. Provider endpoints, query authentication, provider time units, and reporting DTOs stay outside the controller.
 
 ## Tests
 
@@ -67,5 +67,6 @@ A `PlaybackDescriptor` is valid when it has a valid `MediaRef` and finalized `St
 - token-free, round-trippable artwork cache keys
 - provider-neutral playback descriptor projections
 - Jellyfin stream finalization, canonical timing/tracks, and current credential injection at the playback-provider boundary
+- provider-owned playback report endpoint selection and millisecond-to-Jellyfin-tick serialization
 
 `SimilarItemsRetryTest` asserts Movie and Series detail shelves keep canonical request ownership and item/chapter shapes. `SeriesDetailsCacheTest` covers canonical series/list cache persistence, freshness, and wire-cache rejection. `EpisodeSelectionScriptTest` exercises canonical episode identity, season ownership, watched state, and millisecond resume selection. `LibraryViewModelCanonicalTest` covers canonical root-library roles, empty-container filtering, wire-cache rejection, and SWR identity/order checks.

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -103,8 +103,8 @@ Key components
 - MpvVideoItem / VideoSurface: minimal viewport plumbing for embedded backend integration.
 - PlayerProcessManager: manages external mpv process lifetime, sockets/pipes, scripts and config dir. Observes `time-pos`, `duration`, `pause`, `aid`, and `sid` properties.
 - PlayerController: provider-neutral state machine that handles play/pause/resume, listens for backend updates, manages track selection, and sends canonical playback state through `PlaybackService`.
-- `IPlaybackProvider` / `JellyfinPlaybackProvider`: finalize provider PlaybackInfo into Bloom `PlaybackDescriptor` values, including the authenticated stream request, canonical timing/tracks, playback method, and session identity.
-- PlaybackService: stable application façade for playback preparation and provider-specific reporting transport.
+- `IPlaybackProvider` / `JellyfinPlaybackProvider`: finalize provider PlaybackInfo into Bloom `PlaybackDescriptor` values and serialize canonical playback reports into provider endpoints and wire payloads.
+- PlaybackService: stable application façade for playback preparation and reporting transport; its public timing contract uses milliseconds.
 - TrackPreferencesManager: persists explicit audio/subtitle user choices to a separate JSON file using a versioned schema.
 
 HDR and Dolby Vision policy

--- a/docs/services.md
+++ b/docs/services.md
@@ -16,10 +16,10 @@ Key services
 - `IProviderAdapter` / `JellyfinProviderAdapter` — Selected provider implementation bundle consumed by stable application façades.
 - `IProviderRequestFactory` / `JellyfinRequestFactory` — Provider-owned URL and authorization-header construction.
 - `IProviderAuthenticator` / `JellyfinAuthenticator` — Provider-owned login payload, response parsing, and validation routes.
-- `IPlaybackProvider` / `JellyfinPlaybackProvider` — Provider-owned finalization of canonical playback descriptors and authenticated stream requests.
+- `IPlaybackProvider` / `JellyfinPlaybackProvider` — Provider-owned finalization of canonical playback descriptors and serialization of canonical playback reports into provider endpoints and payloads.
 - `AuthenticationService` — Stable QML façade for login, logout, session persistence, and token validation; delegates provider wire details and HTTP execution.
 - `LibraryService` — Library views/items, series details, search, reusable chapter metadata, image/theme-song URLs.
-- `PlaybackService` — Playback reporting, stream info, media segments, trickplay URLs and info.
+- `PlaybackService` — Millisecond-based playback reporting transport, stream info, media segments, trickplay URLs and info.
 - `MediaSegmentProviderService` — Fetches and normalizes external intro/recap/credits/preview markers from configured providers; used by `PlaybackService` after server segment lookup.
 - `SeerrService` — Seerr/Jellyseerr search integration, request-option loading, request submission, and similar-title provider endpoints.
 - `PlayerController` — Orchestrates playback using `IPlayerBackend` and services; owns `TrickplayProcessor`.

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -17,47 +17,41 @@
 #include "../utils/BloomLogging.h"
 
 namespace {
-QString jellyfinPlayMethod(const QString &method)
+
+PlaybackReport makePlaybackReport(PlaybackReportEvent event,
+                                  const QString &itemId,
+                                  qint64 positionMs,
+                                  const QString &mediaSourceId,
+                                  int audioStreamIndex,
+                                  int subtitleStreamIndex,
+                                  const QString &playSessionId,
+                                  bool canSeek,
+                                  bool isPaused,
+                                  bool isMuted,
+                                  const QString &playMethod,
+                                  const QString &repeatMode,
+                                  const QString &playbackOrder)
 {
-    const QString normalized = method.trimmed().toLower();
-    if (normalized == QStringLiteral("transcode")) {
-        return QStringLiteral("Transcode");
-    }
-    if (normalized == QStringLiteral("directstream")) {
-        return QStringLiteral("DirectStream");
-    }
-    return QStringLiteral("DirectPlay");
+    PlaybackReport report;
+    report.event = event;
+    report.media.itemId = itemId;
+    report.positionMs = positionMs;
+    report.mediaVersionId = mediaSourceId;
+    report.audioTrackId = audioStreamIndex >= 0
+        ? QString::number(audioStreamIndex) : QString();
+    report.subtitleTrackId = subtitleStreamIndex >= 0
+        ? QString::number(subtitleStreamIndex) : QString();
+    report.playbackSessionId = playSessionId;
+    report.canSeek = canSeek;
+    report.isPaused = isPaused;
+    report.isMuted = isMuted;
+    report.playbackMethod = playMethod;
+    report.repeatMode = repeatMode;
+    report.playbackOrder = playbackOrder;
+    return report;
 }
 
-QJsonObject buildPlaybackPayload(const QString &itemId, qint64 positionTicks,
-                                 const QString &mediaSourceId,
-                                 int audioStreamIndex, int subtitleStreamIndex,
-                                 const QString &playSessionId,
-                                 bool canSeek, bool isPaused, bool isMuted,
-                                 const QString &playMethod,
-                                 const QString &repeatMode,
-                                 const QString &playbackOrder)
-{
-    QJsonObject json;
-    json["ItemId"] = itemId;
-    if (positionTicks >= 0) {
-        json["PositionTicks"] = positionTicks;
-    }
-    json["CanSeek"] = canSeek;
-    json["IsPaused"] = isPaused;
-    json["IsMuted"] = isMuted;
-    json["PlayMethod"] = jellyfinPlayMethod(playMethod);
-    json["RepeatMode"] = repeatMode.isEmpty() ? QStringLiteral("RepeatNone") : repeatMode;
-    json["PlaybackOrder"] = playbackOrder.isEmpty() ? QStringLiteral("Default") : playbackOrder;
-
-    if (!mediaSourceId.isEmpty()) json["MediaSourceId"] = mediaSourceId;
-    if (audioStreamIndex >= 0) json["AudioStreamIndex"] = audioStreamIndex;
-    if (subtitleStreamIndex >= 0) json["SubtitleStreamIndex"] = subtitleStreamIndex;
-    if (!playSessionId.isEmpty()) json["PlaySessionId"] = playSessionId;
-
-    return json;
-}
-}
+} // namespace
 
 PlaybackService::PlaybackService(AuthenticationService *authService,
                                  ConfigManager *configManager,
@@ -596,34 +590,14 @@ void PlaybackService::reportPlaybackStart(const QString &itemId, const QString &
                                           const QString &repeatMode,
                                           const QString &playbackOrder)
 {
-    if (!m_authService->isAuthenticated()) return;
-
-    qCDebug(lcPlayback) << "Reporting playback start for item:" << itemId
-                             << "mediaSourceId:" << mediaSourceId
-                             << "audioIndex:" << audioStreamIndex
-                             << "subtitleIndex:" << subtitleStreamIndex;
-
-    QJsonObject json = buildPlaybackPayload(itemId, -1, mediaSourceId,
-                                            audioStreamIndex, subtitleStreamIndex,
-                                            playSessionId,
-                                            canSeek, isPaused, isMuted,
-                                            playMethod, repeatMode, playbackOrder);
-    
-    QNetworkRequest request = m_authService->createRequest("/Sessions/Playing");
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    
-    QNetworkReply *reply = m_authService->networkManager()->post(request, QJsonDocument(json).toJson());
-    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
-        reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply, true)) return;
-        if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(lcPlayback) << "Failed to report playback start for" << itemId 
-                                       << ":" << reply->errorString();
-        }
-    });
+    sendPlaybackReport(makePlaybackReport(PlaybackReportEvent::Start, itemId, -1,
+                                          mediaSourceId, audioStreamIndex,
+                                          subtitleStreamIndex, playSessionId,
+                                          canSeek, isPaused, isMuted, playMethod,
+                                          repeatMode, playbackOrder));
 }
 
-void PlaybackService::reportPlaybackProgress(const QString &itemId, qint64 positionTicks,
+void PlaybackService::reportPlaybackProgress(const QString &itemId, qint64 positionMs,
                                               const QString &mediaSourceId,
                                               int audioStreamIndex, int subtitleStreamIndex,
                                               const QString &playSessionId,
@@ -632,33 +606,14 @@ void PlaybackService::reportPlaybackProgress(const QString &itemId, qint64 posit
                                               const QString &repeatMode,
                                               const QString &playbackOrder)
 {
-    if (!m_authService->isAuthenticated()) return;
-
-    qCDebug(lcPlayback) << "Reporting playback progress for item:" << itemId 
-                             << "position:" << positionTicks;
-
-    QJsonObject json = buildPlaybackPayload(itemId, positionTicks, mediaSourceId,
-                                            audioStreamIndex, subtitleStreamIndex,
-                                            playSessionId,
-                                            canSeek, isPaused, isMuted,
-                                            playMethod, repeatMode, playbackOrder);
-    json["EventName"] = "TimeUpdate";
-    
-    QNetworkRequest request = m_authService->createRequest("/Sessions/Playing/Progress");
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    
-    QNetworkReply *reply = m_authService->networkManager()->post(request, QJsonDocument(json).toJson());
-    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
-        reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply, true)) return;
-        if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(lcPlayback) << "Failed to report playback progress for" << itemId 
-                                       << ":" << reply->errorString();
-        }
-    });
+    sendPlaybackReport(makePlaybackReport(PlaybackReportEvent::Progress, itemId, positionMs,
+                                          mediaSourceId, audioStreamIndex,
+                                          subtitleStreamIndex, playSessionId,
+                                          canSeek, isPaused, isMuted, playMethod,
+                                          repeatMode, playbackOrder));
 }
 
-void PlaybackService::reportPlaybackPaused(const QString &itemId, qint64 positionTicks,
+void PlaybackService::reportPlaybackPaused(const QString &itemId, qint64 positionMs,
                                             const QString &mediaSourceId,
                                             int audioStreamIndex, int subtitleStreamIndex,
                                             const QString &playSessionId,
@@ -667,33 +622,14 @@ void PlaybackService::reportPlaybackPaused(const QString &itemId, qint64 positio
                                             const QString &repeatMode,
                                             const QString &playbackOrder)
 {
-    if (!m_authService->isAuthenticated()) return;
-
-    qCDebug(lcPlayback) << "Reporting playback paused for item:" << itemId 
-                             << "position:" << positionTicks;
-
-    QJsonObject json = buildPlaybackPayload(itemId, positionTicks, mediaSourceId,
-                                            audioStreamIndex, subtitleStreamIndex,
-                                            playSessionId,
-                                            canSeek, true, isMuted,
-                                            playMethod, repeatMode, playbackOrder);
-    json["EventName"] = "Pause";
-    
-    QNetworkRequest request = m_authService->createRequest("/Sessions/Playing/Progress");
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    
-    QNetworkReply *reply = m_authService->networkManager()->post(request, QJsonDocument(json).toJson());
-    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
-        reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply, true)) return;
-        if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(lcPlayback) << "Failed to report playback paused for" << itemId 
-                                       << ":" << reply->errorString();
-        }
-    });
+    sendPlaybackReport(makePlaybackReport(PlaybackReportEvent::Pause, itemId, positionMs,
+                                          mediaSourceId, audioStreamIndex,
+                                          subtitleStreamIndex, playSessionId,
+                                          canSeek, true, isMuted, playMethod,
+                                          repeatMode, playbackOrder));
 }
 
-void PlaybackService::reportPlaybackResumed(const QString &itemId, qint64 positionTicks,
+void PlaybackService::reportPlaybackResumed(const QString &itemId, qint64 positionMs,
                                              const QString &mediaSourceId,
                                              int audioStreamIndex, int subtitleStreamIndex,
                                              const QString &playSessionId,
@@ -702,33 +638,14 @@ void PlaybackService::reportPlaybackResumed(const QString &itemId, qint64 positi
                                              const QString &repeatMode,
                                              const QString &playbackOrder)
 {
-    if (!m_authService->isAuthenticated()) return;
-
-    qCDebug(lcPlayback) << "Reporting playback resumed for item:" << itemId 
-                             << "position:" << positionTicks;
-
-    QJsonObject json = buildPlaybackPayload(itemId, positionTicks, mediaSourceId,
-                                            audioStreamIndex, subtitleStreamIndex,
-                                            playSessionId,
-                                            canSeek, false, isMuted,
-                                            playMethod, repeatMode, playbackOrder);
-    json["EventName"] = "Unpause";
-    
-    QNetworkRequest request = m_authService->createRequest("/Sessions/Playing/Progress");
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    
-    QNetworkReply *reply = m_authService->networkManager()->post(request, QJsonDocument(json).toJson());
-    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
-        reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply, true)) return;
-        if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(lcPlayback) << "Failed to report playback resumed for" << itemId 
-                                       << ":" << reply->errorString();
-        }
-    });
+    sendPlaybackReport(makePlaybackReport(PlaybackReportEvent::Resume, itemId, positionMs,
+                                          mediaSourceId, audioStreamIndex,
+                                          subtitleStreamIndex, playSessionId,
+                                          canSeek, false, isMuted, playMethod,
+                                          repeatMode, playbackOrder));
 }
 
-void PlaybackService::reportPlaybackStopped(const QString &itemId, qint64 positionTicks,
+void PlaybackService::reportPlaybackStopped(const QString &itemId, qint64 positionMs,
                                              const QString &mediaSourceId,
                                              int audioStreamIndex, int subtitleStreamIndex,
                                              const QString &playSessionId,
@@ -737,28 +654,55 @@ void PlaybackService::reportPlaybackStopped(const QString &itemId, qint64 positi
                                              const QString &repeatMode,
                                              const QString &playbackOrder)
 {
-    if (!m_authService->isAuthenticated()) return;
+    sendPlaybackReport(makePlaybackReport(PlaybackReportEvent::Stop, itemId, positionMs,
+                                          mediaSourceId, audioStreamIndex,
+                                          subtitleStreamIndex, playSessionId,
+                                          canSeek, isPaused, isMuted, playMethod,
+                                          repeatMode, playbackOrder));
+}
 
-    qCDebug(lcPlayback) << "Reporting playback stopped for item:" << itemId 
-                             << "position:" << positionTicks;
+void PlaybackService::sendPlaybackReport(const PlaybackReport &report)
+{
+    if (!m_authService || !m_authService->isAuthenticated() || !m_provider) {
+        return;
+    }
 
-    QJsonObject json = buildPlaybackPayload(itemId, positionTicks, mediaSourceId,
-                                            audioStreamIndex, subtitleStreamIndex,
-                                            playSessionId,
-                                            canSeek, isPaused, isMuted,
-                                            playMethod, repeatMode, playbackOrder);
-    json["EventName"] = "Stop";
-    
-    QNetworkRequest request = m_authService->createRequest("/Sessions/Playing/Stopped");
+    PlaybackReport providerReport = report;
+    ConfigManager *config = m_configManager
+        ? m_configManager
+        : m_authService->configManager();
+    const auto connection = config ? config->getActiveConnection() : std::nullopt;
+    if (connection.has_value()) {
+        providerReport.media.connectionId = connection->connectionId;
+    }
+
+    const PlaybackReportRequest providerRequest =
+        m_provider->createReportRequest(providerReport);
+    if (!providerRequest.isValid()) {
+        qCWarning(lcPlayback) << "Playback provider returned an invalid report request"
+                              << "itemId=" << report.media.itemId;
+        return;
+    }
+
+    qCDebug(lcPlayback) << "Reporting playback event"
+                        << "itemId=" << report.media.itemId
+                        << "positionMs=" << report.positionMs
+                        << "endpoint=" << providerRequest.endpoint;
+
+    QNetworkRequest request = m_authService->createRequest(providerRequest.endpoint);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    
-    QNetworkReply *reply = m_authService->networkManager()->post(request, QJsonDocument(json).toJson());
-    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
+    QNetworkReply *reply = m_authService->networkManager()->post(
+        request, QJsonDocument(providerRequest.body).toJson());
+    connect(reply, &QNetworkReply::finished, this,
+            [this, reply, itemId = report.media.itemId,
+             deferSessionExpiry = providerRequest.deferSessionExpiry]() {
         reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply, false)) return;
+        if (m_authService->checkForSessionExpiry(reply, deferSessionExpiry)) {
+            return;
+        }
         if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(lcPlayback) << "Failed to report playback stopped for" << itemId 
-                                       << ":" << reply->errorString();
+            qCWarning(lcPlayback) << "Failed to report playback event for" << itemId
+                                  << ":" << reply->errorString();
         }
     });
 }

--- a/src/network/PlaybackService.h
+++ b/src/network/PlaybackService.h
@@ -11,6 +11,7 @@ class AuthenticationService;
 class ConfigManager;
 class HttpTransport;
 class MediaSegmentProviderService;
+struct PlaybackReport;
 
 /**
  * @brief Handles playback reporting and playback-related metadata.
@@ -64,7 +65,7 @@ public:
                                                  const QString &playMethod = QStringLiteral("DirectPlay"),
                                                  const QString &repeatMode = QStringLiteral("RepeatNone"),
                                                  const QString &playbackOrder = QStringLiteral("Default"));
-    Q_INVOKABLE virtual void reportPlaybackProgress(const QString &itemId, qint64 positionTicks,
+    Q_INVOKABLE virtual void reportPlaybackProgress(const QString &itemId, qint64 positionMs,
                                                     const QString &mediaSourceId = QString(),
                                                     int audioStreamIndex = -1, int subtitleStreamIndex = -1,
                                                     const QString &playSessionId = QString(),
@@ -72,7 +73,7 @@ public:
                                                     const QString &playMethod = QStringLiteral("DirectPlay"),
                                                     const QString &repeatMode = QStringLiteral("RepeatNone"),
                                                     const QString &playbackOrder = QStringLiteral("Default"));
-    Q_INVOKABLE virtual void reportPlaybackPaused(const QString &itemId, qint64 positionTicks,
+    Q_INVOKABLE virtual void reportPlaybackPaused(const QString &itemId, qint64 positionMs,
                                                   const QString &mediaSourceId = QString(),
                                                   int audioStreamIndex = -1, int subtitleStreamIndex = -1,
                                                   const QString &playSessionId = QString(),
@@ -80,7 +81,7 @@ public:
                                                   const QString &playMethod = QStringLiteral("DirectPlay"),
                                                   const QString &repeatMode = QStringLiteral("RepeatNone"),
                                                   const QString &playbackOrder = QStringLiteral("Default"));
-    Q_INVOKABLE virtual void reportPlaybackResumed(const QString &itemId, qint64 positionTicks,
+    Q_INVOKABLE virtual void reportPlaybackResumed(const QString &itemId, qint64 positionMs,
                                                    const QString &mediaSourceId = QString(),
                                                    int audioStreamIndex = -1, int subtitleStreamIndex = -1,
                                                    const QString &playSessionId = QString(),
@@ -88,7 +89,7 @@ public:
                                                    const QString &playMethod = QStringLiteral("DirectPlay"),
                                                    const QString &repeatMode = QStringLiteral("RepeatNone"),
                                                    const QString &playbackOrder = QStringLiteral("Default"));
-    Q_INVOKABLE virtual void reportPlaybackStopped(const QString &itemId, qint64 positionTicks,
+    Q_INVOKABLE virtual void reportPlaybackStopped(const QString &itemId, qint64 positionMs,
                                                    const QString &mediaSourceId = QString(),
                                                    int audioStreamIndex = -1, int subtitleStreamIndex = -1,
                                                    const QString &playSessionId = QString(),
@@ -155,4 +156,5 @@ private:
                                      const QList<MediaSegmentInfo> &serverSegments,
                                      const QList<MediaSegmentInfo> &mergedSegments);
     void finishMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &segments);
+    void sendPlaybackReport(const PlaybackReport &report);
 };

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -1099,7 +1099,7 @@ void PlayerController::onEnterPausedState()
         : segment.value(QStringLiteral("itemId")).toString();
     if (!reportItemId.isEmpty()) {
         m_playbackService->reportPlaybackPaused(reportItemId,
-                                                currentReportingPositionTicks(),
+                                                currentReportingPositionMs(),
                                                 segment.isEmpty() ? m_mediaSourceId : segment.value(QStringLiteral("mediaSourceId")).toString(),
                                                 segment.isEmpty() ? m_selectedAudioTrack : segment.value(QStringLiteral("audioIndex")).toInt(),
                                                 segment.isEmpty() ? m_selectedSubtitleTrack : segment.value(QStringLiteral("subtitleIndex")).toInt(),
@@ -1236,7 +1236,7 @@ void PlayerController::onPositionChanged(double seconds)
 {
     double previousPosition = m_currentPosition;
     m_segmentRelativePosition = seconds;
-    const double offsetSeconds = static_cast<double>(m_activePlaybackSegmentOffsetTicks) / 10000000.0;
+    const double offsetSeconds = static_cast<double>(m_activePlaybackSegmentOffsetMs) / 1000.0;
     const double aggregatePosition = offsetSeconds + seconds;
     m_currentPosition = aggregatePosition;
     if (m_reportProgressOnNextPositionUpdate
@@ -1347,7 +1347,7 @@ void PlayerController::onPauseChanged(bool paused)
         processEvent(Event::Pause);
     } else if (!paused && m_playbackState == Paused) {
         // Report resume to server
-        m_playbackService->reportPlaybackResumed(reportItemId, currentReportingPositionTicks(),
+        m_playbackService->reportPlaybackResumed(reportItemId, currentReportingPositionMs(),
                                                  segment.isEmpty() ? m_mediaSourceId : segment.value(QStringLiteral("mediaSourceId")).toString(),
                                                  segment.isEmpty() ? m_selectedAudioTrack : segment.value(QStringLiteral("audioIndex")).toInt(),
                                                  segment.isEmpty() ? m_selectedSubtitleTrack : segment.value(QStringLiteral("subtitleIndex")).toInt(),
@@ -1390,11 +1390,11 @@ void PlayerController::onPlaylistPositionChanged(int index)
 
     const QVariantMap previousSegment = activePlaybackSegment();
     if (!previousSegment.isEmpty()) {
-        qint64 stopTicks = previousSegment.value(QStringLiteral("runTimeTicks")).toLongLong();
-        if (stopTicks <= 0) {
-            stopTicks = currentReportingPositionTicks();
+        qint64 stopMs = previousSegment.value(QStringLiteral("durationMs")).toLongLong();
+        if (stopMs <= 0) {
+            stopMs = currentReportingPositionMs();
         }
-        reportPlaybackStopForSegment(previousSegment, stopTicks);
+        reportPlaybackStopForSegment(previousSegment, stopMs);
     }
 
     applyPlaybackSegment(index, m_playbackState == Playing || m_playbackState == Paused);
@@ -1638,7 +1638,7 @@ bool PlayerController::stashRecoveryContextForCurrentPlayback()
     m_recoveryContext.isHDR = m_contentIsHDR;
     m_recoveryContext.playbackSegments = m_playbackSegments;
     m_recoveryContext.activePlaybackSegmentIndex = m_activePlaybackSegmentIndex;
-    m_recoveryContext.activePlaybackSegmentOffsetTicks = m_activePlaybackSegmentOffsetTicks;
+    m_recoveryContext.activePlaybackSegmentOffsetMs = m_activePlaybackSegmentOffsetMs;
     m_recoveryContext.segmentRelativePosition = m_segmentRelativePosition;
     m_recoveryContext.valid = true;
 
@@ -2091,6 +2091,7 @@ void PlayerController::onPlaybackInfoLoaded(const QString &itemId, const Playbac
                       resolved.subtitleIndex,
                       availableAudioTracks,
                       availableSubtitleTracks,
+                      descriptor.durationMs,
                       videoFramerateForMediaSource(mediaSource),
                       mediaSourceIsHdr(mediaSource),
                       kindShouldToneMapToSdr(classifyMediaSourceHdr(mediaSource),
@@ -2452,6 +2453,7 @@ void PlayerController::launchResolvedPlaybackRequest(const QString &requestId)
                       firstSegment.value(QStringLiteral("subtitleIndex"), -1).toInt(),
                       firstSegment.value(QStringLiteral("availableAudioTracks")).toList(),
                       firstSegment.value(QStringLiteral("availableSubtitleTracks")).toList(),
+                      firstSegment.value(QStringLiteral("durationMs")).toLongLong(),
                       firstSegment.value(QStringLiteral("framerate")).toDouble(),
                       firstSegment.value(QStringLiteral("isHDR")).toBool(),
                       firstSegment.value(QStringLiteral("toneMapToSdr")).toBool());
@@ -2582,8 +2584,7 @@ QVariantMap PlayerController::resolveSegmentPlaybackContext(const QString &scope
         {QStringLiteral("framerate"), videoFramerateForMediaSource(resolvedSource)},
         {QStringLiteral("isHDR"), kindIsHdr(hdrKind)},
         {QStringLiteral("hdrKind"), QString::fromLatin1(hdrContentKindName(hdrKind))},
-        {QStringLiteral("toneMapToSdr"), kindShouldToneMapToSdr(hdrKind, m_config->getDolbyVisionFallbackMode())},
-        {QStringLiteral("runTimeTicks"), resolvedSource.value(QStringLiteral("runTimeTicks")).toLongLong()}
+        {QStringLiteral("toneMapToSdr"), kindShouldToneMapToSdr(hdrKind, m_config->getDolbyVisionFallbackMode())}
     };
 }
 
@@ -2637,6 +2638,7 @@ QVariantList PlayerController::buildMultipartSegments(const QVariantMap &request
         primaryDescriptor.stream.pinnedAudioTrackId.toInt();
     primarySegment[QStringLiteral("pinnedSubtitleTrack")] =
         primaryDescriptor.stream.pinnedSubtitleTrackId.toInt();
+    primarySegment[QStringLiteral("durationMs")] = primaryDescriptor.durationMs;
     segments.append(primarySegment);
 
     for (const PendingPlaybackRequest &pendingRequest : m_pendingPlaybackRequests) {
@@ -2693,6 +2695,7 @@ QVariantList PlayerController::buildMultipartSegments(const QVariantMap &request
                 partDescriptor.stream.pinnedAudioTrackId.toInt();
             segment[QStringLiteral("pinnedSubtitleTrack")] =
                 partDescriptor.stream.pinnedSubtitleTrackId.toInt();
+            segment[QStringLiteral("durationMs")] = partDescriptor.durationMs;
             segments.append(segment);
         }
         break;
@@ -2705,7 +2708,7 @@ void PlayerController::clearPlaybackSegments()
 {
     m_playbackSegments.clear();
     m_activePlaybackSegmentIndex = -1;
-    m_activePlaybackSegmentOffsetTicks = 0;
+    m_activePlaybackSegmentOffsetMs = 0;
     m_segmentRelativePosition = 0.0;
     m_aggregatePlaybackDuration = 0.0;
     m_pendingPlaylistAppendUrls.clear();
@@ -2735,9 +2738,9 @@ void PlayerController::applyPlaybackSegment(int index, bool reportSegmentStart)
     }
 
     m_activePlaybackSegmentIndex = index;
-    m_activePlaybackSegmentOffsetTicks = 0;
+    m_activePlaybackSegmentOffsetMs = 0;
     for (int i = 0; i < index; ++i) {
-        m_activePlaybackSegmentOffsetTicks += m_playbackSegments.at(i).value(QStringLiteral("runTimeTicks")).toLongLong();
+        m_activePlaybackSegmentOffsetMs += m_playbackSegments.at(i).value(QStringLiteral("durationMs")).toLongLong();
     }
     m_segmentRelativePosition = 0.0;
 
@@ -2794,17 +2797,12 @@ void PlayerController::applyPlaybackSegment(int index, bool reportSegmentStart)
     }
 }
 
-qint64 PlayerController::currentReportingPositionTicks() const
+qint64 PlayerController::currentReportingPositionMs() const
 {
     if (m_activePlaybackSegmentIndex >= 0) {
-        return static_cast<qint64>(m_segmentRelativePosition * 10000000.0);
+        return qRound64(m_segmentRelativePosition * 1000.0);
     }
-    return static_cast<qint64>(m_currentPosition * 10000000.0);
-}
-
-qint64 PlayerController::currentAggregatePositionTicks() const
-{
-    return static_cast<qint64>(m_currentPosition * 10000000.0);
+    return qRound64(m_currentPosition * 1000.0);
 }
 
 void PlayerController::reportPlaybackStartForSegment(const QVariantMap &segment)
@@ -2829,7 +2827,7 @@ void PlayerController::reportPlaybackStartForSegment(const QVariantMap &segment)
                                            m_playMethod);
 }
 
-void PlayerController::reportPlaybackStopForSegment(const QVariantMap &segment, qint64 positionTicks)
+void PlayerController::reportPlaybackStopForSegment(const QVariantMap &segment, qint64 positionMs)
 {
     if (segment.isEmpty() || !m_playbackService) {
         return;
@@ -2841,7 +2839,7 @@ void PlayerController::reportPlaybackStopForSegment(const QVariantMap &segment, 
     }
 
     m_playbackService->reportPlaybackStopped(itemId,
-                                             positionTicks,
+                                             positionMs,
                                              segment.value(QStringLiteral("mediaSourceId")).toString(),
                                              segment.value(QStringLiteral("audioIndex"), -1).toInt(),
                                              segment.value(QStringLiteral("subtitleIndex"), -1).toInt(),
@@ -2919,9 +2917,8 @@ QString PlayerController::buildVersionSubtitle(const QVariantMap &mediaSource) c
  * currently stashed autoplay parameters. Clears the pending autoplay context on success
  * or if the episode data is invalid.
  *
- * @param episodeData JSON object describing the episode. If present, the function reads
- *                    "Id", "Name", "SeriesName", "ParentIndexNumber" (season), "IndexNumber"
- *                    (episode), and "UserData.PlaybackPositionTicks" (resume position).
+ * @param episodeData Provider episode object. Identity and display fields retain the legacy
+ *                    compatibility shape; resume timing is normalized through the active adapter.
  * @param seriesId    Series identifier associated with the episode (used for playback metadata).
  */
 void PlayerController::playNextEpisode(const QJsonObject &episodeData, const QString &seriesId)
@@ -3312,7 +3309,7 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
                 QVariant::fromValue(requestedPlaybackAttemptId);
             m_playbackSegments.append(segmentMap);
             m_aggregatePlaybackDuration += static_cast<double>(
-                segmentMap.value(QStringLiteral("runTimeTicks")).toLongLong()) / 10000000.0;
+                segmentMap.value(QStringLiteral("durationMs")).toLongLong()) / 1000.0;
         }
         if (!m_playbackSegments.isEmpty()) {
             if (m_aggregatePlaybackDuration > 0.0) {
@@ -4165,7 +4162,8 @@ void PlayerController::playUrlWithTracks(const QString &url, const QString &item
                                          int audioStreamIndex, int subtitleStreamIndex,
                                          const QVariantList &availableAudioTracks,
                                          const QVariantList &availableSubtitleTracks,
-                                         double framerate, bool isHDR, bool toneMapToSdr)
+                                         qint64 durationMs, double framerate,
+                                         bool isHDR, bool toneMapToSdr)
 {
     qCDebug(lcPlayback) << "PlayerController: playUrlWithTracks called with itemId:" << itemId
              << "audioIndex:" << audioStreamIndex
@@ -4199,7 +4197,7 @@ void PlayerController::playUrlWithTracks(const QString &url, const QString &item
                 {QStringLiteral("subtitleIndex"), subtitleStreamIndex},
                 {QStringLiteral("availableAudioTracks"), resolvedAvailableAudioTracks},
                 {QStringLiteral("availableSubtitleTracks"), resolvedAvailableSubtitleTracks},
-                {QStringLiteral("runTimeTicks"), mediaSource.value(QStringLiteral("runTimeTicks")).toLongLong()},
+                {QStringLiteral("durationMs"), durationMs},
                 {QStringLiteral("playMethod"), requestedPlayMethod},
                 {QStringLiteral("pinsAudioTrack"), requestedPinsAudioTrack},
                 {QStringLiteral("pinsSubtitleTrack"), requestedPinsSubtitleTrack},
@@ -4815,7 +4813,7 @@ void PlayerController::reportPlaybackProgress()
         : segment.value(QStringLiteral("itemId")).toString();
     if (!reportItemId.isEmpty() && m_playbackService && m_playbackState == Playing) {
         m_playbackService->reportPlaybackProgress(reportItemId,
-                                                  currentReportingPositionTicks(),
+                                                  currentReportingPositionMs(),
                                                   segment.isEmpty() ? m_mediaSourceId : segment.value(QStringLiteral("mediaSourceId")).toString(),
                                                   segment.isEmpty() ? m_selectedAudioTrack : segment.value(QStringLiteral("audioIndex")).toInt(),
                                                   segment.isEmpty() ? m_selectedSubtitleTrack : segment.value(QStringLiteral("subtitleIndex")).toInt(),
@@ -4834,7 +4832,7 @@ void PlayerController::reportPlaybackProgressNow()
     if (!reportItemId.isEmpty() && m_playbackService
         && (m_playbackState == Playing || m_playbackState == Paused)) {
         m_playbackService->reportPlaybackProgress(reportItemId,
-                                                  currentReportingPositionTicks(),
+                                                  currentReportingPositionMs(),
                                                   segment.isEmpty() ? m_mediaSourceId : segment.value(QStringLiteral("mediaSourceId")).toString(),
                                                   segment.isEmpty() ? m_selectedAudioTrack : segment.value(QStringLiteral("audioIndex")).toInt(),
                                                   segment.isEmpty() ? m_selectedSubtitleTrack : segment.value(QStringLiteral("subtitleIndex")).toInt(),
@@ -4865,7 +4863,7 @@ PlayerController::PlaybackStopReportSnapshot PlayerController::capturePlaybackSt
     snapshot.playSessionId = segment.isEmpty()
         ? m_playSessionId
         : segment.value(QStringLiteral("playSessionId")).toString();
-    snapshot.positionTicks = currentReportingPositionTicks();
+    snapshot.positionMs = currentReportingPositionMs();
     snapshot.canSeek = m_duration > 0.0;
     snapshot.isPaused = m_playbackState == Paused;
     snapshot.isMuted = m_muted;
@@ -4893,7 +4891,7 @@ void PlayerController::reportPlaybackStop()
                            << "position=" << snapshot.aggregatePositionSeconds << "s /" << snapshot.durationSeconds << "s"
                            << "(" << percentage << "%)";
         m_playbackService->reportPlaybackProgress(snapshot.itemId,
-                                                  snapshot.positionTicks,
+                                                  snapshot.positionMs,
                                                   snapshot.mediaSourceId,
                                                   snapshot.audioStreamIndex,
                                                   snapshot.subtitleStreamIndex,
@@ -4903,7 +4901,7 @@ void PlayerController::reportPlaybackStop()
                                                   snapshot.isMuted,
                                                   snapshot.playMethod);
         m_playbackService->reportPlaybackStopped(snapshot.itemId,
-                                                 snapshot.positionTicks,
+                                                 snapshot.positionMs,
                                                  snapshot.mediaSourceId,
                                                  snapshot.audioStreamIndex,
                                                  snapshot.subtitleStreamIndex,

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -264,7 +264,8 @@ public:
                                        int audioStreamIndex, int subtitleStreamIndex,
                                        const QVariantList &availableAudioTracks = {},
                                        const QVariantList &availableSubtitleTracks = {},
-                                       double framerate = 0.0, bool isHDR = false, bool toneMapToSdr = false);
+                                       qint64 durationMs = 0, double framerate = 0.0,
+                                       bool isHDR = false, bool toneMapToSdr = false);
     
     Q_INVOKABLE void stop();
     Q_INVOKABLE void pause();
@@ -498,7 +499,7 @@ private:
         QString playSessionId;
         int audioStreamIndex = -1;
         int subtitleStreamIndex = -1;
-        qint64 positionTicks = 0;
+        qint64 positionMs = 0;
         bool canSeek = false;
         bool isPaused = false;
         bool isMuted = false;
@@ -708,10 +709,9 @@ private:
     QString activePlaybackSegmentItemId() const;
     void applyPlaybackSegment(int index, bool reportSegmentStart);
     void clearPlaybackSegments();
-    qint64 currentReportingPositionTicks() const;
-    qint64 currentAggregatePositionTicks() const;
+    qint64 currentReportingPositionMs() const;
     void reportPlaybackStartForSegment(const QVariantMap &segment);
-    void reportPlaybackStopForSegment(const QVariantMap &segment, qint64 positionTicks);
+    void reportPlaybackStopForSegment(const QVariantMap &segment, qint64 positionMs);
     void updateVersionAffinityFromMediaSource(const QVariantMap &mediaSource);
     [[nodiscard]] QString mediaSourceParentPath(const QVariantMap &mediaSource) const;
     [[nodiscard]] QString mediaSourceSignature(const QVariantMap &mediaSource) const;
@@ -804,7 +804,7 @@ private:
         bool isHDR = false;
         QList<QVariantMap> playbackSegments;
         int activePlaybackSegmentIndex = -1;
-        qint64 activePlaybackSegmentOffsetTicks = 0;
+        qint64 activePlaybackSegmentOffsetMs = 0;
         double segmentRelativePosition = 0.0;
         bool valid = false;
     };
@@ -888,7 +888,7 @@ private:
     QVariantList m_nextPlaybackSegments;
     QStringList m_nextPlaylistAppendUrls;
     int m_activePlaybackSegmentIndex = -1;
-    qint64 m_activePlaybackSegmentOffsetTicks = 0;
+    qint64 m_activePlaybackSegmentOffsetMs = 0;
     double m_segmentRelativePosition = 0.0;
     double m_aggregatePlaybackDuration = 0.0;
     QStringList m_pendingPlaylistAppendUrls;

--- a/src/providers/IPlaybackProvider.h
+++ b/src/providers/IPlaybackProvider.h
@@ -2,7 +2,42 @@
 
 #include "models/MediaModels.h"
 
+#include <QJsonObject>
 #include <QVariantMap>
+
+enum class PlaybackReportEvent {
+    Start,
+    Progress,
+    Pause,
+    Resume,
+    Stop
+};
+
+struct PlaybackReport
+{
+    PlaybackReportEvent event = PlaybackReportEvent::Progress;
+    Bloom::MediaRef media;
+    qint64 positionMs = -1;
+    QString mediaVersionId;
+    QString audioTrackId;
+    QString subtitleTrackId;
+    QString playbackSessionId;
+    bool canSeek = true;
+    bool isPaused = false;
+    bool isMuted = false;
+    QString playbackMethod;
+    QString repeatMode;
+    QString playbackOrder;
+};
+
+struct PlaybackReportRequest
+{
+    QString endpoint;
+    QJsonObject body;
+    bool deferSessionExpiry = true;
+
+    [[nodiscard]] bool isValid() const { return !endpoint.isEmpty(); }
+};
 
 struct PlaybackProviderContext
 {
@@ -28,4 +63,6 @@ public:
         int selectedSubtitleTrack,
         qint64 startPositionMs,
         const QString &playbackSessionId = QString()) const = 0;
+
+    virtual PlaybackReportRequest createReportRequest(const PlaybackReport &report) const = 0;
 };

--- a/src/providers/jellyfin/JellyfinPlaybackProvider.cpp
+++ b/src/providers/jellyfin/JellyfinPlaybackProvider.cpp
@@ -49,6 +49,27 @@ Bloom::PlaybackTrack mapTrack(const QVariantMap &stream)
     return track;
 }
 
+QString jellyfinPlayMethod(const QString &method)
+{
+    const QString normalized = method.trimmed().toLower();
+    if (normalized == QStringLiteral("transcode")) {
+        return QStringLiteral("Transcode");
+    }
+    if (normalized == QStringLiteral("directstream")) {
+        return QStringLiteral("DirectStream");
+    }
+    return QStringLiteral("DirectPlay");
+}
+
+void addTrackIndex(QJsonObject &body, const QString &field, const QString &trackId)
+{
+    bool ok = false;
+    const int index = trackId.toInt(&ok);
+    if (ok && index >= 0) {
+        body.insert(field, index);
+    }
+}
+
 } // namespace
 
 Bloom::PlaybackDescriptor JellyfinPlaybackProvider::createDescriptor(
@@ -137,4 +158,60 @@ Bloom::PlaybackDescriptor JellyfinPlaybackProvider::createDescriptor(
     url.setQuery(query);
     descriptor.stream.url = url;
     return descriptor;
+}
+
+PlaybackReportRequest JellyfinPlaybackProvider::createReportRequest(
+    const PlaybackReport &report) const
+{
+    PlaybackReportRequest request;
+    QJsonObject body{
+        {QStringLiteral("ItemId"), report.media.itemId},
+        {QStringLiteral("CanSeek"), report.canSeek},
+        {QStringLiteral("IsPaused"), report.isPaused},
+        {QStringLiteral("IsMuted"), report.isMuted},
+        {QStringLiteral("PlayMethod"), jellyfinPlayMethod(report.playbackMethod)},
+        {QStringLiteral("RepeatMode"), report.repeatMode.isEmpty()
+             ? QStringLiteral("RepeatNone") : report.repeatMode},
+        {QStringLiteral("PlaybackOrder"), report.playbackOrder.isEmpty()
+             ? QStringLiteral("Default") : report.playbackOrder}
+    };
+
+    if (report.positionMs >= 0) {
+        body.insert(QStringLiteral("PositionTicks"),
+                    JellyfinModelMapper::millisecondsToTicks(report.positionMs));
+    }
+    if (!report.mediaVersionId.isEmpty()) {
+        body.insert(QStringLiteral("MediaSourceId"), report.mediaVersionId);
+    }
+    addTrackIndex(body, QStringLiteral("AudioStreamIndex"), report.audioTrackId);
+    addTrackIndex(body, QStringLiteral("SubtitleStreamIndex"), report.subtitleTrackId);
+    if (!report.playbackSessionId.isEmpty()) {
+        body.insert(QStringLiteral("PlaySessionId"), report.playbackSessionId);
+    }
+
+    switch (report.event) {
+    case PlaybackReportEvent::Start:
+        request.endpoint = QStringLiteral("/Sessions/Playing");
+        break;
+    case PlaybackReportEvent::Progress:
+        request.endpoint = QStringLiteral("/Sessions/Playing/Progress");
+        body.insert(QStringLiteral("EventName"), QStringLiteral("TimeUpdate"));
+        break;
+    case PlaybackReportEvent::Pause:
+        request.endpoint = QStringLiteral("/Sessions/Playing/Progress");
+        body.insert(QStringLiteral("EventName"), QStringLiteral("Pause"));
+        break;
+    case PlaybackReportEvent::Resume:
+        request.endpoint = QStringLiteral("/Sessions/Playing/Progress");
+        body.insert(QStringLiteral("EventName"), QStringLiteral("Unpause"));
+        break;
+    case PlaybackReportEvent::Stop:
+        request.endpoint = QStringLiteral("/Sessions/Playing/Stopped");
+        request.deferSessionExpiry = false;
+        body.insert(QStringLiteral("EventName"), QStringLiteral("Stop"));
+        break;
+    }
+
+    request.body = body;
+    return request;
 }

--- a/src/providers/jellyfin/JellyfinPlaybackProvider.h
+++ b/src/providers/jellyfin/JellyfinPlaybackProvider.h
@@ -13,4 +13,6 @@ public:
         int selectedSubtitleTrack,
         qint64 startPositionMs,
         const QString &playbackSessionId = QString()) const override;
+
+    PlaybackReportRequest createReportRequest(const PlaybackReport &report) const override;
 };

--- a/tests/CanonicalModelsTest.cpp
+++ b/tests/CanonicalModelsTest.cpp
@@ -22,6 +22,7 @@ private slots:
     void jellyfinArtworkEndpointContainsNoCredential();
     void playbackDescriptorExposesProviderNeutralShape();
     void jellyfinPlaybackProviderFinalizesStreamAtBoundary();
+    void jellyfinPlaybackReportsSerializeAtProviderBoundary();
 };
 
 void CanonicalModelsTest::jellyfinTimeConversionUsesMilliseconds()
@@ -394,6 +395,58 @@ void CanonicalModelsTest::playbackDescriptorExposesProviderNeutralShape()
                  .value(QStringLiteral("method")).toString(), QStringLiteral("directPlay"));
     QVERIFY(!map.contains(QStringLiteral("RunTimeTicks")));
     QVERIFY(!map.contains(QStringLiteral("MediaSourceId")));
+}
+
+void CanonicalModelsTest::jellyfinPlaybackReportsSerializeAtProviderBoundary()
+{
+    const JellyfinPlaybackProvider provider;
+    PlaybackReport report;
+    report.event = PlaybackReportEvent::Progress;
+    report.media = {QStringLiteral("connection-1"), QStringLiteral("movie-1")};
+    report.positionMs = 1234;
+    report.mediaVersionId = QStringLiteral("source-1");
+    report.audioTrackId = QStringLiteral("2");
+    report.subtitleTrackId = QStringLiteral("4");
+    report.playbackSessionId = QStringLiteral("session-1");
+    report.canSeek = true;
+    report.isPaused = false;
+    report.isMuted = true;
+    report.playbackMethod = QStringLiteral("directStream");
+
+    const PlaybackReportRequest progress = provider.createReportRequest(report);
+    QCOMPARE(progress.endpoint, QStringLiteral("/Sessions/Playing/Progress"));
+    QVERIFY(progress.deferSessionExpiry);
+    QCOMPARE(progress.body.value(QStringLiteral("ItemId")).toString(),
+             QStringLiteral("movie-1"));
+    QCOMPARE(progress.body.value(QStringLiteral("PositionTicks")).toVariant().toLongLong(),
+             12'340'000LL);
+    QCOMPARE(progress.body.value(QStringLiteral("MediaSourceId")).toString(),
+             QStringLiteral("source-1"));
+    QCOMPARE(progress.body.value(QStringLiteral("AudioStreamIndex")).toInt(), 2);
+    QCOMPARE(progress.body.value(QStringLiteral("SubtitleStreamIndex")).toInt(), 4);
+    QCOMPARE(progress.body.value(QStringLiteral("PlaySessionId")).toString(),
+             QStringLiteral("session-1"));
+    QCOMPARE(progress.body.value(QStringLiteral("PlayMethod")).toString(),
+             QStringLiteral("DirectStream"));
+    QCOMPARE(progress.body.value(QStringLiteral("EventName")).toString(),
+             QStringLiteral("TimeUpdate"));
+
+    report.event = PlaybackReportEvent::Start;
+    report.positionMs = -1;
+    const PlaybackReportRequest start = provider.createReportRequest(report);
+    QCOMPARE(start.endpoint, QStringLiteral("/Sessions/Playing"));
+    QVERIFY(!start.body.contains(QStringLiteral("PositionTicks")));
+    QVERIFY(!start.body.contains(QStringLiteral("EventName")));
+
+    report.event = PlaybackReportEvent::Stop;
+    report.positionMs = 4321;
+    const PlaybackReportRequest stop = provider.createReportRequest(report);
+    QCOMPARE(stop.endpoint, QStringLiteral("/Sessions/Playing/Stopped"));
+    QVERIFY(!stop.deferSessionExpiry);
+    QCOMPARE(stop.body.value(QStringLiteral("PositionTicks")).toVariant().toLongLong(),
+             43'210'000LL);
+    QCOMPARE(stop.body.value(QStringLiteral("EventName")).toString(),
+             QStringLiteral("Stop"));
 }
 
 QTEST_MAIN(CanonicalModelsTest)

--- a/tests/PlayerControllerAutoplayContextTest.cpp
+++ b/tests/PlayerControllerAutoplayContextTest.cpp
@@ -218,7 +218,7 @@ public:
     struct Report
     {
         QString itemId;
-        qint64 positionTicks = 0;
+        qint64 positionMs = 0;
         QString mediaSourceId;
         int audioStreamIndex = -1;
         int subtitleStreamIndex = -1;
@@ -300,7 +300,7 @@ public:
         requestedAdditionalPartsContexts.append(requestContext);
     }
 
-    void reportPlaybackProgress(const QString &itemId, qint64 positionTicks,
+    void reportPlaybackProgress(const QString &itemId, qint64 positionMs,
                                 const QString &mediaSourceId,
                                 int audioStreamIndex, int subtitleStreamIndex,
                                 const QString &playSessionId,
@@ -311,12 +311,12 @@ public:
     {
         Q_UNUSED(repeatMode);
         Q_UNUSED(playbackOrder);
-        progressReports.append({itemId, positionTicks, mediaSourceId, audioStreamIndex,
+        progressReports.append({itemId, positionMs, mediaSourceId, audioStreamIndex,
                                 subtitleStreamIndex, playSessionId, canSeek, isPaused,
                                 isMuted, playMethod});
     }
 
-    void reportPlaybackStopped(const QString &itemId, qint64 positionTicks,
+    void reportPlaybackStopped(const QString &itemId, qint64 positionMs,
                                const QString &mediaSourceId,
                                int audioStreamIndex, int subtitleStreamIndex,
                                const QString &playSessionId,
@@ -327,7 +327,7 @@ public:
     {
         Q_UNUSED(repeatMode);
         Q_UNUSED(playbackOrder);
-        stoppedReports.append({itemId, positionTicks, mediaSourceId, audioStreamIndex,
+        stoppedReports.append({itemId, positionMs, mediaSourceId, audioStreamIndex,
                                subtitleStreamIndex, playSessionId, canSeek, isPaused,
                                isMuted, playMethod});
     }
@@ -834,7 +834,7 @@ void PlayerControllerAutoplayContextTest::explicitStopReportsFinalProgressAndSto
     const FakePlaybackService::Report progress = playbackService.progressReports.first();
     const FakePlaybackService::Report stopped = playbackService.stoppedReports.first();
     QCOMPARE(progress.itemId, QStringLiteral("item-1"));
-    QCOMPARE(progress.positionTicks, 425000000LL);
+    QCOMPARE(progress.positionMs, 42500LL);
     QCOMPARE(progress.mediaSourceId, QStringLiteral("media-source-1"));
     QCOMPARE(progress.audioStreamIndex, 2);
     QCOMPARE(progress.subtitleStreamIndex, 5);
@@ -842,7 +842,7 @@ void PlayerControllerAutoplayContextTest::explicitStopReportsFinalProgressAndSto
     QVERIFY(progress.canSeek);
     QVERIFY(!progress.isPaused);
     QCOMPARE(stopped.itemId, progress.itemId);
-    QCOMPARE(stopped.positionTicks, progress.positionTicks);
+    QCOMPARE(stopped.positionMs, progress.positionMs);
     QCOMPARE(stopped.mediaSourceId, progress.mediaSourceId);
     QCOMPARE(stopped.audioStreamIndex, progress.audioStreamIndex);
     QCOMPARE(stopped.subtitleStreamIndex, progress.subtitleStreamIndex);
@@ -922,7 +922,7 @@ void PlayerControllerAutoplayContextTest::explicitMultipartStopReportsActiveSegm
             {QStringLiteral("playSessionId"), QStringLiteral("session-1")},
             {QStringLiteral("audioIndex"), 2},
             {QStringLiteral("subtitleIndex"), -1},
-            {QStringLiteral("runTimeTicks"), 600000000LL}
+            {QStringLiteral("durationMs"), 60000LL}
         },
         QVariantMap{
             {QStringLiteral("itemId"), QStringLiteral("part-2")},
@@ -930,7 +930,7 @@ void PlayerControllerAutoplayContextTest::explicitMultipartStopReportsActiveSegm
             {QStringLiteral("playSessionId"), QStringLiteral("session-2")},
             {QStringLiteral("audioIndex"), 3},
             {QStringLiteral("subtitleIndex"), 7},
-            {QStringLiteral("runTimeTicks"), 600000000LL}
+            {QStringLiteral("durationMs"), 60000LL}
         }
     };
 
@@ -942,11 +942,11 @@ void PlayerControllerAutoplayContextTest::explicitMultipartStopReportsActiveSegm
     const FakePlaybackService::Report progress = playbackService.progressReports.first();
     const FakePlaybackService::Report stopped = playbackService.stoppedReports.first();
     QCOMPARE(progress.itemId, QStringLiteral("part-2"));
-    QCOMPARE(progress.positionTicks, 100000000LL);
+    QCOMPARE(progress.positionMs, 10000LL);
     QCOMPARE(progress.mediaSourceId, QStringLiteral("part-2-source"));
     QCOMPARE(progress.playSessionId, QStringLiteral("session-2"));
     QCOMPARE(stopped.itemId, QStringLiteral("part-2"));
-    QCOMPARE(stopped.positionTicks, 100000000LL);
+    QCOMPARE(stopped.positionMs, 10000LL);
     QCOMPARE(stopped.mediaSourceId, QStringLiteral("part-2-source"));
     QCOMPARE(stopped.playSessionId, QStringLiteral("session-2"));
     QCOMPARE(stopped.audioStreamIndex, 3);
@@ -3190,7 +3190,7 @@ void PlayerControllerAutoplayContextTest::multipartIntermediateEndIsIgnoredUntil
             {QStringLiteral("subtitleIndex"), -1},
             {QStringLiteral("availableAudioTracks"), controller.buildAvailableTrackOptions(part1Source, QStringLiteral("Audio"))},
             {QStringLiteral("availableSubtitleTracks"), controller.buildAvailableTrackOptions(part1Source, QStringLiteral("Subtitle"))},
-            {QStringLiteral("runTimeTicks"), 600000000LL},
+            {QStringLiteral("durationMs"), 60000LL},
             {QStringLiteral("url"), QStringLiteral("https://example.invalid/part-1")}
         },
         QVariantMap{
@@ -3202,7 +3202,7 @@ void PlayerControllerAutoplayContextTest::multipartIntermediateEndIsIgnoredUntil
             {QStringLiteral("subtitleIndex"), -1},
             {QStringLiteral("availableAudioTracks"), controller.buildAvailableTrackOptions(part2Source, QStringLiteral("Audio"))},
             {QStringLiteral("availableSubtitleTracks"), controller.buildAvailableTrackOptions(part2Source, QStringLiteral("Subtitle"))},
-            {QStringLiteral("runTimeTicks"), 600000000LL},
+            {QStringLiteral("durationMs"), 60000LL},
             {QStringLiteral("url"), QStringLiteral("https://example.invalid/part-2")}
         }
     };
@@ -3216,7 +3216,7 @@ void PlayerControllerAutoplayContextTest::multipartIntermediateEndIsIgnoredUntil
 
     controller.onPlaylistPositionChanged(1);
     QCOMPARE(controller.m_activePlaybackSegmentIndex, 1);
-    QCOMPARE(controller.m_activePlaybackSegmentOffsetTicks, 600000000LL);
+    QCOMPARE(controller.m_activePlaybackSegmentOffsetMs, 60000LL);
     QCOMPARE(controller.m_mediaSourceId, QStringLiteral("part-2-source"));
     QCOMPARE(controller.m_playSessionId, QStringLiteral("session-2"));
     QCOMPARE(controller.activePlaybackSegmentItemId(), QStringLiteral("part-2"));


### PR DESCRIPTION
## Summary

- add provider-neutral playback report events and request descriptors to `IPlaybackProvider`
- move Jellyfin `/Sessions/Playing*` endpoint selection and wire payload serialization into `JellyfinPlaybackProvider`
- keep `PlaybackService` and `PlayerController` report positions in canonical milliseconds
- keep multipart durations and offsets in milliseconds inside the player
- preserve Jellyfin pause/resume/stop event names and deferred session-expiry behavior

Stacked on #98. Part of #76.

## Testing

- `./scripts/dev-build.sh`
- `nix flake check` (21/21 tests passed)
- `nix build`

## Manual verification

- [ ] Start, pause, resume, seek, and stop playback; confirm server progress updates
- [ ] Complete an item and confirm watched/progress state updates
- [ ] Play multipart media and confirm aggregate timeline plus per-part progress reporting
- [ ] Let a session expire during playback and confirm stop reporting retains existing expiry handling

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize playback reports in provider adapters and replace ticks with milliseconds throughout
> - Moves playback report serialization (endpoint, payload, tick conversion) into `IPlaybackProvider`/`JellyfinPlaybackProvider` via a new `createReportRequest` method, so `PlaybackService` becomes a millisecond-based transport that delegates all Jellyfin-specific formatting to the provider.
> - Converts all internal position tracking in `PlayerController`, `PlaybackService`, and the UI layer from ticks (`positionTicks`, `runTimeTicks`, `startPositionTicks`) to milliseconds (`positionMs`, `durationMs`, `startPositionMs`).
> - Scopes chapter loading and failure handling by `connectionId` in `LibraryService`, `MovieDetailsViewModel`, and `SeriesDetailsViewModel`, so cached chapters and failure signals from a previous connection do not affect the active one.
> - Adds a `resumePositionMs` helper in `PlayerController` that normalizes provider-specific resume data into milliseconds via `AuthenticationService::mapMediaItem`.
> - Risk: `playUrl`, `playUrlWithTracks`, `reportPlaybackProgress/Paused/Resumed/Stopped`, `LibraryService::chaptersFailed`, and `IPlaybackProvider` all have changed signatures; any external or QML callers using the old tick-based names or two-argument `chaptersFailed` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c975d34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->