### PR TITLE
refactor(playback): normalize media segments to milliseconds

### DIFF
--- a/docs/media-segments.md
+++ b/docs/media-segments.md
@@ -18,7 +18,7 @@ Provider parsing
 
 Adding a provider
 - Add request and parser code to `MediaSegmentProviderService`.
-- Normalize all times to `MediaSegmentInfo` ticks.
+- Normalize all times to `MediaSegmentInfo` milliseconds (`startMs` / `endMs`).
 - Set `source` to a stable lowercase provider id.
 - Add the provider id to `ConfigManager::getMediaSegmentProviderOrder()` defaults only when it is suitable as a default.
 - Add parser and merge tests in `MediaSegmentProviderServiceTest`.

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -280,7 +280,7 @@ Multipart reporting model
 - Bloom keeps two playback identities for multipart items:
   - logical item: the original movie/episode shown in the overlay and used for completion/autoplay decisions
   - reporting segment: the currently active physical part used for Jellyfin start/progress/pause/stop reporting
-- Progress shown in the client is aggregate across all parts. The controller tracks the prior-segment tick offset and combines it with the current segment position for timeline and completion-threshold calculations.
+- Progress shown in the client is aggregate across all parts. The controller tracks the prior-segment millisecond offset and combines it with the current segment position for timeline and completion-threshold calculations.
 - On playlist position changes, Bloom swaps the active segment metadata, refreshes per-part media segments/trickplay data, reports the segment handoff to Jellyfin, and suppresses terminal playback-end handling until the final playlist entry finishes.
 
 Playback Reporting

--- a/src/network/MediaSegmentProviderService.cpp
+++ b/src/network/MediaSegmentProviderService.cpp
@@ -16,7 +16,6 @@
 #include "../utils/BloomLogging.h"
 
 namespace {
-constexpr double kTicksPerSecond = 10000000.0;
 constexpr int kProviderTransferTimeoutMs = 30000;
 
 const QSet<MediaSegmentType> kSupportedFillTypes = {
@@ -248,8 +247,8 @@ QList<MediaSegmentInfo> MediaSegmentProviderService::parseTheIntroDbSegments(con
     };
 
     QList<MediaSegmentInfo> segments;
-    const double durationSeconds = context.durationTicks > 0
-        ? static_cast<double>(context.durationTicks) / kTicksPerSecond
+    const double durationSeconds = context.durationMs > 0
+        ? static_cast<double>(context.durationMs) / 1000.0
         : 0.0;
 
     for (const Mapping &mapping : mappings) {
@@ -359,7 +358,7 @@ MediaSegmentInfo MediaSegmentProviderService::buildSegment(const MediaSegmentLoo
         return {};
     }
 
-    info.startTicks = static_cast<qint64>(startSeconds * kTicksPerSecond);
-    info.endTicks = static_cast<qint64>(endSeconds * kTicksPerSecond);
+    info.startMs = qRound64(startSeconds * 1000.0);
+    info.endMs = qRound64(endSeconds * 1000.0);
     return info;
 }

--- a/src/network/MediaSegmentProviderService.h
+++ b/src/network/MediaSegmentProviderService.h
@@ -22,7 +22,7 @@ struct MediaSegmentLookupContext
     QString tvdbId;
     int seasonNumber = -1;
     int episodeNumber = -1;
-    qint64 durationTicks = 0;
+    qint64 durationMs = 0;
 };
 
 struct MediaSegmentProviderResult

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -346,8 +346,8 @@ QList<MediaSegmentInfo> PlaybackService::parseIntroSkipperSegments(const QString
         if (startSeconds < 0.0 || endSeconds <= startSeconds) {
             continue;
         }
-        info.startTicks = static_cast<qint64>(startSeconds * 10000000.0);
-        info.endTicks = static_cast<qint64>(endSeconds * 10000000.0);
+        info.startMs = qRound64(startSeconds * 1000.0);
+        info.endMs = qRound64(endSeconds * 1000.0);
 
         if (typeMapping.contains(typeName)) {
             const auto mapping = typeMapping[typeName];
@@ -393,16 +393,16 @@ void PlaybackService::loadMediaSegmentLookupContext(const QString &itemId, const
         },
         [this, itemId, serverSegments](QNetworkReply *reply) {
             const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-            const QJsonObject item = doc.object();
+            const QVariantMap item = m_authService->mapMediaItem(doc.object(), QString());
             MediaSegmentLookupContext context;
             context.itemId = itemId;
-            context.type = item.value(QStringLiteral("Type")).toString();
-            context.seriesId = item.value(QStringLiteral("SeriesId")).toString();
-            context.seasonNumber = item.value(QStringLiteral("ParentIndexNumber")).toInt(-1);
-            context.episodeNumber = item.value(QStringLiteral("IndexNumber")).toInt(-1);
-            context.durationTicks = static_cast<qint64>(item.value(QStringLiteral("RunTimeTicks")).toDouble());
+            context.type = item.value(QStringLiteral("mediaType")).toString();
+            context.seriesId = item.value(QStringLiteral("seriesId")).toString();
+            context.seasonNumber = item.value(QStringLiteral("parentIndexNumber"), -1).toInt();
+            context.episodeNumber = item.value(QStringLiteral("indexNumber"), -1).toInt();
+            context.durationMs = item.value(QStringLiteral("durationMs")).toLongLong();
 
-            const QJsonObject providerIds = item.value(QStringLiteral("ProviderIds")).toObject();
+            const QVariantMap providerIds = item.value(QStringLiteral("providerIds")).toMap();
             context.imdbId = providerIds.value(QStringLiteral("Imdb")).toString();
             context.tmdbId = providerIds.value(QStringLiteral("Tmdb")).toString();
             context.tvdbId = providerIds.value(QStringLiteral("Tvdb")).toString();
@@ -510,9 +510,9 @@ void PlaybackService::getTrickplayInfo(const QString &itemId)
             QJsonDocument doc = QJsonDocument::fromJson(data);
             QJsonObject obj = doc.object();
             
-            // Get RunTimeTicks to calculate actual thumbnail count
-            qint64 runTimeTicks = static_cast<qint64>(obj["RunTimeTicks"].toDouble());
-            double durationSeconds = runTimeTicks / 10000000.0;
+            const QVariantMap item = m_authService->mapMediaItem(obj, QString());
+            const double durationSeconds =
+                static_cast<double>(item.value(QStringLiteral("durationMs")).toLongLong()) / 1000.0;
             
             // Debug: Log the raw Trickplay JSON response
             QJsonObject trickplayRaw = obj["Trickplay"].toObject();

--- a/src/network/Types.cpp
+++ b/src/network/Types.cpp
@@ -384,62 +384,6 @@ QVariantMap ChapterInfo::toVariantMap(const QString &thumbnailUrl) const
 }
 
 // ============================================================================
-// MediaSegmentInfo Implementation
-// ============================================================================
-
-/**
- * @brief Parse MediaSegmentInfo from Jellyfin API JSON response
- * 
- * Deserializes media segment markers (intro/outro/credits) from Jellyfin plugins
- * like "Intro Skipper". These segments define time ranges for UI skip buttons.
- * 
- * Jellyfin API reference:
- * Endpoint: GET /Episode/{itemId}/IntroTimestamps (plugin-specific)
- * 
- * Key fields:
- * - StartTicks/EndTicks: Time range in ticks (1 tick = 100ns)
- * - Type: Segment type string ("IntroStart", "IntroEnd", "OutroStart", etc.)
- * 
- * The Type string is parsed into a MediaSegmentType enum for easier handling.
- * Ticks are converted to seconds via startSeconds()/endSeconds() helpers.
- * 
- * @param json JSON object representing a media segment
- * @return Populated MediaSegmentInfo with parsed type enum
- */
-MediaSegmentInfo MediaSegmentInfo::fromJson(const QJsonObject &json)
-{
-    MediaSegmentInfo info;
-    info.id = json["Id"].toString();
-    info.itemId = json["ItemId"].toString();
-    info.startTicks = static_cast<qint64>(json["StartTicks"].toDouble());
-    info.endTicks = static_cast<qint64>(json["EndTicks"].toDouble());
-    info.source = json.value("Source").toString(json.value("source").toString());
-    info.confidence = json.value("Confidence").toDouble(json.value("confidence").toDouble());
-    if (json.contains("SubmissionCount")) {
-        info.submissionCount = json.value("SubmissionCount").toInt();
-    } else {
-        info.submissionCount = json.value("submission_count").toInt();
-    }
-    
-    QString typeStr = json["Type"].toString();
-    info.typeString = typeStr;
-    
-    if (typeStr.compare("IntroStart", Qt::CaseInsensitive) == 0) {
-        info.type = MediaSegmentType::IntroStart;
-    } else if (typeStr.compare("IntroEnd", Qt::CaseInsensitive) == 0) {
-        info.type = MediaSegmentType::IntroEnd;
-    } else if (typeStr.compare("OutroStart", Qt::CaseInsensitive) == 0) {
-        info.type = MediaSegmentType::OutroStart;
-    } else if (typeStr.compare("OutroEnd", Qt::CaseInsensitive) == 0) {
-        info.type = MediaSegmentType::OutroEnd;
-    } else {
-        info.type = MediaSegmentType::Unknown;
-    }
-    
-    return info;
-}
-
-// ============================================================================
 // TrickplayTileInfo Implementation
 // ============================================================================
 

--- a/src/network/Types.h
+++ b/src/network/Types.h
@@ -185,23 +185,22 @@ struct MediaSegmentInfo
     Q_PROPERTY(QString id MEMBER id)
     Q_PROPERTY(QString itemId MEMBER itemId)
     Q_PROPERTY(QString type MEMBER typeString)
-    Q_PROPERTY(qint64 startTicks MEMBER startTicks)
-    Q_PROPERTY(qint64 endTicks MEMBER endTicks)
+    Q_PROPERTY(qint64 startMs MEMBER startMs)
+    Q_PROPERTY(qint64 endMs MEMBER endMs)
 
 public:
     QString id;
     QString itemId;
     MediaSegmentType type = MediaSegmentType::Unknown;
     QString typeString;
-    qint64 startTicks = 0;
-    qint64 endTicks = 0;
+    qint64 startMs = 0;
+    qint64 endMs = 0;
     QString source;
     double confidence = 0.0;
     int submissionCount = 0;
 
-    [[nodiscard]] static MediaSegmentInfo fromJson(const QJsonObject &json);
-    [[nodiscard]] constexpr double startSeconds() const { return static_cast<double>(startTicks) / 10000000.0; }
-    [[nodiscard]] constexpr double endSeconds() const { return static_cast<double>(endTicks) / 10000000.0; }
+    [[nodiscard]] constexpr double startSeconds() const { return static_cast<double>(startMs) / 1000.0; }
+    [[nodiscard]] constexpr double endSeconds() const { return static_cast<double>(endMs) / 1000.0; }
 };
 
 struct TrickplayTileInfo

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -5574,7 +5574,7 @@ void PlayerController::updateSkipSegmentState()
     bool inOutro = false;
 
     for (const auto &segment : std::as_const(m_currentSegments)) {
-        if (segment.startTicks < 0 || segment.endTicks <= segment.startTicks) {
+        if (segment.startMs < 0 || segment.endMs <= segment.startMs) {
             continue;
         }
 
@@ -5626,7 +5626,7 @@ void PlayerController::updateSkipSegmentState()
 bool PlayerController::seekToSegmentEnd(MediaSegmentType segmentType)
 {
     for (const auto &segment : std::as_const(m_currentSegments)) {
-        if (segment.type != segmentType || segment.endTicks <= 0) {
+        if (segment.type != segmentType || segment.endMs <= 0) {
             continue;
         }
 
@@ -5879,8 +5879,8 @@ void PlayerController::onMediaSegmentsLoaded(const QString &itemId, const QList<
     
     // Segment metadata is kept in controller state for native overlay handling.
     for (const auto &segment : segments) {
-        double startSeconds = static_cast<double>(segment.startTicks) / 10000000.0;
-        double endSeconds = static_cast<double>(segment.endTicks) / 10000000.0;
+        const double startSeconds = static_cast<double>(segment.startMs) / 1000.0;
+        const double endSeconds = static_cast<double>(segment.endMs) / 1000.0;
 
         if (segment.type == MediaSegmentType::Intro) {
             qCDebug(lcPlayback) << "PlayerController: Intro segment:" << startSeconds << "->" << endSeconds;

--- a/tests/MediaSegmentProviderServiceTest.cpp
+++ b/tests/MediaSegmentProviderServiceTest.cpp
@@ -29,7 +29,7 @@ MediaSegmentLookupContext episodeContext()
     context.tmdbId = QStringLiteral("1396");
     context.seasonNumber = 1;
     context.episodeNumber = 1;
-    context.durationTicks = 3600LL * 10000000LL;
+    context.durationMs = 3600LL * 1000LL;
     return context;
 }
 }
@@ -114,7 +114,7 @@ void MediaSegmentProviderServiceTest::dropsOpenEndedSegmentsWithoutDuration()
         }}}
     };
 
-    context.durationTicks = 0;
+    context.durationMs = 0;
     const QList<MediaSegmentInfo> segments = MediaSegmentProviderService::parseTheIntroDbSegments(payload, context);
     QVERIFY(segments.isEmpty());
 }
@@ -182,21 +182,21 @@ void MediaSegmentProviderServiceTest::mergeKeepsServerSegmentAndFillsMissingType
     serverIntro.type = MediaSegmentType::Intro;
     serverIntro.typeString = QStringLiteral("Intro");
     serverIntro.source = QStringLiteral("jellyfin");
-    serverIntro.startTicks = 10 * 10000000LL;
-    serverIntro.endTicks = 70 * 10000000LL;
+    serverIntro.startMs = 10 * 1000LL;
+    serverIntro.endMs = 70 * 1000LL;
 
     MediaSegmentInfo externalIntro = serverIntro;
     externalIntro.source = QStringLiteral("theintrodb");
-    externalIntro.startTicks = 30 * 10000000LL;
-    externalIntro.endTicks = 90 * 10000000LL;
+    externalIntro.startMs = 30 * 1000LL;
+    externalIntro.endMs = 90 * 1000LL;
 
     MediaSegmentInfo externalOutro;
     externalOutro.itemId = QStringLiteral("episode-1");
     externalOutro.type = MediaSegmentType::Outro;
     externalOutro.typeString = QStringLiteral("Outro");
     externalOutro.source = QStringLiteral("theintrodb");
-    externalOutro.startTicks = 3300 * 10000000LL;
-    externalOutro.endTicks = 3600 * 10000000LL;
+    externalOutro.startMs = 3300 * 1000LL;
+    externalOutro.endMs = 3600 * 1000LL;
 
     const QList<MediaSegmentInfo> merged = MediaSegmentProviderService::mergeSegmentsByType(
         {serverIntro},


### PR DESCRIPTION
## Summary

- replace `MediaSegmentInfo` tick fields with canonical `startMs` / `endMs`
- keep external segment provider lookup duration and parsed segment timing in milliseconds
- remove the unused Jellyfin wire parser from the shared network type
- normalize playback metadata through the active provider mapper before segment lookup and trickplay duration calculations
- remove Jellyfin tick conversion from intro/outro skip handling in `PlayerController`

Stacked on #99 and #98. Part of #76.

## Testing

- `./scripts/dev-build.sh`
- `nix flake check` (21/21 tests passed)
- `nix build`

## Manual verification

- [ ] Confirm intro/outro skip buttons appear at the expected times
- [ ] Seek into and out of segment boundaries and confirm state updates correctly
- [ ] Enable TheIntroDB/AniSkip and confirm external segments merge with server segments
- [ ] Confirm trickplay thumbnail counts remain correct for known-duration media

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize all media segment and playback timing from ticks to milliseconds
> - Replaces all internal tick-based timing fields (`startTicks`, `endTicks`, `runTimeTicks`, `positionTicks`, `startPositionTicks`) with millisecond equivalents across `PlayerController`, `PlaybackService`, `MediaSegmentProviderService`, and QML UI layers.
> - Introduces a provider abstraction for playback reporting: a new `PlaybackReport` struct and `IPlaybackProvider::createReportRequest()` method allow `JellyfinPlaybackProvider` to own endpoint selection and ms-to-ticks serialization, removing hardcoded Jellyfin HTTP logic from `PlaybackService`.
> - `chaptersFailed` and chapter cache/request tracking in `MovieDetailsViewModel` and `SeriesDetailsViewModel` are now scoped by `connectionId`, preventing stale cross-connection data from affecting UI state.
> - QML views (`HomeScreen`, `MovieDetailsView`, `SeasonView`, `SeriesDetailsView`, `SeriesSeasonEpisodeView`) now pass `startPositionMs` directly instead of computing ticks with `* 10000`.
> - Risk: Public API of `PlaybackService` reporting methods and `PlayerController::playUrl`/`playUrlWithTracks` have changed signatures from ticks to milliseconds — callers outside this PR must be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b20ed1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->