### PR TITLE
refactor(playback): canonicalize playback source timing

### DIFF
--- a/docs/canonical-models.md
+++ b/docs/canonical-models.md
@@ -32,7 +32,7 @@ The types expose temporary `QVariantMap` projections so existing QML-facing faç
 
 ## Jellyfin conversion
 
-`JellyfinModelMapper` converts Jellyfin item, user-state, person, artwork, chapter, and tick fields into Bloom canonical values. Jellyfin ticks are converted to milliseconds there and must not be introduced into new model or QML APIs.
+`JellyfinModelMapper` converts Jellyfin item, user-state, person, artwork, chapter, playback-source, stream, and tick fields into Bloom canonical values. Jellyfin `PlaybackInfo` DTO parsing and tick conversion occur there; shared playback-source projections expose `durationMs` and must not carry provider time units.
 
 `LibraryService` asks the selected `IProviderAdapter` to map item, item-list, similar-item, series, next-episode, and chapter wire DTOs exactly once. Next-episode timeline resolution runs only on canonical episode maps and compares millisecond resume positions. Connection-aware canonical signals carry the `connectionId` captured when the request starts, so asynchronous mapping and consumers never substitute a later active connection.
 
@@ -56,7 +56,7 @@ Existing list/detail/player flows are migrated in reviewable slices. During migr
 
 ## Playback boundary
 
-A `PlaybackDescriptor` is valid when it has a valid `MediaRef` and finalized `StreamRequest`. `PlaybackService` obtains the selected adapter's `IPlaybackProvider`; `JellyfinPlaybackProvider` resolves relative PlaybackInfo URLs, adds current request authentication and track hints, converts timing, and identifies the canonical playback method. `PlayerController` consumes only the finalized descriptor and may map canonical tracks to mpv runtime track IDs. Playback positions and multipart durations remain milliseconds through the controller and service façade. The provider serializes report endpoints and payloads, including Jellyfin's final millisecond-to-tick conversion. Provider endpoints, query authentication, provider time units, and reporting DTOs stay outside the controller.
+A `PlaybackDescriptor` is valid when it has a valid `MediaRef` and finalized `StreamRequest`. `PlaybackService` parses the response and delegates `PlaybackInfo` mapping through `AuthenticationService::mapPlaybackInfo`; `AuthenticationService` forwards it to the selected `IProviderAdapter`. `PlaybackService` then obtains the adapter's `IPlaybackProvider` to finalize the stream. `JellyfinPlaybackProvider` resolves relative stream URLs, adds current request authentication and track hints, and identifies the canonical playback method. `PlayerController` consumes only millisecond playback-source projections and finalized descriptors, and may map canonical tracks to mpv runtime track IDs. Playback positions and multipart durations remain milliseconds through the controller and service façade. The provider serializes report endpoints and payloads, including Jellyfin's final millisecond-to-tick conversion. Provider endpoints, query authentication, provider time units, and reporting DTOs stay outside the controller.
 
 ## Tests
 
@@ -69,6 +69,7 @@ A `PlaybackDescriptor` is valid when it has a valid `MediaRef` and finalized `St
 - canonical chapter mapping with millisecond starts and token-free chapter artwork references
 - token-free, round-trippable artwork cache keys
 - provider-neutral playback descriptor projections
+- Jellyfin `PlaybackInfo`, media-source, and stream mapping with millisecond durations and no shared tick fields
 - Jellyfin stream finalization, canonical timing/tracks, and current credential injection at the playback-provider boundary
 - provider-owned playback report endpoint selection and millisecond-to-Jellyfin-tick serialization
 

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -85,7 +85,7 @@ Config v29 stores server-owned preferences under `settings.connection_state.scop
 
 Bloom-owned media contracts live in `src/models/MediaModels.*` and are documented in [`canonical-models.md`](canonical-models.md). `MediaRef` always combines connection and remote item identity; canonical times use milliseconds; `ArtworkRef` cache identities contain no credentials; and `PlaybackDescriptor` carries a finalized provider-neutral stream request. Temporary `QVariantMap` projections use Bloom-defined camelCase fields.
 
-Provider conversion belongs inside provider adapters. `JellyfinModelMapper` is the initial Jellyfin DTO boundary and owns tick-to-millisecond conversion for mapped items and chapters. Existing catalog, artwork, and player consumers migrate to these contracts in focused slices while stable QML-facing façade names remain available.
+Provider conversion belongs inside provider adapters. `JellyfinModelMapper` is the Jellyfin DTO boundary and owns tick-to-millisecond conversion for mapped items, chapters, playback sources, and streams. Shared playback projections expose milliseconds only while stable QML-facing façade names remain available.
 
 ## Request, authentication, and transport boundaries
 

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -66,6 +66,14 @@ const IPlaybackProvider *AuthenticationService::playbackProvider() const
     return m_providerAdapter ? m_providerAdapter->playbackProvider() : nullptr;
 }
 
+PlaybackInfoResponse AuthenticationService::mapPlaybackInfo(
+    const QJsonObject &wirePlaybackInfo) const
+{
+    return m_providerAdapter
+        ? m_providerAdapter->mapPlaybackInfo(wirePlaybackInfo)
+        : PlaybackInfoResponse{};
+}
+
 QVariantMap AuthenticationService::mapMediaItem(const QJsonObject &wireItem,
                                                  const QString &connectionId) const
 {

--- a/src/network/AuthenticationService.h
+++ b/src/network/AuthenticationService.h
@@ -23,6 +23,7 @@ class IProviderRequestFactory;
 class ISecretStore;
 class ConfigManager;
 class HttpTransport;
+struct PlaybackInfoResponse;
 
 /**
  * @brief Handles user authentication, session management, and token validation.
@@ -98,6 +99,7 @@ public:
     QString getAccessToken() const { return m_accessToken; }
     QString getUsername() const { return m_username; }
     const IPlaybackProvider *playbackProvider() const;
+    PlaybackInfoResponse mapPlaybackInfo(const QJsonObject &wirePlaybackInfo) const;
     QVariantMap mapMediaItem(const QJsonObject &wireItem,
                              const QString &connectionId) const;
     QVariantList mapMediaItems(const QJsonArray &wireItems,

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -202,9 +202,8 @@ void PlaybackService::getPlaybackInfo(const QString &itemId, const QString &requ
             return m_authService->networkManager()->post(request, QByteArray("{}"));
         },
         [this, itemId, requestContext](QNetworkReply *reply) {
-            QByteArray data = reply->readAll();
-            QJsonDocument doc = QJsonDocument::fromJson(data);
-            PlaybackInfoResponse info = PlaybackInfoResponse::fromJson(doc.object());
+            const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+            const PlaybackInfoResponse info = m_authService->mapPlaybackInfo(doc.object());
             emit playbackInfoLoaded(itemId, info);
             if (!requestContext.isEmpty()) {
                 emit playbackInfoLoadedForRequest(itemId, info, requestContext);

--- a/src/network/Types.cpp
+++ b/src/network/Types.cpp
@@ -1,9 +1,7 @@
 #include "Types.h"
 #include <QJsonDocument>
 #include <QJsonParseError>
-#include <QtMath>
 #include "../utils/BloomLogging.h"
-#include <cmath>
 
 /**
  * @brief Register Qt metatypes for network data structures
@@ -32,116 +30,6 @@ void registerNetworkMetaTypes()
 // ============================================================================
 // MediaStreamInfo Implementation
 // ============================================================================
-
-namespace {
-
-QString jsonValueToString(const QJsonValue &value)
-{
-    if (value.isString()) {
-        return value.toString();
-    }
-    if (value.isDouble()) {
-        const double number = value.toDouble();
-        if (qFuzzyCompare(number, std::round(number))) {
-            return QString::number(static_cast<int>(number));
-        }
-        return QString::number(number);
-    }
-    return QString();
-}
-
-int jsonValueToInt(const QJsonValue &value, int defaultValue = 0)
-{
-    if (value.isDouble()) {
-        return value.toInt(defaultValue);
-    }
-    if (value.isString()) {
-        bool ok = false;
-        const int parsed = value.toString().toInt(&ok);
-        return ok ? parsed : defaultValue;
-    }
-    return defaultValue;
-}
-
-QString jsonValueToStreamType(const QJsonValue &value)
-{
-    if (value.isString()) {
-        return value.toString();
-    }
-    if (!value.isDouble()) {
-        return QString();
-    }
-
-    switch (value.toInt(-1)) {
-    case 0:
-        return QStringLiteral("Audio");
-    case 1:
-        return QStringLiteral("Video");
-    case 2:
-        return QStringLiteral("Subtitle");
-    default:
-        return QString();
-    }
-}
-
-} // namespace
-
-/**
- * @brief Parse MediaStreamInfo from Jellyfin API JSON response
- * 
- * Deserializes a single media stream (audio/video/subtitle) from the Jellyfin API.
- * Typically found in the "MediaStreams" array within MediaSource objects.
- * 
- * Jellyfin API reference: /Items/{itemId}/PlaybackInfo response
- * Endpoint: GET /Items/{itemId}/PlaybackInfo
- * 
- * Key fields:
- * - Index: Stream index for mpv selection (e.g., --aid=1, --sid=2)
- * - Type: "Video", "Audio", or "Subtitle"
- * - Codec: Codec identifier (e.g., "h264", "aac", "srt")
- * - DisplayTitle: Human-readable stream description for UI
- * - IsDefault/IsForced: Stream selection hints from server
- * - Language: ISO 639 language code (e.g., "eng", "jpn")
- * 
- * @param json JSON object representing a single MediaStream from Jellyfin
- * @return Populated MediaStreamInfo struct
- */
-MediaStreamInfo MediaStreamInfo::fromJson(const QJsonObject &json)
-{
-    MediaStreamInfo info;
-    info.index = json["Index"].toInt(-1);
-    info.type = jsonValueToStreamType(json["Type"]);
-    info.codec = json["Codec"].toString();
-    info.language = json["Language"].toString();
-    info.title = json["Title"].toString();
-    info.displayTitle = json["DisplayTitle"].toString();
-    info.isDefault = json["IsDefault"].toBool();
-    info.isForced = json["IsForced"].toBool();
-    info.isExternal = json["IsExternal"].toBool();
-    info.isHearingImpaired = json["IsHearingImpaired"].toBool();
-    info.channels = json["Channels"].toInt();
-    info.channelLayout = json["ChannelLayout"].toString();
-    info.bitRate = json["BitRate"].toInt();
-    info.width = json["Width"].toInt();
-    info.height = json["Height"].toInt();
-    info.averageFrameRate = json["AverageFrameRate"].toDouble();
-    info.realFrameRate = json["RealFrameRate"].toDouble();
-    info.profile = json["Profile"].toString();
-    info.videoRange = jsonValueToString(json["VideoRange"]);
-    info.videoRangeType = jsonValueToString(json["VideoRangeType"]);
-    info.codecTag = jsonValueToString(json["CodecTag"]);
-    info.codecTagString = jsonValueToString(json["CodecTagString"]);
-    info.codecId = jsonValueToString(json["CodecId"]);
-    info.dolbyVisionProfile = jsonValueToInt(json.contains(QStringLiteral("DvProfile"))
-                                                 ? json[QStringLiteral("DvProfile")]
-                                                 : json[QStringLiteral("DolbyVisionProfile")]);
-    info.dolbyVisionLevel = jsonValueToInt(json.contains(QStringLiteral("DvLevel"))
-                                               ? json[QStringLiteral("DvLevel")]
-                                               : json[QStringLiteral("DolbyVisionLevel")]);
-    info.dolbyVisionBlSignalCompatibilityId = jsonValueToInt(json[QStringLiteral("DvBlSignalCompatibilityId")]);
-    info.videoDoViTitle = json[QStringLiteral("VideoDoViTitle")].toString();
-    return info;
-}
 
 /**
  * @brief Convert MediaStreamInfo to QVariantMap for QML exposure
@@ -187,52 +75,6 @@ QVariantMap MediaStreamInfo::toVariantMap() const
 // ============================================================================
 // MediaSourceInfo Implementation
 // ============================================================================
-
-/**
- * @brief Parse MediaSourceInfo from Jellyfin API JSON response
- * 
- * Deserializes a media source container from the Jellyfin PlaybackInfo response.
- * A MediaSource represents a single playable version of an item (e.g., different
- * qualities, direct play vs. transcode).
- * 
- * Jellyfin API reference: /Items/{itemId}/PlaybackInfo response
- * Endpoint: GET /Items/{itemId}/PlaybackInfo
- * 
- * Key fields:
- * - Id: Unique identifier for this media source
- * - Container: File container format (e.g., "mkv", "mp4")
- * - RunTimeTicks: Duration in ticks (1 tick = 100ns, divide by 10,000,000 for seconds)
- * - MediaStreams: Array of audio/video/subtitle streams (parsed recursively)
- * - DefaultAudioStreamIndex/DefaultSubtitleStreamIndex: Server-recommended defaults
- * 
- * The MediaStreams array is parsed into MediaStreamInfo objects for stream selection.
- * 
- * @param json JSON object representing a MediaSource from Jellyfin
- * @return Populated MediaSourceInfo struct with nested MediaStreamInfo list
- */
-MediaSourceInfo MediaSourceInfo::fromJson(const QJsonObject &json)
-{
-    MediaSourceInfo info;
-    info.id = json["Id"].toString();
-    info.name = json["Name"].toString();
-    info.path = json["Path"].toString();
-    info.directStreamUrl = json["DirectStreamUrl"].toString();
-    info.transcodingUrl = json["TranscodingUrl"].toString();
-    info.container = json["Container"].toString();
-    info.size = static_cast<qint64>(json["Size"].toDouble());
-    info.bitRate = json["Bitrate"].toInt();
-    info.videoType = json["VideoType"].toString();
-    info.runTimeTicks = static_cast<qint64>(json["RunTimeTicks"].toDouble());
-    info.defaultAudioStreamIndex = json["DefaultAudioStreamIndex"].toInt(-1);
-    info.defaultSubtitleStreamIndex = json["DefaultSubtitleStreamIndex"].toInt(-1);
-    
-    QJsonArray streamsArray = json["MediaStreams"].toArray();
-    for (const QJsonValue &streamVal : streamsArray) {
-        info.mediaStreams.append(MediaStreamInfo::fromJson(streamVal.toObject()));
-    }
-    
-    return info;
-}
 
 /**
  * @brief Filter and return only video streams from mediaStreams
@@ -295,38 +137,6 @@ QVariantList MediaSourceInfo::getMediaStreamsVariant() const
 // PlaybackInfoResponse Implementation
 // ============================================================================
 
-/**
- * @brief Parse PlaybackInfoResponse from Jellyfin API JSON response
- * 
- * Deserializes the top-level response from the Jellyfin PlaybackInfo endpoint.
- * This endpoint is called before starting playback to retrieve available media
- * sources, streams, and the play session ID for progress reporting.
- * 
- * Jellyfin API reference:
- * Endpoint: POST /Items/{itemId}/PlaybackInfo
- * Response contains:
- * - PlaySessionId: Unique session identifier for progress reporting
- * - MediaSources: Array of available sources (direct play, transcode options)
- * 
- * The PlaySessionId is used in subsequent /Sessions/Playing/* endpoints to report
- * playback progress, pause, and stop events.
- * 
- * @param json JSON object from Jellyfin PlaybackInfo response
- * @return Populated PlaybackInfoResponse with MediaSources and session ID
- */
-PlaybackInfoResponse PlaybackInfoResponse::fromJson(const QJsonObject &json)
-{
-    PlaybackInfoResponse response;
-    response.playSessionId = json["PlaySessionId"].toString();
-    
-    QJsonArray sourcesArray = json["MediaSources"].toArray();
-    for (const QJsonValue &sourceVal : sourcesArray) {
-        response.mediaSources.append(MediaSourceInfo::fromJson(sourceVal.toObject()));
-    }
-    
-    return response;
-}
-
 QVariantList PlaybackInfoResponse::getMediaSourcesVariant() const
 {
     QVariantList result;
@@ -341,7 +151,7 @@ QVariantList PlaybackInfoResponse::getMediaSourcesVariant() const
         sourceMap["size"] = source.size;
         sourceMap["bitRate"] = source.bitRate;
         sourceMap["videoType"] = source.videoType;
-        sourceMap["runTimeTicks"] = source.runTimeTicks;
+        sourceMap["durationMs"] = source.durationMs;
         sourceMap["defaultAudioStreamIndex"] = source.defaultAudioStreamIndex;
         sourceMap["defaultSubtitleStreamIndex"] = source.defaultSubtitleStreamIndex;
         sourceMap["mediaStreams"] = source.getMediaStreamsVariant();

--- a/src/network/Types.h
+++ b/src/network/Types.h
@@ -75,7 +75,6 @@ public:
     int dolbyVisionBlSignalCompatibilityId = 0;
     QString videoDoViTitle;
 
-    [[nodiscard]] static MediaStreamInfo fromJson(const QJsonObject &json);
     [[nodiscard]] QVariantMap toVariantMap() const;
 };
 
@@ -91,7 +90,7 @@ struct MediaSourceInfo
     Q_PROPERTY(qint64 size MEMBER size)
     Q_PROPERTY(int bitRate MEMBER bitRate)
     Q_PROPERTY(QString videoType MEMBER videoType)
-    Q_PROPERTY(qint64 runTimeTicks MEMBER runTimeTicks)
+    Q_PROPERTY(qint64 durationMs MEMBER durationMs)
     Q_PROPERTY(int defaultAudioStreamIndex MEMBER defaultAudioStreamIndex)
     Q_PROPERTY(int defaultSubtitleStreamIndex MEMBER defaultSubtitleStreamIndex)
     Q_PROPERTY(QVariantList mediaStreams READ getMediaStreamsVariant)
@@ -106,12 +105,10 @@ public:
     qint64 size = 0;
     int bitRate = 0;
     QString videoType;
-    qint64 runTimeTicks = 0;
+    qint64 durationMs = 0;
     int defaultAudioStreamIndex = -1;
     int defaultSubtitleStreamIndex = -1;
     QList<MediaStreamInfo> mediaStreams;
-
-    [[nodiscard]] static MediaSourceInfo fromJson(const QJsonObject &json);
 
     [[nodiscard]] QList<MediaStreamInfo> getVideoStreams() const;
     [[nodiscard]] QList<MediaStreamInfo> getAudioStreams() const;
@@ -129,7 +126,6 @@ public:
     QString playSessionId;
     QList<MediaSourceInfo> mediaSources;
 
-    [[nodiscard]] static PlaybackInfoResponse fromJson(const QJsonObject &json);
     [[nodiscard]] QVariantList getMediaSourcesVariant() const;
 };
 

--- a/src/providers/IProviderAdapter.h
+++ b/src/providers/IProviderAdapter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "network/Types.h"
 #include "providers/ServerConnection.h"
 
 #include <QJsonArray>
@@ -27,6 +28,8 @@ public:
     virtual const IProviderAuthenticator *authenticator() const = 0;
     virtual const IProviderRequestFactory *requestFactory() const = 0;
     virtual const IPlaybackProvider *playbackProvider() const = 0;
+    virtual PlaybackInfoResponse mapPlaybackInfo(
+        const QJsonObject &wirePlaybackInfo) const = 0;
     virtual QVariantMap mapMediaItem(const QJsonObject &wireItem,
                                      const QString &connectionId) const = 0;
     virtual QVariantList mapMediaItems(const QJsonArray &wireItems,

--- a/src/providers/jellyfin/JellyfinModelMapper.cpp
+++ b/src/providers/jellyfin/JellyfinModelMapper.cpp
@@ -3,6 +3,7 @@
 #include <QDateTime>
 #include <QJsonValue>
 #include <QUrlQuery>
+#include <cmath>
 #include <limits>
 
 namespace {
@@ -76,6 +77,57 @@ QVariantList people(const QJsonArray &wirePeople, const QString &connectionId)
     return result;
 }
 
+QString wireString(const QJsonValue &value)
+{
+    if (value.isString()) {
+        return value.toString();
+    }
+    if (value.isDouble()) {
+        const double number = value.toDouble();
+        const double rounded = std::round(number);
+        const double qint64Minimum =
+            static_cast<double>(std::numeric_limits<qint64>::min());
+        const double qint64UpperBoundExclusive = -qint64Minimum;
+        if (qFuzzyCompare(number, rounded)
+            && rounded >= qint64Minimum
+            && rounded < qint64UpperBoundExclusive) {
+            return QString::number(static_cast<qint64>(rounded));
+        }
+        return QString::number(number);
+    }
+    return {};
+}
+
+int wireInt(const QJsonValue &value, int defaultValue = 0)
+{
+    if (value.isDouble()) {
+        return value.toInt(defaultValue);
+    }
+    if (value.isString()) {
+        bool ok = false;
+        const int parsed = value.toString().toInt(&ok);
+        return ok ? parsed : defaultValue;
+    }
+    return defaultValue;
+}
+
+QString streamType(const QJsonValue &value)
+{
+    if (value.isString()) {
+        return value.toString();
+    }
+    if (!value.isDouble()) {
+        return {};
+    }
+
+    switch (value.toInt(-1)) {
+    case 0: return QStringLiteral("Audio");
+    case 1: return QStringLiteral("Video");
+    case 2: return QStringLiteral("Subtitle");
+    default: return {};
+    }
+}
+
 } // namespace
 
 qint64 JellyfinModelMapper::ticksToMilliseconds(qint64 ticks)
@@ -93,6 +145,87 @@ qint64 JellyfinModelMapper::millisecondsToTicks(qint64 milliseconds)
         return std::numeric_limits<qint64>::max();
     }
     return milliseconds * multiplier;
+}
+
+MediaStreamInfo JellyfinModelMapper::mediaStream(const QJsonObject &wireStream)
+{
+    MediaStreamInfo info;
+    info.index = wireStream.value(QStringLiteral("Index")).toInt(-1);
+    info.type = streamType(wireStream.value(QStringLiteral("Type")));
+    info.codec = wireStream.value(QStringLiteral("Codec")).toString();
+    info.language = wireStream.value(QStringLiteral("Language")).toString();
+    info.title = wireStream.value(QStringLiteral("Title")).toString();
+    info.displayTitle = wireStream.value(QStringLiteral("DisplayTitle")).toString();
+    info.isDefault = wireStream.value(QStringLiteral("IsDefault")).toBool();
+    info.isForced = wireStream.value(QStringLiteral("IsForced")).toBool();
+    info.isExternal = wireStream.value(QStringLiteral("IsExternal")).toBool();
+    info.isHearingImpaired = wireStream.value(QStringLiteral("IsHearingImpaired")).toBool();
+    info.channels = wireStream.value(QStringLiteral("Channels")).toInt();
+    info.channelLayout = wireStream.value(QStringLiteral("ChannelLayout")).toString();
+    info.bitRate = wireStream.value(QStringLiteral("BitRate")).toInt();
+    info.width = wireStream.value(QStringLiteral("Width")).toInt();
+    info.height = wireStream.value(QStringLiteral("Height")).toInt();
+    info.averageFrameRate = wireStream.value(QStringLiteral("AverageFrameRate")).toDouble();
+    info.realFrameRate = wireStream.value(QStringLiteral("RealFrameRate")).toDouble();
+    info.profile = wireStream.value(QStringLiteral("Profile")).toString();
+    info.videoRange = wireString(wireStream.value(QStringLiteral("VideoRange")));
+    info.videoRangeType = wireString(wireStream.value(QStringLiteral("VideoRangeType")));
+    info.codecTag = wireString(wireStream.value(QStringLiteral("CodecTag")));
+    info.codecTagString = wireString(wireStream.value(QStringLiteral("CodecTagString")));
+    info.codecId = wireString(wireStream.value(QStringLiteral("CodecId")));
+    info.dolbyVisionProfile = wireInt(wireStream.contains(QStringLiteral("DvProfile"))
+                                          ? wireStream.value(QStringLiteral("DvProfile"))
+                                          : wireStream.value(QStringLiteral("DolbyVisionProfile")));
+    info.dolbyVisionLevel = wireInt(wireStream.contains(QStringLiteral("DvLevel"))
+                                        ? wireStream.value(QStringLiteral("DvLevel"))
+                                        : wireStream.value(QStringLiteral("DolbyVisionLevel")));
+    info.dolbyVisionBlSignalCompatibilityId = wireInt(
+        wireStream.value(QStringLiteral("DvBlSignalCompatibilityId")));
+    info.videoDoViTitle = wireStream.value(QStringLiteral("VideoDoViTitle")).toString();
+    return info;
+}
+
+MediaSourceInfo JellyfinModelMapper::mediaSource(const QJsonObject &wireSource)
+{
+    MediaSourceInfo info;
+    info.id = wireSource.value(QStringLiteral("Id")).toString();
+    info.name = wireSource.value(QStringLiteral("Name")).toString();
+    info.path = wireSource.value(QStringLiteral("Path")).toString();
+    info.directStreamUrl = wireSource.value(QStringLiteral("DirectStreamUrl")).toString();
+    info.transcodingUrl = wireSource.value(QStringLiteral("TranscodingUrl")).toString();
+    info.container = wireSource.value(QStringLiteral("Container")).toString();
+    info.size = wireSource.value(QStringLiteral("Size")).toVariant().toLongLong();
+    info.bitRate = wireSource.value(QStringLiteral("Bitrate")).toInt();
+    info.videoType = wireSource.value(QStringLiteral("VideoType")).toString();
+    info.durationMs = ticksToMilliseconds(
+        wireSource.value(QStringLiteral("RunTimeTicks")).toVariant().toLongLong());
+    info.defaultAudioStreamIndex = wireSource.value(
+        QStringLiteral("DefaultAudioStreamIndex")).toInt(-1);
+    info.defaultSubtitleStreamIndex = wireSource.value(
+        QStringLiteral("DefaultSubtitleStreamIndex")).toInt(-1);
+
+    const QJsonArray streams = wireSource.value(QStringLiteral("MediaStreams")).toArray();
+    info.mediaStreams.reserve(streams.size());
+    for (const QJsonValue &value : streams) {
+        if (value.isObject()) {
+            info.mediaStreams.append(mediaStream(value.toObject()));
+        }
+    }
+    return info;
+}
+
+PlaybackInfoResponse JellyfinModelMapper::playbackInfo(const QJsonObject &wirePlaybackInfo)
+{
+    PlaybackInfoResponse response;
+    response.playSessionId = wirePlaybackInfo.value(QStringLiteral("PlaySessionId")).toString();
+    const QJsonArray sources = wirePlaybackInfo.value(QStringLiteral("MediaSources")).toArray();
+    response.mediaSources.reserve(sources.size());
+    for (const QJsonValue &value : sources) {
+        if (value.isObject()) {
+            response.mediaSources.append(mediaSource(value.toObject()));
+        }
+    }
+    return response;
 }
 
 QVariantMap JellyfinModelMapper::mediaItem(const QJsonObject &wireItem,

--- a/src/providers/jellyfin/JellyfinModelMapper.h
+++ b/src/providers/jellyfin/JellyfinModelMapper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "models/MediaModels.h"
+#include "network/Types.h"
 
 #include <QJsonArray>
 #include <QJsonObject>
@@ -12,6 +13,10 @@ class JellyfinModelMapper
 public:
     static qint64 ticksToMilliseconds(qint64 ticks);
     static qint64 millisecondsToTicks(qint64 milliseconds);
+
+    static MediaStreamInfo mediaStream(const QJsonObject &wireStream);
+    static MediaSourceInfo mediaSource(const QJsonObject &wireSource);
+    static PlaybackInfoResponse playbackInfo(const QJsonObject &wirePlaybackInfo);
 
     static QVariantMap mediaItem(const QJsonObject &wireItem,
                                  const QString &connectionId);

--- a/src/providers/jellyfin/JellyfinPlaybackProvider.cpp
+++ b/src/providers/jellyfin/JellyfinPlaybackProvider.cpp
@@ -85,8 +85,8 @@ Bloom::PlaybackDescriptor JellyfinPlaybackProvider::createDescriptor(
     descriptor.media = media;
     descriptor.mediaVersionId = providerSource.value(QStringLiteral("id")).toString();
     descriptor.playbackSessionId = playbackSessionId;
-    descriptor.durationMs = JellyfinModelMapper::ticksToMilliseconds(
-        providerSource.value(QStringLiteral("runTimeTicks")).toLongLong());
+    descriptor.durationMs = qMax<qint64>(
+        0, providerSource.value(QStringLiteral("durationMs")).toLongLong());
     descriptor.startPositionMs = qMax<qint64>(0, startPositionMs);
     descriptor.selectedAudioTrackId = selectedAudioTrack >= 0
         ? QString::number(selectedAudioTrack) : QString();

--- a/src/providers/jellyfin/JellyfinProviderAdapter.h
+++ b/src/providers/jellyfin/JellyfinProviderAdapter.h
@@ -14,6 +14,11 @@ public:
     const IProviderAuthenticator *authenticator() const override { return &m_authenticator; }
     const IProviderRequestFactory *requestFactory() const override { return &m_requestFactory; }
     const IPlaybackProvider *playbackProvider() const override { return &m_playbackProvider; }
+    PlaybackInfoResponse mapPlaybackInfo(
+        const QJsonObject &wirePlaybackInfo) const override
+    {
+        return JellyfinModelMapper::playbackInfo(wirePlaybackInfo);
+    }
     QVariantMap mapMediaItem(const QJsonObject &wireItem,
                              const QString &connectionId) const override
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -262,8 +262,10 @@ add_test(NAME ProviderTransportTest COMMAND ProviderTransportTest)
 add_executable(CanonicalModelsTest
     CanonicalModelsTest.cpp
     ${CMAKE_SOURCE_DIR}/src/models/MediaModels.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinModelMapper.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinPlaybackProvider.cpp
+    ${TEST_LOGGING_SOURCES}
 )
 
 target_include_directories(CanonicalModelsTest PRIVATE
@@ -274,6 +276,7 @@ target_include_directories(CanonicalModelsTest PRIVATE
 target_link_libraries(CanonicalModelsTest
     PRIVATE
         Qt6::Core
+        Qt6::Network
         Qt6::Test
 )
 

--- a/tests/CanonicalModelsTest.cpp
+++ b/tests/CanonicalModelsTest.cpp
@@ -15,6 +15,7 @@ class CanonicalModelsTest : public QObject
 
 private slots:
     void jellyfinTimeConversionUsesMilliseconds();
+    void jellyfinPlaybackInfoMapsToMilliseconds();
     void jellyfinItemMapsToCanonicalCamelCase();
     void jellyfinParentBackdropUsesImageItemId();
     void jellyfinSeriesFieldsAndChaptersMapCanonically();
@@ -33,6 +34,38 @@ void CanonicalModelsTest::jellyfinTimeConversionUsesMilliseconds()
     QCOMPARE(JellyfinModelMapper::millisecondsToTicks(-1), 0);
     QCOMPARE(JellyfinModelMapper::millisecondsToTicks(std::numeric_limits<qint64>::max()),
              std::numeric_limits<qint64>::max());
+}
+
+void CanonicalModelsTest::jellyfinPlaybackInfoMapsToMilliseconds()
+{
+    const PlaybackInfoResponse playbackInfo = JellyfinModelMapper::playbackInfo(
+        QJsonObject{
+            {QStringLiteral("PlaySessionId"), QStringLiteral("session-1")},
+            {QStringLiteral("MediaSources"), QJsonArray{
+                 QJsonObject{
+                     {QStringLiteral("Id"), QStringLiteral("source-1")},
+                     {QStringLiteral("RunTimeTicks"), 20'000'000},
+                     {QStringLiteral("MediaStreams"), QJsonArray{
+                          QJsonObject{
+                              {QStringLiteral("Index"), 3},
+                              {QStringLiteral("Type"), QStringLiteral("Audio")},
+                              {QStringLiteral("DisplayTitle"), QStringLiteral("English")},
+                              {QStringLiteral("CodecTag"), 4'294'967'295.0}
+                          }
+                      }}
+                 }
+             }}
+        });
+
+    QCOMPARE(playbackInfo.playSessionId, QStringLiteral("session-1"));
+    QCOMPARE(playbackInfo.mediaSources.size(), 1);
+    QCOMPARE(playbackInfo.mediaSources.first().durationMs, 2000);
+    QCOMPARE(playbackInfo.mediaSources.first().mediaStreams.first().index, 3);
+    QCOMPARE(playbackInfo.mediaSources.first().mediaStreams.first().codecTag,
+             QStringLiteral("4294967295"));
+    const QVariantMap source = playbackInfo.getMediaSourcesVariant().first().toMap();
+    QCOMPARE(source.value(QStringLiteral("durationMs")).toLongLong(), 2000);
+    QVERIFY(!source.contains(QStringLiteral("runTimeTicks")));
 }
 
 void CanonicalModelsTest::jellyfinItemMapsToCanonicalCamelCase()
@@ -319,7 +352,7 @@ void CanonicalModelsTest::jellyfinPlaybackProviderFinalizesStreamAtBoundary()
     const QVariantMap source{
         {QStringLiteral("id"), QStringLiteral("source-1")},
         {QStringLiteral("directStreamUrl"), QStringLiteral("/Videos/movie-1/stream")},
-        {QStringLiteral("runTimeTicks"), 20'000'000},
+        {QStringLiteral("durationMs"), 2000},
         {QStringLiteral("mediaStreams"), QVariantList{
              QVariantMap{
                  {QStringLiteral("type"), QStringLiteral("Audio")},

--- a/tests/PlayerControllerAutoplayContextTest.cpp
+++ b/tests/PlayerControllerAutoplayContextTest.cpp
@@ -12,6 +12,7 @@
 #include "network/AuthenticationService.h"
 #include "network/LibraryService.h"
 #include "network/PlaybackService.h"
+#include "providers/jellyfin/JellyfinModelMapper.h"
 #include "providers/jellyfin/JellyfinPlaybackProvider.h"
 #include "utils/ConfigManager.h"
 #include "utils/DisplayManager.h"
@@ -361,7 +362,7 @@ static MediaSourceInfo buildMediaSourceInfo(const QString &id,
                                             int defaultSubtitle = -1,
                                             const QString &container = QStringLiteral("mkv"),
                                             int bitRate = 0,
-                                            qint64 runTimeTicks = 0,
+                                            qint64 durationMs = 0,
                                             const QString &directStreamUrl = QString(),
                                             const QString &transcodingUrl = QString())
 {
@@ -373,7 +374,7 @@ static MediaSourceInfo buildMediaSourceInfo(const QString &id,
     info.transcodingUrl = transcodingUrl;
     info.container = container;
     info.bitRate = bitRate;
-    info.runTimeTicks = runTimeTicks;
+    info.durationMs = durationMs;
     info.defaultAudioStreamIndex = defaultAudio;
     info.defaultSubtitleStreamIndex = defaultSubtitle;
     for (const QVariantMap &stream : streams) {
@@ -1537,7 +1538,7 @@ void PlayerControllerAutoplayContextTest::dolbyVisionWithHdr10BaseLayerDoesNotFo
     QCOMPARE(context.value(QStringLiteral("hdrKind")).toString(), QStringLiteral("dolby-vision-compatible"));
     QVERIFY(!context.value(QStringLiteral("toneMapToSdr")).toBool());
 
-    const MediaSourceInfo jellyfinNumericSource = MediaSourceInfo::fromJson(QJsonObject{
+    const MediaSourceInfo jellyfinNumericSource = JellyfinModelMapper::mediaSource(QJsonObject{
         {QStringLiteral("Id"), QStringLiteral("media-source-dv-p7-json")},
         {QStringLiteral("Name"), QStringLiteral("Obsession (2026) [DV HDR10]")},
         {QStringLiteral("Path"), QStringLiteral("/library/Obsession (2026) [DV HDR10].mkv")},
@@ -2185,7 +2186,7 @@ void PlayerControllerAutoplayContextTest::requestPlaybackPromptsForVersionSelect
         -1,
         QStringLiteral("mkv"),
         8000000,
-        1200000000);
+        120000);
     const MediaSourceInfo versionB = buildMediaSourceInfo(
         QStringLiteral("source-4k"),
         QStringLiteral("4K"),
@@ -2202,7 +2203,7 @@ void PlayerControllerAutoplayContextTest::requestPlaybackPromptsForVersionSelect
         -1,
         QStringLiteral("mkv"),
         22000000,
-        1200000000);
+        120000);
 
     const QString requestId = controller.m_pendingPlaybackRequests.constBegin().key();
     emit playbackService.playbackInfoLoadedForRequest(QStringLiteral("episode-1"),
@@ -2275,7 +2276,7 @@ void PlayerControllerAutoplayContextTest::requestPlaybackRecoversLibraryProfileF
         -1,
         QStringLiteral("mkv"),
         8000000,
-        1200000000);
+        120000);
 
     const QString requestId = controller.m_pendingPlaybackRequests.constBegin().key();
     emit playbackService.playbackInfoLoadedForRequest(QStringLiteral("episode-1"),
@@ -2481,7 +2482,7 @@ void PlayerControllerAutoplayContextTest::requestPlaybackWaitsForSeriesDetailsPa
         -1,
         QStringLiteral("mkv"),
         8000000,
-        1200000000);
+        120000);
 
     const QString requestId = controller.m_pendingPlaybackRequests.constBegin().key();
     emit playbackService.playbackInfoLoadedForRequest(QStringLiteral("episode-1"),
@@ -2565,7 +2566,7 @@ void PlayerControllerAutoplayContextTest::requestPlaybackUsesRecoveredLibraryWhe
         -1,
         QStringLiteral("mkv"),
         8000000,
-        1200000000);
+        120000);
 
     const QString requestId = controller.m_pendingPlaybackRequests.constBegin().key();
     emit playbackService.playbackInfoLoadedForRequest(QStringLiteral("episode-1"),
@@ -2639,7 +2640,7 @@ void PlayerControllerAutoplayContextTest::requestPlaybackFallsBackWithoutRecover
         -1,
         QStringLiteral("mkv"),
         8000000,
-        1200000000);
+        120000);
 
     const QString requestId = controller.m_pendingPlaybackRequests.constBegin().key();
     emit playbackService.playbackInfoLoadedForRequest(QStringLiteral("episode-1"),
@@ -2719,7 +2720,7 @@ void PlayerControllerAutoplayContextTest::requestPlaybackKeepsSeriesProfilePrior
         -1,
         QStringLiteral("mkv"),
         8000000,
-        1200000000);
+        120000);
 
     const QString requestId = controller.m_pendingPlaybackRequests.constBegin().key();
     emit playbackService.playbackInfoLoadedForRequest(QStringLiteral("episode-1"),
@@ -3219,7 +3220,7 @@ void PlayerControllerAutoplayContextTest::multipartIntermediateEndIsIgnoredUntil
                              -1,
                              QStringLiteral("mkv"),
                              8000000,
-                             600000000),
+                             60000),
         buildMediaSourceInfo(QStringLiteral("part-2-source"),
                              QStringLiteral("1080p"),
                              QStringLiteral("/library/show/1080p/part-2.mkv"),
@@ -3231,7 +3232,7 @@ void PlayerControllerAutoplayContextTest::multipartIntermediateEndIsIgnoredUntil
                              -1,
                              QStringLiteral("mkv"),
                              8000000,
-                             600000000)
+                             60000)
     });
 
     const QVariantMap part1Source = segmentInfo.getMediaSourcesVariant().at(0).toMap();


### PR DESCRIPTION
## Summary
- move Jellyfin PlaybackInfo, media-source, and stream DTO parsing into `JellyfinModelMapper`
- expose canonical playback-source durations as milliseconds only
- route PlaybackService mapping through the selected provider adapter

## Verification
- `./scripts/dev-build.sh --tests`
- `ctest --test-dir build-dev --output-on-failure`

Part of #76.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `runTimeTicks` with `durationMs` in playback source timing across the provider boundary
> - Moves Jellyfin PlaybackInfo JSON parsing (including tick-to-millisecond conversion) from `Types.cpp` into `JellyfinModelMapper`, adding `mediaStream`, `mediaSource`, and `playbackInfo` mapping methods.
> - Adds `IProviderAdapter::mapPlaybackInfo` and `AuthenticationService::mapPlaybackInfo` so `PlaybackService` delegates parsing to the active provider adapter instead of calling `PlaybackInfoResponse::fromJson` directly.
> - Replaces the `runTimeTicks` field on `MediaSourceInfo` with `durationMs`; `getMediaSourcesVariant` and `JellyfinPlaybackProvider::createDescriptor` are updated to read the new field.
> - Adds a `CanonicalModelsTest` that verifies tick conversion, field normalization, and that variant maps expose `durationMs` and not `runTimeTicks`.
> - Behavioral Change: QML consumers and provider code that previously read `runTimeTicks` from media source objects must now read `durationMs`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01c7a2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playback information is now mapped into a consistent format with media durations represented in milliseconds.
  * Playback sources and streams expose normalized metadata, including audio, video, and subtitle details.
  * Playback requests now support provider-specific mapping before playback begins.

* **Bug Fixes**
  * Improved playback duration handling and stream finalization.
  * Removed provider-specific time units from playback data exposed to the application.

* **Tests**
  * Added coverage for playback metadata mapping, millisecond durations, and finalized playback streams.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->