### PR TITLE
refactor(series): resolve next episodes from canonical models

### DIFF
--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -34,7 +34,7 @@ The types expose temporary `QVariantMap` projections so existing QML-facing faç
 
 `JellyfinModelMapper` converts Jellyfin item, user-state, person, artwork, chapter, and tick fields into Bloom canonical values. Jellyfin ticks are converted to milliseconds there and must not be introduced into new model or QML APIs.
 
-`LibraryService` asks the selected `IProviderAdapter` to map item, item-list, similar-item, series, next-episode, and chapter wire DTOs exactly once. Connection-aware canonical signals carry the `connectionId` captured when the request starts, so asynchronous mapping and consumers never substitute a later active connection.
+`LibraryService` asks the selected `IProviderAdapter` to map item, item-list, similar-item, series, next-episode, and chapter wire DTOs exactly once. Next-episode timeline resolution runs only on canonical episode maps and compares millisecond resume positions; compatibility payloads are selected separately for unmigrated consumers. Connection-aware canonical signals carry the `connectionId` captured when the request starts, so asynchronous mapping and consumers never substitute a later active connection.
 
 Raw compatibility signals remain for unmigrated flows. Migrated consumers connect only to the parallel `canonical*` signals and must not fall back to PascalCase wire keys.
 
@@ -69,4 +69,4 @@ A `PlaybackDescriptor` is valid when it has a valid `MediaRef` and finalized `St
 - Jellyfin stream finalization, canonical timing/tracks, and current credential injection at the playback-provider boundary
 - provider-owned playback report endpoint selection and millisecond-to-Jellyfin-tick serialization
 
-`SimilarItemsRetryTest` asserts Movie and Series detail shelves keep canonical request ownership and item/chapter shapes. `SeriesDetailsCacheTest` covers canonical series/list cache persistence, freshness, and wire-cache rejection. `EpisodeSelectionScriptTest` exercises canonical episode identity, season ownership, watched state, and millisecond resume selection. `LibraryViewModelCanonicalTest` covers canonical root-library roles, empty-container filtering, wire-cache rejection, and SWR identity/order checks.
+`SimilarItemsRetryTest` asserts Movie and Series detail shelves keep canonical request ownership and item/chapter shapes. `SeriesDetailsCacheTest` covers canonical series/list cache persistence, freshness, and wire-cache rejection. `NextEpisodeResolverTest` covers canonical timeline ordering, watched/resume state in milliseconds, special placement, and preferred-payload merging without provider DTO fields. `EpisodeSelectionScriptTest` exercises canonical episode identity, season ownership, watched state, and millisecond resume selection. `LibraryViewModelCanonicalTest` covers canonical root-library roles, empty-container filtering, wire-cache rejection, and SWR identity/order checks.

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -1398,17 +1398,25 @@ void LibraryService::getNextUnplayedEpisode(const QString &seriesId,
                 emit nextUnplayedEpisodeFailed(seriesId, error.userMessage, requestContext);
                 return;
             }
-            const QJsonArray items = root.value("Items").toArray();
-            const QJsonObject selectedEpisode =
-                NextEpisodeResolver::resolveBestNextEpisode(items, excludeItemId);
-            emit nextUnplayedEpisodeLoaded(seriesId, selectedEpisode, requestContext);
+            const QJsonArray wireItems = root.value("Items").toArray();
+            const QVariantMap selectedEpisode = NextEpisodeResolver::resolveBestNextEpisode(
+                m_authService->mapMediaItems(wireItems, connectionId), excludeItemId);
+
+            QJsonObject selectedWireEpisode;
+            const QString selectedItemId = selectedEpisode.value(QStringLiteral("itemId")).toString();
+            if (!selectedItemId.isEmpty()) {
+                for (const QJsonValue &value : wireItems) {
+                    if (value.isObject()
+                        && value.toObject().value(QStringLiteral("Id")).toString() == selectedItemId) {
+                        selectedWireEpisode = value.toObject();
+                        break;
+                    }
+                }
+            }
+
+            emit nextUnplayedEpisodeLoaded(seriesId, selectedWireEpisode, requestContext);
             emit canonicalNextUnplayedEpisodeLoaded(
-                connectionId,
-                seriesId,
-                selectedEpisode.isEmpty()
-                    ? QVariantMap{}
-                    : m_authService->mapMediaItem(selectedEpisode, connectionId),
-                requestContext);
+                connectionId, seriesId, selectedEpisode, requestContext);
         },
         [this, seriesId, requestContext](const NetworkError &error) {
             emit nextUnplayedEpisodeFailed(seriesId, error.userMessage, requestContext);

--- a/src/network/NextEpisodeResolver.cpp
+++ b/src/network/NextEpisodeResolver.cpp
@@ -10,12 +10,12 @@
 namespace {
 
 struct EpisodeEntry {
-    QJsonObject m_episode;
+    QVariantMap m_episode;
     QString m_id;
     QString m_sortName;
     QDateTime m_premiereDate;
     QDateTime m_lastPlayedDate;
-    qint64 m_playbackPositionTicks = 0;
+    qint64 m_positionMs = 0;
     int m_seasonNumber = 0;
     int m_episodeNumber = 0;
     int m_airsBeforeSeason = -1;
@@ -40,35 +40,35 @@ QDateTime parseIsoDate(const QString &value)
     return parsed.toUTC();
 }
 
-QString episodeSortName(const QJsonObject &episode)
+QString episodeSortName(const QVariantMap &episode)
 {
-    const QString sortName = episode.value(QStringLiteral("SortName")).toString();
+    const QString sortName = episode.value(QStringLiteral("sortName")).toString();
     if (!sortName.isEmpty()) {
         return sortName;
     }
-    return episode.value(QStringLiteral("Name")).toString();
+    return episode.value(QStringLiteral("name")).toString();
 }
 
-EpisodeEntry toEntry(const QJsonObject &episode)
+EpisodeEntry toEntry(const QVariantMap &episode)
 {
-    const QJsonObject userData = episode.value(QStringLiteral("UserData")).toObject();
+    const QVariantMap userState = episode.value(QStringLiteral("userState")).toMap();
 
     EpisodeEntry entry;
     entry.m_episode = episode;
-    entry.m_id = episode.value(QStringLiteral("Id")).toString();
+    entry.m_id = episode.value(QStringLiteral("itemId")).toString();
     entry.m_sortName = episodeSortName(episode);
-    entry.m_premiereDate = parseIsoDate(episode.value(QStringLiteral("PremiereDate")).toString());
-    entry.m_lastPlayedDate = parseIsoDate(userData.value(QStringLiteral("LastPlayedDate")).toString());
-    entry.m_playbackPositionTicks = userData.value(QStringLiteral("PlaybackPositionTicks")).toVariant().toLongLong();
-    entry.m_seasonNumber = episode.value(QStringLiteral("ParentIndexNumber")).toInt();
-    entry.m_episodeNumber = episode.value(QStringLiteral("IndexNumber")).toInt();
-    entry.m_airsBeforeSeason = episode.value(QStringLiteral("AirsBeforeSeasonNumber")).toInt(-1);
-    entry.m_airsAfterSeason = episode.value(QStringLiteral("AirsAfterSeasonNumber")).toInt(-1);
-    entry.m_airsBeforeEpisode = episode.value(QStringLiteral("AirsBeforeEpisodeNumber")).toInt(-1);
+    entry.m_premiereDate = parseIsoDate(episode.value(QStringLiteral("premiereDate")).toString());
+    entry.m_lastPlayedDate = parseIsoDate(userState.value(QStringLiteral("lastPlayedAt")).toString());
+    entry.m_positionMs = userState.value(QStringLiteral("positionMs")).toLongLong();
+    entry.m_seasonNumber = episode.value(QStringLiteral("parentIndexNumber")).toInt();
+    entry.m_episodeNumber = episode.value(QStringLiteral("indexNumber")).toInt();
+    entry.m_airsBeforeSeason = episode.value(QStringLiteral("airsBeforeSeasonNumber"), -1).toInt();
+    entry.m_airsAfterSeason = episode.value(QStringLiteral("airsAfterSeasonNumber"), -1).toInt();
+    entry.m_airsBeforeEpisode = episode.value(QStringLiteral("airsBeforeEpisodeNumber"), -1).toInt();
     entry.m_hasPlacementMetadata = entry.m_airsBeforeSeason > 0
                                 || entry.m_airsAfterSeason > 0
                                 || entry.m_airsBeforeEpisode > 0;
-    entry.m_isPlayed = userData.value(QStringLiteral("Played")).toBool();
+    entry.m_isPlayed = userState.value(QStringLiteral("watched")).toBool();
     entry.m_isSpecial = entry.m_seasonNumber == 0 || entry.m_hasPlacementMetadata;
     return entry;
 }
@@ -117,7 +117,7 @@ void appendSorted(QVector<EpisodeEntry> &ordered, QVector<EpisodeEntry> bucket)
     ordered += bucket;
 }
 
-QVector<EpisodeEntry> buildCanonicalTimeline(const QJsonArray &episodes)
+QVector<EpisodeEntry> buildCanonicalTimeline(const QVariantList &episodes)
 {
     QVector<EpisodeEntry> regularEpisodes;
     QMap<int, QVector<EpisodeEntry>> specialsBeforeSeason;
@@ -126,17 +126,17 @@ QVector<EpisodeEntry> buildCanonicalTimeline(const QJsonArray &episodes)
     QVector<EpisodeEntry> unresolvedSpecials;
     QSet<int> referencedSeasons;
 
-    for (const QJsonValue &value : episodes) {
-        if (!value.isObject()) {
+    for (const QVariant &value : episodes) {
+        if (!value.canConvert<QVariantMap>()) {
             continue;
         }
 
-        const QJsonObject episode = value.toObject();
-        const QString type = episode.value(QStringLiteral("Type")).toString();
+        const QVariantMap episode = value.toMap();
+        const QString type = episode.value(QStringLiteral("mediaType")).toString();
         if (!type.isEmpty() && type != QStringLiteral("Episode")) {
             continue;
         }
-        if (episode.value(QStringLiteral("LocationType")).toString() == QStringLiteral("Virtual")) {
+        if (episode.value(QStringLiteral("locationType")).toString() == QStringLiteral("Virtual")) {
             continue;
         }
 
@@ -220,13 +220,13 @@ bool anchorIsMoreRecent(const EpisodeEntry &candidate, const EpisodeEntry &best)
     if (candidate.m_canonicalIndex != best.m_canonicalIndex) {
         return candidate.m_canonicalIndex > best.m_canonicalIndex;
     }
-    if (candidate.m_playbackPositionTicks != best.m_playbackPositionTicks) {
-        return candidate.m_playbackPositionTicks > best.m_playbackPositionTicks;
+    if (candidate.m_positionMs != best.m_positionMs) {
+        return candidate.m_positionMs > best.m_positionMs;
     }
     return candidate.m_id > best.m_id;
 }
 
-QJsonObject mergePreferredEpisode(const QJsonObject &selectedEpisode, const QJsonObject &preferredEpisode)
+QVariantMap mergePreferredEpisode(const QVariantMap &selectedEpisode, const QVariantMap &preferredEpisode)
 {
     if (selectedEpisode.isEmpty()) {
         return preferredEpisode;
@@ -234,13 +234,14 @@ QJsonObject mergePreferredEpisode(const QJsonObject &selectedEpisode, const QJso
     if (preferredEpisode.isEmpty()) {
         return selectedEpisode;
     }
-    if (selectedEpisode.value(QStringLiteral("Id")).toString() != preferredEpisode.value(QStringLiteral("Id")).toString()) {
+    if (selectedEpisode.value(QStringLiteral("itemId")).toString()
+        != preferredEpisode.value(QStringLiteral("itemId")).toString()) {
         return selectedEpisode;
     }
 
-    QJsonObject merged = selectedEpisode;
+    QVariantMap merged = selectedEpisode;
     for (auto it = preferredEpisode.constBegin(); it != preferredEpisode.constEnd(); ++it) {
-        if (it.key() == QStringLiteral("UserData")) {
+        if (it.key() == QStringLiteral("userState")) {
             continue;
         }
         merged.insert(it.key(), it.value());
@@ -248,10 +249,10 @@ QJsonObject mergePreferredEpisode(const QJsonObject &selectedEpisode, const QJso
     return merged;
 }
 
-QJsonObject resolveFromAnchor(const QVector<EpisodeEntry> &ordered,
+QVariantMap resolveFromAnchor(const QVector<EpisodeEntry> &ordered,
                               int anchorIndex,
                               const QString &excludeItemId,
-                              const QJsonObject &preferredEpisode)
+                              const QVariantMap &preferredEpisode)
 {
     if (anchorIndex < 0 || anchorIndex >= ordered.size()) {
         return {};
@@ -271,9 +272,9 @@ QJsonObject resolveFromAnchor(const QVector<EpisodeEntry> &ordered,
 
 namespace NextEpisodeResolver {
 
-QJsonObject resolveBestNextEpisode(const QJsonArray &episodes,
+QVariantMap resolveBestNextEpisode(const QVariantList &episodes,
                                    const QString &excludeItemId,
-                                   const QJsonObject &preferredEpisode)
+                                   const QVariantMap &preferredEpisode)
 {
     const QVector<EpisodeEntry> ordered = buildCanonicalTimeline(episodes);
     if (ordered.isEmpty()) {
@@ -291,7 +292,7 @@ QJsonObject resolveBestNextEpisode(const QJsonArray &episodes,
     bool haveInProgress = false;
     EpisodeEntry bestInProgress;
     for (const EpisodeEntry &entry : ordered) {
-        if (entry.m_isPlayed || entry.m_playbackPositionTicks <= 0) {
+        if (entry.m_isPlayed || entry.m_positionMs <= 0) {
             continue;
         }
         if (!haveInProgress || anchorIsMoreRecent(entry, bestInProgress)) {

--- a/src/network/NextEpisodeResolver.h
+++ b/src/network/NextEpisodeResolver.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <QJsonArray>
-#include <QJsonObject>
 #include <QString>
+#include <QVariantList>
+#include <QVariantMap>
 
 namespace NextEpisodeResolver {
 
-QJsonObject resolveBestNextEpisode(const QJsonArray &episodes,
+QVariantMap resolveBestNextEpisode(const QVariantList &episodes,
                                    const QString &excludeItemId = QString(),
-                                   const QJsonObject &preferredEpisode = QJsonObject());
+                                   const QVariantMap &preferredEpisode = QVariantMap());
 
 }

--- a/src/test/MockLibraryService.cpp
+++ b/src/test/MockLibraryService.cpp
@@ -429,14 +429,29 @@ void MockLibraryService::getNextUnplayedEpisode(const QString &seriesId,
                                                 const QString &excludeItemId,
                                                 const QString &requestContext)
 {
-    const QJsonArray episodes = findEpisodesBySeriesId(seriesId);
-    const QJsonObject resolvedEpisode =
-        NextEpisodeResolver::resolveBestNextEpisode(episodes, excludeItemId);
+    const QJsonArray wireEpisodes = findEpisodesBySeriesId(seriesId);
+    const QVariantMap resolvedEpisode = NextEpisodeResolver::resolveBestNextEpisode(
+        JellyfinModelMapper::mediaItems(wireEpisodes, QStringLiteral("mock-connection")),
+        excludeItemId);
+
+    QJsonObject resolvedWireEpisode;
+    const QString resolvedItemId = resolvedEpisode.value(QStringLiteral("itemId")).toString();
+    if (!resolvedItemId.isEmpty()) {
+        for (const QJsonValue &value : wireEpisodes) {
+            if (value.isObject()
+                && value.toObject().value(QStringLiteral("Id")).toString() == resolvedItemId) {
+                resolvedWireEpisode = value.toObject();
+                break;
+            }
+        }
+    }
 
     qCDebug(lcTest) << "MockLibraryService::getNextUnplayedEpisode(" << seriesId
              << ", exclude:" << excludeItemId << ") ->"
              << (resolvedEpisode.isEmpty() ? "no eligible episodes" : "resolved");
-    emit nextUnplayedEpisodeLoaded(seriesId, resolvedEpisode, requestContext);
+    emit nextUnplayedEpisodeLoaded(seriesId, resolvedWireEpisode, requestContext);
+    emit canonicalNextUnplayedEpisodeLoaded(
+        QStringLiteral("mock-connection"), seriesId, resolvedEpisode, requestContext);
 }
 
 void MockLibraryService::markSeriesWatched(const QString &seriesId)

--- a/tests/NextEpisodeResolverTest.cpp
+++ b/tests/NextEpisodeResolverTest.cpp
@@ -4,51 +4,49 @@
 
 namespace {
 
-QJsonObject buildEpisode(const QString &id,
+QVariantMap buildEpisode(const QString &id,
                          int seasonNumber,
                          int episodeNumber,
-                         bool played = false,
-                         qint64 playbackPositionTicks = 0,
-                         const QString &lastPlayedDate = QString(),
-                         const QJsonObject &extra = QJsonObject())
+                         bool watched = false,
+                         qint64 positionMs = 0,
+                         const QString &lastPlayedAt = QString(),
+                         const QVariantMap &extra = QVariantMap())
 {
-    QJsonObject episode{
-        {QStringLiteral("Id"), id},
-        {QStringLiteral("Type"), QStringLiteral("Episode")},
-        {QStringLiteral("Name"), id},
-        {QStringLiteral("SortName"), id},
-        {QStringLiteral("SeriesId"), QStringLiteral("series-1")},
-        {QStringLiteral("SeriesName"), QStringLiteral("Series One")},
-        {QStringLiteral("ParentIndexNumber"), seasonNumber},
-        {QStringLiteral("IndexNumber"), episodeNumber},
-        {QStringLiteral("UserData"), QJsonObject{
-            {QStringLiteral("Played"), played},
-            {QStringLiteral("PlaybackPositionTicks"), static_cast<double>(playbackPositionTicks)}
-        }}
+    QVariantMap userState{
+        {QStringLiteral("watched"), watched},
+        {QStringLiteral("positionMs"), positionMs}
     };
-
-    if (!lastPlayedDate.isEmpty()) {
-        QJsonObject userData = episode.value(QStringLiteral("UserData")).toObject();
-        userData.insert(QStringLiteral("LastPlayedDate"), lastPlayedDate);
-        episode.insert(QStringLiteral("UserData"), userData);
+    if (!lastPlayedAt.isEmpty()) {
+        userState.insert(QStringLiteral("lastPlayedAt"), lastPlayedAt);
     }
+
+    QVariantMap episode{
+        {QStringLiteral("itemId"), id},
+        {QStringLiteral("mediaType"), QStringLiteral("Episode")},
+        {QStringLiteral("name"), id},
+        {QStringLiteral("sortName"), id},
+        {QStringLiteral("seriesId"), QStringLiteral("series-1")},
+        {QStringLiteral("seriesName"), QStringLiteral("Series One")},
+        {QStringLiteral("parentIndexNumber"), seasonNumber},
+        {QStringLiteral("indexNumber"), episodeNumber},
+        {QStringLiteral("userState"), userState}
+    };
 
     for (auto it = extra.constBegin(); it != extra.constEnd(); ++it) {
         episode.insert(it.key(), it.value());
     }
-
     return episode;
 }
 
-QString resolvedId(const QJsonArray &episodes,
+QString resolvedId(const QVariantList &episodes,
                    const QString &excludeItemId = QString(),
-                   const QJsonObject &preferredEpisode = QJsonObject())
+                   const QVariantMap &preferredEpisode = QVariantMap())
 {
     return NextEpisodeResolver::resolveBestNextEpisode(episodes, excludeItemId, preferredEpisode)
-        .value(QStringLiteral("Id")).toString();
+        .value(QStringLiteral("itemId")).toString();
 }
 
-}  // namespace
+} // namespace
 
 class NextEpisodeResolverTest : public QObject
 {
@@ -67,17 +65,17 @@ private slots:
     void fallsBackToFirstRegularEpisodeWithoutHistory();
     void fallsBackToSpecialOnlyWhenNoRegularEpisodesRemain();
     void prefersPreferredPayloadWhenIdsMatch();
-    void preservesCanonicalUserDataWhenMergingPreferredPayload();
+    void preservesCanonicalUserStateWhenMergingPreferredPayload();
 };
 
 void NextEpisodeResolverTest::resolvesEpisodeAfterMostRecentPlayedAnchor()
 {
-    const QJsonArray episodes{
-        buildEpisode(QStringLiteral("special-movie"), 0, 1, false),
+    const QVariantList episodes{
+        buildEpisode(QStringLiteral("special-movie"), 0, 1),
         buildEpisode(QStringLiteral("s1e1"), 1, 1, true, 0, QStringLiteral("2026-03-01T18:00:00Z")),
-        buildEpisode(QStringLiteral("s1e2"), 1, 2, false),
+        buildEpisode(QStringLiteral("s1e2"), 1, 2),
         buildEpisode(QStringLiteral("s1e3"), 1, 3, true, 0, QStringLiteral("2026-03-05T18:00:00Z")),
-        buildEpisode(QStringLiteral("s1e4"), 1, 4, false)
+        buildEpisode(QStringLiteral("s1e4"), 1, 4)
     };
 
     QCOMPARE(resolvedId(episodes), QStringLiteral("s1e4"));
@@ -85,10 +83,10 @@ void NextEpisodeResolverTest::resolvesEpisodeAfterMostRecentPlayedAnchor()
 
 void NextEpisodeResolverTest::prefersMostRecentInProgressEpisode()
 {
-    const QJsonArray episodes{
+    const QVariantList episodes{
         buildEpisode(QStringLiteral("s1e1"), 1, 1, true, 0, QStringLiteral("2026-03-01T18:00:00Z")),
-        buildEpisode(QStringLiteral("s1e2"), 1, 2, false, 9000, QStringLiteral("2026-03-04T18:00:00Z")),
-        buildEpisode(QStringLiteral("s1e3"), 1, 3, false, 3000, QStringLiteral("2026-03-03T18:00:00Z"))
+        buildEpisode(QStringLiteral("s1e2"), 1, 2, false, 9'000, QStringLiteral("2026-03-04T18:00:00Z")),
+        buildEpisode(QStringLiteral("s1e3"), 1, 3, false, 3'000, QStringLiteral("2026-03-03T18:00:00Z"))
     };
 
     QCOMPARE(resolvedId(episodes), QStringLiteral("s1e2"));
@@ -96,10 +94,10 @@ void NextEpisodeResolverTest::prefersMostRecentInProgressEpisode()
 
 void NextEpisodeResolverTest::skipsExplicitExcludedAnchorToFollowingEpisode()
 {
-    const QJsonArray episodes{
+    const QVariantList episodes{
         buildEpisode(QStringLiteral("s1e1"), 1, 1, true),
-        buildEpisode(QStringLiteral("s1e2"), 1, 2, false, 4000),
-        buildEpisode(QStringLiteral("s1e3"), 1, 3, false)
+        buildEpisode(QStringLiteral("s1e2"), 1, 2, false, 4'000),
+        buildEpisode(QStringLiteral("s1e3"), 1, 3)
     };
 
     QCOMPARE(resolvedId(episodes, QStringLiteral("s1e2")), QStringLiteral("s1e3"));
@@ -107,17 +105,17 @@ void NextEpisodeResolverTest::skipsExplicitExcludedAnchorToFollowingEpisode()
 
 void NextEpisodeResolverTest::placesSpecialsUsingPlacementFields()
 {
-    const QJsonArray episodes{
+    const QVariantList episodes{
         buildEpisode(QStringLiteral("s1e1"), 1, 1, true),
-        buildEpisode(QStringLiteral("special-before-e2"), 0, 1, false, 0, QString(), QJsonObject{
-            {QStringLiteral("AirsBeforeSeasonNumber"), 1},
-            {QStringLiteral("AirsBeforeEpisodeNumber"), 2}
+        buildEpisode(QStringLiteral("special-before-e2"), 0, 1, false, 0, QString(), QVariantMap{
+            {QStringLiteral("airsBeforeSeasonNumber"), 1},
+            {QStringLiteral("airsBeforeEpisodeNumber"), 2}
         }),
-        buildEpisode(QStringLiteral("s1e2"), 1, 2, false),
-        buildEpisode(QStringLiteral("special-after-s1"), 0, 2, false, 0, QString(), QJsonObject{
-            {QStringLiteral("AirsAfterSeasonNumber"), 1}
+        buildEpisode(QStringLiteral("s1e2"), 1, 2),
+        buildEpisode(QStringLiteral("special-after-s1"), 0, 2, false, 0, QString(), QVariantMap{
+            {QStringLiteral("airsAfterSeasonNumber"), 1}
         }),
-        buildEpisode(QStringLiteral("s2e1"), 2, 1, false)
+        buildEpisode(QStringLiteral("s2e1"), 2, 1)
     };
 
     QCOMPARE(resolvedId(episodes), QStringLiteral("special-before-e2"));
@@ -126,12 +124,12 @@ void NextEpisodeResolverTest::placesSpecialsUsingPlacementFields()
 
 void NextEpisodeResolverTest::resolvesSpecialAfterSeasonFinaleWhenExcludedAnchorIsSeasonEpisode()
 {
-    const QJsonArray episodes{
+    const QVariantList episodes{
         buildEpisode(QStringLiteral("s1e22"), 1, 22, true),
-        buildEpisode(QStringLiteral("special-after-s1"), 0, 1, false, 0, QString(), QJsonObject{
-            {QStringLiteral("AirsAfterSeasonNumber"), 1}
+        buildEpisode(QStringLiteral("special-after-s1"), 0, 1, false, 0, QString(), QVariantMap{
+            {QStringLiteral("airsAfterSeasonNumber"), 1}
         }),
-        buildEpisode(QStringLiteral("s2e1"), 2, 1, false)
+        buildEpisode(QStringLiteral("s2e1"), 2, 1)
     };
 
     QCOMPARE(resolvedId(episodes, QStringLiteral("s1e22")), QStringLiteral("special-after-s1"));
@@ -139,13 +137,13 @@ void NextEpisodeResolverTest::resolvesSpecialAfterSeasonFinaleWhenExcludedAnchor
 
 void NextEpisodeResolverTest::resolvesSpecialAfterSeasonFinaleWhenSpecialAndNextSeasonAreBothUnplayed()
 {
-    const QJsonArray episodes{
+    const QVariantList episodes{
         buildEpisode(QStringLiteral("s1e21"), 1, 21, true, 0, QStringLiteral("2026-03-01T18:00:00Z")),
         buildEpisode(QStringLiteral("s1e22"), 1, 22, true, 0, QStringLiteral("2026-03-05T18:00:00Z")),
-        buildEpisode(QStringLiteral("special-after-s1"), 0, 1, false, 0, QString(), QJsonObject{
-            {QStringLiteral("AirsAfterSeasonNumber"), 1}
+        buildEpisode(QStringLiteral("special-after-s1"), 0, 1, false, 0, QString(), QVariantMap{
+            {QStringLiteral("airsAfterSeasonNumber"), 1}
         }),
-        buildEpisode(QStringLiteral("s2e1"), 2, 1, false)
+        buildEpisode(QStringLiteral("s2e1"), 2, 1)
     };
 
     QCOMPARE(resolvedId(episodes), QStringLiteral("special-after-s1"));
@@ -153,12 +151,12 @@ void NextEpisodeResolverTest::resolvesSpecialAfterSeasonFinaleWhenSpecialAndNext
 
 void NextEpisodeResolverTest::fallsThroughToNextSeasonOnlyAfterAfterSeasonSpecialIsPlayed()
 {
-    const QJsonArray episodes{
+    const QVariantList episodes{
         buildEpisode(QStringLiteral("s1e22"), 1, 22, true, 0, QStringLiteral("2026-03-05T18:00:00Z")),
-        buildEpisode(QStringLiteral("special-after-s1"), 0, 1, true, 0, QStringLiteral("2026-03-06T18:00:00Z"), QJsonObject{
-            {QStringLiteral("AirsAfterSeasonNumber"), 1}
+        buildEpisode(QStringLiteral("special-after-s1"), 0, 1, true, 0, QStringLiteral("2026-03-06T18:00:00Z"), QVariantMap{
+            {QStringLiteral("airsAfterSeasonNumber"), 1}
         }),
-        buildEpisode(QStringLiteral("s2e1"), 2, 1, false)
+        buildEpisode(QStringLiteral("s2e1"), 2, 1)
     };
 
     QCOMPARE(resolvedId(episodes), QStringLiteral("s2e1"));
@@ -166,12 +164,12 @@ void NextEpisodeResolverTest::fallsThroughToNextSeasonOnlyAfterAfterSeasonSpecia
 
 void NextEpisodeResolverTest::supportsPlacementDrivenSpecialEvenIfPayloadShapeIsSparse()
 {
-    const QJsonArray episodes{
+    const QVariantList episodes{
         buildEpisode(QStringLiteral("s1e22"), 1, 22, true),
-        buildEpisode(QStringLiteral("special-sparse"), 3, 1, false, 0, QString(), QJsonObject{
-            {QStringLiteral("AirsAfterSeasonNumber"), 1}
+        buildEpisode(QStringLiteral("special-sparse"), 3, 1, false, 0, QString(), QVariantMap{
+            {QStringLiteral("airsAfterSeasonNumber"), 1}
         }),
-        buildEpisode(QStringLiteral("s2e1"), 2, 1, false)
+        buildEpisode(QStringLiteral("s2e1"), 2, 1)
     };
 
     QCOMPARE(resolvedId(episodes, QStringLiteral("s1e22")), QStringLiteral("special-sparse"));
@@ -179,12 +177,12 @@ void NextEpisodeResolverTest::supportsPlacementDrivenSpecialEvenIfPayloadShapeIs
 
 void NextEpisodeResolverTest::ignoresVirtualEpisodes()
 {
-    const QJsonArray episodes{
+    const QVariantList episodes{
         buildEpisode(QStringLiteral("s1e1"), 1, 1, true),
-        buildEpisode(QStringLiteral("virtual-s1e2"), 1, 2, false, 0, QString(), QJsonObject{
-            {QStringLiteral("LocationType"), QStringLiteral("Virtual")}
+        buildEpisode(QStringLiteral("virtual-s1e2"), 1, 2, false, 0, QString(), QVariantMap{
+            {QStringLiteral("locationType"), QStringLiteral("Virtual")}
         }),
-        buildEpisode(QStringLiteral("s1e3"), 1, 3, false)
+        buildEpisode(QStringLiteral("s1e3"), 1, 3)
     };
 
     QCOMPARE(resolvedId(episodes), QStringLiteral("s1e3"));
@@ -192,10 +190,10 @@ void NextEpisodeResolverTest::ignoresVirtualEpisodes()
 
 void NextEpisodeResolverTest::fallsBackToFirstRegularEpisodeWithoutHistory()
 {
-    const QJsonArray episodes{
-        buildEpisode(QStringLiteral("late-special"), 0, 1, false),
-        buildEpisode(QStringLiteral("s1e1"), 1, 1, false),
-        buildEpisode(QStringLiteral("s1e2"), 1, 2, false)
+    const QVariantList episodes{
+        buildEpisode(QStringLiteral("late-special"), 0, 1),
+        buildEpisode(QStringLiteral("s1e1"), 1, 1),
+        buildEpisode(QStringLiteral("s1e2"), 1, 2)
     };
 
     QCOMPARE(resolvedId(episodes), QStringLiteral("s1e1"));
@@ -203,10 +201,10 @@ void NextEpisodeResolverTest::fallsBackToFirstRegularEpisodeWithoutHistory()
 
 void NextEpisodeResolverTest::fallsBackToSpecialOnlyWhenNoRegularEpisodesRemain()
 {
-    const QJsonArray episodes{
+    const QVariantList episodes{
         buildEpisode(QStringLiteral("s1e1"), 1, 1, true),
         buildEpisode(QStringLiteral("s1e2"), 1, 2, true),
-        buildEpisode(QStringLiteral("special-1"), 0, 1, false)
+        buildEpisode(QStringLiteral("special-1"), 0, 1)
     };
 
     QCOMPARE(resolvedId(episodes), QStringLiteral("special-1"));
@@ -214,52 +212,46 @@ void NextEpisodeResolverTest::fallsBackToSpecialOnlyWhenNoRegularEpisodesRemain(
 
 void NextEpisodeResolverTest::prefersPreferredPayloadWhenIdsMatch()
 {
-    const QJsonArray episodes{
+    const QVariantList episodes{
         buildEpisode(QStringLiteral("s1e1"), 1, 1, true),
-        buildEpisode(QStringLiteral("s1e2"), 1, 2, false)
+        buildEpisode(QStringLiteral("s1e2"), 1, 2)
+    };
+    const QVariantMap preferred{
+        {QStringLiteral("itemId"), QStringLiteral("s1e2")},
+        {QStringLiteral("path"), QStringLiteral("/preferred/path.mkv")}
     };
 
-    const QJsonObject preferred{
-        {QStringLiteral("Id"), QStringLiteral("s1e2")},
-        {QStringLiteral("Path"), QStringLiteral("/preferred/path.mkv")}
-    };
-
-    const QJsonObject resolved =
+    const QVariantMap resolved =
         NextEpisodeResolver::resolveBestNextEpisode(episodes, QString(), preferred);
-    QCOMPARE(resolved.value(QStringLiteral("Id")).toString(), QStringLiteral("s1e2"));
-    QCOMPARE(resolved.value(QStringLiteral("Path")).toString(), QStringLiteral("/preferred/path.mkv"));
+    QCOMPARE(resolved.value(QStringLiteral("itemId")).toString(), QStringLiteral("s1e2"));
+    QCOMPARE(resolved.value(QStringLiteral("path")).toString(), QStringLiteral("/preferred/path.mkv"));
 }
 
-void NextEpisodeResolverTest::preservesCanonicalUserDataWhenMergingPreferredPayload()
+void NextEpisodeResolverTest::preservesCanonicalUserStateWhenMergingPreferredPayload()
 {
-    const QJsonArray episodes{
+    const QVariantList episodes{
         buildEpisode(QStringLiteral("s1e1"), 1, 1, true),
-        buildEpisode(QStringLiteral("s1e2"),
-                     1,
-                     2,
-                     false,
-                     5000,
+        buildEpisode(QStringLiteral("s1e2"), 1, 2, false, 5'000,
                      QStringLiteral("2026-03-05T18:00:00Z"))
     };
-
-    const QJsonObject preferred{
-        {QStringLiteral("Id"), QStringLiteral("s1e2")},
-        {QStringLiteral("Path"), QStringLiteral("/preferred/path.mkv")},
-        {QStringLiteral("UserData"), QJsonObject{
-            {QStringLiteral("Played"), true},
-            {QStringLiteral("PlaybackPositionTicks"), 0.0},
-            {QStringLiteral("LastPlayedDate"), QStringLiteral("2026-03-01T18:00:00Z")}
+    const QVariantMap preferred{
+        {QStringLiteral("itemId"), QStringLiteral("s1e2")},
+        {QStringLiteral("path"), QStringLiteral("/preferred/path.mkv")},
+        {QStringLiteral("userState"), QVariantMap{
+            {QStringLiteral("watched"), true},
+            {QStringLiteral("positionMs"), 0},
+            {QStringLiteral("lastPlayedAt"), QStringLiteral("2026-03-01T18:00:00Z")}
         }}
     };
 
-    const QJsonObject resolved =
+    const QVariantMap resolved =
         NextEpisodeResolver::resolveBestNextEpisode(episodes, QString(), preferred);
-    QCOMPARE(resolved.value(QStringLiteral("Path")).toString(), QStringLiteral("/preferred/path.mkv"));
+    QCOMPARE(resolved.value(QStringLiteral("path")).toString(), QStringLiteral("/preferred/path.mkv"));
 
-    const QJsonObject userData = resolved.value(QStringLiteral("UserData")).toObject();
-    QCOMPARE(userData.value(QStringLiteral("Played")).toBool(), false);
-    QCOMPARE(userData.value(QStringLiteral("PlaybackPositionTicks")).toInteger(), 5000LL);
-    QCOMPARE(userData.value(QStringLiteral("LastPlayedDate")).toString(),
+    const QVariantMap userState = resolved.value(QStringLiteral("userState")).toMap();
+    QCOMPARE(userState.value(QStringLiteral("watched")).toBool(), false);
+    QCOMPARE(userState.value(QStringLiteral("positionMs")).toLongLong(), 5'000LL);
+    QCOMPARE(userState.value(QStringLiteral("lastPlayedAt")).toString(),
              QStringLiteral("2026-03-05T18:00:00Z"));
 }
 

--- a/tests/SimilarItemsRetryTest.cpp
+++ b/tests/SimilarItemsRetryTest.cpp
@@ -442,12 +442,25 @@ void SimilarItemsRetryTest::movieChaptersScopeMismatchAllowsCurrentScopeRequest(
 {
     ServiceLocator::clear();
     auto *service = new EpisodeChaptersLibraryService(this);
+    auto *config = new ConfigManager(this);
+    config->upsertConnection(ServerConnection{
+        .connectionId = QStringLiteral("connection-a"),
+        .baseUrl = QStringLiteral("https://a.example.test"),
+        .accountId = QStringLiteral("user-a")
+    });
     ServiceLocator::registerService<LibraryService>(service);
+    ServiceLocator::registerService<ConfigManager>(config);
 
     MovieDetailsViewModel vm;
     vm.loadMovieChapters(QStringLiteral("movie-1"));
     QCOMPARE(service->requests, QStringList{QStringLiteral("movie-1")});
     QVERIFY(vm.chaptersLoading());
+
+    config->upsertConnection(ServerConnection{
+        .connectionId = QStringLiteral("connection-b"),
+        .baseUrl = QStringLiteral("https://b.example.test"),
+        .accountId = QStringLiteral("user-b")
+    });
 
     emit service->canonicalChaptersLoaded(QStringLiteral("connection-a"),
                                           QStringLiteral("movie-1"),


### PR DESCRIPTION
## Summary

Continues #76 by moving next-episode timeline resolution onto Bloom-owned canonical episode models.

- maps provider episode lists once before timeline selection
- compares canonical `positionMs` and camelCase user state instead of Jellyfin ticks/DTO fields
- keeps the temporary raw compatibility signal by selecting the matching wire item separately
- makes test-mode delivery emit the canonical next-episode signal
- rewrites resolver coverage around canonical watched/resume/special-placement contracts

## Verification

- `./scripts/dev-build.sh`
- `nix flake check` (21/21 tests)
- `nix build`

Part of #76 and epic #73.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve next episodes from canonical models and migrate all playback timing to milliseconds
> - `NextEpisodeResolver` now accepts canonical `QVariantList`/`QVariantMap` instead of raw `QJsonObject`/`QJsonArray`, reading camelCase keys and millisecond resume positions from the canonical schema.
> - `PlayerController` and `PlaybackService` replace all tick-based position tracking with milliseconds: internal state, public `playUrl`/`playUrlWithTracks` APIs, reporting methods, recovery context, and segment offsets.
> - Playback reporting is refactored behind a provider abstraction: `PlaybackService` builds a provider-agnostic `PlaybackReport`; `JellyfinPlaybackProvider` owns endpoint selection, JSON serialization, and ms→ticks conversion via a new `createReportRequest` method.
> - `MediaSegmentInfo` fields `startTicks`/`endTicks` are replaced by `startMs`/`endMs`; `MediaSegmentLookupContext` renames `durationTicks` to `durationMs`.
> - UI views (`SeasonView`, `MovieDetailsView`, `SeriesDetailsView`, `HomeScreen`, etc.) now pass `startPositionMs` instead of `startPositionTicks` to playback requests.
> - Chapter loading in `MovieDetailsViewModel` and `SeriesDetailsViewModel` is scoped per connection ID to prevent cross-connection cache hits and stale state.
> - Risk: public `PlayerController` QML API (`playUrl`, `playUrlWithTracks`) parameter names changed; any QML callers passing `startPositionTicks` will silently pass the wrong unit if not updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d3d05d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->