### PR TITLE
feat(providers): add native Silo auth and catalog

### DIFF
--- a/docs/provider-compatibility.md
+++ b/docs/provider-compatibility.md
@@ -7,7 +7,7 @@ The machine-readable source is [`tests/contracts/provider-contracts.json`](../te
 ## Support terminology
 
 - **Silo compatibility support**: Bloom connects to Silo's optional Jellyfin compatibility listener. The native API is not used, and household-profile login has compatibility-specific limitations.
-- **Experimental native Silo support**: Bloom connects to `/api/v1`, but the complete release matrix has not passed.
+- **Experimental native Silo support**: Bloom connects to `/api/v1` with Silo's compatibility listener disabled and implements the native authentication, household-profile, catalog, and signed-artwork boundaries from PR #111; native playback remains outside this release gate.
 - **First-class Silo support**: Bloom connects to `/api/v1` without the compatibility listener and passes the authentication, profile, catalog, playback, recovery, and platform gates in issue #73.
 
 These labels describe a connection's protocol mode, not an application-wide provider choice. A future provider can add another protocol surface and deployment to the contract matrix without changing existing Jellyfin or Silo rows.
@@ -51,8 +51,8 @@ Ports are deployment configuration, not protocol identity.
 2. Copy `.env.example` to `.env`. Set `MEDIA_ROOT` to a test library, set a durable `SILO_DATA_ROOT`, and generate the required `SECRET_KEY`.
 3. Pin `SILO_IMAGE` to the digest above.
 4. Start the bundled PostgreSQL, Redis, and Silo services.
-5. Complete onboarding at `http://127.0.0.1:8090`, add a movie and series library, and enable Jellyfin-compatible app support. The setting requires a Silo restart.
-6. Point Bloom at `http://127.0.0.1:8096`, not the native port.
+5. Complete onboarding at `http://127.0.0.1:8090` and add a movie and series library. For compatibility coverage, enable Jellyfin-compatible app support and restart Silo.
+6. Point Bloom at `http://127.0.0.1:8096` for compatibility coverage, or leave the compatibility listener disabled and point Bloom at `http://127.0.0.1:8090` for the native mode implemented by PR #111.
 
 Example Fish session after editing `.env`:
 
@@ -90,7 +90,7 @@ podman run --rm --name bloom-jellyfin-contract \
 
 The live deployments are intentionally not started inside `nix flake check`. They require operator-owned media, credentials, mutable databases, and platform playback checks. The checked-in validator keeps the matrix complete and immutable between live runs.
 
-The native deployment has one deterministic, read-only live probe. It checks only public health shape, accepts an omitted `server_id`, does not require credentials, and never creates or changes server state:
+The native deployment runs without the compatibility listener. Without credentials, the live runner performs only the deterministic public health check and never creates server state. Set `BLOOM_CONTRACT_USERNAME` and `BLOOM_CONTRACT_PASSWORD` (and, for a PIN profile, `BLOOM_CONTRACT_PROFILE_PIN`) to extend the run with provider discovery, login/refresh/error envelopes, account/profile shapes, catalog pagination/query/detail shapes, and one opaque artwork fetch; it logs no token, password, or PIN:
 
 ```fish
 python3 tests/contracts/run_live_contracts.py \
@@ -118,7 +118,7 @@ python3 tests/contracts/run_live_contracts.py \
   --output .contract-data/jellyfin-report.json
 ```
 
-The live driver is selected by protocol surface, while expectations are selected by deployment. Native live coverage is intentionally limited to public health: authentication creates sessions, refresh extends a session, logout/revoke remove sessions, catalog requires fixture-specific profiles, and playback/user-state routes mutate data. Those behaviors remain source-validated until an operator runs them against a dedicated fixture server. MediaBrowser mutating probes are opt-in. Played/favorite probes restore their exact original booleans; playback reporting can change resume state, so run it only with a dedicated fixture account/library. The harness never forwards a MediaBrowser token to a different origin and refuses automatic redirects; opaque cross-origin URLs are fetched without Bloom authorization headers.
+The live driver is selected by protocol surface, while expectations are selected by deployment. Native health is always safe without credentials; credentialed native runs use a dedicated fixture account, perform only the auth/profile/catalog/artwork reads needed for shape checks plus login/refresh/logout lifecycle cleanup, and never enable `--allow-mutations`. MediaBrowser mutating probes remain opt-in. Played/favorite probes restore their exact original booleans; playback reporting can change resume state, so run it only with a dedicated fixture account/library. The harness rejects embedded base-URL credentials, never writes password/PIN/token values to reports, never forwards provider authorization to a different origin, and refuses automatic redirects.
 
 ## Bloom's current MediaBrowser contract
 
@@ -220,7 +220,7 @@ GET    /api/v1/profiles
 POST   /api/v1/profiles/{id}/verify-pin
 ```
 
-Use bearer access tokens and store both token types only in the platform secret store. Send `X-Profile-Id` after selection and `X-Profile-Token` after successful PIN verification. Client/device identity headers are `X-Silo-Client`, `X-Silo-Client-Version`, `X-Silo-Device-Id`, `X-Silo-Device-Name`, and `X-Silo-Device-Platform`; which are mandatory remains an upstream question.
+Use bearer access tokens and store both token types only in the platform secret store. Bloom sends `X-Profile-Id` after selection and `X-Profile-Token` after successful PIN verification, together with the Silo client/device identity headers (`X-Silo-Client`, `X-Silo-Client-Version`, `X-Silo-Device-Id`, `X-Silo-Device-Name`, and `X-Silo-Device-Platform`).
 
 ### Catalog, state, and artwork
 
@@ -244,9 +244,9 @@ GET `/catalog` supports snapshot-aware offset pagination and reports `total_exac
 
 Profile state uses `POST`/`DELETE /api/v1/watched/{content_id}` and `GET`/`PUT`/`DELETE /api/v1/favorites/{content_id}`. Artwork fields are fetch locations, not durable identity. On an expired or missing signed URL, refetch the owning resource and replace the whole URL.
 
-### Legacy native playback, markers, and chapters
+### Native playback, markers, and chapters (future #79/#80 baseline)
 
-Bloom/mpv must use the legacy envelope at this pin. `GET /api/v1/playback/capability` describes protocol v3 only; enabled v3 includes `media3_only`, while disabled v3 returns empty features, deliveries, and transformations with `reason: "disabled"`.
+Native playback is outside PR #111. The matrix records the pinned Silo envelope for later work; Bloom/mpv must not infer support from this documentation. At this pin, `GET /api/v1/playback/capability` describes protocol v3 only; enabled v3 includes `media3_only`, while disabled v3 returns empty features, deliveries, and transformations with `reason: "disabled"`.
 
 The legacy lifecycle is:
 
@@ -260,9 +260,9 @@ GET    /api/v1/markers/items/{content_id}
 GET    /api/v1/markers/files/{file_id}
 ```
 
-Legacy start is selected when `protocol_version: 3` is absent. The request carries `file_id`, optional matching `profile_id`, play method or codec/container/HDR capabilities, start position seconds, and optional audio track. The `201` response carries session/file IDs, effective play method, position, stream URL, selected audio index, duration, subtitle URLs, and playback info. Transcode responses add a replacement manifest and explicit player/origin/timeline offsets. Audio switching returns a replacement stream URL with `switch_mode: "reload"` and may promote direct play to remux or transcode.
+For future implementation, legacy start is selected when `protocol_version: 3` is absent. The request carries `file_id`, optional matching `profile_id`, play method or codec/container/HDR capabilities, start position seconds, and optional audio track. The `201` response carries session/file IDs, effective play method, position, stream URL, selected audio index, duration, subtitle URLs, and playback info. Transcode responses add a replacement manifest and explicit player/origin/timeline offsets. Audio switching returns a replacement stream URL with `switch_mode: "reload"` and may promote direct play to remux or transcode.
 
-Progress accepts `{position, is_paused}` in seconds and persists profile state best-effort. Stop persists final progress and tears down the session and transcode resources. Marker reads expose nullable intro/credits/recap/preview ranges plus provenance. Version chapters expose index, title, start/end seconds, source, optional thumbnail URL, and optional thumbhash. Native trickplay and playable media theme songs are explicitly unavailable at the pinned revision.
+For future implementation, progress accepts `{position, is_paused}` in seconds and persists profile state best-effort. Stop persists final progress and tears down the session and transcode resources. Marker reads expose nullable intro/credits/recap/preview ranges plus provenance. Version chapters expose index, title, start/end seconds, source, optional thumbnail URL, and optional thumbhash. Native trickplay and playable media theme songs are explicitly unavailable at the pinned revision.
 
 ### Current upstream HEAD research
 

--- a/docs/provider-compatibility.md
+++ b/docs/provider-compatibility.md
@@ -1,8 +1,8 @@
 # Provider compatibility and contract baseline
 
-This page defines the server contract baseline for [issue #74](https://github.com/crowquillx/Bloom/issues/74), the first increment of the Silo support epic. It records Bloom's current MediaBrowser/Jellyfin wire assumptions, the Silo compatibility result, and the native Silo assumptions needed by later provider adapters.
+This page defines the server contract baseline for [issue #74](https://github.com/crowquillx/Bloom/issues/74), the first increment of the Silo support epic. It records Bloom's current MediaBrowser/Jellyfin wire assumptions, the Silo compatibility result, and machine-checkable native Silo expectations for [#77](https://github.com/crowquillx/Bloom/issues/77) through [#80](https://github.com/crowquillx/Bloom/issues/80).
 
-The machine-readable source is [`tests/contracts/provider-contracts.json`](../tests/contracts/provider-contracts.json). Its validator requires semantic evidence for every result; an HTTP `200` alone never means a feature is supported. The implementation boundaries and connection/credential migration are documented in [provider architecture](provider-architecture.md).
+The machine-readable source is [`tests/contracts/provider-contracts.json`](../tests/contracts/provider-contracts.json). Its validator requires semantic evidence for every result, pins every native expectation to the recorded Silo revision, and rejects unavailable capabilities labeled as supported; an HTTP `200` alone never means a feature is supported. The implementation boundaries and connection/credential migration are documented in [provider architecture](provider-architecture.md).
 
 ## Support terminology
 
@@ -90,8 +90,16 @@ podman run --rm --name bloom-jellyfin-contract \
 
 The live deployments are intentionally not started inside `nix flake check`. They require operator-owned media, credentials, mutable databases, and platform playback checks. The checked-in validator keeps the matrix complete and immutable between live runs.
 
-Run the same provider-neutral probe against either MediaBrowser deployment. The password is read from the environment and is never written to the report:
+The native deployment has one deterministic, read-only live probe. It checks only public health shape, accepts an omitted `server_id`, does not require credentials, and never creates or changes server state:
 
+```fish
+python3 tests/contracts/run_live_contracts.py \
+  --deployment silo-8044eb8-native \
+  --base-url http://127.0.0.1:8090 \
+  --output .contract-data/silo-native-health-report.json
+```
+
+MediaBrowser deployments use the same provider-neutral authenticated probe. The password is read from the environment and is never written to the report:
 ```fish
 set -x BLOOM_CONTRACT_USERNAME bloom-contract
 read --silent --prompt-str 'Contract password: ' BLOOM_CONTRACT_PASSWORD
@@ -110,7 +118,7 @@ python3 tests/contracts/run_live_contracts.py \
   --output .contract-data/jellyfin-report.json
 ```
 
-The live driver is selected by protocol surface (`mediabrowser-v1` today), while expectations are selected by deployment. New providers can add a surface driver and deployment without adding product checks to existing probes. Mutating probes are opt-in. Played/favorite probes restore their exact original booleans; playback reporting can change resume state, so run it only with a dedicated fixture account/library. The harness never forwards a MediaBrowser token to a different origin and refuses automatic redirects; opaque cross-origin URLs are fetched without Bloom authorization headers.
+The live driver is selected by protocol surface, while expectations are selected by deployment. Native live coverage is intentionally limited to public health: authentication creates sessions, refresh extends a session, logout/revoke remove sessions, catalog requires fixture-specific profiles, and playback/user-state routes mutate data. Those behaviors remain source-validated until an operator runs them against a dedicated fixture server. MediaBrowser mutating probes are opt-in. Played/favorite probes restore their exact original booleans; playback reporting can change resume state, so run it only with a dedicated fixture account/library. The harness never forwards a MediaBrowser token to a different origin and refuses automatic redirects; opaque cross-origin URLs are fetched without Bloom authorization headers.
 
 ## Bloom's current MediaBrowser contract
 
@@ -171,32 +179,52 @@ A route is not supported merely because it returns `200`. Live evidence should i
 - `ETag` support requires a validator round trip that returns `304` while unchanged;
 - external subtitle support requires the advertised URL to be fetchable and passed to mpv.
 
-## Native Silo contract decisions for later issues
+## Native Silo #77-#80 baseline
 
-Native Silo detection uses `GET /api/v1/health` and requires `server_id`. Do not identify Silo from compatibility `/System/Info`, which intentionally reports `ProductName: "Jellyfin Server"` and an emulated version.
+The native baseline is source-grounded in Silo revision `8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6`. Each JSON requirement records its issue, route, outcome, capability state, request/response semantics, immutable upstream source links, and whether it is safe for the read-only live runner.
 
-### Authentication and profiles
+| Native requirement | Pinned outcome | Capability rule |
+|---|---|---|
+| Health detection | Partial | `status: "ok"` is required. `server_id` is optional and Silo's configured default is deterministic across installations, so it cannot be the sole globally unique connection identity. |
+| Providers, login, error envelopes, `/auth/me` | Supported | Provider discovery precedes login; errors carry `error` and `message`. |
+| Refresh | Partial | A fresh access/refresh pair is returned and the session window slides, but the prior refresh JWT is not revoked at this revision. Bloom must store the returned pair without treating old-token reuse as proof of failed rotation. |
+| Caller logout and auth-session list/revoke | Supported | Logout revokes the caller; session deletion is account-scoped. These are auth sessions, not playback sessions. |
+| Profile list and PIN verification | Supported | `profiles[].has_pin` gates verification. Wrong PIN is `200 {"valid": false}`; success returns a session/profile/policy-bound `profile_token`. |
+| Libraries, canonical details, versions, hierarchy | Supported | `content_id` is catalog/state identity; `file_id` selects playback versions. |
+| GET catalog snapshot and totals | Supported | Replay the returned RFC3339Nano `snapshot`; honor `total_exact` and `has_more`. Grouped work views deliberately report inexact totals. |
+| POST catalog query/capability truthfulness | Partial | Invalid rules fail instead of disappearing, but this response has no snapshot and reports `total_exact: false` even when its window count is exact. Use GET `/catalog` for snapshot-aware paging. |
+| Watched and favorite routes | Supported | Mutations are profile-scoped and observable through subsequent user-state/detail reads. |
+| Artwork refetch | Supported when artwork exists | URLs are opaque, may expire, and are not cache identity. Refetch the owning catalog/detail/person/chapter resource after expiry; never reconstruct or strip signed query parameters. |
+| Playback capability | Partial | Protocol v3 truthfully reports disabled state and runtime-probed transformations, but advertises `media3_only`; that is not an mpv capability and does not describe the legacy envelope. |
+| Legacy start/progress/stop | Supported | Omit `protocol_version: 3`; preserve session/file identity, seconds, opaque URLs, pause state, and teardown. |
+| Legacy transcode and audio switch | Supported when policy/runtime permits | Replacement manifest/stream URLs carry the new signed recipe. Policy errors are capability outcomes, not silent fallbacks. |
+| Markers and chapters | Supported when media/routes expose them | Markers cover intro, credits, recap, and preview with provenance; chapters are file-version scoped and use seconds plus optional opaque thumbnail URLs. |
+| Native trickplay | Missing | No native metadata/tile route or capability is registered. Hide/degrade seek previews. |
+| Native media theme songs | Missing | `/api/v1/theme/*` is UI branding, not playable item theme media. Hide/degrade theme-song playback. |
 
-Required route groups:
+### Detection, authentication, and profiles
+
+`GET /api/v1/health` is public and must return JSON with `status: "ok"`. `server_name` and `server_id` use `omitempty`; minimal fixtures can omit them. The default `server_id` is derived deterministically from `https://silo.local/jellycompat`, so even a present value does not establish installation uniqueness. Do not identify Silo from compatibility `/System/Info`.
+
+Authentication routes are:
 
 ```text
-GET  /api/v1/auth/providers
-POST /api/v1/auth/login
-POST /api/v1/auth/refresh
-GET  /api/v1/auth/me
-POST /api/v1/auth/logout
-GET  /api/v1/auth/sessions
+GET    /api/v1/auth/providers
+POST   /api/v1/auth/login
+POST   /api/v1/auth/refresh
+GET    /api/v1/auth/me
+POST   /api/v1/auth/logout
+GET    /api/v1/auth/sessions
 DELETE /api/v1/auth/sessions/{id}
-
-GET  /api/v1/profiles
-POST /api/v1/profiles/{id}/verify-pin
+GET    /api/v1/profiles
+POST   /api/v1/profiles/{id}/verify-pin
 ```
 
-Use bearer access tokens, refresh once after a native `401`, and store access/refresh tokens only in the platform secret store. Send `X-Profile-Id` after selection and `X-Profile-Token` after PIN verification. Client/device identity is represented by `X-Silo-Client`, `X-Silo-Client-Version`, `X-Silo-Device-Id`, `X-Silo-Device-Name`, and `X-Silo-Device-Platform`; which are mandatory remains an upstream question.
+Use bearer access tokens and store both token types only in the platform secret store. Send `X-Profile-Id` after selection and `X-Profile-Token` after successful PIN verification. Client/device identity headers are `X-Silo-Client`, `X-Silo-Client-Version`, `X-Silo-Device-Id`, `X-Silo-Device-Name`, and `X-Silo-Device-Platform`; which are mandatory remains an upstream question.
 
-### Catalog identity
+### Catalog, state, and artwork
 
-The initial catalog surface is:
+The canonical read routes are:
 
 ```text
 GET  /api/v1/user/libraries
@@ -204,17 +232,41 @@ GET  /api/v1/catalog
 POST /api/v1/catalog/query
 GET  /api/v1/catalog/items/{id}
 GET  /api/v1/catalog/items/{id}/versions
+GET  /api/v1/catalog/items/{id}/episodes
 GET  /api/v1/catalog/series/{id}/seasons
+GET  /api/v1/catalog/series/{id}/seasons/{number}
 GET  /api/v1/catalog/series/{id}/seasons/{number}/episodes
 ```
 
-Use `content_id` for catalog and profile-state identity and `file_id` for playback. Bloom-owned references must also carry `connectionId`, preventing collisions across servers and future providers. Convert native durations to milliseconds at the adapter boundary.
+Use `content_id` for catalog, detail, hierarchy, watched, and favorite identity. Preserve `file_id` for playback/version selection. Detail/version responses carry provider IDs, technical tracks, alternate editions, multipart `playback_variants`, marker ranges, and per-version chapters when data exists. Silo durations, progress, markers, and chapters use seconds; convert once at Bloom's adapter boundary.
 
-Native artwork may be opaque, presigned, and expiring. Cache identity must be a token-free Bloom `ArtworkRef`; refetch the owning catalog/detail resource when a fetch URL expires.
+GET `/catalog` supports snapshot-aware offset pagination and reports `total_exact`. POST `/catalog/query` is useful for structured filters but is not an equivalent paging capability at the pin: it omits snapshots and conservatively leaves `total_exact` false. The adapter must choose based on those explicit response capabilities rather than silently pretending a filter or count mode is stronger than it is.
 
-### Playback
+Profile state uses `POST`/`DELETE /api/v1/watched/{content_id}` and `GET`/`PUT`/`DELETE /api/v1/favorites/{content_id}`. Artwork fields are fetch locations, not durable identity. On an expired or missing signed URL, refetch the owning resource and replace the whole URL.
 
-Probe `GET /api/v1/playback/capability`. At the pinned revision, protocol v3 advertises `media3_only` and Media3-oriented engine semantics. Bloom/mpv should use the legacy native start envelope until Silo documents an mpv-compatible v3 contract. A finalized provider-neutral playback descriptor must own URLs, headers, track normalization, session IDs, reporting, and recovery; `PlayerController` must not construct provider query parameters.
+### Legacy native playback, markers, and chapters
+
+Bloom/mpv must use the legacy envelope at this pin. `GET /api/v1/playback/capability` describes protocol v3 only; enabled v3 includes `media3_only`, while disabled v3 returns empty features, deliveries, and transformations with `reason: "disabled"`.
+
+The legacy lifecycle is:
+
+```text
+POST   /api/v1/playback/start
+POST   /api/v1/playback/{session_id}/progress
+DELETE /api/v1/playback/{session_id}
+POST   /api/v1/playback/transcode/start
+PATCH  /api/v1/playback/{session_id}/audio
+GET    /api/v1/markers/items/{content_id}
+GET    /api/v1/markers/files/{file_id}
+```
+
+Legacy start is selected when `protocol_version: 3` is absent. The request carries `file_id`, optional matching `profile_id`, play method or codec/container/HDR capabilities, start position seconds, and optional audio track. The `201` response carries session/file IDs, effective play method, position, stream URL, selected audio index, duration, subtitle URLs, and playback info. Transcode responses add a replacement manifest and explicit player/origin/timeline offsets. Audio switching returns a replacement stream URL with `switch_mode: "reload"` and may promote direct play to remux or transcode.
+
+Progress accepts `{position, is_paused}` in seconds and persists profile state best-effort. Stop persists final progress and tears down the session and transcode resources. Marker reads expose nullable intro/credits/recap/preview ranges plus provenance. Version chapters expose index, title, start/end seconds, source, optional thumbnail URL, and optional thumbhash. Native trickplay and playable media theme songs are explicitly unavailable at the pinned revision.
+
+### Current upstream HEAD research
+
+Research on 2026-08-07 inspected Silo HEAD `39efe308afe903c0fab4cc06fa1795449e6fc2e1`. Its [playback handler](https://github.com/Silo-Server/silo-server/blob/39efe308afe903c0fab4cc06fa1795449e6fc2e1/internal/api/handlers/playback.go) still dispatches requests without protocol v3 to the legacy decoder, and the pinned start/progress/stop/transcode/audio request fields remain compatible. The audio-switch response adds timeline fields. This is source research only: it is not a container pin, release claim, or live release validation, and it does not move the baseline away from `8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6`.
 
 ## Open upstream contract questions
 
@@ -233,7 +285,7 @@ Before native implementation is called stable, coordinate with Silo maintainers 
 
 ## Validation
 
-The offline validator checks matrix completeness, immutable image pins, deployment coverage, native route/header decisions, and semantic assertions:
+The offline validator checks matrix completeness, immutable image pins, Jellyfin/compatibility deployment coverage, native #77-#80 coverage, pinned source evidence, health identity caveats, capability states, safe live-probe declarations, and semantic assertions:
 
 ```fish
 python3 tests/contracts/validate_contracts.py

--- a/docs/provider-compatibility.md
+++ b/docs/provider-compatibility.md
@@ -220,7 +220,7 @@ GET    /api/v1/profiles
 POST   /api/v1/profiles/{id}/verify-pin
 ```
 
-Use bearer access tokens and store both token types only in the platform secret store. Bloom sends `X-Profile-Id` after selection and `X-Profile-Token` after successful PIN verification, together with the Silo client/device identity headers (`X-Silo-Client`, `X-Silo-Client-Version`, `X-Silo-Device-Id`, `X-Silo-Device-Name`, and `X-Silo-Device-Platform`).
+Use bearer access tokens and store access, refresh, and profile tokens only in the platform secret store. Bloom's native client contract requires all five Silo client/device headers on its requests: `X-Silo-Client`, `X-Silo-Client-Version`, `X-Silo-Device-Id`, `X-Silo-Device-Name`, and `X-Silo-Device-Platform`. At the pinned server revision, the login handler consumes `User-Agent` as the auth-session device name, but the source does not establish that every `X-Silo-*` header is server-mandated or rejected when absent; treat the five-header set as Bloom's required request contract, not as a claim of universal upstream enforcement. Bloom sends `X-Profile-Id` after selection and `X-Profile-Token` after successful PIN verification.
 
 ### Catalog, state, and artwork
 

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -78,6 +78,7 @@ stdenv.mkDerivation {
   doCheck = true;
   checkPhase = ''
     runHook preCheck
+    python3 "$src/tests/contracts/validate_contracts.py"
     export QT_QPA_PLATFORM=offscreen
     ctest --output-on-failure \
       --exclude-regex '^(VisualRegressionTest|SeriesDetailsCacheTest)$'

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -58,6 +58,10 @@ stdenv.mkDerivation {
       ConnectionPersistenceTest \
       BloomProfileRepositoryTest \
       ProviderTransportTest \
+      SiloAuthenticationTest \
+      ProviderCatalogTest \
+      SiloCatalogServiceTest \
+      ArtworkRefreshTest \
       CanonicalModelsTest \
       InputBindingManagerTest \
       PlayerBackendFactoryTest \

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation {
   doCheck = true;
   checkPhase = ''
     runHook preCheck
-    python3 "$src/tests/contracts/validate_contracts.py"
+    python3 -m unittest "$src/tests/contracts/provider_contracts_test.py"
     export QT_QPA_PLATFORM=offscreen
     ctest --output-on-failure \
       --exclude-regex '^(VisualRegressionTest|SeriesDetailsCacheTest)$'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,13 +18,17 @@ qt_add_executable(Bloom
     profiles/BloomProfileRepository.h
     profiles/BloomProfileRepository.cpp
     providers/IProviderAdapter.h
+    providers/ICatalogProvider.h
     providers/IArtworkProvider.h
+    providers/ActiveArtworkProvider.h
+    providers/ActiveArtworkProvider.cpp
     providers/IProviderAuthenticator.h
     providers/IProviderRequestFactory.h
     providers/jellyfin/JellyfinAuthenticator.h
     providers/jellyfin/JellyfinAuthenticator.cpp
     providers/jellyfin/JellyfinArtworkProvider.h
     providers/jellyfin/JellyfinArtworkProvider.cpp
+    providers/jellyfin/JellyfinCatalogProvider.h
     providers/jellyfin/JellyfinRequestFactory.h
     providers/jellyfin/JellyfinRequestFactory.cpp
     providers/jellyfin/JellyfinModelMapper.h
@@ -33,6 +37,14 @@ qt_add_executable(Bloom
     providers/jellyfin/JellyfinPlaybackProvider.h
     providers/jellyfin/JellyfinPlaybackProvider.cpp
     providers/jellyfin/JellyfinProviderAdapter.h
+    providers/silo/SiloAuthenticator.h
+    providers/silo/SiloArtworkProvider.h
+    providers/silo/SiloArtworkProvider.cpp
+    providers/silo/SiloCatalogProvider.h
+    providers/silo/SiloRequestFactory.h
+    providers/silo/SiloModelMapper.h
+    providers/silo/SiloModelMapper.cpp
+    providers/silo/SiloProviderAdapter.h
     resources/fonts.qrc
     resources/sounds.qrc
     resources/images.qrc

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -358,14 +358,20 @@ void ApplicationInitializer::initializeServices()
     // clearing centralized here so real and mock services share logout behavior.
     connect(auth, &AuthenticationService::loggedOut,
         [config]() {
-            config->clearJellyfinSession();
+            config->clearActiveConnection();
     });
     connect(auth, &AuthenticationService::loggedOut, this, [this]() {
+        if (m_libraryViewModel) {
+            m_libraryViewModel->clear();
+        }
         if (m_seriesDetailsViewModel) {
             m_seriesDetailsViewModel->clear();
         }
         if (m_movieDetailsViewModel) {
             m_movieDetailsViewModel->clear();
+        }
+        if (m_upNextRecommendationsViewModel) {
+            m_upNextRecommendationsViewModel->clear();
         }
     });
 

--- a/src/core/ApplicationInitializer.cpp
+++ b/src/core/ApplicationInitializer.cpp
@@ -35,12 +35,14 @@
 #include "network/SessionService.h"
 #include "providers/IProviderAdapter.h"
 #include "providers/jellyfin/JellyfinProviderAdapter.h"
+#include "providers/silo/SiloProviderAdapter.h"
 #include "updates/UpdateService.h"
 #include "test/TestModeController.h"
 #include "test/MockAuthenticationService.h"
 #include "test/MockLibraryService.h"
 
 #include <QGuiApplication>
+#include <QList>
 #include <QDebug>
 #include <cstdio>
 
@@ -218,15 +220,21 @@ void ApplicationInitializer::registerServices()
         // 2.5 SecretStore - Create platform-specific secure storage
         m_secretStore = SecretStoreFactory::create();
         
-        // 3. Provider-neutral transport and Jellyfin wire adapters
+        // 3. Provider-neutral transport and provider adapters. Jellyfin stays first
+        // so it remains the safe default until automatic or explicit selection runs.
         m_httpTransport = std::make_unique<HttpTransport>();
-        m_providerAdapter = std::make_unique<JellyfinProviderAdapter>();
+        m_jellyfinProviderAdapter = std::make_unique<JellyfinProviderAdapter>();
+        m_siloProviderAdapter = std::make_unique<SiloProviderAdapter>();
+        const QList<IProviderAdapter *> providerAdapters{
+            m_jellyfinProviderAdapter.get(),
+            m_siloProviderAdapter.get(),
+        };
 
         // 3.1 AuthenticationService - stable façade over provider boundaries
         m_authService = std::make_unique<AuthenticationService>(
             m_secretStore.get(),
             m_httpTransport.get(),
-            m_providerAdapter.get());
+            providerAdapters);
         ServiceLocator::registerService<AuthenticationService>(m_authService.get());
         
         // 3.2 LibraryService - Depends on AuthenticationService

--- a/src/core/ApplicationInitializer.h
+++ b/src/core/ApplicationInitializer.h
@@ -24,7 +24,8 @@ class LibraryViewModel;
 class SeriesDetailsViewModel;
 class MovieDetailsViewModel;
 class UpNextRecommendationsViewModel;
-class IProviderAdapter;
+class JellyfinProviderAdapter;
+class SiloProviderAdapter;
 class ISecretStore;
 class HttpTransport;
 class SidebarSettings;
@@ -105,10 +106,11 @@ private:
     std::unique_ptr<DisplayManager> m_displayManager;
     std::unique_ptr<TrackPreferencesManager> m_trackPreferencesManager;
     std::unique_ptr<IPlayerBackend> m_playerBackend;
-    // ISecretStore — owned here, raw pointer passed to AuthenticationService
+    // Declared before AuthenticationService so transport and adapters outlive its raw pointers.
     std::unique_ptr<ISecretStore> m_secretStore;
     std::unique_ptr<HttpTransport> m_httpTransport;
-    std::unique_ptr<IProviderAdapter> m_providerAdapter;
+    std::unique_ptr<JellyfinProviderAdapter> m_jellyfinProviderAdapter;
+    std::unique_ptr<SiloProviderAdapter> m_siloProviderAdapter;
 
     std::unique_ptr<AuthenticationService> m_authService;
     std::unique_ptr<LibraryService> m_libraryService;

--- a/src/models/MediaModels.cpp
+++ b/src/models/MediaModels.cpp
@@ -1,8 +1,34 @@
 #include "MediaModels.h"
 
+#include <QCache>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QMutex>
+#include <QMutexLocker>
 #include <string>
+
+namespace {
+
+QMutex transientArtworkSourceMutex;
+QCache<QString, QString> transientArtworkSources(512);
+
+void rememberTransientArtworkSource(const QString &cacheKey, const QString &sourceUrl)
+{
+    if (cacheKey.isEmpty() || sourceUrl.isEmpty()) {
+        return;
+    }
+    QMutexLocker locker(&transientArtworkSourceMutex);
+    transientArtworkSources.insert(cacheKey, new QString(sourceUrl));
+}
+
+QString transientArtworkSource(const QString &cacheKey)
+{
+    QMutexLocker locker(&transientArtworkSourceMutex);
+    const QString *source = transientArtworkSources.object(cacheKey);
+    return source ? *source : QString();
+}
+
+} // namespace
 
 namespace Bloom {
 
@@ -46,10 +72,16 @@ QString artworkOwnerKindName(ArtworkOwnerKind kind)
 ArtworkOwnerKind artworkOwnerKindFromName(const QString &name)
 {
     const QString normalized = name.trimmed().toLower();
+    if (normalized == QStringLiteral("mediaitem")) return ArtworkOwnerKind::MediaItem;
     if (normalized == QStringLiteral("library")) return ArtworkOwnerKind::Library;
     if (normalized == QStringLiteral("person")) return ArtworkOwnerKind::Person;
     if (normalized == QStringLiteral("chapter")) return ArtworkOwnerKind::Chapter;
     return ArtworkOwnerKind::MediaItem;
+}
+
+QString ArtworkRef::transientSourceUrlForCacheKey(const QString &key)
+{
+    return transientArtworkSource(key);
 }
 
 bool MediaRef::isValid() const
@@ -99,11 +131,14 @@ QString ArtworkRef::cacheKey() const
     const QByteArray payload = QJsonDocument(object).toJson(QJsonDocument::Compact)
                                    .toBase64(QByteArray::Base64UrlEncoding
                                              | QByteArray::OmitTrailingEquals);
-    return QStringLiteral("artwork:") + QString::fromLatin1(payload);
+    const QString key = QStringLiteral("artwork:") + QString::fromLatin1(payload);
+    rememberTransientArtworkSource(key, sourceUrl);
+    return key;
 }
 
 QVariantMap ArtworkRef::toVariantMap() const
 {
+    const QString key = cacheKey();
     return {
         {QStringLiteral("connectionId"), connectionId},
         {QStringLiteral("itemId"), itemId},
@@ -112,8 +147,7 @@ QVariantMap ArtworkRef::toVariantMap() const
         {QStringLiteral("index"), index},
         {QStringLiteral("tag"), tag},
         {QStringLiteral("requestedWidth"), requestedWidth},
-        {QStringLiteral("sourceUrl"), sourceUrl},
-        {QStringLiteral("cacheKey"), cacheKey()}
+        {QStringLiteral("cacheKey"), key}
     };
 }
 
@@ -132,6 +166,9 @@ ArtworkRef ArtworkRef::fromCacheKey(const QString &key)
     }
     return fromVariantMap(document.object().toVariantMap());
 }
+
+// Cache keys never restore sourceUrl. Persistent model metadata does not
+// contain it; in-memory callers may provide it through a QVariantMap.
 
 ArtworkRef ArtworkRef::fromVariantMap(const QVariantMap &map)
 {

--- a/src/models/MediaModels.cpp
+++ b/src/models/MediaModels.cpp
@@ -180,6 +180,24 @@ QVariantMap Chapter::toVariantMap() const
         {QStringLiteral("name"), name},
         {QStringLiteral("startMs"), startMs}
     };
+    if (index >= 0) {
+        map[QStringLiteral("index")] = index;
+    }
+    if (!fileId.isEmpty()) {
+        map[QStringLiteral("fileId")] = fileId;
+    }
+    if (endMs > 0) {
+        map[QStringLiteral("endMs")] = endMs;
+    }
+    if (!source.isEmpty()) {
+        map[QStringLiteral("source")] = source;
+    }
+    if (!thumbnailUrl.isEmpty()) {
+        map[QStringLiteral("thumbnailUrl")] = thumbnailUrl;
+    }
+    if (!thumbnailThumbhash.isEmpty()) {
+        map[QStringLiteral("thumbnailThumbhash")] = thumbnailThumbhash;
+    }
     if (artwork.isValid()) {
         map[QStringLiteral("artwork")] = artwork.toVariantMap();
     }

--- a/src/models/MediaModels.cpp
+++ b/src/models/MediaModels.cpp
@@ -32,6 +32,26 @@ ArtworkKind artworkKindFromName(const QString &name)
     return ArtworkKind::Unknown;
 }
 
+QString artworkOwnerKindName(ArtworkOwnerKind kind)
+{
+    switch (kind) {
+    case ArtworkOwnerKind::MediaItem: return QStringLiteral("mediaItem");
+    case ArtworkOwnerKind::Library: return QStringLiteral("library");
+    case ArtworkOwnerKind::Person: return QStringLiteral("person");
+    case ArtworkOwnerKind::Chapter: return QStringLiteral("chapter");
+    }
+    return QStringLiteral("mediaItem");
+}
+
+ArtworkOwnerKind artworkOwnerKindFromName(const QString &name)
+{
+    const QString normalized = name.trimmed().toLower();
+    if (normalized == QStringLiteral("library")) return ArtworkOwnerKind::Library;
+    if (normalized == QStringLiteral("person")) return ArtworkOwnerKind::Person;
+    if (normalized == QStringLiteral("chapter")) return ArtworkOwnerKind::Chapter;
+    return ArtworkOwnerKind::MediaItem;
+}
+
 bool MediaRef::isValid() const
 {
     return !connectionId.trimmed().isEmpty() && !itemId.trimmed().isEmpty();
@@ -54,12 +74,24 @@ bool ArtworkRef::isValid() const
         && requestedWidth >= 0;
 }
 
+bool ArtworkRef::operator==(const ArtworkRef &other) const
+{
+    return connectionId == other.connectionId
+        && itemId == other.itemId
+        && kind == other.kind
+        && ownerKind == other.ownerKind
+        && index == other.index
+        && tag == other.tag
+        && requestedWidth == other.requestedWidth;
+}
+
 QString ArtworkRef::cacheKey() const
 {
     const QJsonObject object{
         {QStringLiteral("connectionId"), connectionId},
         {QStringLiteral("itemId"), itemId},
         {QStringLiteral("kind"), artworkKindName(kind)},
+        {QStringLiteral("ownerKind"), artworkOwnerKindName(ownerKind)},
         {QStringLiteral("index"), index},
         {QStringLiteral("tag"), tag},
         {QStringLiteral("requestedWidth"), requestedWidth}
@@ -76,9 +108,11 @@ QVariantMap ArtworkRef::toVariantMap() const
         {QStringLiteral("connectionId"), connectionId},
         {QStringLiteral("itemId"), itemId},
         {QStringLiteral("kind"), artworkKindName(kind)},
+        {QStringLiteral("ownerKind"), artworkOwnerKindName(ownerKind)},
         {QStringLiteral("index"), index},
         {QStringLiteral("tag"), tag},
         {QStringLiteral("requestedWidth"), requestedWidth},
+        {QStringLiteral("sourceUrl"), sourceUrl},
         {QStringLiteral("cacheKey"), cacheKey()}
     };
 }
@@ -105,9 +139,12 @@ ArtworkRef ArtworkRef::fromVariantMap(const QVariantMap &map)
     ref.connectionId = map.value(QStringLiteral("connectionId")).toString();
     ref.itemId = map.value(QStringLiteral("itemId")).toString();
     ref.kind = artworkKindFromName(map.value(QStringLiteral("kind")).toString());
+    ref.ownerKind = artworkOwnerKindFromName(
+        map.value(QStringLiteral("ownerKind")).toString());
     ref.index = map.value(QStringLiteral("index"), 0).toInt();
     ref.tag = map.value(QStringLiteral("tag")).toString();
     ref.requestedWidth = map.value(QStringLiteral("requestedWidth"), 0).toInt();
+    ref.sourceUrl = map.value(QStringLiteral("sourceUrl")).toString();
     return ref;
 }
 

--- a/src/models/MediaModels.h
+++ b/src/models/MediaModels.h
@@ -85,6 +85,14 @@ struct Chapter {
     QString name;
     qint64 startMs = 0;
     ArtworkRef artwork;
+    // Optional canonical metadata preserved by providers that expose richer
+    // chapter envelopes (for example, file-scoped native chapters).
+    int index = -1;
+    QString fileId;
+    qint64 endMs = 0;
+    QString source;
+    QString thumbnailUrl;
+    QString thumbnailThumbhash;
 
     QVariantMap toVariantMap() const;
 };

--- a/src/models/MediaModels.h
+++ b/src/models/MediaModels.h
@@ -49,7 +49,8 @@ struct ArtworkRef {
     int index = 0;
     QString tag;
     int requestedWidth = 0;
-    // Opaque, transient fetch location; excluded from equality and cache identity.
+    // Opaque, transient fetch location. It is retained only in memory and is
+    // excluded from equality, cache identity, and serialized model metadata.
     QString sourceUrl;
 
     bool isValid() const;
@@ -57,6 +58,9 @@ struct ArtworkRef {
     QString cacheKey() const;
     QVariantMap toVariantMap() const;
 
+    // Resolves the in-process source associated with a token-free cache key.
+    // The value is intentionally unavailable after process restart.
+    static QString transientSourceUrlForCacheKey(const QString &key);
     static ArtworkRef fromCacheKey(const QString &key);
     static ArtworkRef fromVariantMap(const QVariantMap &map);
 };

--- a/src/models/MediaModels.h
+++ b/src/models/MediaModels.h
@@ -23,6 +23,16 @@ enum class ArtworkKind {
 QString artworkKindName(ArtworkKind kind);
 ArtworkKind artworkKindFromName(const QString &name);
 
+enum class ArtworkOwnerKind {
+    MediaItem,
+    Library,
+    Person,
+    Chapter
+};
+
+QString artworkOwnerKindName(ArtworkOwnerKind kind);
+ArtworkOwnerKind artworkOwnerKindFromName(const QString &name);
+
 struct MediaRef {
     QString connectionId;
     QString itemId;
@@ -35,11 +45,15 @@ struct ArtworkRef {
     QString connectionId;
     QString itemId;
     ArtworkKind kind = ArtworkKind::Unknown;
+    ArtworkOwnerKind ownerKind = ArtworkOwnerKind::MediaItem;
     int index = 0;
     QString tag;
     int requestedWidth = 0;
+    // Opaque, transient fetch location; excluded from equality and cache identity.
+    QString sourceUrl;
 
     bool isValid() const;
+    bool operator==(const ArtworkRef &other) const;
     QString cacheKey() const;
     QVariantMap toVariantMap() const;
 

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -6,30 +6,59 @@
 #include "providers/IProviderAuthenticator.h"
 #include "providers/IProviderRequestFactory.h"
 #include "providers/jellyfin/JellyfinProviderAdapter.h"
-#include <QNetworkRequest>
-#include <QUrl>
-#include <QJsonDocument>
-#include <QJsonObject>
+#include <algorithm>
+#include <QCoreApplication>
 #include <QDebug>
-#include <QPointer>
-#include <QThreadPool>
+#include <QJsonDocument>
+#include <QNetworkRequest>
+#include <QSysInfo>
+#include <QUrl>
 #include "../utils/BloomLogging.h"
+
+namespace {
+QJsonArray responseArray(const QByteArray &body, const QString &member)
+{
+    const QJsonDocument document = QJsonDocument::fromJson(body);
+    if (document.isArray()) {
+        return document.array();
+    }
+    if (document.isObject()) {
+        return document.object().value(member).toArray();
+    }
+    return {};
+}
+
+QJsonObject capabilitiesObject(ProviderCapabilities capabilities)
+{
+    QJsonObject result;
+    const auto add = [&result, capabilities](ProviderCapability capability, const char *name) {
+        result[QString::fromLatin1(name)] = capabilities.testFlag(capability);
+    };
+    add(ProviderCapability::RefreshAuthentication, "refresh_authentication");
+    add(ProviderCapability::Profiles, "profiles");
+    add(ProviderCapability::ProfilePin, "profile_pin");
+    add(ProviderCapability::AuthSessions, "auth_sessions");
+    add(ProviderCapability::Catalog, "catalog");
+    add(ProviderCapability::NativeState, "native_state");
+    add(ProviderCapability::MediaSegments, "media_segments");
+    add(ProviderCapability::Playback, "playback");
+    add(ProviderCapability::PlaybackReporting, "playback_reporting");
+    return result;
+}
+}
 
 AuthenticationService::AuthenticationService(ISecretStore *secretStore, QObject *parent)
     : QObject(parent)
     , m_ownedTransport(std::make_unique<HttpTransport>())
     , m_ownedProviderAdapter(std::make_unique<JellyfinProviderAdapter>())
+    , m_providerAdapters{m_ownedProviderAdapter.get()}
     , m_transport(m_ownedTransport.get())
     , m_providerAdapter(m_ownedProviderAdapter.get())
     , m_requestFactory(m_providerAdapter->requestFactory())
     , m_providerAuthenticator(m_providerAdapter->authenticator())
     , m_secretStore(secretStore)
 {
-    m_transport->setUrlRedactor([this](const QUrl &url) {
-        return m_requestFactory->redactedUrl(url);
-    });
-    connect(m_transport, &HttpTransport::unauthorized,
-            this, &AuthenticationService::handleUnauthorized);
+    configureTransport();
 }
 
 AuthenticationService::AuthenticationService(ISecretStore *secretStore,
@@ -37,33 +66,101 @@ AuthenticationService::AuthenticationService(ISecretStore *secretStore,
                                                IProviderAdapter *providerAdapter,
                                                QObject *parent)
     : QObject(parent)
+    , m_providerAdapters{providerAdapter}
     , m_transport(transport)
     , m_providerAdapter(providerAdapter)
     , m_requestFactory(providerAdapter ? providerAdapter->requestFactory() : nullptr)
     , m_providerAuthenticator(providerAdapter ? providerAdapter->authenticator() : nullptr)
     , m_secretStore(secretStore)
 {
-    Q_ASSERT(m_transport);
-    Q_ASSERT(m_providerAdapter);
-    Q_ASSERT(m_requestFactory);
-    Q_ASSERT(m_providerAuthenticator);
-    m_transport->setUrlRedactor([this](const QUrl &url) {
-        return m_requestFactory->redactedUrl(url);
-    });
-    connect(m_transport, &HttpTransport::unauthorized,
-            this, &AuthenticationService::handleUnauthorized);
+    configureTransport();
+}
+
+AuthenticationService::AuthenticationService(
+    ISecretStore *secretStore,
+    HttpTransport *transport,
+    const QList<IProviderAdapter *> &providerAdapters,
+    QObject *parent)
+    : QObject(parent)
+    , m_providerAdapters(providerAdapters)
+    , m_transport(transport)
+    , m_secretStore(secretStore)
+{
+    IProviderAdapter *initial = providerForKind(ProviderKind::Jellyfin);
+    if (!initial && !m_providerAdapters.isEmpty()) {
+        initial = m_providerAdapters.constFirst();
+    }
+    activateProvider(initial);
+    configureTransport();
 }
 
 AuthenticationService::~AuthenticationService()
 {
     if (m_transport) {
+        disconnect(m_transport, nullptr, this, nullptr);
+        m_transport->cancelAll();
         m_transport->setUrlRedactor({});
+        m_transport->setUnauthorizedRecovery({});
     }
+}
+
+void AuthenticationService::configureTransport()
+{
+    Q_ASSERT(m_transport);
+    Q_ASSERT(m_providerAdapter);
+    Q_ASSERT(m_requestFactory);
+    Q_ASSERT(m_providerAuthenticator);
+    if (!m_transport) {
+        return;
+    }
+
+    m_transport->setUrlRedactor([this](const QUrl &url) {
+        return m_requestFactory ? m_requestFactory->redactedUrl(url) : url.toString();
+    });
+    m_transport->setUnauthorizedRecovery(
+        [this](std::function<void(bool)> completion) {
+            refreshAuthentication(std::move(completion));
+        });
+    connect(m_transport, &HttpTransport::unauthorized,
+            this, &AuthenticationService::handleUnauthorized, Qt::UniqueConnection);
+}
+
+IProviderAdapter *AuthenticationService::providerForKind(ProviderKind kind) const
+{
+    for (IProviderAdapter *adapter : m_providerAdapters) {
+        if (adapter && adapter->providerKind() == kind) {
+            return adapter;
+        }
+    }
+    return nullptr;
+}
+
+bool AuthenticationService::activateProvider(IProviderAdapter *adapter)
+{
+    if (!adapter || !adapter->requestFactory() || !adapter->authenticator()) {
+        return false;
+    }
+    m_providerAdapter = adapter;
+    m_requestFactory = adapter->requestFactory();
+    m_providerAuthenticator = adapter->authenticator();
+    return true;
 }
 
 const IPlaybackProvider *AuthenticationService::playbackProvider() const
 {
     return m_providerAdapter ? m_providerAdapter->playbackProvider() : nullptr;
+}
+
+const ICatalogProvider *AuthenticationService::catalogProvider() const
+{
+    return m_providerAdapter ? m_providerAdapter->catalogProvider() : nullptr;
+}
+
+ProviderKind AuthenticationService::activeProviderKind() const
+{
+    return m_providerAdapter
+        ? m_providerAdapter->providerKind()
+        : m_activeConnection.providerKind;
 }
 
 PlaybackInfoResponse AuthenticationService::mapPlaybackInfo(
@@ -164,7 +261,7 @@ QVariantList AuthenticationService::mapChaptersFromItem(
 
 QNetworkAccessManager *AuthenticationService::networkManager() const
 {
-    return m_transport->networkManager();
+    return m_transport ? m_transport->networkManager() : nullptr;
 }
 
 void AuthenticationService::initialize(ConfigManager *configManager)
@@ -184,6 +281,7 @@ void AuthenticationService::initialize(ConfigManager *configManager)
     const std::optional<ServerConnection> connection = configManager->getActiveConnection();
     const bool pendingLegacyMigration = configManager->hasPendingLegacyJellyfinMigration();
     const bool legacyMatchesConnection = connection.has_value()
+        && connection->providerKind == ProviderKind::Jellyfin
         && ServerConnection::normalizeBaseUrl(legacySession.serverUrl) == connection->baseUrl
         && legacySession.userId == connection->accountId;
     ISecretStore *store = m_secretStore;
@@ -193,30 +291,37 @@ void AuthenticationService::initialize(ConfigManager *configManager)
         [session, legacySession, connection, pendingLegacyMigration,
          legacyMatchesConnection, store, deviceId]() {
             RestorationResult result{};
-            result.serverUrl = session.serverUrl;
-            result.userId = session.userId;
-            result.username = session.username;
             result.connection = connection.value_or(ServerConnection{});
+            if (connection.has_value()) {
+                result.serverUrl = connection->baseUrl;
+                result.userId = connection->accountId;
+                result.username = connection->username;
+            }
 
-            if (!store || !connection.has_value() || !connection->isValid()
-                || connection->providerKind != ProviderKind::Jellyfin || !session.isValid()) {
+            if (!store || !connection.has_value() || !connection->isValid()) {
                 return result;
             }
 
             CredentialStore credentials(store);
-            const CredentialReadResult credentialResult = credentials.readAccessToken(
-                *connection,
-                deviceId,
-                legacyMatchesConnection ? legacySession.serverUrl : QString(),
-                legacyMatchesConnection ? legacySession.username : QString(),
-                session.accessToken);
-            result.accessToken = credentialResult.secret;
-            result.success = !result.accessToken.isEmpty();
-            result.error = credentialResult.error;
-            result.cleanupError = credentialResult.cleanupError;
-            result.legacyMigrationComplete = pendingLegacyMigration
-                && legacyMatchesConnection && result.success && result.error.isEmpty()
-                && result.cleanupError.isEmpty();
+            if (connection->providerKind == ProviderKind::Jellyfin) {
+                const CredentialReadResult access = credentials.readAccessToken(
+                    *connection,
+                    deviceId,
+                    legacyMatchesConnection ? legacySession.serverUrl : QString(),
+                    legacyMatchesConnection ? legacySession.username : QString(),
+                    session.accessToken);
+                result.accessToken = access.secret;
+                result.error = access.error;
+                result.cleanupError = access.cleanupError;
+                result.legacyMigrationComplete = pendingLegacyMigration
+                    && legacyMatchesConnection && !result.accessToken.isEmpty()
+                    && result.error.isEmpty() && result.cleanupError.isEmpty();
+            } else {
+                result.accessToken = credentials.read(*connection, CredentialKind::AccessToken);
+            }
+            result.refreshToken = credentials.read(*connection, CredentialKind::RefreshToken);
+            result.profileToken = credentials.read(*connection, CredentialKind::ProfileToken);
+            result.success = !result.accessToken.isEmpty() || !result.refreshToken.isEmpty();
             return result;
         });
 
@@ -231,26 +336,26 @@ void AuthenticationService::initialize(ConfigManager *configManager)
 
         if (connectionChanged) {
             qCInfo(lcAuth) << "Ignoring stale session restoration result after connection switch";
-        } else {
+        } else if (result.success && activateProvider(
+                       providerForKind(result.connection.providerKind))) {
             if (result.legacyMigrationComplete) {
                 configManager->finalizeLegacyJellyfinMigration();
             }
-
-            if (result.success) {
-                m_activeConnection = result.connection;
-                restoreSession(result.serverUrl,
-                               result.userId,
-                               result.accessToken,
-                               result.username);
-            } else if (!result.error.isEmpty()) {
-                qCWarning(lcAuth) << "Session restoration failed:" << result.error;
-            }
+            m_activeConnection = result.connection;
+            m_refreshToken = result.refreshToken;
+            m_profileToken = result.profileToken;
+            restoreSession(result.serverUrl,
+                           result.userId,
+                           result.accessToken,
+                           result.username);
+        } else if (!result.error.isEmpty()) {
+            qCWarning(lcAuth) << "Session restoration failed:" << result.error;
         }
+
         if (!result.cleanupError.isEmpty()) {
             qCWarning(lcAuth) << "Legacy credential cleanup failed:"
                               << result.cleanupError;
         }
-
         m_isRestoringSession = false;
         emit isRestoringSessionChanged();
     });
@@ -258,47 +363,217 @@ void AuthenticationService::initialize(ConfigManager *configManager)
     m_restorationWatcher.setFuture(future);
 }
 
-QString AuthenticationService::normalizeUrl(const QString &url)
+QString AuthenticationService::normalizeUrl(const QString &url) const
 {
-    QString normalized = url.trimmed();
-    while (normalized.endsWith('/')) {
-        normalized.chop(1);
+    return ServerConnection::normalizeBaseUrl(url);
+}
+
+ProviderRequestContext AuthenticationService::requestContext(bool includeAuthentication) const
+{
+    ProviderRequestContext context;
+    context.baseUrl = m_serverUrl;
+    if (includeAuthentication) {
+        context.accessToken = m_accessToken;
+        context.profileId = m_pendingProfileId.isEmpty()
+            ? m_activeConnection.profileId : m_pendingProfileId;
+        context.profileToken = m_profileToken;
     }
-    return normalized;
+    context.clientName = QStringLiteral("Bloom");
+    context.clientVersion = QCoreApplication::applicationVersion();
+    context.deviceId = m_configManager
+        ? m_configManager->getDeviceId()
+        : QStringLiteral("bloom-desktop-fallback");
+    context.deviceName = QSysInfo::machineHostName();
+    if (context.deviceName.isEmpty()) {
+        context.deviceName = QStringLiteral("Bloom Device");
+    }
+    context.devicePlatform = QSysInfo::productType();
+    if (context.devicePlatform.isEmpty()) {
+        context.devicePlatform = QSysInfo::kernelType();
+    }
+    return context;
 }
 
 QNetworkRequest AuthenticationService::createRequest(const QString &endpoint) const
 {
-    ProviderRequestContext context;
-    context.baseUrl = m_serverUrl;
-    context.accessToken = m_accessToken;
-    context.deviceId = m_configManager
-        ? m_configManager->getDeviceId()
-        : QStringLiteral("bloom-desktop-fallback");
-    return m_requestFactory->createRequest(context, endpoint);
+    return m_requestFactory
+        ? m_requestFactory->createRequest(requestContext(true), endpoint)
+        : QNetworkRequest{};
 }
 
-void AuthenticationService::authenticate(const QString &serverUrl, const QString &username, const QString &password)
+QNetworkRequest AuthenticationService::createUnauthenticatedRequest(
+    const QString &endpoint) const
 {
-    m_serverUrl = normalizeUrl(serverUrl);
+    return m_requestFactory
+        ? m_requestFactory->createRequest(requestContext(false), endpoint)
+        : QNetworkRequest{};
+}
 
-    const ProviderAuthenticationRequest authenticationRequest =
-        m_providerAuthenticator->createLoginRequest(username, password);
-    const QNetworkRequest request = createRequest(authenticationRequest.endpoint);
+void AuthenticationService::setProviderSelection(const QString &selection)
+{
+    const QString normalized = selection.trimmed().toLower();
+    if (normalized != QStringLiteral("auto")
+        && normalized != QStringLiteral("jellyfin")
+        && normalized != QStringLiteral("silo")) {
+        emit loginError(tr("Unknown provider selection: %1").arg(selection));
+        return;
+    }
+    if (normalized == m_providerSelection) {
+        return;
+    }
+
+    const bool wasAuthenticated = isAuthenticated();
+    clearAccountStateInternal(false, wasAuthenticated);
+    m_providerSelection = normalized;
+    emit providerSelectionChanged();
+
+    if (normalized != QStringLiteral("auto")) {
+        const ProviderKind kind = normalized == QStringLiteral("silo")
+            ? ProviderKind::Silo : ProviderKind::Jellyfin;
+        if (IProviderAdapter *adapter = providerForKind(kind)) {
+            activateProvider(adapter);
+        }
+    }
+}
+
+void AuthenticationService::authenticate(const QString &serverUrl,
+                                           const QString &username,
+                                           const QString &password)
+{
+    clearAccountStateInternal(false, false);
+    m_serverUrl = normalizeUrl(serverUrl);
+    emit serverUrlChanged();
+    const quint64 generation = m_stateGeneration;
+
+    if (m_serverUrl.isEmpty()) {
+        emit loginError(tr("Server URL is required."));
+        return;
+    }
+
+    if (m_providerSelection == QStringLiteral("auto")) {
+        probeProviderAndLogin(username, password, generation);
+        return;
+    }
+
+    const ProviderKind kind = m_providerSelection == QStringLiteral("silo")
+        ? ProviderKind::Silo : ProviderKind::Jellyfin;
+    if (!activateProvider(providerForKind(kind))) {
+        emit loginError(tr("The selected provider is not available."));
+        return;
+    }
+    performLogin(username, password, generation);
+}
+
+void AuthenticationService::probeProviderAndLogin(const QString &username,
+                                                    const QString &password,
+                                                    quint64 generation)
+{
+    IProviderAdapter *silo = providerForKind(ProviderKind::Silo);
+    IProviderAdapter *jellyfin = providerForKind(ProviderKind::Jellyfin);
+    const auto fallback = [this, jellyfin, username, password, generation]() {
+        if (generation != m_stateGeneration) {
+            return;
+        }
+        m_detectionResult = {};
+        if (!activateProvider(jellyfin)) {
+            emit loginError(tr("No compatible authentication provider is available."));
+            return;
+        }
+        performLogin(username, password, generation);
+    };
+
+    if (!silo || !silo->requestFactory()) {
+        fallback();
+        return;
+    }
+
+    const QString endpoint = QStringLiteral("/api/v1/health");
+    ProviderRequestContext context = requestContext(false);
+    const IProviderRequestFactory *factory = silo->requestFactory();
     HttpRequestOptions options;
     options.retryEnabled = false;
     options.unauthorizedPolicy = UnauthorizedPolicy::Ignore;
+    m_transport->sendWithRetry(
+        this,
+        endpoint,
+        [this, factory, context, endpoint]() {
+            return networkManager()->get(factory->createRequest(context, endpoint));
+        },
+        [this, silo, username, password, generation, fallback](QNetworkReply *reply) {
+            if (generation != m_stateGeneration) {
+                return;
+            }
+            const QJsonObject payload = QJsonDocument::fromJson(reply->readAll()).object();
+            if (payload.value(QStringLiteral("status")).toString()
+                != QStringLiteral("ok")) {
+                fallback();
+                return;
+            }
+            if (!activateProvider(silo)) {
+                fallback();
+                return;
+            }
+            if (const auto detected = silo->mapDetectionResult(payload);
+                detected.has_value()) {
+                m_detectionResult = *detected;
+            } else {
+                m_detectionResult = {};
+                m_detectionResult.providerKind = ProviderKind::Silo;
+                m_detectionResult.protocolMode = ProtocolMode::Native;
+                m_detectionResult.serverId =
+                    payload.value(QStringLiteral("server_id")).toString();
+                m_detectionResult.serverName =
+                    payload.value(QStringLiteral("server_name")).toString();
+            }
+            performLogin(username, password, generation);
+        },
+        [fallback](const NetworkError &) {
+            fallback();
+        },
+        options);
+}
 
+void AuthenticationService::performLogin(const QString &username,
+                                          const QString &password,
+                                          quint64 generation)
+{
+    if (!m_providerAuthenticator) {
+        emit loginError(tr("Authentication provider is unavailable."));
+        return;
+    }
+    const ProviderAuthenticationRequest authenticationRequest =
+        m_providerAuthenticator->createLoginRequest(username, password);
+    if (!authenticationRequest.isValid()) {
+        emit loginError(tr("The provider cannot create a login request."));
+        return;
+    }
+
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::Ignore;
     m_transport->sendWithRetry(
         this,
         authenticationRequest.endpoint,
-        [this, request, body = authenticationRequest.body]() {
-            return networkManager()->post(request, body);
+        [this, endpoint = authenticationRequest.endpoint,
+         body = authenticationRequest.body]() {
+            return networkManager()->post(createUnauthenticatedRequest(endpoint), body);
         },
-        [this](QNetworkReply *reply) {
-            onAuthenticateFinished(reply);
+        [this, generation](QNetworkReply *reply) {
+            if (generation != m_stateGeneration) {
+                return;
+            }
+            const ProviderAuthenticationResult authentication =
+                m_providerAuthenticator->parseLoginResponse(reply->readAll());
+            if (!authentication.isValid()) {
+                emit loginError(tr("Authentication response was incomplete."));
+                return;
+            }
+            handleAuthenticationResult(authentication, generation);
         },
-        [this](const NetworkError &error) {
+        [this, generation](const NetworkError &error) {
+            if (generation != m_stateGeneration) {
+                return;
+            }
             if (error.code == 401) {
                 emit loginError(tr("Invalid username or password"));
                 return;
@@ -311,85 +586,531 @@ void AuthenticationService::authenticate(const QString &serverUrl, const QString
         options);
 }
 
-void AuthenticationService::onAuthenticateFinished(QNetworkReply *reply)
+void AuthenticationService::handleAuthenticationResult(
+    const ProviderAuthenticationResult &authentication,
+    quint64 generation)
 {
-    const ProviderAuthenticationResult authentication =
-        m_providerAuthenticator->parseLoginResponse(reply->readAll());
-    if (!authentication.isValid()) {
-        emit loginError(tr("Authentication response was incomplete."));
+    if (generation != m_stateGeneration || !authentication.isValid()) {
         return;
     }
 
     m_accessToken = authentication.accessToken;
+    if (!authentication.refreshToken.isEmpty()) {
+        m_refreshToken = authentication.refreshToken;
+    }
+    if (!authentication.profileToken.isEmpty()) {
+        m_profileToken = authentication.profileToken;
+    }
     m_userId = authentication.accountId;
-    m_username = authentication.username;
-    
-    qCDebug(lcAuth) << "Authentication successful. User ID:" << m_userId << "Username:" << m_username;
+    if (!authentication.username.isEmpty()) {
+        m_username = authentication.username;
+    }
 
+    ServerConnection connection;
     if (m_configManager) {
-        m_configManager->setJellyfinSession(m_serverUrl, m_userId, QString(), m_username);
-        m_activeConnection = m_configManager->getActiveConnection().value_or(ServerConnection{});
+        for (const ServerConnection &candidate : m_configManager->getConnections()) {
+            if (candidate.providerKind == m_providerAdapter->providerKind()
+                && candidate.baseUrl == m_serverUrl
+                && candidate.accountId == m_userId) {
+                connection = candidate;
+                break;
+            }
+        }
+    }
+    connection.providerKind = m_providerAdapter->providerKind();
+    connection.protocolMode = m_providerAdapter->protocolMode();
+    connection.baseUrl = m_serverUrl;
+    connection.accountId = m_userId;
+    connection.profileId = authentication.profileId;
+    if (connection.providerKind == ProviderKind::Jellyfin
+        && connection.profileId.isEmpty()) {
+        connection.profileId = m_userId;
+    }
+    connection.username = m_username;
+    connection.displayName = m_username;
+    if (m_detectionResult.providerKind == connection.providerKind) {
+        connection.serverId = m_detectionResult.serverId;
+        connection.serverName = m_detectionResult.serverName;
+        connection.capabilities = capabilitiesObject(m_detectionResult.capabilities);
+    }
+    if (connection.connectionId.isEmpty()) {
+        connection.connectionId = ServerConnection::createDeterministicConnectionId(
+            connection.providerKind, connection.baseUrl, connection.accountId);
+    }
+    if (connection.credentialReference.isEmpty()) {
+        connection.credentialReference =
+            ServerConnection::createCredentialReference(connection.connectionId);
+    }
+    m_activeConnection = connection;
+
+    persistConnection();
+    persistCredentials();
+
+    if (m_providerAdapter->supportsCapability(ProviderCapability::Profiles)) {
+        loadProfiles(true);
+    } else {
+        finishAuthentication();
+    }
+}
+
+void AuthenticationService::persistConnection()
+{
+    if (!m_configManager || !m_activeConnection.isValid()) {
+        return;
+    }
+    m_configManager->upsertConnection(m_activeConnection, true);
+    if (m_activeConnection.providerKind == ProviderKind::Jellyfin) {
+        m_configManager->setJellyfinSession(
+            m_serverUrl, m_userId, QString(), m_username);
+    }
+    m_activeConnection = m_configManager->getActiveConnection().value_or(m_activeConnection);
+}
+
+void AuthenticationService::persistCredentials()
+{
+    if (!m_secretStore || !m_activeConnection.isValid()) {
+        return;
     }
 
-    if (m_secretStore && m_activeConnection.isValid()) {
-        const QString token = m_accessToken;
-        const ServerConnection connection = m_activeConnection;
-        const QString deviceId = m_configManager ? m_configManager->getDeviceId() : QString();
-        const ConfigManager::SessionData legacySession = m_configManager
-            ? m_configManager->getPendingLegacyJellyfinSession()
-            : ConfigManager::SessionData{};
-        const bool legacyMatchesConnection =
-            ServerConnection::normalizeBaseUrl(legacySession.serverUrl) == connection.baseUrl
-            && legacySession.userId == connection.accountId;
-        ISecretStore *store = m_secretStore;
-        QPointer<ConfigManager> configManager = m_configManager;
-
-        QThreadPool::globalInstance()->start(
-            [store, connection, token, deviceId, legacySession,
-             legacyMatchesConnection, configManager]() {
-                CredentialStore credentials(store);
-                if (!credentials.write(connection, CredentialKind::AccessToken, token)) {
-                    qCWarning(lcAuth) << "Failed to store token in keychain:" << store->lastError();
-                    return;
-                }
-                if (credentials.read(connection, CredentialKind::AccessToken) != token) {
-                    credentials.remove(connection, CredentialKind::AccessToken);
-                    qCWarning(lcAuth) << "Stored token failed keychain verification";
-                    return;
-                }
-
-                if (legacyMatchesConnection) {
-                    const CredentialReadResult cleanup = credentials.readAccessToken(
-                        connection,
-                        deviceId,
-                        legacySession.serverUrl,
-                        legacySession.username);
-                    if (!cleanup.error.isEmpty() || !cleanup.cleanupError.isEmpty()
-                        || cleanup.secret != token) {
-                        qCWarning(lcAuth) << "Legacy credential cleanup failed:"
-                                          << (cleanup.error.isEmpty()
-                                                  ? cleanup.cleanupError
-                                                  : cleanup.error);
-                        return;
-                    }
-                }
-
-                qCDebug(lcAuth) << "Token stored in provider-neutral keychain entry";
-                if (legacyMatchesConnection && configManager) {
-                    QMetaObject::invokeMethod(configManager, [configManager]() {
-                        if (configManager) {
-                            configManager->finalizeLegacyJellyfinMigration();
-                        }
-                    }, Qt::QueuedConnection);
-                }
-            });
+    CredentialStore credentials(m_secretStore);
+    bool accessStored = true;
+    if (!m_accessToken.isEmpty()) {
+        accessStored = credentials.write(
+            m_activeConnection, CredentialKind::AccessToken, m_accessToken);
+    } else {
+        accessStored = credentials.remove(
+            m_activeConnection, CredentialKind::AccessToken);
     }
-    
+    const bool refreshStored = !m_refreshToken.isEmpty()
+        ? credentials.write(
+              m_activeConnection, CredentialKind::RefreshToken, m_refreshToken)
+        : credentials.remove(m_activeConnection, CredentialKind::RefreshToken);
+    const bool profileStored = !m_profileToken.isEmpty()
+        ? credentials.write(
+              m_activeConnection, CredentialKind::ProfileToken, m_profileToken)
+        : credentials.remove(m_activeConnection, CredentialKind::ProfileToken);
+    if (!accessStored || !refreshStored || !profileStored) {
+        qCWarning(lcAuth) << "Failed to persist one or more authentication credentials:"
+                          << m_secretStore->lastError();
+    }
+
+    if (!accessStored || m_accessToken.isEmpty() || !m_configManager
+        || m_activeConnection.providerKind != ProviderKind::Jellyfin) {
+        return;
+    }
+    const ConfigManager::SessionData legacy =
+        m_configManager->getPendingLegacyJellyfinSession();
+    if (ServerConnection::normalizeBaseUrl(legacy.serverUrl) != m_activeConnection.baseUrl
+        || legacy.userId != m_activeConnection.accountId) {
+        return;
+    }
+    const CredentialReadResult cleanup = credentials.readAccessToken(
+        m_activeConnection,
+        m_configManager->getDeviceId(),
+        legacy.serverUrl,
+        legacy.username);
+    if (cleanup.secret == m_accessToken && cleanup.error.isEmpty()
+        && cleanup.cleanupError.isEmpty()) {
+        m_configManager->finalizeLegacyJellyfinMigration();
+    }
+}
+
+void AuthenticationService::finishAuthentication()
+{
+    if (m_accessToken.isEmpty() || m_userId.isEmpty()) {
+        emit loginError(tr("Authentication response was incomplete."));
+        return;
+    }
+    m_sessionExpiredPending = false;
+    m_sessionExpiredEmitted = false;
+    updateAuthenticationStep(QStringLiteral("authenticated"));
     emit serverUrlChanged();
     emit userIdChanged();
-    emit authenticatedChanged();
-    qCCritical(lcAuth) << "=== AuthenticationService: EMITTING loginSuccess signal ===" << m_userId << m_username;
     emit loginSuccess(m_userId, m_accessToken, m_username);
+}
+
+void AuthenticationService::loadProfiles(bool finishWhenUnavailable)
+{
+    if (!m_providerAdapter) {
+        return;
+    }
+    const auto endpoint = m_providerAdapter->endpointFor(ProviderRoute::Profiles);
+    if (!m_providerAdapter->supportsCapability(ProviderCapability::Profiles)
+        || !endpoint.has_value()) {
+        if (finishWhenUnavailable) {
+            finishAuthentication();
+        }
+        return;
+    }
+
+    const quint64 generation = m_stateGeneration;
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    m_transport->sendWithRetry(
+        this,
+        *endpoint,
+        [this, endpoint = *endpoint]() {
+            return networkManager()->get(createRequest(endpoint));
+        },
+        [this, generation, finishWhenUnavailable](QNetworkReply *reply) {
+            if (generation != m_stateGeneration) {
+                return;
+            }
+            const auto mapped = m_providerAdapter->mapProfiles(
+                responseArray(reply->readAll(), QStringLiteral("profiles")));
+            if (!mapped.has_value()) {
+                emit loginError(tr("The provider returned an invalid profile list."));
+                return;
+            }
+            replaceProfiles(*mapped);
+            if (m_providerProfiles.isEmpty()) {
+                if (finishWhenUnavailable) {
+                    emit loginError(tr("No profiles are available for this account."));
+                }
+                return;
+            }
+            if (m_providerProfiles.size() == 1) {
+                selectProfile(m_providerProfiles.constFirst().id);
+            } else {
+                updateAuthenticationStep(QStringLiteral("profiles"));
+            }
+        },
+        [this, generation](const NetworkError &error) {
+            if (generation == m_stateGeneration) {
+                emit loginError(tr("Unable to load profiles: %1").arg(error.userMessage));
+            }
+        },
+        options);
+}
+
+void AuthenticationService::replaceProfiles(const QList<ProviderProfile> &profiles)
+{
+    m_providerProfiles = profiles;
+    QVariantList values;
+    values.reserve(profiles.size());
+    for (const ProviderProfile &profile : profiles) {
+        values.append(QVariantMap{
+            {QStringLiteral("id"), profile.id},
+            {QStringLiteral("name"), profile.name},
+            {QStringLiteral("avatarUrl"), profile.avatarUrl},
+            {QStringLiteral("hasPin"), profile.hasPin},
+            {QStringLiteral("isChild"), profile.isChild},
+            {QStringLiteral("isPrimary"), profile.isPrimary}
+        });
+    }
+    m_profiles = values;
+    emit profilesChanged();
+}
+
+void AuthenticationService::selectProfile(const QString &profileId)
+{
+    const auto profile = std::find_if(
+        m_providerProfiles.cbegin(), m_providerProfiles.cend(),
+        [&profileId](const ProviderProfile &candidate) {
+            return candidate.id == profileId;
+        });
+    if (profile == m_providerProfiles.cend()) {
+        emit loginError(tr("Unknown profile."));
+        return;
+    }
+
+    m_pendingProfileId = profileId;
+    if (profile->hasPin) {
+        updateAuthenticationStep(QStringLiteral("pin"));
+        return;
+    }
+    verifyProfilePin(profileId, QString());
+}
+
+void AuthenticationService::verifyProfilePin(const QString &profileId, const QString &pin)
+{
+    if (!m_providerAuthenticator || profileId.isEmpty()) {
+        emit loginError(tr("A profile must be selected."));
+        return;
+    }
+    const auto request = m_providerAuthenticator->createProfileLoginRequest(profileId, pin);
+    if (!request.has_value() || !request->isValid()) {
+        const auto profile = std::find_if(
+            m_providerProfiles.cbegin(), m_providerProfiles.cend(),
+            [&profileId](const ProviderProfile &candidate) {
+                return candidate.id == profileId;
+            });
+        if (profile != m_providerProfiles.cend() && !profile->hasPin && pin.isEmpty()) {
+            m_activeConnection.profileId = profileId;
+            m_pendingProfileId.clear();
+            persistConnection();
+            persistCredentials();
+            finishAuthentication();
+            return;
+        }
+        emit loginError(tr("The provider does not support profile PIN verification."));
+        return;
+    }
+
+    m_pendingProfileId = profileId;
+    const quint64 generation = m_stateGeneration;
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    m_transport->sendWithRetry(
+        this,
+        request->endpoint,
+        [this, endpoint = request->endpoint, body = request->body]() {
+            return networkManager()->post(createRequest(endpoint), body);
+        },
+        [this, generation](QNetworkReply *reply) {
+            if (generation != m_stateGeneration) {
+                return;
+            }
+            const ProviderProfileAuthenticationResult authentication =
+                m_providerAuthenticator->parseProfileLoginResponse(reply->readAll());
+            if (authentication.isIncorrectPin()) {
+                updateAuthenticationStep(QStringLiteral("pin"));
+                emit loginError(tr("Invalid profile PIN"));
+                return;
+            }
+            if (!authentication.isValid() || authentication.profileToken.isEmpty()) {
+                emit loginError(tr("Profile verification response was incomplete."));
+                return;
+            }
+            m_profileToken = authentication.profileToken;
+            m_activeConnection.profileId = m_pendingProfileId;
+            m_pendingProfileId.clear();
+            persistConnection();
+            persistCredentials();
+            finishAuthentication();
+        },
+        [this, generation](const NetworkError &error) {
+            if (generation == m_stateGeneration) {
+                emit loginError(error.code == 401
+                    ? tr("Invalid profile PIN")
+                    : tr("Profile verification failed: %1").arg(error.userMessage));
+            }
+        },
+        options);
+}
+
+void AuthenticationService::switchProfile()
+{
+    if (m_accessToken.isEmpty() || !m_providerAdapter
+        || !m_providerAdapter->supportsCapability(ProviderCapability::Profiles)) {
+        return;
+    }
+    clearProfileStateInternal(true);
+    loadProfiles(false);
+}
+
+void AuthenticationService::loadAuthSessions()
+{
+    if (!isAuthenticated() || !m_providerAdapter) {
+        return;
+    }
+    const auto endpoint = m_providerAdapter->endpointFor(ProviderRoute::AuthSessions);
+    if (!m_providerAdapter->supportsCapability(ProviderCapability::AuthSessions)
+        || !endpoint.has_value()) {
+        replaceAuthSessions({});
+        return;
+    }
+
+    const quint64 generation = m_stateGeneration;
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    m_transport->sendWithRetry(
+        this,
+        *endpoint,
+        [this, endpoint = *endpoint]() {
+            return networkManager()->get(createRequest(endpoint));
+        },
+        [this, generation](QNetworkReply *reply) {
+            if (generation != m_stateGeneration) {
+                return;
+            }
+            const auto mapped = m_providerAdapter->mapAuthSessions(
+                responseArray(reply->readAll(), QStringLiteral("sessions")));
+            if (!mapped.has_value()) {
+                emit loginError(tr("The provider returned an invalid session list."));
+                return;
+            }
+            replaceAuthSessions(*mapped);
+        },
+        [this, generation](const NetworkError &error) {
+            if (generation == m_stateGeneration) {
+                emit loginError(tr("Unable to load authentication sessions: %1")
+                                    .arg(error.userMessage));
+            }
+        },
+        options);
+}
+
+void AuthenticationService::replaceAuthSessions(
+    const QList<ProviderAuthSession> &sessions)
+{
+    QVariantList values;
+    values.reserve(sessions.size());
+    for (const ProviderAuthSession &session : sessions) {
+        values.append(QVariantMap{
+            {QStringLiteral("id"), session.id},
+            {QStringLiteral("deviceName"), session.deviceName},
+            {QStringLiteral("ipAddress"), session.ipAddress},
+            {QStringLiteral("createdAt"), session.createdAt},
+            {QStringLiteral("expiresAt"), session.expiresAt},
+            {QStringLiteral("revokedAt"), session.revokedAt},
+            {QStringLiteral("isCurrent"), session.isCurrent}
+        });
+    }
+    m_authSessions = values;
+    emit authSessionsChanged();
+}
+
+void AuthenticationService::revokeAuthSession(const QString &sessionId)
+{
+    if (!isAuthenticated() || !m_providerAdapter || sessionId.isEmpty()) {
+        return;
+    }
+    ProviderRouteContext routeContext;
+    routeContext.accountId = m_userId;
+    routeContext.profileId = m_activeConnection.profileId;
+    routeContext.sessionId = sessionId;
+    const auto endpoint = m_providerAdapter->endpointFor(
+        ProviderRoute::RevokeAuthSession, routeContext);
+    if (!endpoint.has_value()) {
+        emit loginError(tr("The provider does not support session revocation."));
+        return;
+    }
+    bool revokingCurrent = false;
+    for (const QVariant &value : m_authSessions) {
+        const QVariantMap session = value.toMap();
+        if (session.value(QStringLiteral("id")).toString() == sessionId) {
+            revokingCurrent =
+                session.value(QStringLiteral("isCurrent")).toBool();
+            break;
+        }
+    }
+
+    const quint64 generation = m_stateGeneration;
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    m_transport->sendWithRetry(
+        this,
+        *endpoint,
+        [this, endpoint = *endpoint]() {
+            return networkManager()->deleteResource(createRequest(endpoint));
+        },
+        [this, generation, revokingCurrent](QNetworkReply *) {
+            if (generation != m_stateGeneration) {
+                return;
+            }
+            if (revokingCurrent) {
+                logout();
+            } else {
+                loadAuthSessions();
+            }
+        },
+        [this, generation](const NetworkError &error) {
+            if (generation == m_stateGeneration) {
+                emit loginError(tr("Unable to revoke authentication session: %1")
+                                    .arg(error.userMessage));
+            }
+        },
+        options);
+}
+
+void AuthenticationService::remoteLogout()
+{
+    if (m_accessToken.isEmpty() || !m_providerAdapter) {
+        logout();
+        return;
+    }
+    const QString endpoint = m_providerAdapter->providerKind() == ProviderKind::Silo
+        ? QStringLiteral("/api/v1/auth/logout")
+        : QStringLiteral("/Sessions/Logout");
+    const quint64 generation = m_stateGeneration;
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    m_transport->sendWithRetry(
+        this,
+        endpoint,
+        [this, endpoint]() {
+            return networkManager()->post(createRequest(endpoint), QByteArray{});
+        },
+        [this, generation](QNetworkReply *) {
+            if (generation == m_stateGeneration) {
+                logout();
+            }
+        },
+        [this, generation](const NetworkError &error) {
+            if (generation != m_stateGeneration) {
+                return;
+            }
+            if (error.code == 401) {
+                logout();
+            } else {
+                emit loginError(tr("Remote logout failed: %1").arg(error.userMessage));
+            }
+        },
+        options);
+}
+
+void AuthenticationService::refreshAuthentication(std::function<void(bool)> completion)
+{
+    if (!m_providerAuthenticator || m_refreshToken.isEmpty()) {
+        completion(false);
+        return;
+    }
+    const auto request = m_providerAuthenticator->createRefreshRequest(m_refreshToken);
+    if (!request.has_value() || !request->isValid()) {
+        completion(false);
+        return;
+    }
+
+    const quint64 generation = m_stateGeneration;
+    const auto sharedCompletion =
+        std::make_shared<std::function<void(bool)>>(std::move(completion));
+    const auto complete = [sharedCompletion](bool success) {
+        if (!*sharedCompletion) {
+            return;
+        }
+        auto callback = std::move(*sharedCompletion);
+        callback(success);
+    };
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::Ignore;
+    m_transport->sendWithRetry(
+        this,
+        request->endpoint,
+        [this, endpoint = request->endpoint, body = request->body]() {
+            return networkManager()->post(createUnauthenticatedRequest(endpoint), body);
+        },
+        [this, generation, complete](QNetworkReply *reply) {
+            if (generation != m_stateGeneration) {
+                complete(false);
+                return;
+            }
+            const ProviderAuthenticationResult authentication =
+                m_providerAuthenticator->parseRefreshResponse(reply->readAll());
+            if (!authentication.isValidRefresh()) {
+                complete(false);
+                return;
+            }
+
+            QString nextAccessToken = authentication.accessToken;
+            QString nextRefreshToken = authentication.refreshToken;
+            m_accessToken.swap(nextAccessToken);
+            m_refreshToken.swap(nextRefreshToken);
+            persistCredentials();
+            complete(true);
+        },
+        [this, generation, complete](const NetworkError &) {
+            if (generation == m_stateGeneration) {
+                complete(false);
+            }
+        },
+        options);
 }
 
 void AuthenticationService::restoreSession(const QString &serverUrl,
@@ -397,28 +1118,58 @@ void AuthenticationService::restoreSession(const QString &serverUrl,
                                            const QString &accessToken,
                                            const QString &username)
 {
+    m_transport->cancelAll();
+    ++m_stateGeneration;
+    const quint64 generation = m_stateGeneration;
     m_serverUrl = normalizeUrl(serverUrl);
     m_userId = userId;
     m_accessToken = accessToken;
     m_username = username;
     m_sessionExpiredPending = false;
     m_sessionExpiredEmitted = false;
-    
-    qCDebug(lcAuth) << "Restoring session for user:" << userId << "on server:" << serverUrl;
-    
-    // Validate the restored session
-    validateAccessToken([this](bool valid) {
-        if (valid) {
-            qCDebug(lcAuth) << "Session restored successfully";
-            emit serverUrlChanged();
-            emit userIdChanged();
-            emit authenticatedChanged();
-            qCCritical(lcAuth) << "=== AuthenticationService: EMITTING loginSuccess from restoreSession ===" << m_userId;
-            emit loginSuccess(m_userId, m_accessToken, m_username);
-        } else {
-            qCWarning(lcAuth) << "Stored session is invalid or expired";
-            logout();
+    updateAuthenticationStep(QStringLiteral("credentials"));
+
+    const auto finishRestore = [this, generation]() {
+        if (generation != m_stateGeneration) {
+            return;
         }
+        if (m_providerAdapter
+            && m_providerAdapter->supportsCapability(ProviderCapability::Profiles)
+            && m_activeConnection.profileId.isEmpty()) {
+            loadProfiles(true);
+        } else {
+            finishAuthentication();
+        }
+    };
+
+    validateAccessToken([this, generation, finishRestore](bool valid) {
+        if (generation != m_stateGeneration) {
+            return;
+        }
+        if (valid) {
+            finishRestore();
+            return;
+        }
+        refreshAuthentication([this, generation, finishRestore](bool refreshed) {
+            if (generation != m_stateGeneration) {
+                return;
+            }
+            if (!refreshed) {
+                qCWarning(lcAuth) << "Stored session is invalid or expired";
+                clearAccountStateInternal(true, true);
+                return;
+            }
+            validateAccessToken([this, generation, finishRestore](bool refreshValid) {
+                if (generation != m_stateGeneration) {
+                    return;
+                }
+                if (refreshValid) {
+                    finishRestore();
+                } else {
+                    clearAccountStateInternal(true, true);
+                }
+            });
+        });
     });
 }
 
@@ -433,58 +1184,109 @@ void AuthenticationService::seedSession(const QString &serverUrl,
     m_username = username;
     m_sessionExpiredPending = false;
     m_sessionExpiredEmitted = false;
-
+    updateAuthenticationStep(QStringLiteral("authenticated"));
     emit serverUrlChanged();
     emit userIdChanged();
-    emit authenticatedChanged();
 }
 
 void AuthenticationService::logout()
 {
-    qCDebug(lcAuth) << "Logging out user:" << m_userId;
-    m_transport->cancelAll();
+    clearAccountStateInternal(true, true);
+}
 
-    ServerConnection connection = m_activeConnection;
-    if (!connection.isValid() && m_configManager) {
-        connection = m_configManager->getActiveConnection().value_or(ServerConnection{});
-    }
-    if (m_secretStore && connection.isValid() && m_configManager) {
-        const QString deviceId = m_configManager->getDeviceId();
-        ConfigManager::SessionData legacySession =
-            m_configManager->getPendingLegacyJellyfinSession();
-        const bool legacyMatchesConnection =
-            ServerConnection::normalizeBaseUrl(legacySession.serverUrl) == connection.baseUrl
-            && legacySession.userId == connection.accountId;
-        if (!legacyMatchesConnection) {
-            legacySession = {};
+void AuthenticationService::clearAccountState()
+{
+    clearAccountStateInternal(true, true);
+}
+
+void AuthenticationService::clearProfileState()
+{
+    clearProfileStateInternal(true);
+}
+
+void AuthenticationService::clearProfileStateInternal(bool persist)
+{
+    const bool wasAuthenticated = isAuthenticated();
+    m_pendingProfileId.clear();
+    m_profileToken.clear();
+    m_activeConnection.profileId.clear();
+    replaceProfiles({});
+    replaceAuthSessions({});
+    if (persist && m_activeConnection.isValid()) {
+        if (m_secretStore) {
+            CredentialStore(m_secretStore).remove(
+                m_activeConnection, CredentialKind::ProfileToken);
         }
-        ISecretStore *store = m_secretStore;
-        QThreadPool::globalInstance()->start(
-            [store, connection, deviceId, legacySession]() {
-                CredentialStore credentials(store);
-                if (!credentials.removeAll(connection,
-                                           deviceId,
-                                           legacySession.serverUrl,
-                                           legacySession.username)) {
-                    qCWarning(lcAuth) << "Failed to remove one or more session credentials:"
-                                      << store->lastError();
-                } else {
-                    qCDebug(lcAuth) << "Session credentials deleted from keychain";
-                }
-            });
+        persistConnection();
+    }
+    m_authenticationStep = m_accessToken.isEmpty()
+        ? QStringLiteral("credentials") : QStringLiteral("profiles");
+    emit authenticationStepChanged();
+    if (wasAuthenticated != isAuthenticated()) {
+        emit authenticatedChanged();
+    }
+}
+
+void AuthenticationService::clearAccountStateInternal(bool removeCredentials,
+                                                       bool emitLogout)
+{
+    const bool wasAuthenticated = isAuthenticated();
+    m_transport->cancelAll();
+    ++m_stateGeneration;
+
+    const ServerConnection connection = m_activeConnection.isValid()
+        ? m_activeConnection
+        : (m_configManager
+               ? m_configManager->getActiveConnection().value_or(ServerConnection{})
+               : ServerConnection{});
+    if (removeCredentials && m_secretStore && connection.isValid()) {
+        CredentialStore credentials(m_secretStore);
+        const QString deviceId = m_configManager ? m_configManager->getDeviceId() : QString();
+        credentials.removeAll(connection, deviceId);
+    }
+    if (m_configManager) {
+        if (removeCredentials && connection.providerKind == ProviderKind::Jellyfin) {
+            m_configManager->clearJellyfinSession();
+        } else {
+            m_configManager->clearActiveConnection();
+        }
     }
 
     m_activeConnection = {};
+    m_detectionResult = {};
     m_accessToken.clear();
+    m_refreshToken.clear();
+    m_profileToken.clear();
     m_userId.clear();
     m_username.clear();
+    m_pendingProfileId.clear();
     m_sessionExpiredPending = false;
     m_sessionExpiredEmitted = false;
-    
+    replaceProfiles({});
+    replaceAuthSessions({});
+    m_authenticationStep = QStringLiteral("credentials");
+    emit authenticationStepChanged();
     emit serverUrlChanged();
     emit userIdChanged();
-    emit authenticatedChanged();
-    emit loggedOut();
+    if (wasAuthenticated) {
+        emit authenticatedChanged();
+    }
+    if (emitLogout) {
+        emit loggedOut();
+    }
+}
+
+void AuthenticationService::updateAuthenticationStep(const QString &step)
+{
+    if (m_authenticationStep == step) {
+        return;
+    }
+    const bool wasAuthenticated = isAuthenticated();
+    m_authenticationStep = step;
+    emit authenticationStepChanged();
+    if (wasAuthenticated != isAuthenticated()) {
+        emit authenticatedChanged();
+    }
 }
 
 void AuthenticationService::checkPendingSessionExpiry()
@@ -502,7 +1304,6 @@ bool AuthenticationService::checkForSessionExpiry(QNetworkReply *reply, bool def
     if (statusCode != 401) {
         return false;
     }
-
     handleUnauthorized(deferLogout);
     return true;
 }
@@ -511,7 +1312,9 @@ void AuthenticationService::handleUnauthorized(bool deferLogout)
 {
     qCWarning(lcAuth) << "Received 401 Unauthorized - session expired";
     if (deferLogout) {
-        m_sessionExpiredPending = true;
+        if (!m_sessionExpiredEmitted) {
+            m_sessionExpiredPending = true;
+        }
     } else if (!m_sessionExpiredEmitted) {
         m_sessionExpiredEmitted = true;
         emit sessionExpired();
@@ -520,32 +1323,41 @@ void AuthenticationService::handleUnauthorized(bool deferLogout)
 
 void AuthenticationService::validateAccessToken(std::function<void(bool)> callback)
 {
-    if (m_accessToken.isEmpty() || m_userId.isEmpty()) {
+    if (!m_providerAuthenticator || m_accessToken.isEmpty() || m_userId.isEmpty()) {
         callback(false);
         return;
     }
-    
     const QString endpoint = m_providerAuthenticator->sessionValidationEndpoint(m_userId);
-    const QNetworkRequest request = createRequest(endpoint);
+    if (endpoint.isEmpty()) {
+        callback(false);
+        return;
+    }
+
+    const auto sharedCallback =
+        std::make_shared<std::function<void(bool)>>(std::move(callback));
+    const auto complete = [sharedCallback](bool valid) {
+        if (!*sharedCallback) {
+            return;
+        }
+        auto resultCallback = std::move(*sharedCallback);
+        resultCallback(valid);
+    };
     HttpRequestOptions options;
     options.retryEnabled = false;
     options.unauthorizedPolicy = UnauthorizedPolicy::Ignore;
-
     m_transport->sendWithRetry(
         this,
         endpoint,
-        [this, request]() {
-            return networkManager()->get(request);
+        [this, endpoint]() {
+            return networkManager()->get(createRequest(endpoint));
         },
-        [callback](QNetworkReply *reply) {
+        [complete](QNetworkReply *reply) {
             const int statusCode = reply->attribute(
                 QNetworkRequest::HttpStatusCodeAttribute).toInt();
-            callback(statusCode == 200);
+            complete(statusCode >= 200 && statusCode < 300);
         },
-        [callback](const NetworkError &error) {
-            qCDebug(lcAuth) << "Token validation failed. Status/error:" << error.code
-                            << error.userMessage;
-            callback(false);
+        [complete](const NetworkError &) {
+            complete(false);
         },
         options);
 }

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -98,7 +98,6 @@ AuthenticationService::~AuthenticationService()
 {
     if (m_transport) {
         disconnect(m_transport, nullptr, this, nullptr);
-        m_transport->cancelAll();
         m_transport->setUrlRedactor({});
         m_transport->setUnauthorizedRecovery({});
     }

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -376,7 +376,9 @@ ProviderRequestContext AuthenticationService::requestContext(bool includeAuthent
         context.accessToken = m_accessToken;
         context.profileId = m_pendingProfileId.isEmpty()
             ? m_activeConnection.profileId : m_pendingProfileId;
-        context.profileToken = m_profileToken;
+        if (!context.profileId.isEmpty()) {
+            context.profileToken = m_profileToken;
+        }
     }
     context.clientName = QStringLiteral("Bloom");
     context.clientVersion = QCoreApplication::applicationVersion();
@@ -504,8 +506,8 @@ void AuthenticationService::probeProviderAndLogin(const QString &username,
                 return;
             }
             const QJsonObject payload = QJsonDocument::fromJson(reply->readAll()).object();
-            if (payload.value(QStringLiteral("status")).toString()
-                != QStringLiteral("ok")) {
+            const auto detected = silo->mapDetectionResult(payload);
+            if (!detected.has_value()) {
                 fallback();
                 return;
             }
@@ -513,18 +515,7 @@ void AuthenticationService::probeProviderAndLogin(const QString &username,
                 fallback();
                 return;
             }
-            if (const auto detected = silo->mapDetectionResult(payload);
-                detected.has_value()) {
-                m_detectionResult = *detected;
-            } else {
-                m_detectionResult = {};
-                m_detectionResult.providerKind = ProviderKind::Silo;
-                m_detectionResult.protocolMode = ProtocolMode::Native;
-                m_detectionResult.serverId =
-                    payload.value(QStringLiteral("server_id")).toString();
-                m_detectionResult.serverName =
-                    payload.value(QStringLiteral("server_name")).toString();
-            }
+            m_detectionResult = *detected;
             performLogin(username, password, generation);
         },
         [fallback](const NetworkError &) {
@@ -595,12 +586,8 @@ void AuthenticationService::handleAuthenticationResult(
     }
 
     m_accessToken = authentication.accessToken;
-    if (!authentication.refreshToken.isEmpty()) {
-        m_refreshToken = authentication.refreshToken;
-    }
-    if (!authentication.profileToken.isEmpty()) {
-        m_profileToken = authentication.profileToken;
-    }
+    m_refreshToken = authentication.refreshToken;
+    m_profileToken = authentication.profileToken;
     m_userId = authentication.accountId;
     if (!authentication.username.isEmpty()) {
         m_username = authentication.username;
@@ -760,6 +747,7 @@ void AuthenticationService::loadProfiles(bool finishWhenUnavailable)
             const auto mapped = m_providerAdapter->mapProfiles(
                 responseArray(reply->readAll(), QStringLiteral("profiles")));
             if (!mapped.has_value()) {
+                replaceProfiles({});
                 emit loginError(tr("The provider returned an invalid profile list."));
                 return;
             }
@@ -778,6 +766,7 @@ void AuthenticationService::loadProfiles(bool finishWhenUnavailable)
         },
         [this, generation](const NetworkError &error) {
             if (generation == m_stateGeneration) {
+                replaceProfiles({});
                 emit loginError(tr("Unable to load profiles: %1").arg(error.userMessage));
             }
         },
@@ -814,7 +803,18 @@ void AuthenticationService::selectProfile(const QString &profileId)
         emit loginError(tr("Unknown profile."));
         return;
     }
+    if (m_transport) {
+        m_transport->cancelAll();
+    }
+    ++m_stateGeneration;
 
+    if (!m_profileToken.isEmpty()) {
+        m_profileToken.clear();
+        if (m_secretStore && m_activeConnection.isValid()) {
+            CredentialStore(m_secretStore).remove(
+                m_activeConnection, CredentialKind::ProfileToken);
+        }
+    }
     m_pendingProfileId = profileId;
     if (profile->hasPin) {
         updateAuthenticationStep(QStringLiteral("pin"));
@@ -825,10 +825,31 @@ void AuthenticationService::selectProfile(const QString &profileId)
 
 void AuthenticationService::verifyProfilePin(const QString &profileId, const QString &pin)
 {
-    if (!m_providerAuthenticator || profileId.isEmpty()) {
+    if (!m_providerAuthenticator || profileId.isEmpty() || m_accessToken.isEmpty()) {
         emit loginError(tr("A profile must be selected."));
         return;
     }
+    const auto profile = std::find_if(
+        m_providerProfiles.cbegin(), m_providerProfiles.cend(),
+        [&profileId](const ProviderProfile &candidate) {
+            return candidate.id == profileId;
+        });
+    if (m_transport) {
+        m_transport->cancelAll();
+    }
+    ++m_stateGeneration;
+    if (profile == m_providerProfiles.cend()) {
+        emit loginError(tr("Unknown profile."));
+        return;
+    }
+    if (!m_profileToken.isEmpty()) {
+        m_profileToken.clear();
+        if (m_secretStore && m_activeConnection.isValid()) {
+            CredentialStore(m_secretStore).remove(
+                m_activeConnection, CredentialKind::ProfileToken);
+        }
+    }
+    m_pendingProfileId = profileId;
     const auto request = m_providerAuthenticator->createProfileLoginRequest(profileId, pin);
     if (!request.has_value() || !request->isValid()) {
         const auto profile = std::find_if(
@@ -930,6 +951,7 @@ void AuthenticationService::loadAuthSessions()
             const auto mapped = m_providerAdapter->mapAuthSessions(
                 responseArray(reply->readAll(), QStringLiteral("sessions")));
             if (!mapped.has_value()) {
+                replaceAuthSessions({});
                 emit loginError(tr("The provider returned an invalid session list."));
                 return;
             }
@@ -937,6 +959,7 @@ void AuthenticationService::loadAuthSessions()
         },
         [this, generation](const NetworkError &error) {
             if (generation == m_stateGeneration) {
+                replaceAuthSessions({});
                 emit loginError(tr("Unable to load authentication sessions: %1")
                                     .arg(error.userMessage));
             }
@@ -1011,6 +1034,7 @@ void AuthenticationService::revokeAuthSession(const QString &sessionId)
         },
         [this, generation](const NetworkError &error) {
             if (generation == m_stateGeneration) {
+                replaceAuthSessions({});
                 emit loginError(tr("Unable to revoke authentication session: %1")
                                     .arg(error.userMessage));
             }
@@ -1121,7 +1145,19 @@ void AuthenticationService::restoreSession(const QString &serverUrl,
     m_transport->cancelAll();
     ++m_stateGeneration;
     const quint64 generation = m_stateGeneration;
-    m_serverUrl = normalizeUrl(serverUrl);
+    const QString normalizedServerUrl = normalizeUrl(serverUrl);
+    const bool switchingAccount = m_activeConnection.isValid()
+        && (m_activeConnection.baseUrl != normalizedServerUrl
+            || m_activeConnection.accountId != userId);
+    if (switchingAccount) {
+        m_refreshToken.clear();
+        m_profileToken.clear();
+        m_pendingProfileId.clear();
+        m_activeConnection.profileId.clear();
+        replaceProfiles({});
+        replaceAuthSessions({});
+    }
+    m_serverUrl = normalizedServerUrl;
     m_userId = userId;
     m_accessToken = accessToken;
     m_username = username;
@@ -1135,7 +1171,9 @@ void AuthenticationService::restoreSession(const QString &serverUrl,
         }
         if (m_providerAdapter
             && m_providerAdapter->supportsCapability(ProviderCapability::Profiles)
-            && m_activeConnection.profileId.isEmpty()) {
+            && (m_activeConnection.profileId.isEmpty() || m_profileToken.isEmpty())) {
+            m_activeConnection.profileId.clear();
+            m_profileToken.clear();
             loadProfiles(true);
         } else {
             finishAuthentication();
@@ -1207,6 +1245,10 @@ void AuthenticationService::clearProfileState()
 void AuthenticationService::clearProfileStateInternal(bool persist)
 {
     const bool wasAuthenticated = isAuthenticated();
+    if (m_transport) {
+        m_transport->cancelAll();
+    }
+    ++m_stateGeneration;
     m_pendingProfileId.clear();
     m_profileToken.clear();
     m_activeConnection.profileId.clear();

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -106,13 +106,12 @@ AuthenticationService::~AuthenticationService()
 
 void AuthenticationService::configureTransport()
 {
-    Q_ASSERT(m_transport);
-    Q_ASSERT(m_providerAdapter);
-    Q_ASSERT(m_requestFactory);
-    Q_ASSERT(m_providerAuthenticator);
     if (!m_transport) {
         return;
     }
+    Q_ASSERT(m_providerAdapter);
+    Q_ASSERT(m_requestFactory);
+    Q_ASSERT(m_providerAuthenticator);
 
     m_transport->setUrlRedactor([this](const QUrl &url) {
         return m_requestFactory ? m_requestFactory->redactedUrl(url) : url.toString();
@@ -350,8 +349,10 @@ void AuthenticationService::initialize(ConfigManager *configManager)
                            result.username);
         } else if (!result.error.isEmpty()) {
             qCWarning(lcAuth) << "Session restoration failed:" << result.error;
+        } else if (result.success) {
+            qCWarning(lcAuth)
+                << "No provider adapter is registered for the stored connection";
         }
-
         if (!result.cleanupError.isEmpty()) {
             qCWarning(lcAuth) << "Legacy credential cleanup failed:"
                               << result.cleanupError;
@@ -425,7 +426,7 @@ void AuthenticationService::setProviderSelection(const QString &selection)
     }
 
     const bool wasAuthenticated = isAuthenticated();
-    clearAccountStateInternal(false, wasAuthenticated);
+    clearAccountStateInternal(true, wasAuthenticated);
     m_providerSelection = normalized;
     emit providerSelectionChanged();
 
@@ -489,7 +490,15 @@ void AuthenticationService::probeProviderAndLogin(const QString &username,
         return;
     }
 
-    const QString endpoint = QStringLiteral("/api/v1/health");
+    if (!m_transport || !networkManager()) {
+        fallback();
+        return;
+    }
+    const auto endpoint = silo->endpointFor(ProviderRoute::Health);
+    if (!endpoint.has_value()) {
+        fallback();
+        return;
+    }
     ProviderRequestContext context = requestContext(false);
     const IProviderRequestFactory *factory = silo->requestFactory();
     HttpRequestOptions options;
@@ -497,8 +506,8 @@ void AuthenticationService::probeProviderAndLogin(const QString &username,
     options.unauthorizedPolicy = UnauthorizedPolicy::Ignore;
     m_transport->sendWithRetry(
         this,
-        endpoint,
-        [this, factory, context, endpoint]() {
+        *endpoint,
+        [this, factory, context, endpoint = *endpoint]() {
             return networkManager()->get(factory->createRequest(context, endpoint));
         },
         [this, silo, username, password, generation, fallback](QNetworkReply *reply) {
@@ -528,12 +537,14 @@ void AuthenticationService::performLogin(const QString &username,
                                           const QString &password,
                                           quint64 generation)
 {
-    if (!m_providerAuthenticator) {
+    if (!m_providerAuthenticator || !m_transport || !networkManager()) {
         emit loginError(tr("Authentication provider is unavailable."));
         return;
     }
     const ProviderAuthenticationRequest authenticationRequest =
-        m_providerAuthenticator->createLoginRequest(username, password);
+        m_providerAuthenticator->createLoginRequest(
+            username, password,
+            m_providerSelection == QStringLiteral("auto") ? QString() : m_providerSelection);
     if (!authenticationRequest.isValid()) {
         emit loginError(tr("The provider cannot create a login request."));
         return;
@@ -718,7 +729,10 @@ void AuthenticationService::finishAuthentication()
 
 void AuthenticationService::loadProfiles(bool finishWhenUnavailable)
 {
-    if (!m_providerAdapter) {
+    if (!m_providerAdapter || !m_transport || !networkManager()) {
+        if (finishWhenUnavailable) {
+            emit loginError(tr("The authentication provider is unavailable."));
+        }
         return;
     }
     const auto endpoint = m_providerAdapter->endpointFor(ProviderRoute::Profiles);
@@ -753,8 +767,9 @@ void AuthenticationService::loadProfiles(bool finishWhenUnavailable)
             }
             replaceProfiles(*mapped);
             if (m_providerProfiles.isEmpty()) {
-                if (finishWhenUnavailable) {
-                    emit loginError(tr("No profiles are available for this account."));
+                emit loginError(tr("No profiles are available for this account."));
+                if (!finishWhenUnavailable) {
+                    updateAuthenticationStep(QStringLiteral("authenticated"));
                 }
                 return;
             }
@@ -825,7 +840,8 @@ void AuthenticationService::selectProfile(const QString &profileId)
 
 void AuthenticationService::verifyProfilePin(const QString &profileId, const QString &pin)
 {
-    if (!m_providerAuthenticator || profileId.isEmpty() || m_accessToken.isEmpty()) {
+    if (!m_providerAuthenticator || profileId.isEmpty() || m_accessToken.isEmpty()
+        || !m_transport || !networkManager()) {
         emit loginError(tr("A profile must be selected."));
         return;
     }
@@ -924,7 +940,7 @@ void AuthenticationService::switchProfile()
 
 void AuthenticationService::loadAuthSessions()
 {
-    if (!isAuthenticated() || !m_providerAdapter) {
+    if (!isAuthenticated() || !m_providerAdapter || !m_transport || !networkManager()) {
         return;
     }
     const auto endpoint = m_providerAdapter->endpointFor(ProviderRoute::AuthSessions);
@@ -989,7 +1005,8 @@ void AuthenticationService::replaceAuthSessions(
 
 void AuthenticationService::revokeAuthSession(const QString &sessionId)
 {
-    if (!isAuthenticated() || !m_providerAdapter || sessionId.isEmpty()) {
+    if (!isAuthenticated() || !m_providerAdapter || !m_transport || !networkManager()
+        || sessionId.isEmpty()) {
         return;
     }
     ProviderRouteContext routeContext;
@@ -1044,21 +1061,24 @@ void AuthenticationService::revokeAuthSession(const QString &sessionId)
 
 void AuthenticationService::remoteLogout()
 {
-    if (m_accessToken.isEmpty() || !m_providerAdapter) {
+    if (m_accessToken.isEmpty() || !m_providerAdapter || !m_transport
+        || !networkManager()) {
         logout();
         return;
     }
-    const QString endpoint = m_providerAdapter->providerKind() == ProviderKind::Silo
-        ? QStringLiteral("/api/v1/auth/logout")
-        : QStringLiteral("/Sessions/Logout");
+    const auto endpoint = m_providerAdapter->endpointFor(ProviderRoute::CallerLogout);
+    if (!endpoint.has_value()) {
+        logout();
+        return;
+    }
     const quint64 generation = m_stateGeneration;
     HttpRequestOptions options;
     options.retryEnabled = false;
     options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
     m_transport->sendWithRetry(
         this,
-        endpoint,
-        [this, endpoint]() {
+        *endpoint,
+        [this, endpoint = *endpoint]() {
             return networkManager()->post(createRequest(endpoint), QByteArray{});
         },
         [this, generation](QNetworkReply *) {
@@ -1081,7 +1101,8 @@ void AuthenticationService::remoteLogout()
 
 void AuthenticationService::refreshAuthentication(std::function<void(bool)> completion)
 {
-    if (!m_providerAuthenticator || m_refreshToken.isEmpty()) {
+    if (!m_providerAuthenticator || m_refreshToken.isEmpty()
+        || !m_transport || !networkManager()) {
         completion(false);
         return;
     }
@@ -1121,11 +1142,10 @@ void AuthenticationService::refreshAuthentication(std::function<void(bool)> comp
                 complete(false);
                 return;
             }
-
-            QString nextAccessToken = authentication.accessToken;
-            QString nextRefreshToken = authentication.refreshToken;
-            m_accessToken.swap(nextAccessToken);
-            m_refreshToken.swap(nextRefreshToken);
+            m_accessToken = authentication.accessToken;
+            if (!authentication.refreshToken.isEmpty()) {
+                m_refreshToken = authentication.refreshToken;
+            }
             persistCredentials();
             complete(true);
         },
@@ -1142,7 +1162,9 @@ void AuthenticationService::restoreSession(const QString &serverUrl,
                                            const QString &accessToken,
                                            const QString &username)
 {
-    m_transport->cancelAll();
+    if (m_transport) {
+        m_transport->cancelAll();
+    }
     ++m_stateGeneration;
     const quint64 generation = m_stateGeneration;
     const QString normalizedServerUrl = normalizeUrl(serverUrl);
@@ -1272,8 +1294,10 @@ void AuthenticationService::clearProfileStateInternal(bool persist)
 void AuthenticationService::clearAccountStateInternal(bool removeCredentials,
                                                        bool emitLogout)
 {
+    if (m_transport) {
+        m_transport->cancelAll();
+    }
     const bool wasAuthenticated = isAuthenticated();
-    m_transport->cancelAll();
     ++m_stateGeneration;
 
     const ServerConnection connection = m_activeConnection.isValid()
@@ -1365,7 +1389,8 @@ void AuthenticationService::handleUnauthorized(bool deferLogout)
 
 void AuthenticationService::validateAccessToken(std::function<void(bool)> callback)
 {
-    if (!m_providerAuthenticator || m_accessToken.isEmpty() || m_userId.isEmpty()) {
+    if (!m_providerAuthenticator || m_accessToken.isEmpty() || m_userId.isEmpty()
+        || !m_transport || !networkManager()) {
         callback(false);
         return;
     }
@@ -1393,10 +1418,13 @@ void AuthenticationService::validateAccessToken(std::function<void(bool)> callba
         [this, endpoint]() {
             return networkManager()->get(createRequest(endpoint));
         },
-        [complete](QNetworkReply *reply) {
+        [this, complete](QNetworkReply *reply) {
             const int statusCode = reply->attribute(
                 QNetworkRequest::HttpStatusCodeAttribute).toInt();
-            complete(statusCode >= 200 && statusCode < 300);
+            const ProviderAuthenticationResult identity =
+                m_providerAuthenticator->parseSessionValidationResponse(reply->readAll());
+            complete(statusCode >= 200 && statusCode < 300
+                     && identity.accountId == m_userId);
         },
         [complete](const NetworkError &) {
             complete(false);

--- a/src/network/AuthenticationService.h
+++ b/src/network/AuthenticationService.h
@@ -1,41 +1,38 @@
 #pragma once
 
-#include <QObject>
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
+#include <QFutureWatcher>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QList>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QObject>
 #include <QString>
 #include <QStringList>
 #include <QVariantList>
 #include <QVariantMap>
+#include <QtConcurrent>
 #include <functional>
 #include <memory>
-#include <QFutureWatcher>
-#include <QtConcurrent>
 
 #include "network/Types.h"
+#include "providers/IProviderAuthenticator.h"
+#include "providers/IProviderRequestFactory.h"
 #include "providers/ServerConnection.h"
 #include "security/CredentialStore.h"
 
+class ICatalogProvider;
 class IPlaybackProvider;
 class IProviderAdapter;
-class IProviderAuthenticator;
-class IProviderRequestFactory;
 class ISecretStore;
 class ConfigManager;
 class HttpTransport;
 
 /**
- * @brief Handles user authentication, session management, and token validation.
- * 
- * This service manages:
- * - Login/logout flows
- * - Session persistence and restoration
- * - Access token validation
- * - Session expiry detection
+ * @brief Stable QML-facing authentication and provider-session facade.
  *
- * Part of the service decomposition formerly handled by the legacy client (Roadmap 1.1).
+ * Provider adapters own wire formats. This service owns provider selection,
+ * persisted connection identity, credentials, profile state, and session expiry.
  */
 class AuthenticationService : public QObject
 {
@@ -44,6 +41,10 @@ class AuthenticationService : public QObject
     Q_PROPERTY(QString userId READ getUserId NOTIFY userIdChanged)
     Q_PROPERTY(bool authenticated READ isAuthenticated NOTIFY authenticatedChanged)
     Q_PROPERTY(bool isRestoringSession READ isRestoringSession NOTIFY isRestoringSessionChanged)
+    Q_PROPERTY(QString providerSelection READ providerSelection WRITE setProviderSelection NOTIFY providerSelectionChanged)
+    Q_PROPERTY(QVariantList profiles READ profiles NOTIFY profilesChanged)
+    Q_PROPERTY(QVariantList authSessions READ authSessions NOTIFY authSessionsChanged)
+    Q_PROPERTY(QString authenticationStep READ authenticationStep NOTIFY authenticationStepChanged)
 
 public:
     explicit AuthenticationService(ISecretStore *secretStore = nullptr, QObject *parent = nullptr);
@@ -51,55 +52,47 @@ public:
                           HttpTransport *transport,
                           IProviderAdapter *providerAdapter,
                           QObject *parent = nullptr);
+    AuthenticationService(ISecretStore *secretStore,
+                          HttpTransport *transport,
+                          const QList<IProviderAdapter *> &providerAdapters,
+                          QObject *parent = nullptr);
     virtual ~AuthenticationService();
-    
-    /**
-     * @brief Initialize service and attempt to restore session asynchronously
-     * @param configManager Pointer to ConfigManager for reading/migrating session data
-     */
-    virtual void initialize(ConfigManager *configManager);
-    
-    /**
-     * @brief Get the ConfigManager instance
-     * @return Pointer to ConfigManager (not owned)
-     */
-    ConfigManager* configManager() const { return m_configManager; }
 
-    /**
-     * @brief Authenticate with username and password
-     * @param serverUrl Jellyfin server URL
-     * @param username User's username
-     * @param password User's password
-     */
-    Q_INVOKABLE virtual void authenticate(const QString &serverUrl, const QString &username, const QString &password);
-    
-    /**
-     * @brief Restore a previously saved session
-     * @param serverUrl Jellyfin server URL
-     * @param userId User ID from previous session
-     * @param accessToken Access token from previous session
-     */
+    virtual void initialize(ConfigManager *configManager);
+    ConfigManager *configManager() const { return m_configManager; }
+
+    Q_INVOKABLE virtual void authenticate(const QString &serverUrl,
+                                          const QString &username,
+                                          const QString &password);
     virtual void restoreSession(const QString &serverUrl,
                                 const QString &userId,
                                 const QString &accessToken,
                                 const QString &username = QString());
-    
-    /**
-     * @brief Log out and clear session data
-     */
     Q_INVOKABLE virtual void logout();
-    
-    /**
-     * @brief Check and emit pending session expiry (call after playback ends)
-     */
+    Q_INVOKABLE void remoteLogout();
+    Q_INVOKABLE void clearAccountState();
+    Q_INVOKABLE void clearProfileState();
+    Q_INVOKABLE void switchProfile();
     Q_INVOKABLE virtual void checkPendingSessionExpiry();
-    
-    // Accessors
+
+    QString providerSelection() const { return m_providerSelection; }
+    QVariantList profiles() const { return m_profiles; }
+    QVariantList authSessions() const { return m_authSessions; }
+    QString authenticationStep() const { return m_authenticationStep; }
+
+    Q_INVOKABLE void setProviderSelection(const QString &selection);
+    Q_INVOKABLE void selectProfile(const QString &profileId);
+    Q_INVOKABLE void verifyProfilePin(const QString &profileId, const QString &pin);
+    Q_INVOKABLE void loadAuthSessions();
+    Q_INVOKABLE void revokeAuthSession(const QString &sessionId);
+
     QString getServerUrl() const { return m_serverUrl; }
     QString getUserId() const { return m_userId; }
     QString getAccessToken() const { return m_accessToken; }
     QString getUsername() const { return m_username; }
     const IPlaybackProvider *playbackProvider() const;
+    const ICatalogProvider *catalogProvider() const;
+    ProviderKind activeProviderKind() const;
     PlaybackInfoResponse mapPlaybackInfo(const QJsonObject &wirePlaybackInfo) const;
     ParsedItemsResult parseItemsResponse(const QByteArray &wireResponse,
                                          const QString &parentId) const;
@@ -120,43 +113,33 @@ public:
     QVariantList mapChaptersFromItem(const QJsonObject &wireItem,
                                      const QString &connectionId,
                                      const QString &itemId) const;
-    bool isAuthenticated() const { return !m_accessToken.isEmpty() && !m_userId.isEmpty(); }
+    bool isAuthenticated() const
+    {
+        return !m_accessToken.isEmpty() && !m_userId.isEmpty()
+            && m_authenticationStep == QStringLiteral("authenticated");
+    }
     bool isRestoringSession() const { return m_isRestoringSession; }
-    
-    /**
-     * @brief Get the shared network access manager
-     * @return Pointer to QNetworkAccessManager (owned by this service)
-     */
-    QNetworkAccessManager* networkManager() const;
-    HttpTransport* transport() const { return m_transport; }
-    
-    /**
-     * @brief Create a network request with authentication headers
-     * @param endpoint API endpoint (will be appended to server URL)
-     * @return Configured QNetworkRequest
-     */
+
+    QNetworkAccessManager *networkManager() const;
+    HttpTransport *transport() const { return m_transport; }
     QNetworkRequest createRequest(const QString &endpoint) const;
-    
-    /**
-     * @brief Check HTTP response for 401 and handle session expiry
-     * @param reply The network reply to check
-     * @param deferLogout If true, defer sessionExpired signal until checkPendingSessionExpiry()
-     * @return true if response was 401 (session expired)
-     */
     bool checkForSessionExpiry(QNetworkReply *reply, bool deferLogout = false);
 
 signals:
     void loginSuccess(const QString &userId, const QString &accessToken, const QString &username);
     void loginError(const QString &error);
     void loggedOut();
-    void sessionExpired();  // Emitted when server returns 401 (token invalid/expired)
-    void sessionExpiredAfterPlayback();  // Emitted after playback ends if session expired during playback
-    
-    // Property change signals
+    void sessionExpired();
+    void sessionExpiredAfterPlayback();
+
     void serverUrlChanged();
     void userIdChanged();
     void authenticatedChanged();
     void isRestoringSessionChanged();
+    void providerSelectionChanged();
+    void profilesChanged();
+    void authSessionsChanged();
+    void authenticationStepChanged();
 
 protected:
     void seedSession(const QString &serverUrl,
@@ -164,48 +147,75 @@ protected:
                      const QString &accessToken,
                      const QString &username = QString());
 
-private slots:
-    void onAuthenticateFinished(QNetworkReply *reply);
-
 private:
     std::unique_ptr<HttpTransport> m_ownedTransport;
     std::unique_ptr<IProviderAdapter> m_ownedProviderAdapter;
+    QList<IProviderAdapter *> m_providerAdapters;
     HttpTransport *m_transport = nullptr;
     IProviderAdapter *m_providerAdapter = nullptr;
     const IProviderRequestFactory *m_requestFactory = nullptr;
     const IProviderAuthenticator *m_providerAuthenticator = nullptr;
     QString m_serverUrl;
     QString m_accessToken;
+    QString m_refreshToken;
+    QString m_profileToken;
     QString m_userId;
     QString m_username;
-    bool m_sessionExpiredPending = false;  // Set when 401 occurs during playback
-    bool m_sessionExpiredEmitted = false;  // Guard against duplicate emissions
-    ISecretStore *m_secretStore;  // Not owned (provided by main)
+    QString m_providerSelection = QStringLiteral("auto");
+    QString m_authenticationStep = QStringLiteral("credentials");
+    QString m_pendingProfileId;
+    QVariantList m_profiles;
+    QVariantList m_authSessions;
+    QList<ProviderProfile> m_providerProfiles;
+    ProviderDetectionResult m_detectionResult;
+    bool m_sessionExpiredPending = false;
+    bool m_sessionExpiredEmitted = false;
+    ISecretStore *m_secretStore = nullptr;
     ServerConnection m_activeConnection;
     bool m_isRestoringSession = false;
-    ConfigManager* m_configManager = nullptr;
-    
-    // Helper struct for async session restoration results
+    ConfigManager *m_configManager = nullptr;
+    quint64 m_stateGeneration = 0;
+
     struct RestorationResult {
         bool success = false;
         QString serverUrl;
         QString userId;
         QString accessToken;
+        QString refreshToken;
+        QString profileToken;
         QString username;
         QString error;
         QString cleanupError;
         ServerConnection connection;
         bool legacyMigrationComplete = false;
     };
-    
+
     QFutureWatcher<RestorationResult> m_restorationWatcher;
-    
-    QString normalizeUrl(const QString &url);
-    void handleUnauthorized(bool deferLogout);
-    
-    /**
-     * @brief Validate the current access token by making a test API call
-     * @param callback Called with true if valid, false if invalid/expired
-     */
+
+    QString normalizeUrl(const QString &url) const;
+    ProviderRequestContext requestContext(bool includeAuthentication = true) const;
+    QNetworkRequest createUnauthenticatedRequest(const QString &endpoint) const;
+    void configureTransport();
+    IProviderAdapter *providerForKind(ProviderKind kind) const;
+    bool activateProvider(IProviderAdapter *adapter);
+    void probeProviderAndLogin(const QString &username,
+                               const QString &password,
+                               quint64 generation);
+    void performLogin(const QString &username,
+                      const QString &password,
+                      quint64 generation);
+    void handleAuthenticationResult(const ProviderAuthenticationResult &authentication,
+                                    quint64 generation);
+    void finishAuthentication();
+    void loadProfiles(bool finishWhenUnavailable);
+    void refreshAuthentication(std::function<void(bool)> completion);
     void validateAccessToken(std::function<void(bool)> callback);
+    void persistConnection();
+    void persistCredentials();
+    void updateAuthenticationStep(const QString &step);
+    void replaceProfiles(const QList<ProviderProfile> &profiles);
+    void replaceAuthSessions(const QList<ProviderAuthSession> &sessions);
+    void clearProfileStateInternal(bool persist);
+    void clearAccountStateInternal(bool removeCredentials, bool emitLogout);
+    void handleUnauthorized(bool deferLogout);
 };

--- a/src/network/HttpTransport.cpp
+++ b/src/network/HttpTransport.cpp
@@ -3,6 +3,8 @@
 #include <QLoggingCategory>
 #include <QNetworkRequest>
 #include <QTimer>
+#include <memory>
+#include <utility>
 #include <QUrl>
 
 Q_LOGGING_CATEGORY(lcHttpTransport, "bloom.network.transport")
@@ -42,11 +44,34 @@ void HttpTransport::setUrlRedactor(UrlRedactor redactor)
     m_urlRedactor = std::move(redactor);
 }
 
+void HttpTransport::setUnauthorizedRecovery(UnauthorizedRecovery recovery)
+{
+    if (!recovery && m_unauthorizedRecoveryInProgress) {
+        ++m_unauthorizedRecoveryGeneration;
+        m_unauthorizedRecoveryInProgress = false;
+        const auto pending = std::exchange(
+            m_pendingUnauthorizedRecoveries,
+            QList<std::function<void(bool)>>{});
+        for (const auto &callback : pending) {
+            callback(false);
+        }
+    }
+    m_unauthorizedRecovery = std::move(recovery);
+}
+
 void HttpTransport::cancelAll()
 {
     const auto handles = findChildren<HttpRequestHandle *>(QString(), Qt::FindDirectChildrenOnly);
     for (HttpRequestHandle *handle : handles) {
         handle->cancel();
+    }
+    ++m_unauthorizedRecoveryGeneration;
+    m_unauthorizedRecoveryInProgress = false;
+    const auto pending = std::exchange(
+        m_pendingUnauthorizedRecoveries,
+        QList<std::function<void(bool)>>{});
+    for (const auto &callback : pending) {
+        callback(false);
     }
 }
 
@@ -73,7 +98,9 @@ HttpRequestHandle *HttpTransport::sendWithRetry(QObject *context,
                  responseHandler,
                  failureHandler,
                  options,
-                 0);
+                 0,
+                 false,
+                 m_authenticationEpoch);
     return handle;
 }
 
@@ -84,7 +111,9 @@ void HttpTransport::startAttempt(const QPointer<HttpRequestHandle> &handle,
                                  const ResponseHandler &responseHandler,
                                  const FailureHandler &failureHandler,
                                  const HttpRequestOptions &options,
-                                 int attemptNumber)
+                                 int attemptNumber,
+                                 bool authenticationRetried,
+                                 quint64 authenticationEpoch)
 {
     if (!handle || !context || handle->isCanceled()) {
         return;
@@ -113,7 +142,8 @@ void HttpTransport::startAttempt(const QPointer<HttpRequestHandle> &handle,
 
     connect(reply, &QNetworkReply::finished, context,
             [this, handle, context, endpoint, requestFactory, responseHandler,
-             failureHandler, options, attemptNumber, reply]() {
+             failureHandler, options, attemptNumber, authenticationRetried,
+             authenticationEpoch, reply]() {
         if (!handle || !context) {
             return;
         }
@@ -139,8 +169,60 @@ void HttpTransport::startAttempt(const QPointer<HttpRequestHandle> &handle,
 
         if (httpStatus == 401) {
             error.code = 401;
+            if (options.unauthorizedPolicy != UnauthorizedPolicy::Ignore
+                && !authenticationRetried
+                && authenticationEpoch < m_authenticationEpoch) {
+                startAttempt(handle,
+                             context,
+                             endpoint,
+                             requestFactory,
+                             responseHandler,
+                             failureHandler,
+                             options,
+                             attemptNumber,
+                             true,
+                             m_authenticationEpoch);
+                return;
+            }
+            if (options.unauthorizedPolicy != UnauthorizedPolicy::Ignore
+                && !authenticationRetried && m_unauthorizedRecovery) {
+                recoverUnauthorized(
+                    [this, handle, context, endpoint, requestFactory, responseHandler,
+                     failureHandler, options, attemptNumber, error](bool recovered) {
+                    if (!handle || !context || handle->isCanceled()) {
+                        return;
+                    }
+                    if (recovered) {
+                        startAttempt(handle,
+                                     context,
+                                     endpoint,
+                                     requestFactory,
+                                     responseHandler,
+                                     failureHandler,
+                                     options,
+                                     attemptNumber,
+                                     true,
+                                     m_authenticationEpoch);
+                        return;
+                    }
+
+                    const bool defer =
+                        options.unauthorizedPolicy == UnauthorizedPolicy::DeferSessionExpiry;
+                    emit unauthorized(defer);
+                    NetworkError sessionError = error;
+                    sessionError.userMessage =
+                        tr("Session expired. Please log in again.");
+                    if (failureHandler) {
+                        failureHandler(sessionError);
+                    }
+                    handle->deleteLater();
+                });
+                return;
+            }
+
             if (options.unauthorizedPolicy != UnauthorizedPolicy::Ignore) {
-                const bool defer = options.unauthorizedPolicy == UnauthorizedPolicy::DeferSessionExpiry;
+                const bool defer =
+                    options.unauthorizedPolicy == UnauthorizedPolicy::DeferSessionExpiry;
                 emit unauthorized(defer);
                 error.userMessage = tr("Session expired. Please log in again.");
             }
@@ -162,7 +244,8 @@ void HttpTransport::startAttempt(const QPointer<HttpRequestHandle> &handle,
                                     << "in" << delayMs << "ms";
             QTimer::singleShot(delayMs, this,
                                [this, handle, context, endpoint, requestFactory,
-                                responseHandler, failureHandler, options, attemptNumber]() {
+                                responseHandler, failureHandler, options, attemptNumber,
+                                authenticationRetried, authenticationEpoch]() {
                 startAttempt(handle,
                              context,
                              endpoint,
@@ -170,7 +253,9 @@ void HttpTransport::startAttempt(const QPointer<HttpRequestHandle> &handle,
                              responseHandler,
                              failureHandler,
                              options,
-                             attemptNumber + 1);
+                             attemptNumber + 1,
+                             authenticationRetried,
+                             authenticationEpoch);
             });
             return;
         }
@@ -179,6 +264,47 @@ void HttpTransport::startAttempt(const QPointer<HttpRequestHandle> &handle,
             failureHandler(error);
         }
         handle->deleteLater();
+    });
+}
+
+void HttpTransport::recoverUnauthorized(std::function<void(bool)> completion)
+{
+    m_pendingUnauthorizedRecoveries.append(std::move(completion));
+    if (m_unauthorizedRecoveryInProgress) {
+        return;
+    }
+
+    if (!m_unauthorizedRecovery) {
+        const auto pending = std::exchange(
+            m_pendingUnauthorizedRecoveries,
+            QList<std::function<void(bool)>>{});
+        for (const auto &callback : pending) {
+            callback(false);
+        }
+        return;
+    }
+
+    m_unauthorizedRecoveryInProgress = true;
+    const quint64 recoveryGeneration = ++m_unauthorizedRecoveryGeneration;
+    const auto completed = std::make_shared<bool>(false);
+    const QPointer<HttpTransport> guardedThis(this);
+    m_unauthorizedRecovery(
+        [guardedThis, completed, recoveryGeneration](bool recovered) {
+        if (!guardedThis || std::exchange(*completed, true)
+            || recoveryGeneration != guardedThis->m_unauthorizedRecoveryGeneration) {
+            return;
+        }
+
+        guardedThis->m_unauthorizedRecoveryInProgress = false;
+        if (recovered) {
+            ++guardedThis->m_authenticationEpoch;
+        }
+        const auto pending = std::exchange(
+            guardedThis->m_pendingUnauthorizedRecoveries,
+            QList<std::function<void(bool)>>{});
+        for (const auto &callback : pending) {
+            callback(recovered);
+        }
     });
 }
 

--- a/src/network/HttpTransport.cpp
+++ b/src/network/HttpTransport.cpp
@@ -1,6 +1,7 @@
 #include "HttpTransport.h"
 
 #include <QLoggingCategory>
+#include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QTimer>
 #include <memory>
@@ -46,7 +47,9 @@ void HttpTransport::setUrlRedactor(UrlRedactor redactor)
 
 void HttpTransport::setUnauthorizedRecovery(UnauthorizedRecovery recovery)
 {
-    if (!recovery && m_unauthorizedRecoveryInProgress) {
+    // A provider/session switch must not let an old refresh replay requests
+    // with credentials belonging to the previous provider.
+    if (m_unauthorizedRecoveryInProgress) {
         ++m_unauthorizedRecoveryGeneration;
         m_unauthorizedRecoveryInProgress = false;
         const auto pending = std::exchange(
@@ -156,7 +159,13 @@ void HttpTransport::startAttempt(const QPointer<HttpRequestHandle> &handle,
             return;
         }
 
-        if (reply->error() == QNetworkReply::NoError) {
+        const int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        const bool isUnauthorized = httpStatus == 401;
+
+        // Some test doubles and custom QNetworkAccessManager implementations
+        // report an HTTP 401 with NoError. Status handling must still take
+        // precedence over the successful-network-error path.
+        if (reply->error() == QNetworkReply::NoError && !isUnauthorized) {
             if (responseHandler) {
                 responseHandler(reply);
             }
@@ -164,10 +173,9 @@ void HttpTransport::startAttempt(const QPointer<HttpRequestHandle> &handle,
             return;
         }
 
-        const int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         NetworkError error = ErrorHandler::createError(reply, endpoint);
 
-        if (httpStatus == 401) {
+        if (isUnauthorized) {
             error.code = 401;
             if (options.unauthorizedPolicy != UnauthorizedPolicy::Ignore
                 && !authenticationRetried

--- a/src/network/HttpTransport.h
+++ b/src/network/HttpTransport.h
@@ -39,8 +39,11 @@ struct HttpRequestOptions {
 /**
  * @brief Shared HTTP execution, retry, cancellation, and error-policy boundary.
  *
- * Request factories remain provider-owned. HttpTransport owns request execution
- * policy and emits a provider-neutral unauthorized signal for session handling.
+ * Request factories remain provider-owned. The factory is invoked again for
+ * every replay, so each invocation must construct the same logical request
+ * (HTTP operation, URL, body, and headers) from its captured request state.
+ * HttpTransport owns request execution policy and emits a provider-neutral
+ * unauthorized signal for session handling.
  */
 class HttpTransport final : public QObject
 {

--- a/src/network/HttpTransport.h
+++ b/src/network/HttpTransport.h
@@ -2,6 +2,7 @@
 
 #include "network/Types.h"
 
+#include <QList>
 #include <QNetworkAccessManager>
 #include <QPointer>
 #include <functional>
@@ -50,12 +51,14 @@ public:
     using ResponseHandler = std::function<void(QNetworkReply *)>;
     using FailureHandler = std::function<void(const NetworkError &)>;
     using UrlRedactor = std::function<QString(const QUrl &)>;
+    using UnauthorizedRecovery = std::function<void(std::function<void(bool)>)>;
 
     explicit HttpTransport(QObject *parent = nullptr);
     explicit HttpTransport(QNetworkAccessManager *networkManager, QObject *parent = nullptr);
 
     QNetworkAccessManager *networkManager() const { return m_networkManager; }
     void setUrlRedactor(UrlRedactor redactor);
+    void setUnauthorizedRecovery(UnauthorizedRecovery recovery);
     void cancelAll();
 
     HttpRequestHandle *sendWithRetry(QObject *context,
@@ -71,6 +74,11 @@ signals:
 private:
     QNetworkAccessManager *m_networkManager = nullptr;
     UrlRedactor m_urlRedactor;
+    UnauthorizedRecovery m_unauthorizedRecovery;
+    bool m_unauthorizedRecoveryInProgress = false;
+    quint64 m_unauthorizedRecoveryGeneration = 0;
+    quint64 m_authenticationEpoch = 0;
+    QList<std::function<void(bool)>> m_pendingUnauthorizedRecoveries;
 
     void startAttempt(const QPointer<HttpRequestHandle> &handle,
                       const QPointer<QObject> &context,
@@ -79,6 +87,9 @@ private:
                       const ResponseHandler &responseHandler,
                       const FailureHandler &failureHandler,
                       const HttpRequestOptions &options,
-                      int attemptNumber);
+                      int attemptNumber,
+                      bool authenticationRetried,
+                      quint64 authenticationEpoch);
+    void recoverUnauthorized(std::function<void(bool)> completion);
     QString redactedEndpoint(const QString &endpoint, const QNetworkReply *reply = nullptr) const;
 };

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -5,14 +5,16 @@
 #include "models/MediaModels.h"
 #include "providers/IPlaybackProvider.h"
 #include "utils/ConfigManager.h"
+#include <QFutureWatcher>
 #include <QJsonObject>
 #include <QTimer>
 #include <QUrl>
+#include <QtConcurrent>
 #include <algorithm>
-#include <QLoggingCategory>
 #include <memory>
 #include <optional>
 #include <utility>
+#include <QLoggingCategory>
 #include "../utils/BloomLogging.h"
 
 namespace {
@@ -299,31 +301,49 @@ void LibraryService::sendCatalogRequest(
                 return;
             }
 
-            ProviderCatalogResponse response = identity.provider->parseResponse(
-                operation, reply->readAll(), responseHeaders(reply));
-            if (!response.valid) {
-                emitCatalogError(
-                    operationName,
-                    response.error.isEmpty()
-                        ? tr("Invalid provider response.") : response.error,
-                    failureHandler,
-                    -2);
-                return;
-            }
+            const QByteArray body = reply->readAll();
+            const QHash<QByteArray, QByteArray> headers = responseHeaders(reply);
+            emit parsingStarted(operationName);
 
-            const QString etag =
-                response.snapshot.value(QStringLiteral("etag")).toString();
-            const QString lastModified =
-                response.snapshot.value(QStringLiteral("lastModified")).toString();
-            if (!etag.isEmpty()) {
-                m_etags.insert(providerRequest.relativeEndpoint, etag);
-            }
-            if (!lastModified.isEmpty()) {
-                m_lastModified.insert(providerRequest.relativeEndpoint, lastModified);
-            }
-            if (responseHandler) {
-                responseHandler(response);
-            }
+            auto *watcher = new QFutureWatcher<ProviderCatalogResponse>(this);
+            connect(watcher, &QFutureWatcher<ProviderCatalogResponse>::finished,
+                    this,
+                    [this, watcher, identity, operationName, operation, providerRequest,
+                     responseHandler = std::move(responseHandler), failureHandler]() mutable {
+                const ProviderCatalogResponse response = watcher->result();
+                watcher->deleteLater();
+                emit parsingFinished(operationName);
+                if (!isCurrent(identity)) {
+                    return;
+                }
+                if (!response.valid) {
+                    emitCatalogError(
+                        operationName,
+                        response.error.isEmpty()
+                            ? tr("Invalid provider response.") : response.error,
+                        failureHandler,
+                        -2);
+                    return;
+                }
+
+                const QString etag =
+                    response.snapshot.value(QStringLiteral("etag")).toString();
+                const QString lastModified =
+                    response.snapshot.value(QStringLiteral("lastModified")).toString();
+                if (!etag.isEmpty()) {
+                    m_etags.insert(providerRequest.relativeEndpoint, etag);
+                }
+                if (!lastModified.isEmpty()) {
+                    m_lastModified.insert(providerRequest.relativeEndpoint, lastModified);
+                }
+                if (responseHandler) {
+                    responseHandler(response);
+                }
+            });
+            watcher->setFuture(QtConcurrent::run(
+                [provider = identity.provider, operation, body, headers]() {
+                    return provider->parseResponse(operation, body, headers);
+                }));
         },
         [this, identity, operationName,
          failureHandler](const NetworkError &transportError) {
@@ -608,18 +628,21 @@ void LibraryService::getHomeBackdropItems(int limit)
         return;
     }
 
-    auto fetchPage = std::make_shared<std::function<void(int)>>();
-    *fetchPage = [this, connectionId, generation, fetchPage](int startIndex) {
+    auto fetchPage =
+        std::make_shared<std::function<void(int, std::optional<QString>)>>();
+    *fetchPage = [this, connectionId, generation, fetchPage](
+                     int startIndex, std::optional<QString> snapshot) {
         if (generation != m_requestGeneration) {
             return;
         }
         ProviderCatalogQuery query = baseCatalogQuery();
         query.startIndex = startIndex;
+        query.snapshot = snapshot;
         sendCatalogRequest(
             QStringLiteral("getHomeBackdropItems"),
             ProviderCatalogOperation::HomeBackdrops,
             query,
-            [this, connectionId, generation, fetchPage, startIndex](
+            [this, connectionId, generation, fetchPage, startIndex, snapshot](
                 const ProviderCatalogResponse &response) {
                 if (!response.rawItems.isEmpty()) {
                     emit homeBackdropItemsLoaded(response.rawItems);
@@ -634,8 +657,14 @@ void LibraryService::getHomeBackdropItems(int limit)
                     && hasMore
                     && !response.rawItems.isEmpty()) {
                     const int nextStart = startIndex + response.rawItems.size();
-                    QTimer::singleShot(250, this, [fetchPage, nextStart]() {
-                        (*fetchPage)(nextStart);
+                    std::optional<QString> nextSnapshot = snapshot;
+                    const QString responseSnapshot =
+                        response.snapshot.value(QStringLiteral("snapshot")).toString();
+                    if (!responseSnapshot.isEmpty()) {
+                        nextSnapshot = responseSnapshot;
+                    }
+                    QTimer::singleShot(250, this, [fetchPage, nextStart, nextSnapshot]() {
+                        (*fetchPage)(nextStart, nextSnapshot);
                     });
                 }
             },
@@ -644,7 +673,7 @@ void LibraryService::getHomeBackdropItems(int limit)
                     connectionId, error.userMessage);
             });
     };
-    (*fetchPage)(0);
+    (*fetchPage)(0, std::nullopt);
 }
 
 void LibraryService::getScreensaverItems(int limit)
@@ -1076,14 +1105,17 @@ void LibraryService::getHeroLibraryItems(int limit,
                                          const QStringList &parentIds,
                                          bool unwatchedOnly)
 {
+    const quint64 heroGeneration = ++m_heroRequestGeneration;
     const QString connectionId = activeConnectionId(m_authService);
     if (!m_authService || !m_authService->isAuthenticated()) {
         emitCatalogError(
             QStringLiteral("getHeroLibraryItems"),
             tr("Not authenticated"),
-            [this, connectionId](const NetworkError &error) {
-                emit canonicalHeroLibraryItemsFailed(
-                    connectionId, error.userMessage);
+            [this, connectionId, heroGeneration](const NetworkError &error) {
+                if (heroGeneration == m_heroRequestGeneration) {
+                    emit canonicalHeroLibraryItemsFailed(
+                        connectionId, error.userMessage);
+                }
             });
         return;
     }
@@ -1108,24 +1140,41 @@ void LibraryService::getHeroLibraryItems(int limit,
             QStringLiteral("getHeroLibraryItems"),
             ProviderCatalogOperation::HeroItems,
             query,
-            [this, connectionId](const ProviderCatalogResponse &response) {
+            [this, connectionId, heroGeneration](
+                const ProviderCatalogResponse &response) {
+                if (heroGeneration != m_heroRequestGeneration) {
+                    return;
+                }
                 emit heroLibraryItemsLoaded(response.rawItems);
                 emit canonicalHeroLibraryItemsLoaded(
                     connectionId,
                     m_authService->mapMediaItems(response.rawItems, connectionId));
             },
-            [this, connectionId](const NetworkError &error) {
-                emit canonicalHeroLibraryItemsFailed(
-                    connectionId, error.userMessage);
+            [this, connectionId, heroGeneration](const NetworkError &error) {
+                if (heroGeneration == m_heroRequestGeneration) {
+                    emit canonicalHeroLibraryItemsFailed(
+                        connectionId, error.userMessage);
+                }
             });
         return;
     }
 
     auto aggregate = std::make_shared<QJsonArray>();
     auto remaining = std::make_shared<int>(ids.size());
-    const auto finish = [this, aggregate, remaining, clampedLimit,
-                         connectionId, generation]() {
-        if (--(*remaining) > 0 || generation != m_requestGeneration) {
+    auto successful = std::make_shared<int>(0);
+    auto failures = std::make_shared<QStringList>();
+    const auto finish = [this, aggregate, remaining, successful, failures,
+                         clampedLimit, connectionId, generation, heroGeneration]() {
+        if (--(*remaining) > 0
+            || generation != m_requestGeneration
+            || heroGeneration != m_heroRequestGeneration) {
+            return;
+        }
+        if (*successful == 0) {
+            const QString message = failures->isEmpty()
+                ? tr("No hero items were available.")
+                : failures->constFirst();
+            emit canonicalHeroLibraryItemsFailed(connectionId, message);
             return;
         }
         QJsonArray items;
@@ -1146,8 +1195,9 @@ void LibraryService::getHeroLibraryItems(int limit,
             QStringLiteral("getHeroLibraryItems"),
             ProviderCatalogOperation::HeroItems,
             query,
-            [aggregate, clampedLimit, finish](
+            [aggregate, successful, clampedLimit, finish](
                 const ProviderCatalogResponse &response) {
+                ++(*successful);
                 for (const QJsonValue &value : response.rawItems) {
                     if (aggregate->size() >= clampedLimit) {
                         break;
@@ -1156,9 +1206,10 @@ void LibraryService::getHeroLibraryItems(int limit,
                 }
                 finish();
             },
-            [this, connectionId, finish](const NetworkError &error) {
-                emit canonicalHeroLibraryItemsFailed(
-                    connectionId, error.userMessage);
+            [failures, finish](const NetworkError &error) {
+                if (!error.userMessage.isEmpty()) {
+                    failures->append(error.userMessage);
+                }
                 finish();
             });
     }
@@ -1166,6 +1217,7 @@ void LibraryService::getHeroLibraryItems(int limit,
 
 void LibraryService::getHeroSeriesOverviews(const QStringList &seriesIds)
 {
+    const quint64 heroGeneration = ++m_heroRequestGeneration;
     const QString connectionId = activeConnectionId(m_authService);
     const quint64 generation = m_requestGeneration;
     QStringList ids;
@@ -1195,8 +1247,11 @@ void LibraryService::getHeroSeriesOverviews(const QStringList &seriesIds)
 
     auto overviews = std::make_shared<QJsonObject>();
     auto remaining = std::make_shared<int>(ids.size());
-    const auto finish = [this, overviews, remaining, connectionId, generation]() {
-        if (--(*remaining) > 0 || generation != m_requestGeneration) {
+    const auto finish = [this, overviews, remaining, connectionId, generation,
+                         heroGeneration]() {
+        if (--(*remaining) > 0
+            || generation != m_requestGeneration
+            || heroGeneration != m_heroRequestGeneration) {
             return;
         }
         emit heroSeriesOverviewsLoaded(*overviews);
@@ -1205,11 +1260,10 @@ void LibraryService::getHeroSeriesOverviews(const QStringList &seriesIds)
     };
     for (const QString &seriesId : ids) {
         ProviderCatalogQuery query = baseCatalogQuery();
-        query.seriesId = seriesId;
         query.itemId = seriesId;
         sendCatalogRequest(
             QStringLiteral("getHeroSeriesOverviews"),
-            ProviderCatalogOperation::HeroOverviews,
+            ProviderCatalogOperation::Item,
             query,
             [this, overviews, finish, seriesId, connectionId](
                 const ProviderCatalogResponse &response) {
@@ -1226,7 +1280,6 @@ void LibraryService::getHeroSeriesOverviews(const QStringList &seriesIds)
             });
     }
 }
-
 QString LibraryService::getActiveConnectionId() const
 {
     return activeConnectionId(m_authService);

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -5,38 +5,17 @@
 #include "models/MediaModels.h"
 #include "providers/IPlaybackProvider.h"
 #include "utils/ConfigManager.h"
-#include <QJsonDocument>
 #include <QJsonObject>
 #include <QTimer>
 #include <QUrl>
-#include <QUrlQuery>
-#include <QSet>
 #include <algorithm>
 #include <QLoggingCategory>
 #include <memory>
 #include <optional>
+#include <utility>
 #include "../utils/BloomLogging.h"
 
 namespace {
-
-const QStringList kItemFields = {
-    "Overview", "ImageTags", "BackdropImageTags", "ParentBackdropImageTags",
-    "Genres", "Studios", "People", "UserData",
-    "ProductionYear", "PremiereDate", "OfficialRating",
-    "RunTimeTicks", "CommunityRating", "ProviderIds"
-};
-
-QString buildItemEndpoint(const QString &userId, const QString &itemId)
-{
-    return QString("/Users/%1/Items/%2?Fields=%3")
-        .arg(userId, itemId, kItemFields.join(","));
-}
-
-QString buildChaptersEndpoint(const QString &userId, const QString &itemId)
-{
-    return QString("/Users/%1/Items/%2?Fields=Chapters&EnableImages=true&EnableImageTypes=Chapter&ImageTypeLimit=100")
-        .arg(userId, itemId);
-}
 
 QString activeConnectionId(const AuthenticationService *authService)
 {
@@ -45,10 +24,11 @@ QString activeConnectionId(const AuthenticationService *authService)
     return connection.has_value() ? connection->connectionId : QString();
 }
 
-bool shouldParseItemsAsync(const QByteArray &data)
+QString activeProfileId(const AuthenticationService *authService)
 {
-    constexpr qsizetype asyncThresholdBytes = 250 * 1024;
-    return data.size() > asyncThresholdBytes;
+    ConfigManager *config = authService ? authService->configManager() : nullptr;
+    const auto connection = config ? config->getActiveConnection() : std::nullopt;
+    return connection.has_value() ? connection->profileId : QString();
 }
 
 QString cachedArtworkSource(const Bloom::ArtworkRef &artwork)
@@ -70,6 +50,23 @@ QStringList sortedList(QStringList values)
     return values;
 }
 
+QStringList metadataStrings(const QVariant &value)
+{
+    if (value.canConvert<QStringList>()) {
+        return value.toStringList();
+    }
+    QStringList result;
+    const QVariantList values = value.toList();
+    result.reserve(values.size());
+    for (const QVariant &entry : values) {
+        const QString text = entry.toString();
+        if (!text.isEmpty()) {
+            result.append(text);
+        }
+    }
+    return result;
+}
+
 QString triStateKey(LibraryItemQuery::TriState state)
 {
     switch (state) {
@@ -83,120 +80,30 @@ QString triStateKey(LibraryItemQuery::TriState state)
     return QStringLiteral("any");
 }
 
-void addJoined(QUrlQuery &urlQuery, const QString &key, const QStringList &values, const QString &separator = QStringLiteral("|"))
+ProviderCatalogTriState providerTriState(LibraryItemQuery::TriState state)
 {
-    const QStringList normalized = sortedList(values);
-    if (!normalized.isEmpty()) {
-        urlQuery.addQueryItem(key, normalized.join(separator));
+    switch (state) {
+    case LibraryItemQuery::TriState::Yes:
+        return ProviderCatalogTriState::Yes;
+    case LibraryItemQuery::TriState::No:
+        return ProviderCatalogTriState::No;
+    case LibraryItemQuery::TriState::Any:
+        return ProviderCatalogTriState::Any;
     }
+    return ProviderCatalogTriState::Any;
 }
 
-void addFields(QUrlQuery &urlQuery, bool includeHeavyFields)
+QHash<QByteArray, QByteArray> responseHeaders(const QNetworkReply *reply)
 {
-    QStringList fields = {
-        "Type",
-        "ParentIndexNumber",
-        "IndexNumber",
-        "LocationType",
-        "ImageTags",
-        "BackdropImageTags",
-        "ParentBackdropImageTags",
-        "ParentBackdropImageItemId",
-        "ParentBackdropItemId",
-        "ParentPrimaryImageTag",
-        "ParentPrimaryImageItemId",
-        "SeriesPrimaryImageTag",
-        "ProductionYear",
-        "PremiereDate",
-        "DateCreated",
-        "ChildCount",
-        "ParentId",
-        "SeasonId",
-        "SeriesId",
-        "SeriesName",
-        "UserData",
-        "RunTimeTicks",
-        "Overview",
-        "CommunityRating",
-        "Studios",
-        "Genres",
-        "Tags",
-        "SpecialEpisodeNumbers",
-        "AirsBeforeSeasonNumber",
-        "AirsAfterSeasonNumber",
-        "AirsBeforeEpisodeNumber"
-    };
-
-    if (includeHeavyFields) {
-        fields.prepend("Path");
-        fields.prepend("MediaSources");
+    QHash<QByteArray, QByteArray> headers;
+    if (!reply) {
+        return headers;
     }
-
-    urlQuery.addQueryItem("Fields", fields.join(","));
-    urlQuery.addQueryItem("EnableImageTypes", "Primary,Backdrop,Thumb,Logo");
-}
-
-QString buildItemsEndpoint(const QString &userId, const LibraryItemQuery &query)
-{
-    QUrl url(QStringLiteral("/Users/%1/Items").arg(userId));
-    QUrlQuery urlQuery;
-
-    if (!query.parentId.isEmpty()) {
-        urlQuery.addQueryItem("ParentId", query.parentId);
+    const auto pairs = reply->rawHeaderPairs();
+    for (const auto &pair : pairs) {
+        headers.insert(pair.first, pair.second);
     }
-    addFields(urlQuery, query.includeHeavyFields);
-    if (query.startIndex > 0) {
-        urlQuery.addQueryItem("StartIndex", QString::number(query.startIndex));
-    }
-    if (query.limit > 0) {
-        urlQuery.addQueryItem("Limit", QString::number(query.limit));
-    }
-    if (!query.searchTerm.trimmed().isEmpty()) {
-        urlQuery.addQueryItem("SearchTerm", query.searchTerm.trimmed());
-    }
-    addJoined(urlQuery, "Genres", query.genres, ",");
-    addJoined(urlQuery, "Tags", query.tags, ",");
-    addJoined(urlQuery, "Studios", query.studios, ",");
-    if (query.minPremiereDate.isValid()) {
-        urlQuery.addQueryItem("MinPremiereDate", query.minPremiereDate.startOfDay(Qt::UTC).toString(Qt::ISODate));
-    }
-    if (query.maxPremiereDate.isValid()) {
-        urlQuery.addQueryItem("MaxPremiereDate", query.maxPremiereDate.endOfDay(Qt::UTC).toString(Qt::ISODate));
-    }
-    if (query.minDateLastSaved.isValid()) {
-        urlQuery.addQueryItem("MinDateLastSaved", query.minDateLastSaved.startOfDay(Qt::UTC).toString(Qt::ISODate));
-    }
-    if (query.watched != LibraryItemQuery::TriState::Any) {
-        urlQuery.addQueryItem("IsPlayed", query.watched == LibraryItemQuery::TriState::Yes ? "true" : "false");
-    }
-    if (query.favorite != LibraryItemQuery::TriState::Any) {
-        urlQuery.addQueryItem("IsFavorite", query.favorite == LibraryItemQuery::TriState::Yes ? "true" : "false");
-    }
-    if (query.minCommunityRating > 0.0) {
-        urlQuery.addQueryItem("MinCommunityRating", QString::number(query.minCommunityRating, 'f', 1));
-    }
-    if (!query.years.isEmpty()) {
-        QStringList years;
-        years.reserve(query.years.size());
-        for (int year : query.years) {
-            if (year > 0) {
-                years.append(QString::number(year));
-            }
-        }
-        addJoined(urlQuery, "Years", years);
-    }
-    addJoined(urlQuery, "IncludeItemTypes", query.includeItemTypes, ",");
-    if (query.recursive) {
-        urlQuery.addQueryItem("Recursive", "true");
-    }
-
-    urlQuery.addQueryItem("SortBy", query.normalizedSortBy());
-    if (!query.sortOrder.isEmpty()) {
-        urlQuery.addQueryItem("SortOrder", query.sortOrder);
-    }
-
-    url.setQuery(urlQuery);
-    return url.toString(QUrl::FullyEncoded);
+    return headers;
 }
 
 }
@@ -243,62 +150,234 @@ LibraryService::LibraryService(AuthenticationService *authService, QObject *pare
     , m_transport(authService ? authService->transport() : nullptr)
     , m_retryPolicy{3, 1000, true}
 {
-    if (m_authService) {
-        const auto clearAccountState = [this]() {
-            m_etags.clear();
-            m_lastModified.clear();
-            m_inFlightChapterRequests.clear();
-            ++m_heroLibraryRequestGeneration;
-        };
-        connect(m_authService, &AuthenticationService::loggedOut,
-                this, clearAccountState);
-        connect(m_authService, &AuthenticationService::loginSuccess,
-                this, [clearAccountState](const QString &, const QString &, const QString &) {
-            clearAccountState();
-        });
+    if (!m_authService) {
+        return;
     }
+
+    const auto invalidateRequests = [this]() {
+        ++m_requestGeneration;
+        for (const QPointer<HttpRequestHandle> &handle : std::as_const(m_catalogRequests)) {
+            if (handle) {
+                handle->cancel();
+            }
+        }
+        m_catalogRequests.clear();
+        m_etags.clear();
+        m_lastModified.clear();
+        m_inFlightChapterRequests.clear();
+    };
+    connect(m_authService, &AuthenticationService::authenticationStepChanged,
+            this, invalidateRequests);
+    connect(m_authService, &AuthenticationService::userIdChanged,
+            this, invalidateRequests);
 }
 
-// ============================================================================
-// Request Helpers
-// ============================================================================
-
-void LibraryService::sendRequestWithRetry(const QString &endpoint,
-                                           RequestFactory requestFactory,
-                                           ResponseHandler responseHandler,
-                                           FailureHandler failureHandler,
-                                           int attemptNumber)
+ProviderCatalogQuery LibraryService::baseCatalogQuery() const
 {
-    Q_UNUSED(attemptNumber)
-    if (!m_transport) {
-        NetworkError error;
-        error.code = -1;
-        error.endpoint = endpoint;
-        error.userMessage = tr("Network transport is unavailable.");
-        if (failureHandler) {
-            failureHandler(error);
-        } else {
-            emitError(error);
-        }
+    ProviderCatalogQuery query;
+    if (m_authService) {
+        query.userId = m_authService->getUserId();
+    }
+    return query;
+}
+
+LibraryService::CatalogRequestIdentity LibraryService::catalogRequestIdentity() const
+{
+    CatalogRequestIdentity identity;
+    identity.generation = m_requestGeneration;
+    identity.connectionId = activeConnectionId(m_authService);
+    identity.userId = m_authService ? m_authService->getUserId() : QString();
+    identity.profileId = activeProfileId(m_authService);
+    identity.provider = m_authService ? m_authService->catalogProvider() : nullptr;
+    return identity;
+}
+
+bool LibraryService::isCurrent(const CatalogRequestIdentity &identity) const
+{
+    return m_authService
+        && m_authService->isAuthenticated()
+        && identity.generation == m_requestGeneration
+        && identity.connectionId == activeConnectionId(m_authService)
+        && identity.userId == m_authService->getUserId()
+        && identity.profileId == activeProfileId(m_authService)
+        && identity.provider == m_authService->catalogProvider();
+}
+
+void LibraryService::sendCatalogRequest(
+    const QString &operationName,
+    ProviderCatalogOperation operation,
+    const ProviderCatalogQuery &query,
+    CatalogResponseHandler responseHandler,
+    FailureHandler failureHandler,
+    CatalogNotModifiedHandler notModifiedHandler)
+{
+    if (!m_authService || !m_authService->isAuthenticated()) {
+        emitCatalogError(operationName, tr("Not authenticated"), std::move(failureHandler));
         return;
+    }
+    if (!m_transport || !m_authService->networkManager()) {
+        emitCatalogError(
+            operationName, tr("Network transport is unavailable."), std::move(failureHandler));
+        return;
+    }
+
+    const CatalogRequestIdentity identity = catalogRequestIdentity();
+    if (!identity.provider) {
+        emitCatalogError(
+            operationName, tr("The active provider has no catalog service."),
+            std::move(failureHandler));
+        return;
+    }
+
+    ProviderCatalogRequest providerRequest =
+        identity.provider->createRequest(operation, query);
+    if (!providerRequest.supported || providerRequest.relativeEndpoint.isEmpty()) {
+        emitCatalogError(
+            operationName,
+            providerRequest.unsupportedReason.isEmpty()
+                ? tr("The active provider does not support this operation.")
+                : providerRequest.unsupportedReason,
+            std::move(failureHandler),
+            -3);
+        return;
+    }
+    if (query.useCacheValidation) {
+        const QString etag = m_etags.value(providerRequest.relativeEndpoint);
+        const QString lastModified = m_lastModified.value(providerRequest.relativeEndpoint);
+        if (!etag.isEmpty()) {
+            providerRequest.extraHeaders.insert(
+                QByteArrayLiteral("If-None-Match"), etag.toUtf8());
+        }
+        if (!lastModified.isEmpty()) {
+            providerRequest.extraHeaders.insert(
+                QByteArrayLiteral("If-Modified-Since"), lastModified.toUtf8());
+        }
     }
 
     HttpRequestOptions options;
     options.retryPolicy = m_retryPolicy;
     options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
-    m_transport->sendWithRetry(
+    HttpRequestHandle *handle = m_transport->sendWithRetry(
         this,
-        endpoint,
-        std::move(requestFactory),
-        std::move(responseHandler),
-        [this, failureHandler = std::move(failureHandler)](const NetworkError &error) {
-            if (failureHandler) {
-                failureHandler(error);
-            } else {
-                emitError(error);
+        providerRequest.relativeEndpoint,
+        [this, identity, providerRequest]() -> QNetworkReply * {
+            if (!isCurrent(identity)) {
+                return nullptr;
+            }
+            QNetworkRequest request =
+                m_authService->createRequest(providerRequest.relativeEndpoint);
+            for (auto it = providerRequest.extraHeaders.cbegin();
+                 it != providerRequest.extraHeaders.cend();
+                 ++it) {
+                request.setRawHeader(it.key(), it.value());
+            }
+            switch (providerRequest.method) {
+            case ProviderHttpMethod::Get:
+                return m_authService->networkManager()->get(request);
+            case ProviderHttpMethod::Post:
+                return m_authService->networkManager()->post(request, providerRequest.body);
+            case ProviderHttpMethod::Put:
+                return m_authService->networkManager()->put(request, providerRequest.body);
+            case ProviderHttpMethod::Delete:
+                return m_authService->networkManager()->deleteResource(request);
+            }
+            return nullptr;
+        },
+        [this, identity, operationName, operation, providerRequest,
+         responseHandler = std::move(responseHandler),
+         failureHandler, notModifiedHandler = std::move(notModifiedHandler)](
+            QNetworkReply *reply) mutable {
+            if (!isCurrent(identity)) {
+                return;
+            }
+            const int status =
+                reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+            if (status == 304) {
+                if (notModifiedHandler) {
+                    notModifiedHandler();
+                }
+                return;
+            }
+
+            ProviderCatalogResponse response = identity.provider->parseResponse(
+                operation, reply->readAll(), responseHeaders(reply));
+            if (!response.valid) {
+                emitCatalogError(
+                    operationName,
+                    response.error.isEmpty()
+                        ? tr("Invalid provider response.") : response.error,
+                    failureHandler,
+                    -2);
+                return;
+            }
+
+            const QString etag =
+                response.snapshot.value(QStringLiteral("etag")).toString();
+            const QString lastModified =
+                response.snapshot.value(QStringLiteral("lastModified")).toString();
+            if (!etag.isEmpty()) {
+                m_etags.insert(providerRequest.relativeEndpoint, etag);
+            }
+            if (!lastModified.isEmpty()) {
+                m_lastModified.insert(providerRequest.relativeEndpoint, lastModified);
+            }
+            if (responseHandler) {
+                responseHandler(response);
             }
         },
+        [this, identity, operationName,
+         failureHandler](const NetworkError &transportError) {
+            if (!isCurrent(identity)) {
+                return;
+            }
+            NetworkError error = transportError;
+            error.endpoint = operationName;
+            if (failureHandler) {
+                failureHandler(error);
+            }
+            emitError(error);
+        },
         options);
+    m_catalogRequests.removeIf(
+        [](const QPointer<HttpRequestHandle> &candidate) { return candidate.isNull(); });
+    m_catalogRequests.append(handle);
+}
+
+void LibraryService::emitCatalogError(
+    const QString &operationName,
+    const QString &message,
+    FailureHandler failureHandler,
+    int code)
+{
+    NetworkError error;
+    error.code = code;
+    error.endpoint = operationName;
+    error.userMessage = message;
+    if (failureHandler) {
+        failureHandler(error);
+    }
+    emitError(error);
+}
+
+void LibraryService::emitItemStateResponse(
+    const QString &itemId,
+    const ProviderCatalogResponse &response)
+{
+    if (response.rawItem.isEmpty()) {
+        return;
+    }
+    QJsonObject state = response.rawItem;
+    if (m_authService
+        && m_authService->activeProviderKind() == ProviderKind::Silo) {
+        const QVariantMap item = m_authService->mapMediaItem(
+            response.rawItem, activeConnectionId(m_authService));
+        const QVariantMap userState =
+            item.value(QStringLiteral("userState")).toMap();
+        if (!userState.isEmpty()) {
+            state = QJsonObject::fromVariantMap(userState);
+        }
+    }
+    emit itemUserDataChanged(itemId, state);
 }
 
 void LibraryService::emitError(const NetworkError &error)
@@ -315,89 +394,25 @@ void LibraryService::emitError(const NetworkError &error)
 
 void LibraryService::getViews()
 {
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getViews";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emitError(error);
-        return;
-    }
-    
     const QString connectionId = activeConnectionId(m_authService);
-    QString endpoint = QString("/Users/%1/Views").arg(m_authService->getUserId());
-    
-    sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            return m_authService->networkManager()->get(request);
-        },
-        [this, connectionId](QNetworkReply *reply) {
-            QByteArray data = reply->readAll();
-            
-            if (shouldParseItemsAsync(data)) {
-                emit parsingStarted("views");
-                
-                auto *watcher = new QFutureWatcher<ParsedItemsResult>(this);
-                connect(watcher, &QFutureWatcher<ParsedItemsResult>::finished, this,
-                        [this, watcher, connectionId]() {
-                    ParsedItemsResult result = watcher->result();
-                    watcher->deleteLater();
-                    
-                    emit parsingFinished("views");
-                    
-                    if (result.success) {
-                        emit viewsLoaded(result.items);
-                        const QVariantList canonicalItems =
-                            m_authService->mapMediaItems(result.items, connectionId);
-                        emit canonicalViewsLoaded(canonicalItems);
-                        emit canonicalViewsLoadedForConnection(connectionId, canonicalItems);
-                    } else {
-                        NetworkError error;
-                        error.endpoint = "getViews";
-                        error.code = -2;
-                        error.userMessage = tr("Failed to parse server response");
-                        emitError(error);
-                    }
-                });
-                
-                const auto parseItemsResponse = m_authService->itemsResponseParser();
-                QFuture<ParsedItemsResult> future = QtConcurrent::run(
-                    [parseItemsResponse, data]() {
-                        return parseItemsResponse
-                            ? parseItemsResponse(data, QString())
-                            : ParsedItemsResult{};
-                    });
-                watcher->setFuture(future);
-            } else {
-                const ParsedItemsResult result =
-                    m_authService->parseItemsResponse(data, QString());
-                if (!result.success) {
-                    NetworkError error;
-                    error.endpoint = "getViews";
-                    error.code = -2;
-                    error.userMessage = tr("Invalid server response");
-                    emitError(error);
-                    return;
-                }
-                const QJsonArray items = result.items;
-                emit viewsLoaded(items);
-                const QVariantList canonicalItems =
-                    m_authService->mapMediaItems(items, connectionId);
-                emit canonicalViewsLoaded(canonicalItems);
-                emit canonicalViewsLoadedForConnection(connectionId, canonicalItems);
-            }
+    ProviderCatalogQuery query = baseCatalogQuery();
+    sendCatalogRequest(
+        QStringLiteral("getViews"),
+        ProviderCatalogOperation::Views,
+        query,
+        [this, connectionId](const ProviderCatalogResponse &response) {
+            emit viewsLoaded(response.rawItems);
+            const QVariantList items =
+                m_authService->mapMediaItems(response.rawItems, connectionId);
+            emit canonicalViewsLoaded(items);
+            emit canonicalViewsLoadedForConnection(connectionId, items);
         });
 }
 
-// ============================================================================
-// Items with Pagination
-// ============================================================================
-
 void LibraryService::getItems(const QString &parentId, int startIndex, int limit,
-                               const QStringList &genres, const QStringList &networks,
-                               const QString &sortBy, const QString &sortOrder,
-                               bool includeHeavyFields, bool useCacheValidation)
+                              const QStringList &genres, const QStringList &networks,
+                              const QString &sortBy, const QString &sortOrder,
+                              bool includeHeavyFields, bool useCacheValidation)
 {
     LibraryItemQuery query;
     query.parentId = parentId;
@@ -414,130 +429,55 @@ void LibraryService::getItems(const QString &parentId, int startIndex, int limit
 
 void LibraryService::getItems(const LibraryItemQuery &query)
 {
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getItems";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emitError(error);
-        return;
-    }
-
     const QString parentId = query.parentId;
     const QString queryKey = query.requestKey.isEmpty() ? query.cacheKey() : query.requestKey;
     const QString connectionId = activeConnectionId(m_authService);
-    const QString endpoint = buildItemsEndpoint(m_authService->getUserId(), query);
-    
-    sendRequestWithRetry(endpoint,
-        [this, endpoint, query]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            if (query.useCacheValidation) {
-                if (m_etags.contains(endpoint)) {
-                    request.setRawHeader("If-None-Match", m_etags.value(endpoint).toUtf8());
-                }
-                if (m_lastModified.contains(endpoint)) {
-                    request.setRawHeader("If-Modified-Since", m_lastModified.value(endpoint).toUtf8());
-                }
-            }
-            return m_authService->networkManager()->get(request);
-        },
-        [this, parentId, endpoint, query, queryKey, connectionId](QNetworkReply *reply) {
-            QByteArray data = reply->readAll();
-            int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-            if (httpStatus == 304 && query.useCacheValidation) {
-                emit itemsNotModified(parentId);
-                emit itemsNotModifiedForQuery(parentId, queryKey);
-                emit canonicalItemsNotModifiedForConnection(connectionId, parentId, queryKey);
-                return;
-            }
 
-            if (query.useCacheValidation) {
-                QByteArray etag = reply->rawHeader("ETag");
-                if (!etag.isEmpty()) {
-                    m_etags[endpoint] = QString::fromUtf8(etag);
-                }
-                QByteArray lastMod = reply->rawHeader("Last-Modified");
-                if (!lastMod.isEmpty()) {
-                    m_lastModified[endpoint] = QString::fromUtf8(lastMod);
-                }
-            }
-            
-            if (shouldParseItemsAsync(data)) {
-                emit parsingStarted("library");
-                
-                auto *watcher = new QFutureWatcher<ParsedItemsResult>(this);
-                connect(watcher, &QFutureWatcher<ParsedItemsResult>::finished, this,
-                        [this, watcher, connectionId]() {
-                    ParsedItemsResult result = watcher->result();
-                    watcher->deleteLater();
-                    emit parsingFinished("library");
-                    
-                    if (result.success) {
-                        emit itemsLoaded(result.parentId, result.items);
-                        emit itemsLoadedWithTotal(result.parentId, result.items, result.totalRecordCount);
-                        emit itemsLoadedWithTotalForQuery(result.parentId, result.queryKey, result.items, result.totalRecordCount);
-                        const QVariantList canonicalItems =
-                            m_authService->mapMediaItems(result.items, connectionId);
-                        emit canonicalItemsLoadedWithTotalForQuery(
-                            result.parentId,
-                            result.queryKey,
-                            canonicalItems,
-                            result.totalRecordCount);
-                        emit canonicalItemsLoadedForConnection(
-                            connectionId,
-                            result.parentId,
-                            result.queryKey,
-                            canonicalItems,
-                            result.totalRecordCount);
-                    } else {
-                        NetworkError error;
-                        error.endpoint = "getItems";
-                        error.code = -2;
-                        error.userMessage = tr("Failed to parse library data");
-                        emitError(error);
-                    }
-                });
-                
-                const auto parseItemsResponse = m_authService->itemsResponseParser();
-                QFuture<ParsedItemsResult> future = QtConcurrent::run(
-                    [parseItemsResponse, data, parentId, queryKey]() {
-                        auto result = parseItemsResponse
-                            ? parseItemsResponse(data, parentId)
-                            : ParsedItemsResult{};
-                        result.queryKey = queryKey;
-                        return result;
-                    });
-                watcher->setFuture(future);
-            } else {
-                const ParsedItemsResult result =
-                    m_authService->parseItemsResponse(data, parentId);
-                if (!result.success) {
-                    NetworkError error;
-                    error.endpoint = "getItems";
-                    error.code = -2;
-                    error.userMessage = tr("Invalid library response");
-                    emitError(error);
-                    return;
-                }
-                const QJsonArray items = result.items;
-                const int totalRecordCount = result.totalRecordCount;
-                emit itemsLoaded(parentId, items);
-                emit itemsLoadedWithTotal(parentId, items, totalRecordCount);
-                emit itemsLoadedWithTotalForQuery(parentId, queryKey, items, totalRecordCount);
-                const QVariantList canonicalItems =
-                    m_authService->mapMediaItems(items, connectionId);
-                emit canonicalItemsLoadedWithTotalForQuery(
-                    parentId,
-                    queryKey,
-                    canonicalItems,
-                    totalRecordCount);
-                emit canonicalItemsLoadedForConnection(
-                    connectionId,
-                    parentId,
-                    queryKey,
-                    canonicalItems,
-                    totalRecordCount);
-            }
+    ProviderCatalogQuery providerQuery = baseCatalogQuery();
+    providerQuery.parentId = query.parentId;
+    providerQuery.startIndex = query.startIndex;
+    providerQuery.limit = query.limit;
+    providerQuery.searchTerm = query.searchTerm;
+    providerQuery.genres = query.genres;
+    providerQuery.tags = query.tags;
+    providerQuery.studios = query.studios;
+    providerQuery.minPremiereDate = query.minPremiereDate;
+    providerQuery.maxPremiereDate = query.maxPremiereDate;
+    providerQuery.minDateLastSaved = query.minDateLastSaved;
+    providerQuery.watched = providerTriState(query.watched);
+    providerQuery.favorite = providerTriState(query.favorite);
+    providerQuery.minCommunityRating = query.minCommunityRating;
+    providerQuery.years = query.years;
+    providerQuery.sortBy = query.sortBy;
+    providerQuery.sortOrder = query.sortOrder;
+    providerQuery.includeItemTypes = query.includeItemTypes;
+    providerQuery.recursive = query.recursive;
+    providerQuery.includeHeavyFields = query.includeHeavyFields;
+    providerQuery.useCacheValidation = query.useCacheValidation;
+
+    sendCatalogRequest(
+        QStringLiteral("getItems"),
+        ProviderCatalogOperation::Items,
+        providerQuery,
+        [this, parentId, queryKey, connectionId](
+            const ProviderCatalogResponse &response) {
+            emit itemsLoaded(parentId, response.rawItems);
+            emit itemsLoadedWithTotal(parentId, response.rawItems, response.total);
+            emit itemsLoadedWithTotalForQuery(
+                parentId, queryKey, response.rawItems, response.total);
+            const QVariantList items =
+                m_authService->mapMediaItems(response.rawItems, connectionId);
+            emit canonicalItemsLoadedWithTotalForQuery(
+                parentId, queryKey, items, response.total);
+            emit canonicalItemsLoadedForConnection(
+                connectionId, parentId, queryKey, items, response.total);
+        },
+        FailureHandler(),
+        [this, parentId, queryKey, connectionId]() {
+            emit itemsNotModified(parentId);
+            emit itemsNotModifiedForQuery(parentId, queryKey);
+            emit canonicalItemsNotModifiedForConnection(
+                connectionId, parentId, queryKey);
         });
 }
 
@@ -545,371 +485,181 @@ void LibraryService::getFilterOptions(const QString &parentId,
                                       const QStringList &includeItemTypes,
                                       bool recursive)
 {
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getFilterOptions";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emitError(error);
+    if (!m_authService || !m_authService->isAuthenticated()) {
+        emitCatalogError(
+            QStringLiteral("getFilterOptions"), tr("Not authenticated"));
         return;
     }
-
-    auto buildFacetEndpoint = [this, parentId, includeItemTypes, recursive](const QString &path) {
-        QUrl url(path);
-        QUrlQuery query;
-        query.addQueryItem("UserId", m_authService->getUserId());
-        if (!parentId.isEmpty()) {
-            query.addQueryItem("ParentId", parentId);
-        }
-        if (!includeItemTypes.isEmpty()) {
-            query.addQueryItem("IncludeItemTypes", includeItemTypes.join(","));
-        }
-        if (recursive) {
-            query.addQueryItem("Recursive", "true");
-        }
-        query.addQueryItem("Limit", "500");
-        url.setQuery(query);
-        return url.toString(QUrl::FullyEncoded);
+    const QStringList facets = {
+        QString(),
+        QStringLiteral("genres"),
+        QStringLiteral("studios")
     };
-
-    const QString filtersEndpoint = buildFacetEndpoint("/Items/Filters");
-    const QString genresEndpoint = buildFacetEndpoint("/Genres");
-    const QString studiosEndpoint = buildFacetEndpoint("/Studios");
-
     auto state = std::make_shared<QHash<QString, QStringList>>();
-    auto remaining = std::make_shared<int>(3);
-    auto finish = [this, parentId, state, remaining]() {
-        --(*remaining);
-        if (*remaining > 0) {
+    auto remaining = std::make_shared<int>(facets.size());
+    const auto finish = [this, parentId, state, remaining]() {
+        if (--(*remaining) > 0) {
             return;
         }
-        QStringList genres = state->value("genres");
-        genres.append(state->value("filterGenres"));
-        QStringList tags = state->value("tags");
-        QStringList studios = state->value("studios");
-        genres = sortedList(genres);
-        tags = sortedList(tags);
-        studios = sortedList(studios);
-        emit filterOptionsLoaded(parentId, genres, tags, studios);
+        QStringList genres = state->value(QStringLiteral("genres"));
+        genres.append(state->value(QStringLiteral("filterGenres")));
+        emit filterOptionsLoaded(
+            parentId,
+            sortedList(genres),
+            sortedList(state->value(QStringLiteral("tags"))),
+            sortedList(state->value(QStringLiteral("studios"))));
     };
 
-    sendRequestWithRetry(filtersEndpoint,
-        [this, filtersEndpoint]() {
-            return m_authService->networkManager()->get(m_authService->createRequest(filtersEndpoint));
-        },
-        [this, state, finish](QNetworkReply *reply) {
-            const QVariantMap options = m_authService->mapFilterOptions(
-                QJsonDocument::fromJson(reply->readAll()).object());
-            state->insert("filterGenres", options.value(QStringLiteral("genres")).toStringList());
-            state->insert("tags", options.value(QStringLiteral("tags")).toStringList());
-            finish();
-        },
-        [finish](const NetworkError &) {
-            finish();
-        });
-
-    sendRequestWithRetry(genresEndpoint,
-        [this, genresEndpoint]() {
-            return m_authService->networkManager()->get(m_authService->createRequest(genresEndpoint));
-        },
-        [this, state, finish](QNetworkReply *reply) {
-            state->insert("genres", m_authService->mapNamedItems(
-                QJsonDocument::fromJson(reply->readAll()).object()));
-            finish();
-        },
-        [finish](const NetworkError &) {
-            finish();
-        });
-
-    sendRequestWithRetry(studiosEndpoint,
-        [this, studiosEndpoint]() {
-            return m_authService->networkManager()->get(m_authService->createRequest(studiosEndpoint));
-        },
-        [this, state, finish](QNetworkReply *reply) {
-            state->insert("studios", m_authService->mapNamedItems(
-                QJsonDocument::fromJson(reply->readAll()).object()));
-            finish();
-        },
-        [finish](const NetworkError &) {
-            finish();
-        });
+    for (const QString &facet : facets) {
+        ProviderCatalogQuery providerQuery = baseCatalogQuery();
+        providerQuery.parentId = parentId;
+        providerQuery.includeItemTypes = includeItemTypes;
+        providerQuery.recursive = recursive;
+        providerQuery.filterFacet = facet;
+        sendCatalogRequest(
+            QStringLiteral("getFilterOptions"),
+            ProviderCatalogOperation::FilterOptions,
+            providerQuery,
+            [state, finish, facet](const ProviderCatalogResponse &response) {
+                if (facet.isEmpty()) {
+                    state->insert(
+                        QStringLiteral("filterGenres"),
+                        metadataStrings(response.filterMetadata.value(
+                            QStringLiteral("genres"))));
+                    state->insert(
+                        QStringLiteral("tags"),
+                        metadataStrings(response.filterMetadata.value(
+                            QStringLiteral("tags"))));
+                    const QStringList studios = metadataStrings(
+                        response.filterMetadata.value(QStringLiteral("studios")));
+                    if (!studios.isEmpty()) {
+                        state->insert(QStringLiteral("studios"), studios);
+                    }
+                } else {
+                    state->insert(
+                        facet,
+                        metadataStrings(response.filterMetadata.value(
+                            QStringLiteral("namedItems"))));
+                }
+                finish();
+            },
+            [finish](const NetworkError &) {
+                finish();
+            });
+    }
 }
-
-// ============================================================================
-// Next Up & Latest Media
-// ============================================================================
 
 void LibraryService::getNextUp()
 {
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getNextUp";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emitError(error);
-        return;
-    }
-    
     const QString connectionId = activeConnectionId(m_authService);
-    QString endpoint = QString("/Shows/NextUp?UserId=%1&Limit=10&Fields=Path,Overview,SeriesName,ImageTags,ParentId,SeriesId,SeriesPrimaryImageTag,SeriesThumbImageTag,ParentThumbItemId,ParentThumbImageTag,ParentPrimaryImageTag,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,UserData,RunTimeTicks&EnableImageTypes=Primary,Thumb,Backdrop,Logo")
-        .arg(m_authService->getUserId());
-    
-    sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            return m_authService->networkManager()->get(request);
-        },
-        [this, connectionId](QNetworkReply *reply) {
-            QByteArray data = reply->readAll();
-            QJsonDocument doc = QJsonDocument::fromJson(data);
-            if (!doc.isObject()) {
-                NetworkError error;
-                error.endpoint = "getNextUp";
-                error.code = -2;
-                error.userMessage = tr("Invalid next up response");
-                emitError(error);
-                return;
-            }
-            const QJsonArray items =
-                m_authService->parseItemsResponse(data, QString()).items;
-            emit nextUpLoaded(items);
+    sendCatalogRequest(
+        QStringLiteral("getNextUp"),
+        ProviderCatalogOperation::NextUp,
+        baseCatalogQuery(),
+        [this, connectionId](const ProviderCatalogResponse &response) {
+            emit nextUpLoaded(response.rawItems);
             emit canonicalNextUpLoaded(
-                connectionId, m_authService->mapMediaItems(items, connectionId));
+                connectionId,
+                m_authService->mapMediaItems(response.rawItems, connectionId));
         });
 }
 
 void LibraryService::getLatestMedia(const QString &parentId)
 {
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getLatestMedia";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emitError(error);
-        return;
-    }
-    
     const QString connectionId = activeConnectionId(m_authService);
-    QString endpoint = QString("/Users/%1/Items/Latest?ParentId=%2&Limit=10&Fields=Path,Overview,SeriesName,ImageTags,ParentId,SeriesId,SeriesPrimaryImageTag,SeriesThumbImageTag,ParentThumbItemId,ParentThumbImageTag,ParentPrimaryImageTag,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,ProductionYear,Status,EndDate,ParentIndexNumber,IndexNumber,UserData,RunTimeTicks&EnableImageTypes=Primary,Backdrop,Thumb,Logo")
-        .arg(m_authService->getUserId(), parentId);
-    
-    sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            return m_authService->networkManager()->get(request);
-        },
-        [this, parentId, connectionId](QNetworkReply *reply) {
-            QByteArray data = reply->readAll();
-            QJsonDocument doc = QJsonDocument::fromJson(data);
-            if (!doc.isArray()) {
-                NetworkError error;
-                error.endpoint = "getLatestMedia";
-                error.code = -2;
-                error.userMessage = tr("Invalid latest media response");
-                emitError(error);
-                return;
-            }
-            QJsonArray items = doc.array();
-            emit latestMediaLoaded(parentId, items);
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.parentId = parentId;
+    sendCatalogRequest(
+        QStringLiteral("getLatestMedia"),
+        ProviderCatalogOperation::LatestMedia,
+        query,
+        [this, parentId, connectionId](const ProviderCatalogResponse &response) {
+            emit latestMediaLoaded(parentId, response.rawItems);
             emit canonicalLatestMediaLoaded(
-                connectionId, parentId, m_authService->mapMediaItems(items, connectionId));
+                connectionId,
+                parentId,
+                m_authService->mapMediaItems(response.rawItems, connectionId));
         });
 }
 
 void LibraryService::getHomeBackdropItems(int limit)
 {
     const QString connectionId = activeConnectionId(m_authService);
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getHomeBackdropItems";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emit canonicalHomeBackdropItemsFailed(connectionId, error.userMessage);
-        emitError(error);
-        return;
-    }
+    const quint64 generation = m_requestGeneration;
+    const int requestedLimit = limit > 0 ? qBound(50, limit, 20000) : 0;
 
-    const QStringList fields = {
-        "Id",
-        "ImageTags",
-        "BackdropImageTags",
-        "ParentBackdropImageTags",
-        "ParentBackdropItemId",
-        "SeriesId"
-    };
-    const int requestedLimit = (limit > 0) ? qBound(50, limit, 20000) : 0;
-
-    // Fast starter query: small random sample so Home can show a backdrop quickly.
     if (requestedLimit > 0) {
-        QString endpoint = QString("/Users/%1/Items?Recursive=true&IncludeItemTypes=Movie,Series,Season,Episode&SortBy=Random&Fields=%2&EnableImages=true&EnableImageTypes=Backdrop&ImageTypeLimit=1&EnableTotalRecordCount=false&Limit=%3")
-                               .arg(m_authService->getUserId())
-                               .arg(fields.join(","))
-                               .arg(requestedLimit);
-
-        sendRequestWithRetry(endpoint,
-            [this, endpoint]() {
-                QNetworkRequest request = m_authService->createRequest(endpoint);
-                return m_authService->networkManager()->get(request);
-            },
-            [this, requestedLimit, connectionId](QNetworkReply *reply) {
-                QByteArray data = reply->readAll();
-                QJsonDocument doc = QJsonDocument::fromJson(data);
-                if (!doc.isObject()) {
-                    NetworkError error;
-                    error.endpoint = "getHomeBackdropItems";
-                    error.code = -2;
-                    error.userMessage = tr("Invalid home backdrop response");
-                    emit canonicalHomeBackdropItemsFailed(connectionId, error.userMessage);
-                    emitError(error);
-                    return;
-                }
-                const QJsonArray items =
-                    m_authService->parseItemsResponse(data, QString()).items;
-                qCDebug(lcLibrary) << "getHomeBackdropItems starter sample size:" << items.size()
-                                        << "requestedLimit:" << requestedLimit;
-                emit homeBackdropItemsLoaded(items);
+        ProviderCatalogQuery query = baseCatalogQuery();
+        query.limit = requestedLimit;
+        sendCatalogRequest(
+            QStringLiteral("getHomeBackdropItems"),
+            ProviderCatalogOperation::HomeBackdrops,
+            query,
+            [this, connectionId](const ProviderCatalogResponse &response) {
+                emit homeBackdropItemsLoaded(response.rawItems);
                 emit canonicalHomeBackdropItemsLoaded(
-                    connectionId, m_authService->mapMediaItems(items, connectionId));
+                    connectionId,
+                    m_authService->mapMediaItems(response.rawItems, connectionId));
             },
             [this, connectionId](const NetworkError &error) {
-                emit canonicalHomeBackdropItemsFailed(connectionId, error.userMessage);
-                emitError(error);
+                emit canonicalHomeBackdropItemsFailed(
+                    connectionId, error.userMessage);
             });
         return;
     }
 
-    const int pageSize = 250;
-    const int pageDelayMs = 250;
-
-    auto aggregate = std::make_shared<QJsonArray>();
     auto fetchPage = std::make_shared<std::function<void(int)>>();
-    *fetchPage = [this, fields, pageSize, requestedLimit, aggregate, fetchPage, connectionId](int startIndex) {
-        if (activeConnectionId(m_authService) != connectionId) {
+    *fetchPage = [this, connectionId, generation, fetchPage](int startIndex) {
+        if (generation != m_requestGeneration) {
             return;
         }
-        QString endpoint = QString("/Users/%1/Items?Recursive=true&IncludeItemTypes=Movie,Series,Season,Episode&SortBy=SortName&Fields=%2&EnableImages=true&EnableImageTypes=Backdrop&ImageTypeLimit=1&EnableTotalRecordCount=false&StartIndex=%3&Limit=%4")
-                               .arg(m_authService->getUserId())
-                               .arg(fields.join(","))
-                               .arg(startIndex)
-                               .arg(pageSize);
-
-        sendRequestWithRetry(endpoint,
-            [this, endpoint]() {
-                QNetworkRequest request = m_authService->createRequest(endpoint);
-                return m_authService->networkManager()->get(request);
-            },
-            [this, startIndex, pageSize, requestedLimit, aggregate, fetchPage, connectionId](QNetworkReply *reply) {
-                QByteArray data = reply->readAll();
-                QJsonDocument doc = QJsonDocument::fromJson(data);
-                if (!doc.isObject()) {
-                    NetworkError error;
-                    error.endpoint = "getHomeBackdropItems";
-                    error.code = -2;
-                    error.userMessage = tr("Invalid home backdrop response");
-                    emit canonicalHomeBackdropItemsFailed(connectionId, error.userMessage);
-                    emitError(error);
-                    return;
-                }
-
-                const QJsonArray pageItems =
-                    m_authService->parseItemsResponse(data, QString()).items;
-                qCDebug(lcLibrary) << "getHomeBackdropItems page startIndex:" << startIndex
-                                        << "pageItems:" << pageItems.size()
-                                        << "requestedLimit:" << requestedLimit;
-
-                // Emit progressively so Home can render backdrops immediately.
-                if (!pageItems.isEmpty()) {
-                    emit homeBackdropItemsLoaded(pageItems);
+        ProviderCatalogQuery query = baseCatalogQuery();
+        query.startIndex = startIndex;
+        sendCatalogRequest(
+            QStringLiteral("getHomeBackdropItems"),
+            ProviderCatalogOperation::HomeBackdrops,
+            query,
+            [this, connectionId, generation, fetchPage, startIndex](
+                const ProviderCatalogResponse &response) {
+                if (!response.rawItems.isEmpty()) {
+                    emit homeBackdropItemsLoaded(response.rawItems);
                     emit canonicalHomeBackdropItemsLoaded(
-                        connectionId, m_authService->mapMediaItems(pageItems, connectionId));
+                        connectionId,
+                        m_authService->mapMediaItems(response.rawItems, connectionId));
                 }
-
-                for (const QJsonValue &value : pageItems) {
-                    aggregate->append(value);
+                const bool hasMore = response.hasMore
+                    || (m_authService->activeProviderKind() == ProviderKind::Jellyfin
+                        && response.rawItems.size() == 250);
+                if (generation == m_requestGeneration
+                    && hasMore
+                    && !response.rawItems.isEmpty()) {
+                    const int nextStart = startIndex + response.rawItems.size();
+                    QTimer::singleShot(250, this, [fetchPage, nextStart]() {
+                        (*fetchPage)(nextStart);
+                    });
                 }
-
-                const bool reachedRequestedLimit = requestedLimit > 0 && aggregate->size() >= requestedLimit;
-                const bool reachedServerEndByPage = pageItems.size() < pageSize;
-
-                if (reachedRequestedLimit || reachedServerEndByPage) {
-                    qCDebug(lcLibrary) << "getHomeBackdropItems completed aggregate size:" << aggregate->size()
-                                            << "requestedLimit:" << requestedLimit;
-                    return;
-                }
-
-                const int nextStart = startIndex + pageItems.size();
-                QTimer::singleShot(pageDelayMs, this, [fetchPage, nextStart]() {
-                    (*fetchPage)(nextStart);
-                });
             },
             [this, connectionId](const NetworkError &error) {
-                emit canonicalHomeBackdropItemsFailed(connectionId, error.userMessage);
-                emitError(error);
+                emit canonicalHomeBackdropItemsFailed(
+                    connectionId, error.userMessage);
             });
     };
-
     (*fetchPage)(0);
 }
 
 void LibraryService::getScreensaverItems(int limit)
 {
     const QString connectionId = activeConnectionId(m_authService);
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getScreensaverItems";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emit canonicalScreensaverItemsFailed(connectionId, error.userMessage);
-        emitError(error);
-        return;
-    }
-
-    const int requestedLimit = qBound(10, limit > 0 ? limit : 80, 200);
-    const QString requestUserId = m_authService->getUserId();
-    const QStringList fields = {
-        "Id",
-        "Name",
-        "Overview",
-        "Type",
-        "SeriesName",
-        "SeriesId",
-        "ImageTags",
-        "BackdropImageTags",
-        "ParentBackdropImageTags",
-        "ParentBackdropItemId",
-        "ParentId",
-        "ProductionYear"
-    };
-
-    const QString endpoint = QString("/Users/%1/Items?Recursive=true&IncludeItemTypes=Movie,Series&SortBy=Random&Fields=%2&EnableImages=true&EnableImageTypes=Backdrop,Logo&ImageTypeLimit=1&EnableTotalRecordCount=false&Limit=%3")
-                                 .arg(requestUserId)
-                                 .arg(fields.join(","))
-                                 .arg(requestedLimit);
-
-    sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            return m_authService->networkManager()->get(request);
-        },
-        [this, connectionId, requestUserId](QNetworkReply *reply) {
-            if (!m_authService->isAuthenticated() || m_authService->getUserId() != requestUserId) {
-                return;
-            }
-            const ParsedItemsResult response =
-                m_authService->parseItemsResponse(reply->readAll(), QString());
-            if (!response.success) {
-                NetworkError error;
-                error.endpoint = "getScreensaverItems";
-                error.code = -2;
-                error.userMessage = tr("Invalid screensaver response");
-                emit canonicalScreensaverItemsFailed(connectionId, error.userMessage);
-                emitError(error);
-                return;
-            }
-
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.limit = qBound(10, limit > 0 ? limit : 80, 200);
+    sendCatalogRequest(
+        QStringLiteral("getScreensaverItems"),
+        ProviderCatalogOperation::ScreensaverItems,
+        query,
+        [this, connectionId](const ProviderCatalogResponse &response) {
             QVariantList filteredItems;
             const QVariantList items =
-                m_authService->mapMediaItems(response.items, connectionId);
+                m_authService->mapMediaItems(response.rawItems, connectionId);
             for (const QVariant &value : items) {
                 const QVariantMap item = value.toMap();
                 if (!item.value(QStringLiteral("backdropArtwork")).toMap().isEmpty()) {
@@ -920,13 +670,8 @@ void LibraryService::getScreensaverItems(int limit)
         },
         [this, connectionId](const NetworkError &error) {
             emit canonicalScreensaverItemsFailed(connectionId, error.userMessage);
-            emitError(error);
         });
 }
-
-// ============================================================================
-// Generic Item Details
-// ============================================================================
 
 void LibraryService::getItem(const QString &itemId)
 {
@@ -935,70 +680,29 @@ void LibraryService::getItem(const QString &itemId)
 
 void LibraryService::getItem(const QString &itemId, const QString &requestContext)
 {
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getItem";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emit itemFailed(itemId, error.userMessage, requestContext);
-        emitError(error);
-        return;
-    }
-
     const QString connectionId = activeConnectionId(m_authService);
-    const QString endpoint = buildItemEndpoint(m_authService->getUserId(), itemId);
-    
-    sendRequestWithRetry(endpoint,
-        [this, endpoint, itemId]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            if (m_etags.contains(endpoint)) {
-                request.setRawHeader("If-None-Match", m_etags.value(endpoint).toUtf8());
-            }
-            if (m_lastModified.contains(endpoint)) {
-                request.setRawHeader("If-Modified-Since", m_lastModified.value(endpoint).toUtf8());
-            }
-            return m_authService->networkManager()->get(request);
-        },
-        [this, itemId, endpoint, requestContext, connectionId](QNetworkReply *reply) {
-            QByteArray data = reply->readAll();
-            int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-            if (httpStatus == 304) {
-                emit itemNotModified(itemId, requestContext);
-                emit itemNotModified(itemId);
-                return;
-            }
-
-            QByteArray etag = reply->rawHeader("ETag");
-            if (!etag.isEmpty()) {
-                m_etags[endpoint] = QString::fromUtf8(etag);
-            }
-            QByteArray lastMod = reply->rawHeader("Last-Modified");
-            if (!lastMod.isEmpty()) {
-                m_lastModified[endpoint] = QString::fromUtf8(lastMod);
-            }
-
-            QJsonDocument doc = QJsonDocument::fromJson(data);
-            if (!doc.isObject()) {
-                NetworkError error;
-                error.endpoint = "getItem";
-                error.code = -2;
-                error.userMessage = tr("Invalid item response");
-                emit itemFailed(itemId, error.userMessage, requestContext);
-                emitError(error);
-                return;
-            }
-            const QJsonObject wireItem = doc.object();
-            const QVariantMap canonicalItem = m_authService
-                ? m_authService->mapMediaItem(wireItem, connectionId)
-                : QVariantMap{};
-            emit itemLoaded(itemId, wireItem, requestContext);
-            emit itemLoaded(itemId, wireItem);
-            emit canonicalItemLoaded(itemId, canonicalItem, requestContext);
-            emit canonicalItemLoaded(itemId, canonicalItem);
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = itemId;
+    query.useCacheValidation = true;
+    sendCatalogRequest(
+        QStringLiteral("getItem"),
+        ProviderCatalogOperation::Item,
+        query,
+        [this, itemId, requestContext, connectionId](
+            const ProviderCatalogResponse &response) {
+            const QVariantMap item =
+                m_authService->mapMediaItem(response.rawItem, connectionId);
+            emit itemLoaded(itemId, response.rawItem, requestContext);
+            emit itemLoaded(itemId, response.rawItem);
+            emit canonicalItemLoaded(itemId, item, requestContext);
+            emit canonicalItemLoaded(itemId, item);
         },
         [this, itemId, requestContext](const NetworkError &error) {
             emit itemFailed(itemId, error.userMessage, requestContext);
-            emitError(error);
+        },
+        [this, itemId, requestContext]() {
+            emit itemNotModified(itemId, requestContext);
+            emit itemNotModified(itemId);
         });
 }
 
@@ -1007,51 +711,49 @@ void LibraryService::clearItemCacheValidation(const QString &itemId)
     if (!m_authService || !m_authService->isAuthenticated() || itemId.isEmpty()) {
         return;
     }
-
-    const QString endpoint = buildItemEndpoint(m_authService->getUserId(), itemId);
-    m_etags.remove(endpoint);
-    m_lastModified.remove(endpoint);
+    const ICatalogProvider *provider = m_authService->catalogProvider();
+    if (!provider) {
+        return;
+    }
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = itemId;
+    const ProviderCatalogRequest request =
+        provider->createRequest(ProviderCatalogOperation::Item, query);
+    if (!request.supported || request.relativeEndpoint.isEmpty()) {
+        return;
+    }
+    m_etags.remove(request.relativeEndpoint);
+    m_lastModified.remove(request.relativeEndpoint);
 }
 
 void LibraryService::getChapters(const QString &itemId)
 {
     const QString connectionId = activeConnectionId(m_authService);
-    if (!m_authService->isAuthenticated()) {
-        emit chaptersFailed(connectionId, itemId, tr("Not authenticated"));
-        return;
-    }
     if (itemId.isEmpty()) {
         emit chaptersFailed(connectionId, itemId, tr("Item ID is empty"));
         return;
     }
-
-    const QString requestKey = connectionId + QLatin1Char('\n') + itemId;
+    const QString requestKey = connectionId + QLatin1Char('\n')
+        + activeProfileId(m_authService) + QLatin1Char('\n') + itemId;
     if (m_inFlightChapterRequests.contains(requestKey)) {
-        qCDebug(lcLibrary) << "LibraryService: Skipping duplicate chapter request for item" << itemId;
         return;
     }
     m_inFlightChapterRequests.insert(requestKey);
 
-    const QString endpoint = buildChaptersEndpoint(m_authService->getUserId(), itemId);
-    sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            return m_authService->networkManager()->get(request);
-        },
-        [this, itemId, connectionId, requestKey](QNetworkReply *reply) {
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = itemId;
+    sendCatalogRequest(
+        QStringLiteral("getChapters"),
+        ProviderCatalogOperation::Chapters,
+        query,
+        [this, itemId, connectionId, requestKey](
+            const ProviderCatalogResponse &response) {
             m_inFlightChapterRequests.remove(requestKey);
-            const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-            if (!doc.isObject()) {
-                qCWarning(lcLibrary) << "LibraryService: Invalid chapter response for item" << itemId;
-                emit chaptersFailed(connectionId, itemId, tr("Invalid chapter response"));
-                return;
-            }
-
-            const QVariantList chapters = m_authService->mapChaptersFromItem(
-                doc.object(), connectionId, itemId);
-            qCInfo(lcLibrary) << "LibraryService: Loaded chapter array for item" << itemId
-                              << "count" << chapters.size();
-            emit canonicalChaptersLoaded(connectionId, itemId, chapters);
+            emit canonicalChaptersLoaded(
+                connectionId,
+                itemId,
+                m_authService->mapChaptersFromItem(
+                    response.rawItem, connectionId, itemId));
         },
         [this, itemId, connectionId, requestKey](const NetworkError &error) {
             m_inFlightChapterRequests.remove(requestKey);
@@ -1061,204 +763,86 @@ void LibraryService::getChapters(const QString &itemId)
 
 void LibraryService::resolveLibraryForItem(const QString &itemId)
 {
-    if (!m_authService->isAuthenticated()) {
-        emit itemLibraryResolutionFailed(itemId, tr("Not authenticated"));
-        return;
-    }
-    if (itemId.isEmpty()) {
-        emit itemLibraryResolutionFailed(itemId, tr("Item ID is empty"));
-        return;
-    }
-
-    const QString endpoint = QString("/Items/%1/Ancestors?UserId=%2")
-        .arg(itemId, m_authService->getUserId());
-
-    sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            return m_authService->networkManager()->get(request);
-        },
-        [this, itemId](QNetworkReply *reply) {
-            const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-            if (!doc.isArray()) {
-                emit itemLibraryResolutionFailed(itemId, tr("Invalid ancestors response"));
-                return;
-            }
-
-            const QString libraryId =
-                m_authService->mapLibraryIdFromAncestors(doc.array());
-
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = itemId;
+    sendCatalogRequest(
+        QStringLiteral("resolveLibraryForItem"),
+        ProviderCatalogOperation::ResolveLibrary,
+        query,
+        [this, itemId](const ProviderCatalogResponse &response) {
+            QString libraryId =
+                response.snapshot.value(QStringLiteral("libraryId")).toString();
             if (libraryId.isEmpty()) {
-                emit itemLibraryResolutionFailed(itemId, tr("Library ancestor not found"));
+                libraryId =
+                    m_authService->mapLibraryIdFromAncestors(response.rawItems);
+            }
+            if (libraryId.isEmpty()) {
+                emit itemLibraryResolutionFailed(
+                    itemId, tr("Library ancestor not found"));
                 return;
             }
-
             emit itemLibraryResolved(itemId, libraryId);
+        },
+        [this, itemId](const NetworkError &error) {
+            emit itemLibraryResolutionFailed(itemId, error.userMessage);
         });
 }
-
-// ============================================================================
-// Series Details
-/**
- * Loads detailed metadata for the specified series and emits the result or an error.
- *
- * Sends a GET request for the series item fields and, on success, emits the parsed JSON object.
- * If a 304 Not Modified response is returned the method emits seriesDetailsNotModified(seriesId).
- * On authentication failure or invalid server response it emits an error via emitError.
- * When present, the response ETag and Last-Modified headers are stored in the service's cache.
- *
- * @param seriesId The identifier of the series to fetch.
- */
 
 void LibraryService::getSeriesDetails(const QString &seriesId)
 {
     const QString connectionId = activeConnectionId(m_authService);
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getSeriesDetails";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emit canonicalSeriesDetailsFailed(connectionId, seriesId, error.userMessage);
-        emitError(error);
-        return;
-    }
-    
-    const QStringList fields = {
-        "Overview", "ImageTags", "BackdropImageTags", "ParentBackdropImageTags",
-        "Genres", "Studios", "People", "ChildCount", "ParentId", "UserData",
-        "ProductionYear", "PremiereDate", "EndDate", "ProviderIds",
-        "RecursiveItemCount", "Status"
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = seriesId;
+    query.useCacheValidation = true;
+    query.fields = {
+        QStringLiteral("Overview"), QStringLiteral("ImageTags"),
+        QStringLiteral("BackdropImageTags"),
+        QStringLiteral("ParentBackdropImageTags"), QStringLiteral("Genres"),
+        QStringLiteral("Studios"), QStringLiteral("People"),
+        QStringLiteral("ChildCount"), QStringLiteral("ParentId"),
+        QStringLiteral("UserData"), QStringLiteral("ProductionYear"),
+        QStringLiteral("PremiereDate"), QStringLiteral("EndDate"),
+        QStringLiteral("ProviderIds"), QStringLiteral("RecursiveItemCount"),
+        QStringLiteral("Status")
     };
-    
-    QString endpoint = QString("/Users/%1/Items/%2?Fields=%3")
-        .arg(m_authService->getUserId(), seriesId, fields.join(","));
-    
-    sendRequestWithRetry(endpoint,
-        [this, endpoint, seriesId]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            if (m_etags.contains(endpoint)) {
-                request.setRawHeader("If-None-Match", m_etags.value(endpoint).toUtf8());
-            }
-            if (m_lastModified.contains(endpoint)) {
-                request.setRawHeader("If-Modified-Since", m_lastModified.value(endpoint).toUtf8());
-            }
-            return m_authService->networkManager()->get(request);
-        },
-        [this, seriesId, endpoint, connectionId](QNetworkReply *reply) {
-            QByteArray data = reply->readAll();
-            int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-            if (httpStatus == 304) {
-                emit seriesDetailsNotModified(seriesId);
-                emit canonicalSeriesDetailsNotModified(connectionId, seriesId);
-                return;
-            }
-
-            QByteArray etag = reply->rawHeader("ETag");
-            if (!etag.isEmpty()) {
-                m_etags[endpoint] = QString::fromUtf8(etag);
-            }
-            QByteArray lastMod = reply->rawHeader("Last-Modified");
-            if (!lastMod.isEmpty()) {
-                m_lastModified[endpoint] = QString::fromUtf8(lastMod);
-            }
-
-            QJsonDocument doc = QJsonDocument::fromJson(data);
-            if (!doc.isObject()) {
-                NetworkError error;
-                error.endpoint = "getSeriesDetails";
-                error.code = -2;
-                error.userMessage = tr("Invalid series details response");
-                emit canonicalSeriesDetailsFailed(connectionId, seriesId, error.userMessage);
-                emitError(error);
-                return;
-            }
-            const QJsonObject wireSeries = doc.object();
-            emit seriesDetailsLoaded(seriesId, wireSeries);
+    sendCatalogRequest(
+        QStringLiteral("getSeriesDetails"),
+        ProviderCatalogOperation::Item,
+        query,
+        [this, connectionId, seriesId](const ProviderCatalogResponse &response) {
+            emit seriesDetailsLoaded(seriesId, response.rawItem);
             emit canonicalSeriesDetailsLoaded(
                 connectionId,
                 seriesId,
-                m_authService->mapMediaItem(wireSeries, connectionId));
+                m_authService->mapMediaItem(response.rawItem, connectionId));
         },
         [this, connectionId, seriesId](const NetworkError &error) {
-            emit canonicalSeriesDetailsFailed(connectionId, seriesId, error.userMessage);
-            emitError(error);
+            emit canonicalSeriesDetailsFailed(
+                connectionId, seriesId, error.userMessage);
+        },
+        [this, connectionId, seriesId]() {
+            emit seriesDetailsNotModified(seriesId);
+            emit canonicalSeriesDetailsNotModified(connectionId, seriesId);
         });
 }
 
 void LibraryService::getSimilarItems(const QString &itemId, int limit)
 {
     const QString connectionId = activeConnectionId(m_authService);
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getSimilarItems";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emit similarItemsFailed(itemId, error.userMessage);
-        emit canonicalSimilarItemsFailedForConnection(
-            connectionId, itemId, error.userMessage);
-        return;
-    }
-
-    if (itemId.isEmpty()) {
-        const QString error = tr("Item ID is empty");
-        emit similarItemsFailed(itemId, error);
-        emit canonicalSimilarItemsFailedForConnection(connectionId, itemId, error);
-        return;
-    }
-
-    const QStringList fields = {
-        "Type",
-        "ImageTags",
-        "PrimaryImageAspectRatio",
-        "ProductionYear",
-        "PremiereDate",
-        "Overview",
-        "UserData",
-        "ChildCount"
-    };
-
-    QString endpoint = QString("/Items/%1/Similar?UserId=%2&Limit=%3&Fields=%4&EnableImageTypes=Primary")
-                           .arg(itemId, m_authService->getUserId())
-                           .arg(qMax(1, limit))
-                           .arg(fields.join(","));
-
-    sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            return m_authService->networkManager()->get(request);
-        },
-        [this, itemId, connectionId](QNetworkReply *reply) {
-            const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-            if (!doc.isObject()) {
-                NetworkError error;
-                error.endpoint = "getSimilarItems";
-                error.code = -2;
-                error.userMessage = tr("Invalid similar items response");
-                emit similarItemsFailed(itemId, error.userMessage);
-                emit canonicalSimilarItemsFailedForConnection(
-                    connectionId, itemId, error.userMessage);
-                return;
-            }
-
-            const QJsonObject root = doc.object();
-            if (!root.contains("Items") || !root.value("Items").isArray()) {
-                NetworkError error;
-                error.endpoint = "getSimilarItems";
-                error.code = -2;
-                error.userMessage = tr("Invalid similar items response");
-                emit similarItemsFailed(itemId, error.userMessage);
-                emit canonicalSimilarItemsFailedForConnection(
-                    connectionId, itemId, error.userMessage);
-                return;
-            }
-
-            const QJsonArray wireItems = root.value("Items").toArray();
-            const QVariantList canonicalItems = m_authService
-                ? m_authService->mapMediaItems(wireItems, connectionId)
-                : QVariantList{};
-            emit similarItemsLoaded(itemId, wireItems);
-            emit canonicalSimilarItemsLoaded(itemId, canonicalItems);
-            emit canonicalSimilarItemsLoadedForConnection(connectionId, itemId, canonicalItems);
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = itemId;
+    query.limit = qMax(1, limit);
+    sendCatalogRequest(
+        QStringLiteral("getSimilarItems"),
+        ProviderCatalogOperation::SimilarItems,
+        query,
+        [this, itemId, connectionId](const ProviderCatalogResponse &response) {
+            const QVariantList items =
+                m_authService->mapMediaItems(response.rawItems, connectionId);
+            emit similarItemsLoaded(itemId, response.rawItems);
+            emit canonicalSimilarItemsLoaded(itemId, items);
+            emit canonicalSimilarItemsLoadedForConnection(
+                connectionId, itemId, items);
         },
         [this, itemId, connectionId](const NetworkError &error) {
             emit similarItemsFailed(itemId, error.userMessage);
@@ -1267,192 +851,118 @@ void LibraryService::getSimilarItems(const QString &itemId, int limit)
         });
 }
 
-/**
- * @brief Resolves the best next episode for a series, optionally skipping a specific episode.
- *
- * Fetches the recursive episode list for the series, resolves a canonical series order locally,
- * and emits the best canonical next episode based on watch state. The episode map is empty when
- * no eligible episode is available.
- *
- * @param seriesId The series identifier to query.
- * @param excludeItemId If non-empty, the returned episode will not have this Id; pass an empty string to allow any episode.
- * @param requestContext Optional internal request ownership tag used by playback-prefetch callers.
- */
 void LibraryService::getNextUnplayedEpisode(const QString &seriesId,
                                             const QString &excludeItemId,
                                             const QString &requestContext)
 {
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getNextUnplayedEpisode";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emit nextUnplayedEpisodeFailed(seriesId, error.userMessage, requestContext);
-        return;
-    }
-    
-    const QStringList fields = {
-        QStringLiteral("Name"),
-        QStringLiteral("SortName"),
-        QStringLiteral("Overview"),
-        QStringLiteral("UserData"),
-        QStringLiteral("RunTimeTicks"),
-        QStringLiteral("ImageTags"),
-        QStringLiteral("ParentId"),
-        QStringLiteral("SeasonId"),
-        QStringLiteral("SeriesId"),
-        QStringLiteral("SeriesName"),
-        QStringLiteral("IndexNumber"),
-        QStringLiteral("ParentIndexNumber"),
-        QStringLiteral("PremiereDate"),
-        QStringLiteral("LocationType"),
-        QStringLiteral("AirsBeforeSeasonNumber"),
-        QStringLiteral("AirsAfterSeasonNumber"),
-        QStringLiteral("AirsBeforeEpisodeNumber")
-    };
     const QString connectionId = activeConnectionId(m_authService);
-    QString endpoint = QString("/Users/%1/Items?ParentId=%2&Recursive=true&IncludeItemTypes=Episode&Fields=%3&SortBy=ParentIndexNumber,IndexNumber,SortName&EnableImageTypes=Primary,Thumb")
-        .arg(m_authService->getUserId(), seriesId, fields.join(','));
-    
-    sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            return m_authService->networkManager()->get(request);
-        },
-        [this, seriesId, excludeItemId, requestContext, connectionId](QNetworkReply *reply) {
-            QByteArray data = reply->readAll();
-            QJsonDocument doc = QJsonDocument::fromJson(data);
-            if (!doc.isObject()) {
-                NetworkError error;
-                error.endpoint = "getNextUnplayedEpisode";
-                error.code = -2;
-                error.userMessage = tr("Invalid next unplayed episode response");
-                emit nextUnplayedEpisodeFailed(seriesId, error.userMessage, requestContext);
-                return;
-            }
-            const QJsonObject root = doc.object();
-            if (!root.contains("Items") || !root.value("Items").isArray()) {
-                NetworkError error;
-                error.endpoint = "getNextUnplayedEpisode";
-                error.code = -2;
-                error.userMessage = tr("Invalid next unplayed episode response");
-                emit nextUnplayedEpisodeFailed(seriesId, error.userMessage, requestContext);
-                return;
-            }
-            const QJsonArray wireItems = root.value("Items").toArray();
-            const QVariantMap selectedEpisode = NextEpisodeResolver::resolveBestNextEpisode(
-                m_authService->mapMediaItems(wireItems, connectionId), excludeItemId);
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.seriesId = seriesId;
+    query.excludeItemId = excludeItemId;
+    sendCatalogRequest(
+        QStringLiteral("getNextUnplayedEpisode"),
+        ProviderCatalogOperation::NextUnplayedEpisode,
+        query,
+        [this, connectionId, seriesId, excludeItemId, requestContext](
+            const ProviderCatalogResponse &response) {
+            const QVariantMap episode = NextEpisodeResolver::resolveBestNextEpisode(
+                m_authService->mapMediaItems(response.rawItems, connectionId),
+                excludeItemId);
             emit canonicalNextUnplayedEpisodeLoaded(
-                connectionId, seriesId, selectedEpisode, requestContext);
+                connectionId, seriesId, episode, requestContext);
         },
         [this, seriesId, requestContext](const NetworkError &error) {
-            emit nextUnplayedEpisodeFailed(seriesId, error.userMessage, requestContext);
+            emit nextUnplayedEpisodeFailed(
+                seriesId, error.userMessage, requestContext);
         });
 }
 
 void LibraryService::markSeriesWatched(const QString &seriesId)
 {
-    if (!m_authService->isAuthenticated()) return;
-    
-    QString endpoint = QString("/Users/%1/PlayedItems/%2").arg(m_authService->getUserId(), seriesId);
-    QNetworkRequest request = m_authService->createRequest(endpoint);
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    
-    QNetworkReply *reply = m_authService->networkManager()->post(request, QByteArray());
-    connect(reply, &QNetworkReply::finished, this, [this, reply, seriesId]() {
-        reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply)) return;
-        if (reply->error() == QNetworkReply::NoError) {
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = seriesId;
+    query.stateValue = true;
+    sendCatalogRequest(
+        QStringLiteral("markSeriesWatched"),
+        ProviderCatalogOperation::SetWatched,
+        query,
+        [this, seriesId](const ProviderCatalogResponse &) {
             emit seriesWatchedStatusChanged(seriesId);
-        }
-    });
+        });
 }
 
 void LibraryService::markSeriesUnwatched(const QString &seriesId)
 {
-    if (!m_authService->isAuthenticated()) return;
-    
-    QString endpoint = QString("/Users/%1/PlayedItems/%2").arg(m_authService->getUserId(), seriesId);
-    QNetworkRequest request = m_authService->createRequest(endpoint);
-    
-    QNetworkReply *reply = m_authService->networkManager()->deleteResource(request);
-    connect(reply, &QNetworkReply::finished, this, [this, reply, seriesId]() {
-        reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply)) return;
-        if (reply->error() == QNetworkReply::NoError) {
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = seriesId;
+    query.stateValue = false;
+    sendCatalogRequest(
+        QStringLiteral("markSeriesUnwatched"),
+        ProviderCatalogOperation::SetWatched,
+        query,
+        [this, seriesId](const ProviderCatalogResponse &) {
             emit seriesWatchedStatusChanged(seriesId);
-        }
-    });
+        });
 }
 
 void LibraryService::markItemPlayed(const QString &itemId)
 {
-    if (!m_authService->isAuthenticated()) return;
-    
-    QString endpoint = QString("/Users/%1/PlayedItems/%2").arg(m_authService->getUserId(), itemId);
-    QNetworkRequest request = m_authService->createRequest(endpoint);
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    
-    QNetworkReply *reply = m_authService->networkManager()->post(request, QByteArray());
-    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
-        reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply)) return;
-        if (reply->error() == QNetworkReply::NoError) {
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = itemId;
+    query.stateValue = true;
+    sendCatalogRequest(
+        QStringLiteral("markItemPlayed"),
+        ProviderCatalogOperation::SetWatched,
+        query,
+        [this, itemId](const ProviderCatalogResponse &response) {
+            emitItemStateResponse(itemId, response);
             emit itemPlayedStatusChanged(itemId, true);
-        }
-    });
+        });
 }
 
 void LibraryService::markItemUnplayed(const QString &itemId)
 {
-    if (!m_authService->isAuthenticated()) return;
-    
-    QString endpoint = QString("/Users/%1/PlayedItems/%2").arg(m_authService->getUserId(), itemId);
-    QNetworkRequest request = m_authService->createRequest(endpoint);
-    
-    QNetworkReply *reply = m_authService->networkManager()->deleteResource(request);
-    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
-        reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply)) return;
-        if (reply->error() == QNetworkReply::NoError) {
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = itemId;
+    query.stateValue = false;
+    sendCatalogRequest(
+        QStringLiteral("markItemUnplayed"),
+        ProviderCatalogOperation::SetWatched,
+        query,
+        [this, itemId](const ProviderCatalogResponse &response) {
+            emitItemStateResponse(itemId, response);
             emit itemPlayedStatusChanged(itemId, false);
-        }
-    });
+        });
 }
 
 void LibraryService::markItemFavorite(const QString &itemId)
 {
-    if (!m_authService->isAuthenticated()) return;
-    
-    QString endpoint = QString("/Users/%1/FavoriteItems/%2").arg(m_authService->getUserId(), itemId);
-    QNetworkRequest request = m_authService->createRequest(endpoint);
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    
-    QNetworkReply *reply = m_authService->networkManager()->post(request, QByteArray());
-    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
-        reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply)) return;
-        if (reply->error() == QNetworkReply::NoError) {
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = itemId;
+    query.stateValue = true;
+    sendCatalogRequest(
+        QStringLiteral("markItemFavorite"),
+        ProviderCatalogOperation::SetFavorite,
+        query,
+        [this, itemId](const ProviderCatalogResponse &response) {
+            emitItemStateResponse(itemId, response);
             emit favoriteStatusChanged(itemId, true);
-        }
-    });
+        });
 }
 
 void LibraryService::markItemUnfavorite(const QString &itemId)
 {
-    if (!m_authService->isAuthenticated()) return;
-    
-    QString endpoint = QString("/Users/%1/FavoriteItems/%2").arg(m_authService->getUserId(), itemId);
-    QNetworkRequest request = m_authService->createRequest(endpoint);
-    
-    QNetworkReply *reply = m_authService->networkManager()->deleteResource(request);
-    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
-        reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply)) return;
-        if (reply->error() == QNetworkReply::NoError) {
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = itemId;
+    query.stateValue = false;
+    sendCatalogRequest(
+        QStringLiteral("markItemUnfavorite"),
+        ProviderCatalogOperation::SetFavorite,
+        query,
+        [this, itemId](const ProviderCatalogResponse &response) {
+            emitItemStateResponse(itemId, response);
             emit favoriteStatusChanged(itemId, false);
-        }
-    });
+        });
 }
 
 void LibraryService::toggleFavorite(const QString &itemId, bool isFavorite)
@@ -1466,33 +976,20 @@ void LibraryService::toggleFavorite(const QString &itemId, bool isFavorite)
 
 void LibraryService::getThemeSongs(const QString &seriesId)
 {
-    if (!m_authService->isAuthenticated()) return;
-    
     const QString connectionId = activeConnectionId(m_authService);
-    QString endpoint = QString("/Items/%1/ThemeSongs?UserId=%2").arg(seriesId, m_authService->getUserId());
-    
-    sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            return m_authService->networkManager()->get(request);
-        },
-        [this, seriesId, connectionId](QNetworkReply *reply) {
-            const ParsedItemsResult response =
-                m_authService->parseItemsResponse(reply->readAll(), QString());
-            if (!response.success) {
-                NetworkError error;
-                error.endpoint = "getThemeSongs";
-                error.code = -2;
-                error.userMessage = tr("Invalid theme songs response");
-                emitError(error);
-                return;
-            }
-            const QVariantList items =
-                m_authService->mapMediaItems(response.items, connectionId);
-
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.itemId = seriesId;
+    sendCatalogRequest(
+        QStringLiteral("getThemeSongs"),
+        ProviderCatalogOperation::ThemeSongs,
+        query,
+        [this, seriesId, connectionId](const ProviderCatalogResponse &response) {
             QStringList urls;
-            for (const QVariant &item : items) {
-                const QString itemId = item.toMap().value(QStringLiteral("itemId")).toString();
+            const QVariantList items =
+                m_authService->mapMediaItems(response.rawItems, connectionId);
+            for (const QVariant &value : items) {
+                const QString itemId =
+                    value.toMap().value(QStringLiteral("itemId")).toString();
                 if (!itemId.isEmpty()) {
                     urls.append(getStreamUrl(itemId));
                 }
@@ -1501,300 +998,168 @@ void LibraryService::getThemeSongs(const QString &seriesId)
         });
 }
 
-// ============================================================================
-// Search
-// ============================================================================
-
 void LibraryService::search(const QString &searchTerm, int limit)
 {
     const QString connectionId = activeConnectionId(m_authService);
     const QString normalizedSearchTerm = searchTerm.trimmed();
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "search";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emit canonicalSearchResultsFailed(connectionId, normalizedSearchTerm, error.userMessage);
-        emitError(error);
+    if (!m_authService || !m_authService->isAuthenticated()) {
+        emitCatalogError(
+            QStringLiteral("search"),
+            tr("Not authenticated"),
+            [this, connectionId, normalizedSearchTerm](const NetworkError &error) {
+                emit canonicalSearchResultsFailed(
+                    connectionId, normalizedSearchTerm, error.userMessage);
+            });
         return;
     }
-
     if (normalizedSearchTerm.isEmpty()) {
-        emit canonicalSearchResultsLoaded(connectionId, normalizedSearchTerm, {}, {});
+        emit canonicalSearchResultsLoaded(
+            connectionId, normalizedSearchTerm, {}, {});
         return;
     }
-
-    const QStringList fields = {"Path", "Overview", "ImageTags", "BackdropImageTags", "ProductionYear", "CommunityRating", "UserData"};
-
-    QString endpoint = QString("/Users/%1/Items?SearchTerm=%2&IncludeItemTypes=Movie,Series&Recursive=true&Fields=%3&Limit=%4&EnableImageTypes=Primary,Backdrop")
-                           .arg(m_authService->getUserId())
-                           .arg(QString::fromUtf8(QUrl::toPercentEncoding(normalizedSearchTerm)))
-                           .arg(fields.join(","))
-                           .arg(limit);
-
-    sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            return m_authService->networkManager()->get(request);
-        },
-        [this, connectionId, normalizedSearchTerm](QNetworkReply *reply) {
-            const ParsedItemsResult response =
-                m_authService->parseItemsResponse(reply->readAll(), QString());
-            if (!response.success) {
-                NetworkError error;
-                error.endpoint = "search";
-                error.code = -2;
-                error.userMessage = tr("Invalid search response");
-                emit canonicalSearchResultsFailed(connectionId, normalizedSearchTerm, error.userMessage);
-                emitError(error);
-                return;
-            }
-
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.searchTerm = normalizedSearchTerm;
+    query.limit = limit;
+    query.includeItemTypes = {
+        QStringLiteral("Movie"),
+        QStringLiteral("Series")
+    };
+    sendCatalogRequest(
+        QStringLiteral("search"),
+        ProviderCatalogOperation::Search,
+        query,
+        [this, connectionId, normalizedSearchTerm](
+            const ProviderCatalogResponse &response) {
             QVariantList movies;
             QVariantList series;
             const QVariantList items =
-                m_authService->mapMediaItems(response.items, connectionId);
+                m_authService->mapMediaItems(response.rawItems, connectionId);
             for (const QVariant &value : items) {
                 const QVariantMap item = value.toMap();
-                const QString mediaType = item.value(QStringLiteral("mediaType")).toString();
+                const QString mediaType =
+                    item.value(QStringLiteral("mediaType")).toString();
                 if (mediaType == QStringLiteral("Movie")) {
                     movies.append(item);
                 } else if (mediaType == QStringLiteral("Series")) {
                     series.append(item);
                 }
             }
-
-            emit canonicalSearchResultsLoaded(connectionId, normalizedSearchTerm, movies, series);
+            emit canonicalSearchResultsLoaded(
+                connectionId, normalizedSearchTerm, movies, series);
         },
         [this, connectionId, normalizedSearchTerm](const NetworkError &error) {
-            emit canonicalSearchResultsFailed(connectionId, normalizedSearchTerm, error.userMessage);
-            emitError(error);
+            emit canonicalSearchResultsFailed(
+                connectionId, normalizedSearchTerm, error.userMessage);
         });
 }
 
 void LibraryService::getRandomItems(int limit)
 {
     const QString connectionId = activeConnectionId(m_authService);
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getRandomItems";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emit canonicalRandomItemsFailed(connectionId, error.userMessage);
-        emitError(error);
-        return;
-    }
-
-    const QStringList fields = {"Overview", "ImageTags", "BackdropImageTags", "ProductionYear"};
-
-    QString endpoint = QString("/Users/%1/Items?IncludeItemTypes=Movie,Series&Recursive=true&SortBy=Random&Limit=%2&Fields=%3")
-                           .arg(m_authService->getUserId())
-                           .arg(limit)
-                           .arg(fields.join(","));
-
-    sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            return m_authService->networkManager()->get(request);
-        },
-        [this, connectionId](QNetworkReply *reply) {
-            const ParsedItemsResult response =
-                m_authService->parseItemsResponse(reply->readAll(), QString());
-            if (!response.success) {
-                NetworkError error;
-                error.endpoint = "getRandomItems";
-                error.code = -2;
-                error.userMessage = tr("Invalid random items response");
-                emit canonicalRandomItemsFailed(connectionId, error.userMessage);
-                emitError(error);
-                return;
-            }
+    ProviderCatalogQuery query = baseCatalogQuery();
+    query.limit = limit;
+    sendCatalogRequest(
+        QStringLiteral("getRandomItems"),
+        ProviderCatalogOperation::RandomItems,
+        query,
+        [this, connectionId](const ProviderCatalogResponse &response) {
             emit canonicalRandomItemsLoaded(
                 connectionId,
-                m_authService->mapMediaItems(response.items, connectionId));
+                m_authService->mapMediaItems(response.rawItems, connectionId));
         },
         [this, connectionId](const NetworkError &error) {
             emit canonicalRandomItemsFailed(connectionId, error.userMessage);
-            emitError(error);
         });
 }
 
-// ============================================================================
-// URL Helpers
-// ============================================================================
-
-void LibraryService::getHeroLibraryItems(int limit, const QStringList &parentIds, bool unwatchedOnly)
+void LibraryService::getHeroLibraryItems(int limit,
+                                         const QStringList &parentIds,
+                                         bool unwatchedOnly)
 {
     const QString connectionId = activeConnectionId(m_authService);
-    if (!m_authService->isAuthenticated()) {
-        NetworkError error;
-        error.endpoint = "getHeroLibraryItems";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emit canonicalHeroLibraryItemsFailed(connectionId, error.userMessage);
-        emitError(error);
+    if (!m_authService || !m_authService->isAuthenticated()) {
+        emitCatalogError(
+            QStringLiteral("getHeroLibraryItems"),
+            tr("Not authenticated"),
+            [this, connectionId](const NetworkError &error) {
+                emit canonicalHeroLibraryItemsFailed(
+                    connectionId, error.userMessage);
+            });
         return;
     }
-
-    const quint64 requestGeneration = ++m_heroLibraryRequestGeneration;
+    const quint64 generation = m_requestGeneration;
     const int clampedLimit = qBound(1, limit, 25);
-    const QStringList fields = {
-        "Overview", "SeriesName", "ImageTags", "BackdropImageTags", "ParentBackdropImageTags",
-        "ParentBackdropItemId", "ParentId", "SeriesId", "SeriesPrimaryImageTag",
-        "ParentPrimaryImageTag", "ProductionYear", "PremiereDate", "UserData",
-        "RunTimeTicks", "CommunityRating", "OfficialRating", "Genres", "Studios", "Tags"
-    };
-
-    // Filter out empty parentIds. When none remain, sample across all libraries.
     QStringList ids;
     for (const QString &id : parentIds) {
-        if (!id.trimmed().isEmpty()) ids.append(id.trimmed());
+        const QString trimmed = id.trimmed();
+        if (!trimmed.isEmpty() && !ids.contains(trimmed)) {
+            ids.append(trimmed);
+        }
     }
 
-    auto buildEndpoint = [this, clampedLimit, unwatchedOnly, fields](const QString &parentId) {
-        QString base = QString("/Users/%1/Items?IncludeItemTypes=Movie,Series&Recursive=true"
-                               "&SortBy=Random&Limit=%2&Fields=%3"
-                               "&EnableImageTypes=Primary,Backdrop,Thumb,Logo&ImageTypeLimit=1")
-                           .arg(m_authService->getUserId())
-                           .arg(clampedLimit)
-                           .arg(fields.join(","));
-        if (!parentId.isEmpty()) {
-            base += "&ParentId=" + parentId;
+    if (ids.size() <= 1) {
+        ProviderCatalogQuery query = baseCatalogQuery();
+        query.limit = clampedLimit;
+        query.unwatchedOnly = unwatchedOnly;
+        if (!ids.isEmpty()) {
+            query.parentId = ids.constFirst();
         }
-        if (unwatchedOnly) {
-            base += "&IsPlayed=false";
-        }
-        return base;
-    };
-
-    // No parent filters: single request across all libraries.
-    if (ids.isEmpty()) {
-        const QString endpoint = buildEndpoint(QString());
-        sendRequestWithRetry(endpoint,
-            [this, endpoint]() {
-                QNetworkRequest request = m_authService->createRequest(endpoint);
-                return m_authService->networkManager()->get(request);
-            },
-            [this, connectionId, requestGeneration](QNetworkReply *reply) {
-                if (requestGeneration != m_heroLibraryRequestGeneration) {
-                    return;
-                }
-                QByteArray data = reply->readAll();
-                QJsonDocument doc = QJsonDocument::fromJson(data);
-                if (!doc.isObject()) {
-                    NetworkError error;
-                    error.endpoint = "getHeroLibraryItems";
-                    error.code = -2;
-                    error.userMessage = tr("Invalid hero library items response");
-                    emit canonicalHeroLibraryItemsFailed(connectionId, error.userMessage);
-                    emitError(error);
-                    return;
-                }
-                const QJsonArray items =
-                    m_authService->parseItemsResponse(data, QString()).items;
-                emit heroLibraryItemsLoaded(items);
+        sendCatalogRequest(
+            QStringLiteral("getHeroLibraryItems"),
+            ProviderCatalogOperation::HeroItems,
+            query,
+            [this, connectionId](const ProviderCatalogResponse &response) {
+                emit heroLibraryItemsLoaded(response.rawItems);
                 emit canonicalHeroLibraryItemsLoaded(
-                    connectionId, m_authService->mapMediaItems(items, connectionId));
+                    connectionId,
+                    m_authService->mapMediaItems(response.rawItems, connectionId));
             },
-            [this, connectionId, requestGeneration](const NetworkError &error) {
-                if (requestGeneration != m_heroLibraryRequestGeneration) {
-                    return;
-                }
-                emit canonicalHeroLibraryItemsFailed(connectionId, error.userMessage);
-                emitError(error);
+            [this, connectionId](const NetworkError &error) {
+                emit canonicalHeroLibraryItemsFailed(
+                    connectionId, error.userMessage);
             });
         return;
     }
 
-    // Single parentId: one request.
-    if (ids.size() == 1) {
-        const QString endpoint = buildEndpoint(ids.first());
-        sendRequestWithRetry(endpoint,
-            [this, endpoint]() {
-                QNetworkRequest request = m_authService->createRequest(endpoint);
-                return m_authService->networkManager()->get(request);
-            },
-            [this, connectionId, requestGeneration](QNetworkReply *reply) {
-                if (requestGeneration != m_heroLibraryRequestGeneration) {
-                    return;
-                }
-                QByteArray data = reply->readAll();
-                QJsonDocument doc = QJsonDocument::fromJson(data);
-                if (!doc.isObject()) {
-                    NetworkError error;
-                    error.endpoint = "getHeroLibraryItems";
-                    error.code = -2;
-                    error.userMessage = tr("Invalid hero library items response");
-                    emit canonicalHeroLibraryItemsFailed(connectionId, error.userMessage);
-                    emitError(error);
-                    return;
-                }
-                const QJsonArray items =
-                    m_authService->parseItemsResponse(data, QString()).items;
-                emit heroLibraryItemsLoaded(items);
-                emit canonicalHeroLibraryItemsLoaded(
-                    connectionId, m_authService->mapMediaItems(items, connectionId));
-            },
-            [this, connectionId, requestGeneration](const NetworkError &error) {
-                if (requestGeneration != m_heroLibraryRequestGeneration) {
-                    return;
-                }
-                emit canonicalHeroLibraryItemsFailed(connectionId, error.userMessage);
-                emitError(error);
-            });
-        return;
-    }
-
-    // Multiple parentIds: fan out concurrently and aggregate. Each request asks
-    // for `clampedLimit` items so the union is a bounded random sample across the
-    // selected libraries; the provider caps the final list client-side.
     auto aggregate = std::make_shared<QJsonArray>();
     auto remaining = std::make_shared<int>(ids.size());
+    const auto finish = [this, aggregate, remaining, clampedLimit,
+                         connectionId, generation]() {
+        if (--(*remaining) > 0 || generation != m_requestGeneration) {
+            return;
+        }
+        QJsonArray items;
+        const int count = qMin(aggregate->size(), clampedLimit);
+        for (int index = 0; index < count; ++index) {
+            items.append(aggregate->at(index));
+        }
+        emit heroLibraryItemsLoaded(items);
+        emit canonicalHeroLibraryItemsLoaded(
+            connectionId, m_authService->mapMediaItems(items, connectionId));
+    };
     for (const QString &parentId : ids) {
-        const QString endpoint = buildEndpoint(parentId);
-        sendRequestWithRetry(endpoint,
-            [this, endpoint]() {
-                QNetworkRequest request = m_authService->createRequest(endpoint);
-                return m_authService->networkManager()->get(request);
-            },
-            [this, aggregate, remaining, clampedLimit, connectionId, requestGeneration](QNetworkReply *reply) {
-                if (requestGeneration != m_heroLibraryRequestGeneration) {
-                    return;
-                }
-                QByteArray data = reply->readAll();
-                QJsonDocument doc = QJsonDocument::fromJson(data);
-                if (doc.isObject()) {
-                    const QJsonArray items =
-                        m_authService->parseItemsResponse(data, QString()).items;
-                    for (const QJsonValue &v : items) {
-                        if (aggregate->size() >= clampedLimit) break;
-                        aggregate->append(v);
+        ProviderCatalogQuery query = baseCatalogQuery();
+        query.parentId = parentId;
+        query.limit = clampedLimit;
+        query.unwatchedOnly = unwatchedOnly;
+        sendCatalogRequest(
+            QStringLiteral("getHeroLibraryItems"),
+            ProviderCatalogOperation::HeroItems,
+            query,
+            [aggregate, clampedLimit, finish](
+                const ProviderCatalogResponse &response) {
+                for (const QJsonValue &value : response.rawItems) {
+                    if (aggregate->size() >= clampedLimit) {
+                        break;
                     }
+                    aggregate->append(value);
                 }
-                if (--(*remaining) <= 0) {
-                    // Trim to the requested cap before emitting.
-                    QJsonArray trimmed;
-                    const int total = qMin(aggregate->size(), clampedLimit);
-                    for (int i = 0; i < total; ++i) trimmed.append(aggregate->at(i));
-                    emit heroLibraryItemsLoaded(trimmed);
-                    emit canonicalHeroLibraryItemsLoaded(
-                        connectionId, m_authService->mapMediaItems(trimmed, connectionId));
-                }
+                finish();
             },
-            [this, aggregate, remaining, clampedLimit, connectionId, requestGeneration](const NetworkError &) {
-                if (requestGeneration != m_heroLibraryRequestGeneration) {
-                    return;
-                }
-                if (--(*remaining) <= 0) {
-                    QJsonArray trimmed;
-                    const int total = qMin(aggregate->size(), clampedLimit);
-                    for (int i = 0; i < total; ++i) {
-                        trimmed.append(aggregate->at(i));
-                    }
-                    emit heroLibraryItemsLoaded(trimmed);
-                    emit canonicalHeroLibraryItemsLoaded(
-                        connectionId, m_authService->mapMediaItems(trimmed, connectionId));
-                }
+            [this, connectionId, finish](const NetworkError &error) {
+                emit canonicalHeroLibraryItemsFailed(
+                    connectionId, error.userMessage);
+                finish();
             });
     }
 }
@@ -1802,6 +1167,7 @@ void LibraryService::getHeroLibraryItems(int limit, const QStringList &parentIds
 void LibraryService::getHeroSeriesOverviews(const QStringList &seriesIds)
 {
     const QString connectionId = activeConnectionId(m_authService);
+    const quint64 generation = m_requestGeneration;
     QStringList ids;
     for (const QString &id : seriesIds) {
         const QString trimmed = id.trimmed();
@@ -1809,59 +1175,54 @@ void LibraryService::getHeroSeriesOverviews(const QStringList &seriesIds)
             ids.append(trimmed);
         }
     }
-
     if (ids.isEmpty()) {
-        emit heroSeriesOverviewsLoaded(QJsonObject());
-        emit canonicalHeroSeriesOverviewsLoaded(connectionId, QVariantMap());
+        emit heroSeriesOverviewsLoaded({});
+        emit canonicalHeroSeriesOverviewsLoaded(connectionId, {});
         return;
     }
-
-    if (!m_authService->isAuthenticated()) {
+    if (!m_authService || !m_authService->isAuthenticated()) {
         QJsonObject overviews;
-        for (const QString &id : ids) {
-            overviews.insert(id, QString());
+        for (const QString &seriesId : ids) {
+            overviews.insert(seriesId, QString());
         }
         emit heroSeriesOverviewsLoaded(overviews);
-        emit canonicalHeroSeriesOverviewsLoaded(connectionId, overviews.toVariantMap());
-
-        NetworkError error;
-        error.endpoint = "getHeroSeriesOverviews";
-        error.code = -1;
-        error.userMessage = tr("Not authenticated");
-        emitError(error);
+        emit canonicalHeroSeriesOverviewsLoaded(
+            connectionId, overviews.toVariantMap());
+        emitCatalogError(
+            QStringLiteral("getHeroSeriesOverviews"), tr("Not authenticated"));
         return;
     }
 
     auto overviews = std::make_shared<QJsonObject>();
     auto remaining = std::make_shared<int>(ids.size());
+    const auto finish = [this, overviews, remaining, connectionId, generation]() {
+        if (--(*remaining) > 0 || generation != m_requestGeneration) {
+            return;
+        }
+        emit heroSeriesOverviewsLoaded(*overviews);
+        emit canonicalHeroSeriesOverviewsLoaded(
+            connectionId, overviews->toVariantMap());
+    };
     for (const QString &seriesId : ids) {
-        const QString endpoint = QStringLiteral("/Users/%1/Items/%2?Fields=Overview")
-                                     .arg(m_authService->getUserId(), seriesId);
-        sendRequestWithRetry(endpoint,
-            [this, endpoint]() {
-                QNetworkRequest request = m_authService->createRequest(endpoint);
-                return m_authService->networkManager()->get(request);
-            },
-            [this, overviews, remaining, seriesId, connectionId](QNetworkReply *reply) {
-                const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-                const QString overview = doc.isObject()
-                    ? m_authService->mapMediaItem(doc.object(), connectionId)
-                          .value(QStringLiteral("overview")).toString()
-                    : QString();
+        ProviderCatalogQuery query = baseCatalogQuery();
+        query.seriesId = seriesId;
+        query.itemId = seriesId;
+        sendCatalogRequest(
+            QStringLiteral("getHeroSeriesOverviews"),
+            ProviderCatalogOperation::HeroOverviews,
+            query,
+            [this, overviews, finish, seriesId, connectionId](
+                const ProviderCatalogResponse &response) {
+                const QString overview = m_authService
+                    ->mapMediaItem(response.rawItem, connectionId)
+                    .value(QStringLiteral("overview"))
+                    .toString();
                 overviews->insert(seriesId, overview);
-                if (--(*remaining) <= 0) {
-                    emit heroSeriesOverviewsLoaded(*overviews);
-                    emit canonicalHeroSeriesOverviewsLoaded(connectionId,
-                                                            overviews->toVariantMap());
-                }
+                finish();
             },
-            [this, overviews, remaining, seriesId, connectionId](const NetworkError &) {
+            [overviews, finish, seriesId](const NetworkError &) {
                 overviews->insert(seriesId, QString());
-                if (--(*remaining) <= 0) {
-                    emit heroSeriesOverviewsLoaded(*overviews);
-                    emit canonicalHeroSeriesOverviewsLoaded(connectionId,
-                                                            overviews->toVariantMap());
-                }
+                finish();
             });
     }
 }

--- a/src/network/LibraryService.h
+++ b/src/network/LibraryService.h
@@ -5,19 +5,21 @@
 #include <QJsonObject>
 #include <QStringList>
 #include <QNetworkReply>
-#include <QFuture>
-#include <QFutureWatcher>
-#include <QtConcurrent>
 #include <QHash>
 #include <QSet>
+#include <QList>
+#include <QPointer>
 #include <QDate>
 #include <QVariantList>
 #include <QVariantMap>
 #include <functional>
+
 #include "Types.h"  // Shared data structs and error helpers
+#include "providers/ICatalogProvider.h"
 
 class AuthenticationService;
 class HttpTransport;
+class HttpRequestHandle;
 
 struct LibraryItemQuery {
     QString parentId;
@@ -278,28 +280,46 @@ signals:
     void parsingFinished(const QString &operation);
 
 private:
+    struct CatalogRequestIdentity {
+        quint64 generation = 0;
+        QString connectionId;
+        QString userId;
+        QString profileId;
+        const ICatalogProvider *provider = nullptr;
+    };
+
+    using CatalogResponseHandler =
+        std::function<void(const ProviderCatalogResponse &)>;
+    using CatalogNotModifiedHandler = std::function<void()>;
+    using FailureHandler = std::function<void(const NetworkError &)>;
+
     AuthenticationService *m_authService;
     HttpTransport *m_transport = nullptr;
     RetryPolicy m_retryPolicy;
-    
-    // Retry mechanism types
-    using ResponseHandler = std::function<void(QNetworkReply*)>;
-    using RequestFactory = std::function<QNetworkReply*()>;
-    using FailureHandler = std::function<void(const NetworkError&)>;
-    
-    void sendRequestWithRetry(const QString &endpoint,
-                               RequestFactory requestFactory,
-                               ResponseHandler responseHandler,
-                               FailureHandler failureHandler = FailureHandler(),
-                               int attemptNumber = 0);
-    
+
+    ProviderCatalogQuery baseCatalogQuery() const;
+    CatalogRequestIdentity catalogRequestIdentity() const;
+    bool isCurrent(const CatalogRequestIdentity &identity) const;
+    void sendCatalogRequest(
+        const QString &operationName,
+        ProviderCatalogOperation operation,
+        const ProviderCatalogQuery &query,
+        CatalogResponseHandler responseHandler,
+        FailureHandler failureHandler = FailureHandler(),
+        CatalogNotModifiedHandler notModifiedHandler = CatalogNotModifiedHandler());
+    void emitCatalogError(const QString &operationName,
+                          const QString &message,
+                          FailureHandler failureHandler = FailureHandler(),
+                          int code = -1);
+    void emitItemStateResponse(const QString &itemId,
+                               const ProviderCatalogResponse &response);
     void emitError(const NetworkError &error);
 
-    // In-flight request ownership
     QSet<QString> m_inFlightChapterRequests;
-    quint64 m_heroLibraryRequestGeneration = 0;
+    QList<QPointer<HttpRequestHandle>> m_catalogRequests;
+    quint64 m_requestGeneration = 0;
 
-    // Cache validation state (per endpoint/parent)
+    // Cache validation state (per provider-owned endpoint).
     QHash<QString, QString> m_etags;
     QHash<QString, QString> m_lastModified;
 };

--- a/src/network/LibraryService.h
+++ b/src/network/LibraryService.h
@@ -318,6 +318,7 @@ private:
     QSet<QString> m_inFlightChapterRequests;
     QList<QPointer<HttpRequestHandle>> m_catalogRequests;
     quint64 m_requestGeneration = 0;
+    quint64 m_heroRequestGeneration = 0;
 
     // Cache validation state (per provider-owned endpoint).
     QHash<QString, QString> m_etags;

--- a/src/providers/ActiveArtworkProvider.cpp
+++ b/src/providers/ActiveArtworkProvider.cpp
@@ -1,0 +1,54 @@
+#include "ActiveArtworkProvider.h"
+
+#include "network/AuthenticationService.h"
+#include "providers/jellyfin/JellyfinArtworkProvider.h"
+#include "providers/silo/SiloArtworkProvider.h"
+
+#include <utility>
+
+ActiveArtworkProvider::ActiveArtworkProvider(AuthenticationService *authService)
+    : m_authService(authService)
+    , m_jellyfinProvider(std::make_unique<JellyfinArtworkProvider>(authService))
+    , m_siloProvider(std::make_unique<SiloArtworkProvider>(authService))
+{
+}
+
+ActiveArtworkProvider::~ActiveArtworkProvider() = default;
+
+std::optional<QNetworkRequest> ActiveArtworkProvider::resolveArtwork(
+    const Bloom::ArtworkRef &artwork) const
+{
+    IArtworkProvider *provider = activeProvider();
+    return provider ? provider->resolveArtwork(artwork) : std::nullopt;
+}
+
+void ActiveArtworkProvider::refreshArtwork(
+    const Bloom::ArtworkRef &artwork,
+    RefreshCallback completion) const
+{
+    if (!completion) {
+        return;
+    }
+
+    IArtworkProvider *provider = activeProvider();
+    if (!provider) {
+        completion(std::nullopt);
+        return;
+    }
+    provider->refreshArtwork(artwork, std::move(completion));
+}
+
+IArtworkProvider *ActiveArtworkProvider::activeProvider() const
+{
+    if (!m_authService) {
+        return nullptr;
+    }
+
+    switch (m_authService->activeProviderKind()) {
+    case ProviderKind::Jellyfin:
+        return m_jellyfinProvider.get();
+    case ProviderKind::Silo:
+        return m_siloProvider.get();
+    }
+    return nullptr;
+}

--- a/src/providers/ActiveArtworkProvider.cpp
+++ b/src/providers/ActiveArtworkProvider.cpp
@@ -32,7 +32,7 @@ void ActiveArtworkProvider::refreshArtwork(
 
     IArtworkProvider *provider = activeProvider();
     if (!provider) {
-        completion(std::nullopt);
+        deferRefresh(std::move(completion));
         return;
     }
     provider->refreshArtwork(artwork, std::move(completion));

--- a/src/providers/ActiveArtworkProvider.h
+++ b/src/providers/ActiveArtworkProvider.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "providers/IArtworkProvider.h"
+
+#include <memory>
+
+class AuthenticationService;
+class JellyfinArtworkProvider;
+class SiloArtworkProvider;
+
+class ActiveArtworkProvider final : public IArtworkProvider
+{
+public:
+    explicit ActiveArtworkProvider(AuthenticationService *authService);
+    ~ActiveArtworkProvider() override;
+
+    std::optional<QNetworkRequest> resolveArtwork(
+        const Bloom::ArtworkRef &artwork) const override;
+    void refreshArtwork(const Bloom::ArtworkRef &artwork,
+                        RefreshCallback completion) const override;
+
+private:
+    IArtworkProvider *activeProvider() const;
+
+    AuthenticationService *m_authService = nullptr;
+    std::unique_ptr<JellyfinArtworkProvider> m_jellyfinProvider;
+    std::unique_ptr<SiloArtworkProvider> m_siloProvider;
+};

--- a/src/providers/IArtworkProvider.h
+++ b/src/providers/IArtworkProvider.h
@@ -3,18 +3,39 @@
 #include "models/MediaModels.h"
 
 #include <QNetworkRequest>
+#include <QTimer>
+#include <functional>
 #include <optional>
+#include <utility>
 
 /**
- * @brief Resolves a token-free artwork identity into an authenticated fetch.
+ * @brief Resolves artwork identity and its optional transient source into a fetch.
  *
- * Implementations must not use the resolved URL as a persistent cache key.
+ * Implementations must never use sourceUrl or a resolved URL as a persistent
+ * cache key.
  */
 class IArtworkProvider
 {
 public:
     virtual ~IArtworkProvider() = default;
+    using RefreshCallback =
+        std::function<void(std::optional<QNetworkRequest>)>;
 
     virtual std::optional<QNetworkRequest> resolveArtwork(
         const Bloom::ArtworkRef &artwork) const = 0;
+
+    virtual void refreshArtwork(const Bloom::ArtworkRef &artwork,
+                                RefreshCallback callback) const
+    {
+        if (!callback) {
+            return;
+        }
+        auto resolved = resolveArtwork(artwork);
+        QTimer::singleShot(
+            0,
+            [callback = std::move(callback),
+             resolved = std::move(resolved)]() mutable {
+                callback(std::move(resolved));
+            });
+    }
 };

--- a/src/providers/IArtworkProvider.h
+++ b/src/providers/IArtworkProvider.h
@@ -2,6 +2,7 @@
 
 #include "models/MediaModels.h"
 
+#include <QCoreApplication>
 #include <QNetworkRequest>
 #include <QTimer>
 #include <functional>
@@ -30,9 +31,24 @@ public:
         if (!callback) {
             return;
         }
-        auto resolved = resolveArtwork(artwork);
+        deferRefresh(std::move(callback), resolveArtwork(artwork));
+    }
+
+protected:
+    static void deferRefresh(RefreshCallback callback,
+                              std::optional<QNetworkRequest> resolved = std::nullopt)
+    {
+        if (!callback) {
+            return;
+        }
+        auto *context = QCoreApplication::instance();
+        if (!context) {
+            callback(std::move(resolved));
+            return;
+        }
         QTimer::singleShot(
             0,
+            context,
             [callback = std::move(callback),
              resolved = std::move(resolved)]() mutable {
                 callback(std::move(resolved));

--- a/src/providers/ICatalogProvider.h
+++ b/src/providers/ICatalogProvider.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QByteArray>
+#include <optional>
 #include <QDate>
 #include <QHash>
 #include <QJsonArray>
@@ -58,6 +58,7 @@ struct ProviderCatalogQuery {
 
     int startIndex = 0;
     int limit = 0;
+    std::optional<QString> snapshot;
     QString searchTerm;
     QStringList genres;
     QStringList tags;
@@ -117,5 +118,11 @@ public:
     virtual ProviderCatalogResponse parseResponse(
         ProviderCatalogOperation operation,
         const QByteArray &body,
-        const QHash<QByteArray, QByteArray> &responseHeaders = {}) const = 0;
+        const QHash<QByteArray, QByteArray> &responseHeaders) const = 0;
+
+    ProviderCatalogResponse parseResponse(
+        ProviderCatalogOperation operation, const QByteArray &body) const
+    {
+        return parseResponse(operation, body, {});
+    }
 };

--- a/src/providers/ICatalogProvider.h
+++ b/src/providers/ICatalogProvider.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <QByteArray>
+#include <QDate>
+#include <QHash>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QList>
+#include <QString>
+#include <QStringList>
+#include <QVariantMap>
+
+enum class ProviderCatalogOperation {
+    Views,
+    Items,
+    FilterOptions,
+    NextUp,
+    LatestMedia,
+    HomeBackdrops,
+    ScreensaverItems,
+    Item,
+    Chapters,
+    ResolveLibrary,
+    SimilarItems,
+    NextUnplayedEpisode,
+    SetWatched,
+    SetFavorite,
+    Search,
+    RandomItems,
+    HeroItems,
+    HeroOverviews,
+    Versions,
+    ThemeSongs,
+};
+
+enum class ProviderHttpMethod {
+    Get,
+    Post,
+    Put,
+    Delete
+};
+
+enum class ProviderCatalogTriState {
+    Any,
+    Yes,
+    No
+};
+
+struct ProviderCatalogQuery {
+    QString userId;
+    QString itemId;
+    QString parentId;
+    QString seriesId;
+    QString excludeItemId;
+    QStringList itemIds;
+    QStringList parentIds;
+    QStringList seriesIds;
+
+    int startIndex = 0;
+    int limit = 0;
+    QString searchTerm;
+    QStringList genres;
+    QStringList tags;
+    QStringList studios;
+    QDate minPremiereDate;
+    QDate maxPremiereDate;
+    QDate minDateLastSaved;
+    double minCommunityRating = 0.0;
+    QList<int> years;
+    QString sortBy;
+    QString sortOrder;
+    QStringList includeItemTypes;
+    QStringList fields;
+    QString filterFacet;
+
+    ProviderCatalogTriState watched = ProviderCatalogTriState::Any;
+    ProviderCatalogTriState favorite = ProviderCatalogTriState::Any;
+    bool recursive = false;
+    bool includeHeavyFields = true;
+    bool unwatchedOnly = false;
+    bool stateValue = false;
+
+    bool useCacheValidation = false;
+    QByteArray etag;
+    QByteArray lastModified;
+};
+
+struct ProviderCatalogRequest {
+    ProviderHttpMethod method = ProviderHttpMethod::Get;
+    QString relativeEndpoint;
+    QByteArray body;
+    QHash<QByteArray, QByteArray> extraHeaders;
+    bool supported = false;
+    QString unsupportedReason;
+};
+
+struct ProviderCatalogResponse {
+    bool valid = false;
+    QString error;
+    QJsonArray rawItems;
+    QJsonObject rawItem;
+    int total = 0;
+    bool hasMore = false;
+    QVariantMap snapshot;
+    QVariantMap capabilityMetadata;
+    QVariantMap filterMetadata;
+};
+
+class ICatalogProvider
+{
+public:
+    virtual ~ICatalogProvider() = default;
+
+    virtual ProviderCatalogRequest createRequest(
+        ProviderCatalogOperation operation,
+        const ProviderCatalogQuery &query) const = 0;
+    virtual ProviderCatalogResponse parseResponse(
+        ProviderCatalogOperation operation,
+        const QByteArray &body,
+        const QHash<QByteArray, QByteArray> &responseHeaders = {}) const = 0;
+};

--- a/src/providers/IPlaybackProvider.h
+++ b/src/providers/IPlaybackProvider.h
@@ -43,6 +43,13 @@ struct PlaybackProviderContext
 {
     QUrl serverUrl;
     QString accessToken;
+    QString profileId;
+    QString profileToken;
+    QString clientName;
+    QString clientVersion;
+    QString deviceId;
+    QString deviceName;
+    QString devicePlatform;
 };
 
 /**

--- a/src/providers/IProviderAdapter.h
+++ b/src/providers/IProviderAdapter.h
@@ -8,8 +8,10 @@
 #include <QVariantList>
 #include <QVariantMap>
 #include <functional>
+#include <optional>
 
 class IPlaybackProvider;
+class ICatalogProvider;
 class IProviderAuthenticator;
 class IProviderRequestFactory;
 
@@ -22,6 +24,27 @@ class IProviderRequestFactory;
 using ProviderItemsResponseParser =
     std::function<ParsedItemsResult(const QByteArray &, const QString &)>;
 
+enum class ProviderRoute {
+    Profiles,
+    VerifyProfilePin,
+    AuthSessions,
+    RevokeAuthSession,
+    CatalogItems,
+    CatalogItem,
+    NativeState,
+    UpdateNativeState,
+    MediaSegments,
+    PlaybackInfo,
+    PlaybackCapability
+};
+
+struct ProviderRouteContext {
+    QString accountId;
+    QString profileId;
+    QString itemId;
+    QString sessionId;
+};
+
 class IProviderAdapter
 {
 public:
@@ -32,6 +55,7 @@ public:
     virtual const IProviderAuthenticator *authenticator() const = 0;
     virtual const IProviderRequestFactory *requestFactory() const = 0;
     virtual const IPlaybackProvider *playbackProvider() const = 0;
+    virtual const ICatalogProvider *catalogProvider() const { return nullptr; }
     virtual PlaybackInfoResponse mapPlaybackInfo(
         const QJsonObject &wirePlaybackInfo) const = 0;
     virtual ProviderItemsResponseParser itemsResponseParser() const = 0;
@@ -52,4 +76,52 @@ public:
     virtual QVariantList mapChaptersFromItem(const QJsonObject &wireItem,
                                              const QString &connectionId,
                                              const QString &itemId) const = 0;
+
+    // Optional route discovery is explicit. Callers must not interpret an
+    // empty URL, empty mapping, or HTTP success as feature support.
+    virtual bool supportsCapability(ProviderCapability capability) const
+    {
+        Q_UNUSED(capability)
+        return false;
+    }
+    virtual std::optional<QString> endpointFor(
+        ProviderRoute route, const ProviderRouteContext &context = {}) const
+    {
+        Q_UNUSED(route)
+        Q_UNUSED(context)
+        return std::nullopt;
+    }
+
+    virtual std::optional<ProviderDetectionResult> mapDetectionResult(
+        const QJsonObject &wireResult) const
+    {
+        Q_UNUSED(wireResult)
+        return std::nullopt;
+    }
+    virtual std::optional<QList<ProviderProfile>> mapProfiles(
+        const QJsonArray &wireProfiles) const
+    {
+        Q_UNUSED(wireProfiles)
+        return std::nullopt;
+    }
+    virtual std::optional<QList<ProviderAuthSession>> mapAuthSessions(
+        const QJsonArray &wireSessions) const
+    {
+        Q_UNUSED(wireSessions)
+        return std::nullopt;
+    }
+    virtual std::optional<QVariantMap> mapNativeState(
+        const QJsonObject &wireState, const QString &connectionId) const
+    {
+        Q_UNUSED(wireState)
+        Q_UNUSED(connectionId)
+        return std::nullopt;
+    }
+    virtual std::optional<QList<MediaSegmentInfo>> mapMediaSegments(
+        const QString &itemId, const QJsonObject &wireSegments) const
+    {
+        Q_UNUSED(itemId)
+        Q_UNUSED(wireSegments)
+        return std::nullopt;
+    }
 };

--- a/src/providers/IProviderAdapter.h
+++ b/src/providers/IProviderAdapter.h
@@ -35,7 +35,9 @@ enum class ProviderRoute {
     UpdateNativeState,
     MediaSegments,
     PlaybackInfo,
-    PlaybackCapability
+    PlaybackCapability,
+    Health,
+    CallerLogout
 };
 
 struct ProviderRouteContext {
@@ -85,11 +87,16 @@ public:
         return false;
     }
     virtual std::optional<QString> endpointFor(
-        ProviderRoute route, const ProviderRouteContext &context = {}) const
+        ProviderRoute route, const ProviderRouteContext &context) const
     {
         Q_UNUSED(route)
         Q_UNUSED(context)
         return std::nullopt;
+    }
+
+    std::optional<QString> endpointFor(ProviderRoute route) const
+    {
+        return endpointFor(route, ProviderRouteContext{});
     }
 
     virtual std::optional<ProviderDetectionResult> mapDetectionResult(

--- a/src/providers/IProviderAuthenticator.h
+++ b/src/providers/IProviderAuthenticator.h
@@ -30,10 +30,10 @@ struct ProviderAuthenticationResult {
         return !accessToken.isEmpty() && !accountId.isEmpty();
     }
 
-    // Refresh responses rotate both credentials and do not need to repeat the account ID.
+    // Refresh responses may omit refresh_token when the existing token remains valid.
     [[nodiscard]] bool isValidRefresh() const
     {
-        return !accessToken.isEmpty() && !refreshToken.isEmpty();
+        return !accessToken.isEmpty();
     }
 };
 
@@ -67,6 +67,21 @@ public:
 
     virtual ProviderAuthenticationRequest createLoginRequest(const QString &username,
                                                               const QString &password) const = 0;
+    virtual ProviderAuthenticationRequest createLoginRequest(
+        const QString &username,
+        const QString &password,
+        const QString &provider) const
+    {
+        Q_UNUSED(provider)
+        return createLoginRequest(username, password);
+    }
+
+    virtual ProviderAuthenticationResult parseSessionValidationResponse(
+        const QByteArray &response) const
+    {
+        Q_UNUSED(response)
+        return {};
+    }
     virtual QString sessionValidationEndpoint(const QString &accountId) const = 0;
     virtual ProviderAuthenticationResult parseLoginResponse(const QByteArray &response) const = 0;
 

--- a/src/providers/IProviderAuthenticator.h
+++ b/src/providers/IProviderAuthenticator.h
@@ -2,20 +2,55 @@
 
 #include <QByteArray>
 #include <QString>
+#include <optional>
 
 struct ProviderAuthenticationRequest {
     QString endpoint;
     QByteArray body;
+    QString refreshToken;
+    QString profileId;
+    QString profileToken;
+
+    [[nodiscard]] bool isValid() const { return !endpoint.isEmpty(); }
 };
 
 struct ProviderAuthenticationResult {
     QString accessToken;
+    QString refreshToken;
     QString accountId;
+    QString profileId;
+    QString profileToken;
     QString username;
+    // Relative lifetime reported by the provider. Negative means unspecified.
+    qint64 expiresInSeconds = -1;
 
+    // Full login responses must bind the token to a provider account.
     bool isValid() const
     {
         return !accessToken.isEmpty() && !accountId.isEmpty();
+    }
+
+    // Refresh responses rotate both credentials and do not need to repeat the account ID.
+    [[nodiscard]] bool isValidRefresh() const
+    {
+        return !accessToken.isEmpty() && !refreshToken.isEmpty();
+    }
+};
+
+struct ProviderProfileAuthenticationResult {
+    // Parsed distinguishes a completed wrong-PIN response from malformed or unsupported data.
+    bool responseParsed = false;
+    bool valid = false;
+    QString profileToken;
+
+    [[nodiscard]] bool isValid() const
+    {
+        return responseParsed && valid && !profileToken.isEmpty();
+    }
+
+    [[nodiscard]] bool isIncorrectPin() const
+    {
+        return responseParsed && !valid;
     }
 };
 
@@ -34,4 +69,31 @@ public:
                                                               const QString &password) const = 0;
     virtual QString sessionValidationEndpoint(const QString &accountId) const = 0;
     virtual ProviderAuthenticationResult parseLoginResponse(const QByteArray &response) const = 0;
+
+    // Optional authentication flows return nullopt when the provider does not
+    // implement the operation; an empty request must never mean success.
+    virtual std::optional<ProviderAuthenticationRequest> createRefreshRequest(
+        const QString &refreshToken) const
+    {
+        Q_UNUSED(refreshToken)
+        return std::nullopt;
+    }
+    virtual ProviderAuthenticationResult parseRefreshResponse(const QByteArray &response) const
+    {
+        Q_UNUSED(response)
+        return {};
+    }
+    virtual std::optional<ProviderAuthenticationRequest> createProfileLoginRequest(
+        const QString &profileId, const QString &pin) const
+    {
+        Q_UNUSED(profileId)
+        Q_UNUSED(pin)
+        return std::nullopt;
+    }
+    virtual ProviderProfileAuthenticationResult parseProfileLoginResponse(
+        const QByteArray &response) const
+    {
+        Q_UNUSED(response)
+        return {};
+    }
 };

--- a/src/providers/IProviderAuthenticator.h
+++ b/src/providers/IProviderAuthenticator.h
@@ -11,7 +11,7 @@ struct ProviderAuthenticationRequest {
     QString profileId;
     QString profileToken;
 
-    [[nodiscard]] bool isValid() const { return !endpoint.isEmpty(); }
+    [[nodiscard]] bool isValid() const { return !endpoint.trimmed().isEmpty(); }
 };
 
 struct ProviderAuthenticationResult {

--- a/src/providers/IProviderRequestFactory.h
+++ b/src/providers/IProviderRequestFactory.h
@@ -7,7 +7,13 @@
 struct ProviderRequestContext {
     QString baseUrl;
     QString accessToken;
+    QString profileId;
+    QString profileToken;
+    QString clientName;
+    QString clientVersion;
     QString deviceId;
+    QString deviceName;
+    QString devicePlatform;
 };
 
 /**

--- a/src/providers/ServerConnection.h
+++ b/src/providers/ServerConnection.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QJsonObject>
+#include <QFlags>
 #include <QList>
 #include <QString>
 
@@ -21,6 +22,54 @@ enum class ProviderKind {
 enum class ProtocolMode {
     Native,
     Compatibility
+};
+
+/** Provider-advertised operations. Absence means unsupported, not unprobed. */
+enum class ProviderCapability {
+    RefreshAuthentication = 1 << 0,
+    Profiles = 1 << 1,
+    ProfilePin = 1 << 2,
+    AuthSessions = 1 << 3,
+    Catalog = 1 << 4,
+    NativeState = 1 << 5,
+    MediaSegments = 1 << 6,
+    Playback = 1 << 7,
+    PlaybackReporting = 1 << 8
+};
+Q_DECLARE_FLAGS(ProviderCapabilities, ProviderCapability)
+
+struct ProviderDetectionResult {
+    ProviderKind providerKind = ProviderKind::Jellyfin;
+    ProtocolMode protocolMode = ProtocolMode::Native;
+    QString serverId;
+    QString serverName;
+    ProviderCapabilities capabilities;
+
+    [[nodiscard]] bool isValid() const { return !serverId.isEmpty(); }
+};
+
+struct ProviderProfile {
+    QString id;
+    QString name;
+    QString avatarUrl;
+    bool hasPin = false;
+    bool isChild = false;
+    bool isPrimary = false;
+
+    [[nodiscard]] bool isValid() const { return !id.isEmpty(); }
+};
+
+struct ProviderAuthSession {
+    QString id;
+    QString deviceName;
+    QString ipAddress;
+    // Absolute Unix timestamps in milliseconds; negative means unavailable.
+    qint64 createdAt = -1;
+    qint64 expiresAt = -1;
+    qint64 revokedAt = -1;
+    bool isCurrent = false;
+
+    [[nodiscard]] bool isValid() const { return !id.isEmpty(); }
 };
 
 /**
@@ -61,3 +110,9 @@ struct ServerConnection {
 
 Q_DECLARE_METATYPE(ServerConnection)
 Q_DECLARE_METATYPE(QList<ServerConnection>)
+Q_DECLARE_METATYPE(ProviderDetectionResult)
+Q_DECLARE_METATYPE(ProviderProfile)
+Q_DECLARE_METATYPE(QList<ProviderProfile>)
+Q_DECLARE_METATYPE(ProviderAuthSession)
+Q_DECLARE_METATYPE(QList<ProviderAuthSession>)
+Q_DECLARE_OPERATORS_FOR_FLAGS(ProviderCapabilities)

--- a/src/providers/jellyfin/JellyfinCatalogProvider.h
+++ b/src/providers/jellyfin/JellyfinCatalogProvider.h
@@ -12,6 +12,7 @@
 class JellyfinCatalogProvider final : public ICatalogProvider
 {
 public:
+    using ICatalogProvider::parseResponse;
     ProviderCatalogRequest createRequest(
         ProviderCatalogOperation operation,
         const ProviderCatalogQuery &query) const override
@@ -64,7 +65,7 @@ public:
     ProviderCatalogResponse parseResponse(
         ProviderCatalogOperation operation,
         const QByteArray &body,
-        const QHash<QByteArray, QByteArray> &responseHeaders = {}) const override
+        const QHash<QByteArray, QByteArray> &responseHeaders) const override
     {
         ProviderCatalogResponse response;
         applySnapshot(response, responseHeaders);
@@ -189,6 +190,11 @@ private:
         return supportedRequest(QString());
     }
 
+    static QString encodedPathSegment(const QString &value)
+    {
+        return QString::fromLatin1(QUrl::toPercentEncoding(value));
+    }
+
     static ProviderCatalogRequest userRequest(
         const ProviderCatalogQuery &query,
         const QString &endpointTemplate)
@@ -198,7 +204,7 @@ private:
         if (!validation.supported) {
             return validation;
         }
-        return supportedRequest(endpointTemplate.arg(query.userId));
+        return supportedRequest(endpointTemplate.arg(encodedPathSegment(query.userId)));
     }
 
     static QStringList sortedValues(QStringList values)
@@ -206,7 +212,7 @@ private:
         values.removeAll(QString());
         values.removeDuplicates();
         std::sort(values.begin(), values.end(), [](const QString &left, const QString &right) {
-            return QString::localeAwareCompare(left, right) < 0;
+            return left < right;
         });
         return values;
     }
@@ -306,7 +312,7 @@ private:
             return validation;
         }
 
-        QUrl url(QStringLiteral("/Users/%1/Items").arg(query.userId));
+        QUrl url(QStringLiteral("/Users/%1/Items").arg(encodedPathSegment(query.userId)));
         QUrlQuery urlQuery;
         if (!query.parentId.isEmpty()) {
             urlQuery.addQueryItem(QStringLiteral("ParentId"), query.parentId);
@@ -440,7 +446,7 @@ private:
         }
         return supportedRequest(QStringLiteral(
             "/Shows/NextUp?UserId=%1&Limit=10&Fields=Path,Overview,SeriesName,ImageTags,ParentId,SeriesId,SeriesPrimaryImageTag,SeriesThumbImageTag,ParentThumbItemId,ParentThumbImageTag,ParentPrimaryImageTag,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,UserData,RunTimeTicks&EnableImageTypes=Primary,Thumb,Backdrop,Logo")
-                                    .arg(query.userId));
+                                    .arg(encodedPathSegment(query.userId)));
     }
 
     static ProviderCatalogRequest latestMediaRequest(const ProviderCatalogQuery &query)
@@ -452,7 +458,8 @@ private:
         }
         return supportedRequest(QStringLiteral(
             "/Users/%1/Items/Latest?ParentId=%2&Limit=10&Fields=Path,Overview,SeriesName,ImageTags,ParentId,SeriesId,SeriesPrimaryImageTag,SeriesThumbImageTag,ParentThumbItemId,ParentThumbImageTag,ParentPrimaryImageTag,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,ProductionYear,Status,EndDate,ParentIndexNumber,IndexNumber,UserData,RunTimeTicks&EnableImageTypes=Primary,Backdrop,Thumb,Logo")
-                                    .arg(query.userId, query.parentId));
+                                    .arg(encodedPathSegment(query.userId),
+                                         encodedPathSegment(query.parentId)));
     }
 
     static ProviderCatalogRequest homeBackdropsRequest(const ProviderCatalogQuery &query)
@@ -468,12 +475,12 @@ private:
             const int limit = qBound(50, query.limit, 20000);
             return supportedRequest(QStringLiteral(
                 "/Users/%1/Items?Recursive=true&IncludeItemTypes=Movie,Series,Season,Episode&SortBy=Random&Fields=%2&EnableImages=true&EnableImageTypes=Backdrop&ImageTypeLimit=1&EnableTotalRecordCount=false&Limit=%3")
-                                        .arg(query.userId, fields)
+                                        .arg(encodedPathSegment(query.userId), fields)
                                         .arg(limit));
         }
         return supportedRequest(QStringLiteral(
             "/Users/%1/Items?Recursive=true&IncludeItemTypes=Movie,Series,Season,Episode&SortBy=SortName&Fields=%2&EnableImages=true&EnableImageTypes=Backdrop&ImageTypeLimit=1&EnableTotalRecordCount=false&StartIndex=%3&Limit=250")
-                                    .arg(query.userId, fields)
+                                    .arg(encodedPathSegment(query.userId), fields)
                                     .arg(qMax(0, query.startIndex)));
     }
 
@@ -487,7 +494,7 @@ private:
         const int limit = qBound(10, query.limit > 0 ? query.limit : 80, 200);
         return supportedRequest(QStringLiteral(
             "/Users/%1/Items?Recursive=true&IncludeItemTypes=Movie,Series&SortBy=Random&Fields=Id,Name,Overview,Type,SeriesName,SeriesId,ImageTags,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,ParentId,ProductionYear&EnableImages=true&EnableImageTypes=Backdrop,Logo&ImageTypeLimit=1&EnableTotalRecordCount=false&Limit=%2")
-                                    .arg(query.userId)
+                                    .arg(encodedPathSegment(query.userId))
                                     .arg(limit));
     }
 
@@ -501,7 +508,9 @@ private:
         const QStringList fields = query.fields.isEmpty() ? itemDetailFields() : query.fields;
         ProviderCatalogRequest request = supportedRequest(
             QStringLiteral("/Users/%1/Items/%2?Fields=%3")
-                .arg(query.userId, query.itemId, fields.join(QLatin1Char(','))));
+                .arg(encodedPathSegment(query.userId),
+                     encodedPathSegment(query.itemId),
+                     fields.join(QLatin1Char(','))));
         applyCacheHeaders(request, query);
         return request;
     }
@@ -515,7 +524,8 @@ private:
         }
         return supportedRequest(QStringLiteral(
             "/Users/%1/Items/%2?Fields=Chapters&EnableImages=true&EnableImageTypes=Chapter&ImageTypeLimit=100")
-                                    .arg(query.userId, query.itemId));
+                                    .arg(encodedPathSegment(query.userId),
+                                         encodedPathSegment(query.itemId)));
     }
 
     static ProviderCatalogRequest resolveLibraryRequest(const ProviderCatalogQuery &query)
@@ -526,7 +536,8 @@ private:
             return validation;
         }
         return supportedRequest(QStringLiteral("/Items/%1/Ancestors?UserId=%2")
-                                    .arg(query.itemId, query.userId));
+                                    .arg(encodedPathSegment(query.itemId),
+                                         encodedPathSegment(query.userId)));
     }
 
     static ProviderCatalogRequest similarItemsRequest(const ProviderCatalogQuery &query)
@@ -538,7 +549,8 @@ private:
         }
         return supportedRequest(QStringLiteral(
             "/Items/%1/Similar?UserId=%2&Limit=%3&Fields=Type,ImageTags,PrimaryImageAspectRatio,ProductionYear,PremiereDate,Overview,UserData,ChildCount&EnableImageTypes=Primary")
-                                    .arg(query.itemId, query.userId)
+                                    .arg(encodedPathSegment(query.itemId),
+                                         encodedPathSegment(query.userId))
                                     .arg(qMax(1, query.limit)));
     }
 
@@ -557,7 +569,8 @@ private:
         }
         return supportedRequest(QStringLiteral(
             "/Users/%1/Items?ParentId=%2&Recursive=true&IncludeItemTypes=Episode&Fields=Name,SortName,Overview,UserData,RunTimeTicks,ImageTags,ParentId,SeasonId,SeriesId,SeriesName,IndexNumber,ParentIndexNumber,PremiereDate,LocationType,AirsBeforeSeasonNumber,AirsAfterSeasonNumber,AirsBeforeEpisodeNumber&SortBy=ParentIndexNumber,IndexNumber,SortName&EnableImageTypes=Primary,Thumb")
-                                    .arg(query.userId, seriesId));
+                                    .arg(encodedPathSegment(query.userId),
+                                         encodedPathSegment(seriesId)));
     }
 
     static ProviderCatalogRequest stateRequest(
@@ -570,7 +583,9 @@ private:
             return validation;
         }
         ProviderCatalogRequest request = supportedRequest(
-            QStringLiteral("/Users/%1/%2/%3").arg(query.userId, collection, query.itemId),
+            QStringLiteral("/Users/%1/%2/%3")
+                .arg(encodedPathSegment(query.userId), collection,
+                     encodedPathSegment(query.itemId)),
             query.stateValue ? ProviderHttpMethod::Post : ProviderHttpMethod::Delete);
         if (query.stateValue) {
             request.extraHeaders.insert(
@@ -586,12 +601,13 @@ private:
         if (!validation.supported) {
             return validation;
         }
+        const int limit = query.limit > 0 ? query.limit : 50;
         return supportedRequest(QStringLiteral(
             "/Users/%1/Items?SearchTerm=%2&IncludeItemTypes=Movie,Series&Recursive=true&Fields=Path,Overview,ImageTags,BackdropImageTags,ProductionYear,CommunityRating,UserData&Limit=%3&EnableImageTypes=Primary,Backdrop")
-                                    .arg(query.userId)
+                                    .arg(encodedPathSegment(query.userId))
                                     .arg(QString::fromUtf8(
                                         QUrl::toPercentEncoding(query.searchTerm.trimmed())))
-                                    .arg(query.limit));
+                                    .arg(limit));
     }
 
     static ProviderCatalogRequest randomItemsRequest(const ProviderCatalogQuery &query)
@@ -601,10 +617,11 @@ private:
         if (!validation.supported) {
             return validation;
         }
+        const int limit = query.limit > 0 ? query.limit : 50;
         return supportedRequest(QStringLiteral(
             "/Users/%1/Items?IncludeItemTypes=Movie,Series&Recursive=true&SortBy=Random&Limit=%2&Fields=Overview,ImageTags,BackdropImageTags,ProductionYear")
-                                    .arg(query.userId)
-                                    .arg(query.limit));
+                                    .arg(encodedPathSegment(query.userId))
+                                    .arg(limit));
     }
 
     static ProviderCatalogRequest heroItemsRequest(const ProviderCatalogQuery &query)
@@ -623,10 +640,10 @@ private:
             : (query.parentIds.isEmpty() ? QString() : query.parentIds.constFirst());
         QString endpoint = QStringLiteral(
             "/Users/%1/Items?IncludeItemTypes=Movie,Series&Recursive=true&SortBy=Random&Limit=%2&Fields=Overview,SeriesName,ImageTags,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,ParentId,SeriesId,SeriesPrimaryImageTag,ParentPrimaryImageTag,ProductionYear,PremiereDate,UserData,RunTimeTicks,CommunityRating,OfficialRating,Genres,Studios,Tags&EnableImageTypes=Primary,Backdrop,Thumb,Logo&ImageTypeLimit=1")
-                               .arg(query.userId)
+                               .arg(encodedPathSegment(query.userId))
                                .arg(qBound(1, query.limit, 25));
         if (!parentId.isEmpty()) {
-            endpoint += QStringLiteral("&ParentId=") + parentId;
+            endpoint += QStringLiteral("&ParentId=") + encodedPathSegment(parentId);
         }
         if (query.unwatchedOnly) {
             endpoint += QStringLiteral("&IsPlayed=false");
@@ -652,7 +669,8 @@ private:
             return unsupported(QStringLiteral("Jellyfin hero overview requires a series ID"));
         }
         return supportedRequest(QStringLiteral("/Users/%1/Items/%2?Fields=Overview")
-                                    .arg(query.userId, seriesId));
+                                    .arg(encodedPathSegment(query.userId),
+                                         encodedPathSegment(seriesId)));
     }
 
     static ProviderCatalogRequest versionsRequest(const ProviderCatalogQuery &query)
@@ -663,7 +681,8 @@ private:
             return validation;
         }
         return supportedRequest(QStringLiteral("/Users/%1/Items/%2?Fields=MediaSources")
-                                    .arg(query.userId, query.itemId));
+                                    .arg(encodedPathSegment(query.userId),
+                                         encodedPathSegment(query.itemId)));
     }
 
     static ProviderCatalogRequest themeSongsRequest(const ProviderCatalogQuery &query)

--- a/src/providers/jellyfin/JellyfinCatalogProvider.h
+++ b/src/providers/jellyfin/JellyfinCatalogProvider.h
@@ -1,0 +1,779 @@
+#pragma once
+
+#include "providers/ICatalogProvider.h"
+
+#include <QJsonDocument>
+#include <QJsonParseError>
+#include <QUrl>
+#include <QUrlQuery>
+#include <QtGlobal>
+#include <algorithm>
+
+class JellyfinCatalogProvider final : public ICatalogProvider
+{
+public:
+    ProviderCatalogRequest createRequest(
+        ProviderCatalogOperation operation,
+        const ProviderCatalogQuery &query) const override
+    {
+        switch (operation) {
+        case ProviderCatalogOperation::Views:
+            return userRequest(query, QStringLiteral("/Users/%1/Views"));
+        case ProviderCatalogOperation::Items:
+            return itemsRequest(query);
+        case ProviderCatalogOperation::FilterOptions:
+            return filterOptionsRequest(query);
+        case ProviderCatalogOperation::NextUp:
+            return nextUpRequest(query);
+        case ProviderCatalogOperation::LatestMedia:
+            return latestMediaRequest(query);
+        case ProviderCatalogOperation::HomeBackdrops:
+            return homeBackdropsRequest(query);
+        case ProviderCatalogOperation::ScreensaverItems:
+            return screensaverItemsRequest(query);
+        case ProviderCatalogOperation::Item:
+            return itemRequest(query);
+        case ProviderCatalogOperation::Chapters:
+            return chaptersRequest(query);
+        case ProviderCatalogOperation::ResolveLibrary:
+            return resolveLibraryRequest(query);
+        case ProviderCatalogOperation::SimilarItems:
+            return similarItemsRequest(query);
+        case ProviderCatalogOperation::NextUnplayedEpisode:
+            return nextUnplayedEpisodeRequest(query);
+        case ProviderCatalogOperation::SetWatched:
+            return stateRequest(query, QStringLiteral("PlayedItems"));
+        case ProviderCatalogOperation::SetFavorite:
+            return stateRequest(query, QStringLiteral("FavoriteItems"));
+        case ProviderCatalogOperation::Search:
+            return searchRequest(query);
+        case ProviderCatalogOperation::RandomItems:
+            return randomItemsRequest(query);
+        case ProviderCatalogOperation::HeroItems:
+            return heroItemsRequest(query);
+        case ProviderCatalogOperation::HeroOverviews:
+            return heroOverviewRequest(query);
+        case ProviderCatalogOperation::Versions:
+            return versionsRequest(query);
+        case ProviderCatalogOperation::ThemeSongs:
+            return themeSongsRequest(query);
+        }
+        return unsupported(QStringLiteral("Unknown Jellyfin catalog operation"));
+    }
+
+    ProviderCatalogResponse parseResponse(
+        ProviderCatalogOperation operation,
+        const QByteArray &body,
+        const QHash<QByteArray, QByteArray> &responseHeaders = {}) const override
+    {
+        ProviderCatalogResponse response;
+        applySnapshot(response, responseHeaders);
+
+        if (operation == ProviderCatalogOperation::SetWatched
+            || operation == ProviderCatalogOperation::SetFavorite) {
+            const QJsonDocument mutationDocument = QJsonDocument::fromJson(body);
+            if (mutationDocument.isObject()) {
+                response.rawItem = mutationDocument.object();
+            } else if (mutationDocument.isArray()) {
+                response.rawItems = mutationDocument.array();
+                response.total = response.rawItems.size();
+            }
+            response.valid = true;
+            return response;
+        }
+
+        if (body.trimmed().isEmpty()) {
+            response.error = QStringLiteral("Jellyfin %1 response is empty")
+                                 .arg(operationName(operation));
+            return response;
+        }
+
+        QJsonParseError parseError;
+        const QJsonDocument document = QJsonDocument::fromJson(body, &parseError);
+        if (parseError.error != QJsonParseError::NoError) {
+            response.error = QStringLiteral("Invalid Jellyfin %1 response: %2")
+                                 .arg(operationName(operation), parseError.errorString());
+            return response;
+        }
+
+        if (operation == ProviderCatalogOperation::LatestMedia
+            || operation == ProviderCatalogOperation::ResolveLibrary) {
+            if (!document.isArray()) {
+                response.error = QStringLiteral("Jellyfin %1 response must be an array")
+                                     .arg(operationName(operation));
+                return response;
+            }
+            response.rawItems = document.array();
+            response.total = response.rawItems.size();
+            response.valid = true;
+            return response;
+        }
+
+        if (!document.isObject()) {
+            response.error = QStringLiteral("Jellyfin %1 response must be an object")
+                                 .arg(operationName(operation));
+            return response;
+        }
+
+        const QJsonObject root = document.object();
+        if (operation == ProviderCatalogOperation::Item
+            || operation == ProviderCatalogOperation::Chapters
+            || operation == ProviderCatalogOperation::HeroOverviews
+            || operation == ProviderCatalogOperation::Versions) {
+            response.rawItem = root;
+            response.valid = true;
+            return response;
+        }
+
+        if (operation == ProviderCatalogOperation::FilterOptions) {
+            response.rawItem = root;
+            response.rawItems = root.value(QStringLiteral("Items")).toArray();
+            response.total = root.value(QStringLiteral("TotalRecordCount"))
+                                 .toInt(response.rawItems.size());
+            response.filterMetadata = filterMetadata(root);
+            response.valid = true;
+            return response;
+        }
+
+        if (!root.contains(QStringLiteral("Items"))
+            || !root.value(QStringLiteral("Items")).isArray()) {
+            response.error = QStringLiteral("Jellyfin %1 response has no Items array")
+                                 .arg(operationName(operation));
+            return response;
+        }
+
+        response.rawItems = root.value(QStringLiteral("Items")).toArray();
+        response.total = root.value(QStringLiteral("TotalRecordCount"))
+                             .toInt(response.rawItems.size());
+        const int startIndex = root.value(QStringLiteral("StartIndex")).toInt();
+        response.hasMore = startIndex + response.rawItems.size() < response.total;
+        if (root.value(QStringLiteral("Capabilities")).isObject()) {
+            response.capabilityMetadata = root.value(QStringLiteral("Capabilities"))
+                                              .toObject().toVariantMap();
+        }
+        response.valid = true;
+        return response;
+    }
+
+private:
+    static ProviderCatalogRequest supportedRequest(
+        const QString &endpoint,
+        ProviderHttpMethod method = ProviderHttpMethod::Get)
+    {
+        ProviderCatalogRequest request;
+        request.method = method;
+        request.relativeEndpoint = endpoint;
+        request.supported = true;
+        return request;
+    }
+
+    static ProviderCatalogRequest unsupported(const QString &reason)
+    {
+        ProviderCatalogRequest request;
+        request.unsupportedReason = reason;
+        return request;
+    }
+
+    static ProviderCatalogRequest requireIds(
+        const ProviderCatalogQuery &query,
+        bool requireUser,
+        bool requireItem,
+        const QString &operation)
+    {
+        if (requireUser && query.userId.isEmpty()) {
+            return unsupported(QStringLiteral("Jellyfin %1 requires a user ID").arg(operation));
+        }
+        if (requireItem && query.itemId.isEmpty()) {
+            return unsupported(QStringLiteral("Jellyfin %1 requires an item ID").arg(operation));
+        }
+        return supportedRequest(QString());
+    }
+
+    static ProviderCatalogRequest userRequest(
+        const ProviderCatalogQuery &query,
+        const QString &endpointTemplate)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, false, QStringLiteral("catalog request"));
+        if (!validation.supported) {
+            return validation;
+        }
+        return supportedRequest(endpointTemplate.arg(query.userId));
+    }
+
+    static QStringList sortedValues(QStringList values)
+    {
+        values.removeAll(QString());
+        values.removeDuplicates();
+        std::sort(values.begin(), values.end(), [](const QString &left, const QString &right) {
+            return QString::localeAwareCompare(left, right) < 0;
+        });
+        return values;
+    }
+
+    static void addJoined(
+        QUrlQuery &urlQuery,
+        const QString &key,
+        const QStringList &values,
+        const QString &separator = QStringLiteral("|"))
+    {
+        const QStringList normalized = sortedValues(values);
+        if (!normalized.isEmpty()) {
+            urlQuery.addQueryItem(key, normalized.join(separator));
+        }
+    }
+
+    static QStringList standardItemFields(bool includeHeavyFields)
+    {
+        QStringList fields = {
+            QStringLiteral("Type"),
+            QStringLiteral("ParentIndexNumber"),
+            QStringLiteral("IndexNumber"),
+            QStringLiteral("LocationType"),
+            QStringLiteral("ImageTags"),
+            QStringLiteral("BackdropImageTags"),
+            QStringLiteral("ParentBackdropImageTags"),
+            QStringLiteral("ParentBackdropImageItemId"),
+            QStringLiteral("ParentBackdropItemId"),
+            QStringLiteral("ParentPrimaryImageTag"),
+            QStringLiteral("ParentPrimaryImageItemId"),
+            QStringLiteral("SeriesPrimaryImageTag"),
+            QStringLiteral("ProductionYear"),
+            QStringLiteral("PremiereDate"),
+            QStringLiteral("DateCreated"),
+            QStringLiteral("ChildCount"),
+            QStringLiteral("ParentId"),
+            QStringLiteral("SeasonId"),
+            QStringLiteral("SeriesId"),
+            QStringLiteral("SeriesName"),
+            QStringLiteral("UserData"),
+            QStringLiteral("RunTimeTicks"),
+            QStringLiteral("Overview"),
+            QStringLiteral("CommunityRating"),
+            QStringLiteral("Studios"),
+            QStringLiteral("Genres"),
+            QStringLiteral("Tags"),
+            QStringLiteral("SpecialEpisodeNumbers"),
+            QStringLiteral("AirsBeforeSeasonNumber"),
+            QStringLiteral("AirsAfterSeasonNumber"),
+            QStringLiteral("AirsBeforeEpisodeNumber")
+        };
+        if (includeHeavyFields) {
+            fields.prepend(QStringLiteral("Path"));
+            fields.prepend(QStringLiteral("MediaSources"));
+        }
+        return fields;
+    }
+
+    static QStringList itemDetailFields()
+    {
+        return {
+            QStringLiteral("Overview"),
+            QStringLiteral("ImageTags"),
+            QStringLiteral("BackdropImageTags"),
+            QStringLiteral("ParentBackdropImageTags"),
+            QStringLiteral("Genres"),
+            QStringLiteral("Studios"),
+            QStringLiteral("People"),
+            QStringLiteral("UserData"),
+            QStringLiteral("ProductionYear"),
+            QStringLiteral("PremiereDate"),
+            QStringLiteral("OfficialRating"),
+            QStringLiteral("RunTimeTicks"),
+            QStringLiteral("CommunityRating"),
+            QStringLiteral("ProviderIds")
+        };
+    }
+
+    static void applyCacheHeaders(
+        ProviderCatalogRequest &request,
+        const ProviderCatalogQuery &query)
+    {
+        if (!query.etag.isEmpty()) {
+            request.extraHeaders.insert(QByteArrayLiteral("If-None-Match"), query.etag);
+        }
+        if (!query.lastModified.isEmpty()) {
+            request.extraHeaders.insert(
+                QByteArrayLiteral("If-Modified-Since"), query.lastModified);
+        }
+    }
+
+    static ProviderCatalogRequest itemsRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, false, QStringLiteral("items"));
+        if (!validation.supported) {
+            return validation;
+        }
+
+        QUrl url(QStringLiteral("/Users/%1/Items").arg(query.userId));
+        QUrlQuery urlQuery;
+        if (!query.parentId.isEmpty()) {
+            urlQuery.addQueryItem(QStringLiteral("ParentId"), query.parentId);
+        }
+        const QStringList fields = query.fields.isEmpty()
+            ? standardItemFields(query.includeHeavyFields) : query.fields;
+        urlQuery.addQueryItem(QStringLiteral("Fields"), fields.join(QLatin1Char(',')));
+        urlQuery.addQueryItem(
+            QStringLiteral("EnableImageTypes"), QStringLiteral("Primary,Backdrop,Thumb,Logo"));
+        if (query.startIndex > 0) {
+            urlQuery.addQueryItem(QStringLiteral("StartIndex"), QString::number(query.startIndex));
+        }
+        if (query.limit > 0) {
+            urlQuery.addQueryItem(QStringLiteral("Limit"), QString::number(query.limit));
+        }
+        if (!query.searchTerm.trimmed().isEmpty()) {
+            urlQuery.addQueryItem(QStringLiteral("SearchTerm"), query.searchTerm.trimmed());
+        }
+        addJoined(urlQuery, QStringLiteral("Genres"), query.genres, QStringLiteral(","));
+        addJoined(urlQuery, QStringLiteral("Tags"), query.tags, QStringLiteral(","));
+        addJoined(urlQuery, QStringLiteral("Studios"), query.studios, QStringLiteral(","));
+        if (query.minPremiereDate.isValid()) {
+            urlQuery.addQueryItem(
+                QStringLiteral("MinPremiereDate"),
+                query.minPremiereDate.startOfDay(Qt::UTC).toString(Qt::ISODate));
+        }
+        if (query.maxPremiereDate.isValid()) {
+            urlQuery.addQueryItem(
+                QStringLiteral("MaxPremiereDate"),
+                query.maxPremiereDate.endOfDay(Qt::UTC).toString(Qt::ISODate));
+        }
+        if (query.minDateLastSaved.isValid()) {
+            urlQuery.addQueryItem(
+                QStringLiteral("MinDateLastSaved"),
+                query.minDateLastSaved.startOfDay(Qt::UTC).toString(Qt::ISODate));
+        }
+        if (query.watched != ProviderCatalogTriState::Any) {
+            urlQuery.addQueryItem(
+                QStringLiteral("IsPlayed"),
+                query.watched == ProviderCatalogTriState::Yes
+                    ? QStringLiteral("true") : QStringLiteral("false"));
+        } else if (query.unwatchedOnly) {
+            urlQuery.addQueryItem(QStringLiteral("IsPlayed"), QStringLiteral("false"));
+        }
+        if (query.favorite != ProviderCatalogTriState::Any) {
+            urlQuery.addQueryItem(
+                QStringLiteral("IsFavorite"),
+                query.favorite == ProviderCatalogTriState::Yes
+                    ? QStringLiteral("true") : QStringLiteral("false"));
+        }
+        if (query.minCommunityRating > 0.0) {
+            urlQuery.addQueryItem(
+                QStringLiteral("MinCommunityRating"),
+                QString::number(query.minCommunityRating, 'f', 1));
+        }
+        QStringList years;
+        years.reserve(query.years.size());
+        for (int year : query.years) {
+            if (year > 0) {
+                years.append(QString::number(year));
+            }
+        }
+        addJoined(urlQuery, QStringLiteral("Years"), years);
+        addJoined(
+            urlQuery,
+            QStringLiteral("IncludeItemTypes"),
+            query.includeItemTypes,
+            QStringLiteral(","));
+        if (query.recursive) {
+            urlQuery.addQueryItem(QStringLiteral("Recursive"), QStringLiteral("true"));
+        }
+        urlQuery.addQueryItem(
+            QStringLiteral("SortBy"),
+            query.sortBy.isEmpty()
+                ? QStringLiteral("ParentIndexNumber,IndexNumber,SortName") : query.sortBy);
+        if (!query.sortOrder.isEmpty()) {
+            urlQuery.addQueryItem(QStringLiteral("SortOrder"), query.sortOrder);
+        }
+        url.setQuery(urlQuery);
+
+        ProviderCatalogRequest request = supportedRequest(url.toString(QUrl::FullyEncoded));
+        if (query.useCacheValidation) {
+            applyCacheHeaders(request, query);
+        }
+        return request;
+    }
+
+    static ProviderCatalogRequest filterOptionsRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, false, QStringLiteral("filter options"));
+        if (!validation.supported) {
+            return validation;
+        }
+
+        const QString facet = query.filterFacet.trimmed().toLower();
+        QString path = QStringLiteral("/Items/Filters");
+        if (facet == QStringLiteral("genres")) {
+            path = QStringLiteral("/Genres");
+        } else if (facet == QStringLiteral("studios")) {
+            path = QStringLiteral("/Studios");
+        } else if (!facet.isEmpty() && facet != QStringLiteral("filters")) {
+            return unsupported(QStringLiteral("Unsupported Jellyfin filter facet: %1")
+                                   .arg(query.filterFacet));
+        }
+
+        QUrl url(path);
+        QUrlQuery urlQuery;
+        urlQuery.addQueryItem(QStringLiteral("UserId"), query.userId);
+        if (!query.parentId.isEmpty()) {
+            urlQuery.addQueryItem(QStringLiteral("ParentId"), query.parentId);
+        }
+        if (!query.includeItemTypes.isEmpty()) {
+            urlQuery.addQueryItem(
+                QStringLiteral("IncludeItemTypes"), query.includeItemTypes.join(QLatin1Char(',')));
+        }
+        if (query.recursive) {
+            urlQuery.addQueryItem(QStringLiteral("Recursive"), QStringLiteral("true"));
+        }
+        urlQuery.addQueryItem(QStringLiteral("Limit"), QStringLiteral("500"));
+        url.setQuery(urlQuery);
+        return supportedRequest(url.toString(QUrl::FullyEncoded));
+    }
+
+    static ProviderCatalogRequest nextUpRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, false, QStringLiteral("next up"));
+        if (!validation.supported) {
+            return validation;
+        }
+        return supportedRequest(QStringLiteral(
+            "/Shows/NextUp?UserId=%1&Limit=10&Fields=Path,Overview,SeriesName,ImageTags,ParentId,SeriesId,SeriesPrimaryImageTag,SeriesThumbImageTag,ParentThumbItemId,ParentThumbImageTag,ParentPrimaryImageTag,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,UserData,RunTimeTicks&EnableImageTypes=Primary,Thumb,Backdrop,Logo")
+                                    .arg(query.userId));
+    }
+
+    static ProviderCatalogRequest latestMediaRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, false, QStringLiteral("latest media"));
+        if (!validation.supported) {
+            return validation;
+        }
+        return supportedRequest(QStringLiteral(
+            "/Users/%1/Items/Latest?ParentId=%2&Limit=10&Fields=Path,Overview,SeriesName,ImageTags,ParentId,SeriesId,SeriesPrimaryImageTag,SeriesThumbImageTag,ParentThumbItemId,ParentThumbImageTag,ParentPrimaryImageTag,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,ProductionYear,Status,EndDate,ParentIndexNumber,IndexNumber,UserData,RunTimeTicks&EnableImageTypes=Primary,Backdrop,Thumb,Logo")
+                                    .arg(query.userId, query.parentId));
+    }
+
+    static ProviderCatalogRequest homeBackdropsRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, false, QStringLiteral("home backdrops"));
+        if (!validation.supported) {
+            return validation;
+        }
+        const QString fields = QStringLiteral(
+            "Id,ImageTags,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,SeriesId");
+        if (query.limit > 0) {
+            const int limit = qBound(50, query.limit, 20000);
+            return supportedRequest(QStringLiteral(
+                "/Users/%1/Items?Recursive=true&IncludeItemTypes=Movie,Series,Season,Episode&SortBy=Random&Fields=%2&EnableImages=true&EnableImageTypes=Backdrop&ImageTypeLimit=1&EnableTotalRecordCount=false&Limit=%3")
+                                        .arg(query.userId, fields)
+                                        .arg(limit));
+        }
+        return supportedRequest(QStringLiteral(
+            "/Users/%1/Items?Recursive=true&IncludeItemTypes=Movie,Series,Season,Episode&SortBy=SortName&Fields=%2&EnableImages=true&EnableImageTypes=Backdrop&ImageTypeLimit=1&EnableTotalRecordCount=false&StartIndex=%3&Limit=250")
+                                    .arg(query.userId, fields)
+                                    .arg(qMax(0, query.startIndex)));
+    }
+
+    static ProviderCatalogRequest screensaverItemsRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, false, QStringLiteral("screensaver items"));
+        if (!validation.supported) {
+            return validation;
+        }
+        const int limit = qBound(10, query.limit > 0 ? query.limit : 80, 200);
+        return supportedRequest(QStringLiteral(
+            "/Users/%1/Items?Recursive=true&IncludeItemTypes=Movie,Series&SortBy=Random&Fields=Id,Name,Overview,Type,SeriesName,SeriesId,ImageTags,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,ParentId,ProductionYear&EnableImages=true&EnableImageTypes=Backdrop,Logo&ImageTypeLimit=1&EnableTotalRecordCount=false&Limit=%2")
+                                    .arg(query.userId)
+                                    .arg(limit));
+    }
+
+    static ProviderCatalogRequest itemRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, true, QStringLiteral("item"));
+        if (!validation.supported) {
+            return validation;
+        }
+        const QStringList fields = query.fields.isEmpty() ? itemDetailFields() : query.fields;
+        ProviderCatalogRequest request = supportedRequest(
+            QStringLiteral("/Users/%1/Items/%2?Fields=%3")
+                .arg(query.userId, query.itemId, fields.join(QLatin1Char(','))));
+        applyCacheHeaders(request, query);
+        return request;
+    }
+
+    static ProviderCatalogRequest chaptersRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, true, QStringLiteral("chapters"));
+        if (!validation.supported) {
+            return validation;
+        }
+        return supportedRequest(QStringLiteral(
+            "/Users/%1/Items/%2?Fields=Chapters&EnableImages=true&EnableImageTypes=Chapter&ImageTypeLimit=100")
+                                    .arg(query.userId, query.itemId));
+    }
+
+    static ProviderCatalogRequest resolveLibraryRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, true, QStringLiteral("library resolution"));
+        if (!validation.supported) {
+            return validation;
+        }
+        return supportedRequest(QStringLiteral("/Items/%1/Ancestors?UserId=%2")
+                                    .arg(query.itemId, query.userId));
+    }
+
+    static ProviderCatalogRequest similarItemsRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, true, QStringLiteral("similar items"));
+        if (!validation.supported) {
+            return validation;
+        }
+        return supportedRequest(QStringLiteral(
+            "/Items/%1/Similar?UserId=%2&Limit=%3&Fields=Type,ImageTags,PrimaryImageAspectRatio,ProductionYear,PremiereDate,Overview,UserData,ChildCount&EnableImageTypes=Primary")
+                                    .arg(query.itemId, query.userId)
+                                    .arg(qMax(1, query.limit)));
+    }
+
+    static ProviderCatalogRequest nextUnplayedEpisodeRequest(
+        const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, false, QStringLiteral("next unplayed episode"));
+        if (!validation.supported) {
+            return validation;
+        }
+        const QString seriesId = query.seriesId.isEmpty() ? query.parentId : query.seriesId;
+        if (seriesId.isEmpty()) {
+            return unsupported(QStringLiteral(
+                "Jellyfin next unplayed episode requires a series ID"));
+        }
+        return supportedRequest(QStringLiteral(
+            "/Users/%1/Items?ParentId=%2&Recursive=true&IncludeItemTypes=Episode&Fields=Name,SortName,Overview,UserData,RunTimeTicks,ImageTags,ParentId,SeasonId,SeriesId,SeriesName,IndexNumber,ParentIndexNumber,PremiereDate,LocationType,AirsBeforeSeasonNumber,AirsAfterSeasonNumber,AirsBeforeEpisodeNumber&SortBy=ParentIndexNumber,IndexNumber,SortName&EnableImageTypes=Primary,Thumb")
+                                    .arg(query.userId, seriesId));
+    }
+
+    static ProviderCatalogRequest stateRequest(
+        const ProviderCatalogQuery &query,
+        const QString &collection)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, true, QStringLiteral("state update"));
+        if (!validation.supported) {
+            return validation;
+        }
+        ProviderCatalogRequest request = supportedRequest(
+            QStringLiteral("/Users/%1/%2/%3").arg(query.userId, collection, query.itemId),
+            query.stateValue ? ProviderHttpMethod::Post : ProviderHttpMethod::Delete);
+        if (query.stateValue) {
+            request.extraHeaders.insert(
+                QByteArrayLiteral("Content-Type"), QByteArrayLiteral("application/json"));
+        }
+        return request;
+    }
+
+    static ProviderCatalogRequest searchRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, false, QStringLiteral("search"));
+        if (!validation.supported) {
+            return validation;
+        }
+        return supportedRequest(QStringLiteral(
+            "/Users/%1/Items?SearchTerm=%2&IncludeItemTypes=Movie,Series&Recursive=true&Fields=Path,Overview,ImageTags,BackdropImageTags,ProductionYear,CommunityRating,UserData&Limit=%3&EnableImageTypes=Primary,Backdrop")
+                                    .arg(query.userId)
+                                    .arg(QString::fromUtf8(
+                                        QUrl::toPercentEncoding(query.searchTerm.trimmed())))
+                                    .arg(query.limit));
+    }
+
+    static ProviderCatalogRequest randomItemsRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, false, QStringLiteral("random items"));
+        if (!validation.supported) {
+            return validation;
+        }
+        return supportedRequest(QStringLiteral(
+            "/Users/%1/Items?IncludeItemTypes=Movie,Series&Recursive=true&SortBy=Random&Limit=%2&Fields=Overview,ImageTags,BackdropImageTags,ProductionYear")
+                                    .arg(query.userId)
+                                    .arg(query.limit));
+    }
+
+    static ProviderCatalogRequest heroItemsRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, false, QStringLiteral("hero items"));
+        if (!validation.supported) {
+            return validation;
+        }
+        if (query.parentId.isEmpty() && query.parentIds.size() > 1) {
+            return unsupported(QStringLiteral(
+                "Jellyfin hero items require one request per parent ID"));
+        }
+        const QString parentId = !query.parentId.isEmpty()
+            ? query.parentId
+            : (query.parentIds.isEmpty() ? QString() : query.parentIds.constFirst());
+        QString endpoint = QStringLiteral(
+            "/Users/%1/Items?IncludeItemTypes=Movie,Series&Recursive=true&SortBy=Random&Limit=%2&Fields=Overview,SeriesName,ImageTags,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,ParentId,SeriesId,SeriesPrimaryImageTag,ParentPrimaryImageTag,ProductionYear,PremiereDate,UserData,RunTimeTicks,CommunityRating,OfficialRating,Genres,Studios,Tags&EnableImageTypes=Primary,Backdrop,Thumb,Logo&ImageTypeLimit=1")
+                               .arg(query.userId)
+                               .arg(qBound(1, query.limit, 25));
+        if (!parentId.isEmpty()) {
+            endpoint += QStringLiteral("&ParentId=") + parentId;
+        }
+        if (query.unwatchedOnly) {
+            endpoint += QStringLiteral("&IsPlayed=false");
+        }
+        return supportedRequest(endpoint);
+    }
+
+    static ProviderCatalogRequest heroOverviewRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, false, QStringLiteral("hero overview"));
+        if (!validation.supported) {
+            return validation;
+        }
+        if (query.seriesId.isEmpty() && query.seriesIds.size() > 1) {
+            return unsupported(QStringLiteral(
+                "Jellyfin hero overviews require one request per series ID"));
+        }
+        const QString seriesId = !query.seriesId.isEmpty()
+            ? query.seriesId
+            : (query.seriesIds.isEmpty() ? QString() : query.seriesIds.constFirst());
+        if (seriesId.isEmpty()) {
+            return unsupported(QStringLiteral("Jellyfin hero overview requires a series ID"));
+        }
+        return supportedRequest(QStringLiteral("/Users/%1/Items/%2?Fields=Overview")
+                                    .arg(query.userId, seriesId));
+    }
+
+    static ProviderCatalogRequest versionsRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, true, true, QStringLiteral("versions"));
+        if (!validation.supported) {
+            return validation;
+        }
+        return supportedRequest(QStringLiteral("/Users/%1/Items/%2?Fields=MediaSources")
+                                    .arg(query.userId, query.itemId));
+    }
+
+    static ProviderCatalogRequest themeSongsRequest(const ProviderCatalogQuery &query)
+    {
+        const ProviderCatalogRequest validation = requireIds(
+            query, false, true, QStringLiteral("theme songs"));
+        if (!validation.supported) {
+            return validation;
+        }
+        return supportedRequest(
+            QStringLiteral("/Items/%1/ThemeSongs")
+                .arg(QString::fromLatin1(QUrl::toPercentEncoding(query.itemId))));
+    }
+
+    static QByteArray responseHeader(
+        const QHash<QByteArray, QByteArray> &headers,
+        const QByteArray &name)
+    {
+        for (auto it = headers.cbegin(); it != headers.cend(); ++it) {
+            if (it.key().compare(name, Qt::CaseInsensitive) == 0) {
+                return it.value();
+            }
+        }
+        return {};
+    }
+
+    static void applySnapshot(
+        ProviderCatalogResponse &response,
+        const QHash<QByteArray, QByteArray> &headers)
+    {
+        const QByteArray etag = responseHeader(headers, QByteArrayLiteral("ETag"));
+        const QByteArray lastModified = responseHeader(
+            headers, QByteArrayLiteral("Last-Modified"));
+        if (!etag.isEmpty()) {
+            response.snapshot.insert(
+                QStringLiteral("etag"), QString::fromUtf8(etag));
+        }
+        if (!lastModified.isEmpty()) {
+            response.snapshot.insert(
+                QStringLiteral("lastModified"), QString::fromUtf8(lastModified));
+        }
+    }
+
+    static QVariantList namedValues(const QJsonArray &values)
+    {
+        QVariantList result;
+        result.reserve(values.size());
+        for (const QJsonValue &value : values) {
+            if (value.isString()) {
+                result.append(value.toString());
+            } else if (value.isObject()) {
+                const QString name = value.toObject().value(QStringLiteral("Name")).toString();
+                if (!name.isEmpty()) {
+                    result.append(name);
+                }
+            }
+        }
+        return result;
+    }
+
+    static QVariantMap filterMetadata(const QJsonObject &root)
+    {
+        QVariantMap metadata;
+        if (root.value(QStringLiteral("Genres")).isArray()) {
+            metadata.insert(
+                QStringLiteral("genres"),
+                namedValues(root.value(QStringLiteral("Genres")).toArray()));
+        }
+        if (root.value(QStringLiteral("Tags")).isArray()) {
+            metadata.insert(
+                QStringLiteral("tags"),
+                namedValues(root.value(QStringLiteral("Tags")).toArray()));
+        }
+        if (root.value(QStringLiteral("Items")).isArray()) {
+            metadata.insert(
+                QStringLiteral("namedItems"),
+                namedValues(root.value(QStringLiteral("Items")).toArray()));
+        }
+        if (root.value(QStringLiteral("Filters")).isObject()) {
+            metadata.insert(
+                QStringLiteral("filters"),
+                root.value(QStringLiteral("Filters")).toObject().toVariantMap());
+        }
+        return metadata;
+    }
+
+    static QString operationName(ProviderCatalogOperation operation)
+    {
+        switch (operation) {
+        case ProviderCatalogOperation::Views: return QStringLiteral("views");
+        case ProviderCatalogOperation::Items: return QStringLiteral("items");
+        case ProviderCatalogOperation::FilterOptions: return QStringLiteral("filter options");
+        case ProviderCatalogOperation::NextUp: return QStringLiteral("next up");
+        case ProviderCatalogOperation::LatestMedia: return QStringLiteral("latest media");
+        case ProviderCatalogOperation::HomeBackdrops: return QStringLiteral("home backdrops");
+        case ProviderCatalogOperation::ScreensaverItems: return QStringLiteral("screensaver items");
+        case ProviderCatalogOperation::Item: return QStringLiteral("item");
+        case ProviderCatalogOperation::Chapters: return QStringLiteral("chapters");
+        case ProviderCatalogOperation::ResolveLibrary: return QStringLiteral("library resolution");
+        case ProviderCatalogOperation::SimilarItems: return QStringLiteral("similar items");
+        case ProviderCatalogOperation::NextUnplayedEpisode: return QStringLiteral("next unplayed episode");
+        case ProviderCatalogOperation::SetWatched: return QStringLiteral("watched state");
+        case ProviderCatalogOperation::SetFavorite: return QStringLiteral("favorite state");
+        case ProviderCatalogOperation::Search: return QStringLiteral("search");
+        case ProviderCatalogOperation::RandomItems: return QStringLiteral("random items");
+        case ProviderCatalogOperation::HeroItems: return QStringLiteral("hero items");
+        case ProviderCatalogOperation::HeroOverviews: return QStringLiteral("hero overviews");
+        case ProviderCatalogOperation::Versions: return QStringLiteral("versions");
+        case ProviderCatalogOperation::ThemeSongs: return QStringLiteral("theme songs");
+        }
+        return QStringLiteral("catalog");
+    }
+};

--- a/src/providers/jellyfin/JellyfinProviderAdapter.h
+++ b/src/providers/jellyfin/JellyfinProviderAdapter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "providers/IProviderAdapter.h"
+#include "providers/jellyfin/JellyfinCatalogProvider.h"
 #include "providers/jellyfin/JellyfinAuthenticator.h"
 #include "providers/jellyfin/JellyfinModelMapper.h"
 #include "providers/jellyfin/JellyfinPlaybackProvider.h"
@@ -14,6 +15,7 @@ public:
     const IProviderAuthenticator *authenticator() const override { return &m_authenticator; }
     const IProviderRequestFactory *requestFactory() const override { return &m_requestFactory; }
     const IPlaybackProvider *playbackProvider() const override { return &m_playbackProvider; }
+    const ICatalogProvider *catalogProvider() const override { return &m_catalogProvider; }
     PlaybackInfoResponse mapPlaybackInfo(
         const QJsonObject &wirePlaybackInfo) const override
     {
@@ -72,6 +74,7 @@ public:
     }
 
 private:
+    JellyfinCatalogProvider m_catalogProvider;
     JellyfinAuthenticator m_authenticator;
     JellyfinPlaybackProvider m_playbackProvider;
     JellyfinRequestFactory m_requestFactory;

--- a/src/providers/jellyfin/JellyfinProviderAdapter.h
+++ b/src/providers/jellyfin/JellyfinProviderAdapter.h
@@ -10,12 +10,26 @@
 class JellyfinProviderAdapter final : public IProviderAdapter
 {
 public:
+    using IProviderAdapter::endpointFor;
     ProviderKind providerKind() const override { return ProviderKind::Jellyfin; }
     ProtocolMode protocolMode() const override { return ProtocolMode::Native; }
     const IProviderAuthenticator *authenticator() const override { return &m_authenticator; }
     const IProviderRequestFactory *requestFactory() const override { return &m_requestFactory; }
     const IPlaybackProvider *playbackProvider() const override { return &m_playbackProvider; }
     const ICatalogProvider *catalogProvider() const override { return &m_catalogProvider; }
+    std::optional<QString> endpointFor(
+        ProviderRoute route, const ProviderRouteContext &context) const override
+    {
+        Q_UNUSED(context)
+        switch (route) {
+        case ProviderRoute::Health:
+            return QStringLiteral("/System/Info/Public");
+        case ProviderRoute::CallerLogout:
+            return QStringLiteral("/Sessions/Logout");
+        default:
+            return std::nullopt;
+        }
+    }
     PlaybackInfoResponse mapPlaybackInfo(
         const QJsonObject &wirePlaybackInfo) const override
     {

--- a/src/providers/silo/SiloArtworkProvider.cpp
+++ b/src/providers/silo/SiloArtworkProvider.cpp
@@ -4,6 +4,7 @@
 #include "network/HttpTransport.h"
 #include "utils/ConfigManager.h"
 
+#include <QCoreApplication>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -41,9 +42,17 @@ private:
     IArtworkProvider::RefreshCallback m_callback;
 };
 
-void finishLater(const std::shared_ptr<RefreshCompletion> &completion)
+void finishLater(const std::shared_ptr<RefreshCompletion> &completion,
+                 QObject *context = nullptr)
 {
-    QTimer::singleShot(0, [completion]() {
+    if (!context) {
+        context = QCoreApplication::instance();
+    }
+    if (!context) {
+        completion->finish(std::nullopt);
+        return;
+    }
+    QTimer::singleShot(0, context, [completion]() {
         completion->finish(std::nullopt);
     });
 }
@@ -135,22 +144,7 @@ std::optional<QUrl> resolveOpaqueUrl(const QString &baseUrl,
     return isHttpUrl(resolved) ? std::optional<QUrl>(resolved) : std::nullopt;
 }
 
-int effectivePort(const QUrl &url)
-{
-    if (url.port() >= 0) {
-        return url.port();
-    }
-    return url.scheme().compare(QStringLiteral("https"), Qt::CaseInsensitive) == 0
-        ? 443 : 80;
-}
-
-bool isSameOrigin(const QUrl &base, const QUrl &resolved)
-{
-    return isHttpUrl(base)
-        && base.scheme().compare(resolved.scheme(), Qt::CaseInsensitive) == 0
-        && base.host().compare(resolved.host(), Qt::CaseInsensitive) == 0
-        && effectivePort(base) == effectivePort(resolved);
-}
+constexpr int kArtworkTransferTimeoutMs = 30000;
 
 std::optional<QNetworkRequest> requestForSource(
     AuthenticationService *authService,
@@ -164,13 +158,10 @@ std::optional<QNetworkRequest> requestForSource(
     if (!url.has_value()) {
         return std::nullopt;
     }
-
-    const QUrl base(authService->getServerUrl().trimmed(), QUrl::StrictMode);
-    QNetworkRequest request;
-    if (isSameOrigin(base, *url)) {
-        request = authService->createRequest(QStringLiteral("/api/v1/catalog"));
-    }
+    QNetworkRequest request = authService->createRequest(
+        QString::fromUtf8(url->toEncoded(QUrl::FullyEncoded)));
     request.setUrl(*url);
+    request.setTransferTimeout(kArtworkTransferTimeoutMs);
     request.setRawHeader("Accept", "image/*");
     return request;
 }
@@ -236,8 +227,12 @@ QString chapterSource(const QJsonArray &chapters, int requestedIndex)
 QString chapterSource(const QJsonObject &item,
                       const Bloom::ArtworkRef &artwork)
 {
-    QString source = chapterSource(
-        item.value(QStringLiteral("chapters")).toArray(), artwork.index);
+    QString source;
+    if (artwork.tag.isEmpty()
+        || identityString(item.value(QStringLiteral("file_id"))) == artwork.tag) {
+        source = chapterSource(
+            item.value(QStringLiteral("chapters")).toArray(), artwork.index);
+    }
     if (!source.isEmpty()) {
         return source;
     }
@@ -375,7 +370,7 @@ void SiloArtworkProvider::refreshArtwork(
     auto completion = std::make_shared<RefreshCompletion>(std::move(callback));
     const QString endpoint = refreshEndpoint(artwork);
     if (!hasMatchingSession(m_authService, artwork) || endpoint.isEmpty()) {
-        finishLater(completion);
+        finishLater(completion, m_authService.data());
         return;
     }
 
@@ -383,7 +378,7 @@ void SiloArtworkProvider::refreshArtwork(
     QPointer<HttpTransport> transport(m_authService->transport());
     QPointer<QNetworkAccessManager> networkManager(m_authService->networkManager());
     if (!transport || !networkManager) {
-        finishLater(completion);
+        finishLater(completion, authService.data());
         return;
     }
 
@@ -399,10 +394,11 @@ void SiloArtworkProvider::refreshArtwork(
                 || !hasMatchingSession(authService.data(), artwork)) {
                 return nullptr;
             }
-            const QNetworkRequest request = authService->createRequest(endpoint);
+            QNetworkRequest request = authService->createRequest(endpoint);
             if (!request.url().isValid() || request.url().isEmpty()) {
                 return nullptr;
             }
+            request.setTransferTimeout(kArtworkTransferTimeoutMs);
             return networkManager->get(request);
         },
         [authService, artwork, completion](QNetworkReply *reply) {
@@ -425,10 +421,17 @@ void SiloArtworkProvider::refreshArtwork(
         options);
 
     if (!handle) {
-        finishLater(completion);
+        finishLater(completion, authService.data());
         return;
     }
     QObject::connect(handle, &QObject::destroyed, [completion]() {
+        completion->finish(std::nullopt);
+    });
+    const QPointer<HttpRequestHandle> guardedHandle(handle);
+    QTimer::singleShot(kArtworkTransferTimeoutMs, authService.data(), [completion, guardedHandle]() {
+        if (guardedHandle) {
+            guardedHandle->cancel();
+        }
         completion->finish(std::nullopt);
     });
 }

--- a/src/providers/silo/SiloArtworkProvider.cpp
+++ b/src/providers/silo/SiloArtworkProvider.cpp
@@ -57,15 +57,27 @@ bool hasMatchingSession(AuthenticationService *authService,
 
     ConfigManager *config = authService->configManager();
     const auto connection = config ? config->getActiveConnection() : std::nullopt;
-    return connection.has_value()
-        && connection->connectionId == artwork.connectionId
-        && connection->providerKind == ProviderKind::Silo;
+    if (!connection.has_value()
+        || connection->connectionId != artwork.connectionId
+        || connection->providerKind != ProviderKind::Silo
+        || authService->activeProviderKind() != ProviderKind::Silo) {
+        return false;
+    }
+
+    // The connection id is the cache identity, but it is not sufficient by
+    // itself to authorize a request: a caller can retain an ArtworkRef while
+    // the active connection is replaced in configuration.  Do not let the
+    // current token be sent to a different server in that case.
+    return ServerConnection::normalizeBaseUrl(authService->getServerUrl())
+        == ServerConnection::normalizeBaseUrl(connection->baseUrl);
 }
 
 bool isHttpUrl(const QUrl &url)
 {
     return url.isValid()
         && !url.host().isEmpty()
+        && url.userName().isEmpty()
+        && url.password().isEmpty()
         && (url.scheme().compare(QStringLiteral("http"), Qt::CaseInsensitive) == 0
             || url.scheme().compare(QStringLiteral("https"), Qt::CaseInsensitive) == 0);
 }
@@ -163,6 +175,7 @@ std::optional<QNetworkRequest> requestForSource(
     return request;
 }
 
+
 QString identityString(const QJsonValue &value)
 {
     if (value.isString()) {
@@ -177,8 +190,12 @@ QString identityString(const QJsonValue &value)
 QString sourceForKind(const QJsonObject &object, Bloom::ArtworkKind kind)
 {
     switch (kind) {
-    case Bloom::ArtworkKind::Primary:
-        return object.value(QStringLiteral("poster_url")).toString();
+    case Bloom::ArtworkKind::Primary: {
+        const QString poster = object.value(QStringLiteral("poster_url")).toString();
+        return poster.isEmpty()
+            ? object.value(QStringLiteral("still_url")).toString()
+            : poster;
+    }
     case Bloom::ArtworkKind::Thumb: {
         const QString thumb = object.value(QStringLiteral("thumb_url")).toString();
         return thumb.isEmpty()
@@ -377,8 +394,9 @@ void SiloArtworkProvider::refreshArtwork(
     HttpRequestHandle *handle = transport->sendWithRetry(
         transport.data(),
         endpoint,
-        [authService, networkManager, endpoint]() -> QNetworkReply * {
-            if (!authService || !networkManager) {
+        [authService, artwork, networkManager, endpoint]() -> QNetworkReply * {
+            if (!authService || !networkManager
+                || !hasMatchingSession(authService.data(), artwork)) {
                 return nullptr;
             }
             const QNetworkRequest request = authService->createRequest(endpoint);

--- a/src/providers/silo/SiloArtworkProvider.cpp
+++ b/src/providers/silo/SiloArtworkProvider.cpp
@@ -1,0 +1,416 @@
+#include "SiloArtworkProvider.h"
+
+#include "network/AuthenticationService.h"
+#include "network/HttpTransport.h"
+#include "utils/ConfigManager.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QPointer>
+#include <QTimer>
+#include <QUrl>
+#include <atomic>
+#include <memory>
+#include <utility>
+
+namespace {
+
+class RefreshCompletion final
+{
+public:
+    explicit RefreshCompletion(IArtworkProvider::RefreshCallback callback)
+        : m_callback(std::move(callback))
+    {
+    }
+
+    void finish(std::optional<QNetworkRequest> request)
+    {
+        if (m_finished.exchange(true)) {
+            return;
+        }
+        auto callback = std::move(m_callback);
+        if (callback) {
+            callback(std::move(request));
+        }
+    }
+
+private:
+    std::atomic_bool m_finished = false;
+    IArtworkProvider::RefreshCallback m_callback;
+};
+
+void finishLater(const std::shared_ptr<RefreshCompletion> &completion)
+{
+    QTimer::singleShot(0, [completion]() {
+        completion->finish(std::nullopt);
+    });
+}
+
+bool hasMatchingSession(AuthenticationService *authService,
+                        const Bloom::ArtworkRef &artwork)
+{
+    if (!authService || !artwork.isValid() || !authService->isAuthenticated()) {
+        return false;
+    }
+
+    ConfigManager *config = authService->configManager();
+    const auto connection = config ? config->getActiveConnection() : std::nullopt;
+    return connection.has_value()
+        && connection->connectionId == artwork.connectionId
+        && connection->providerKind == ProviderKind::Silo;
+}
+
+bool isHttpUrl(const QUrl &url)
+{
+    return url.isValid()
+        && !url.host().isEmpty()
+        && (url.scheme().compare(QStringLiteral("http"), Qt::CaseInsensitive) == 0
+            || url.scheme().compare(QStringLiteral("https"), Qt::CaseInsensitive) == 0);
+}
+
+std::optional<QUrl> resolveOpaqueUrl(const QString &baseUrl,
+                                     const QString &sourceUrl)
+{
+    const QByteArray encodedSource = sourceUrl.toUtf8();
+    if (encodedSource.isEmpty()) {
+        return std::nullopt;
+    }
+
+    const QUrl direct = QUrl::fromEncoded(encodedSource, QUrl::StrictMode);
+    if (!direct.isRelative() && !direct.scheme().isEmpty()) {
+        return isHttpUrl(direct) ? std::optional<QUrl>(direct) : std::nullopt;
+    }
+
+    QUrl base(baseUrl.trimmed(), QUrl::StrictMode);
+    if (!isHttpUrl(base)) {
+        return std::nullopt;
+    }
+    base.setQuery(QString());
+    base.setFragment(QString());
+
+    QByteArray combined;
+    if (encodedSource.startsWith("//")) {
+        combined = base.scheme().toUtf8() + QByteArrayLiteral(":") + encodedSource;
+    } else if (encodedSource.startsWith('/')) {
+        QUrl origin = base;
+        origin.setPath(QString());
+        origin.setUserName(QString());
+        origin.setPassword(QString());
+        combined = origin.toEncoded(QUrl::FullyEncoded) + encodedSource;
+    } else {
+        QByteArray encodedBase = base.toEncoded(QUrl::FullyEncoded);
+        if (encodedSource.startsWith('?') || encodedSource.startsWith('#')) {
+            combined = encodedBase + encodedSource;
+        } else if (encodedBase.endsWith('/')) {
+            combined = encodedBase + encodedSource;
+        } else {
+            const qsizetype schemeEnd = encodedBase.indexOf(QByteArrayLiteral("://"));
+            const qsizetype pathStart = schemeEnd < 0
+                ? -1
+                : encodedBase.indexOf('/', schemeEnd + 3);
+            if (pathStart < 0) {
+                combined = encodedBase + QByteArrayLiteral("/") + encodedSource;
+            } else {
+                combined = encodedBase.left(encodedBase.lastIndexOf('/') + 1)
+                    + encodedSource;
+            }
+        }
+    }
+
+    const QUrl resolved = QUrl::fromEncoded(combined, QUrl::StrictMode);
+    return isHttpUrl(resolved) ? std::optional<QUrl>(resolved) : std::nullopt;
+}
+
+int effectivePort(const QUrl &url)
+{
+    if (url.port() >= 0) {
+        return url.port();
+    }
+    return url.scheme().compare(QStringLiteral("https"), Qt::CaseInsensitive) == 0
+        ? 443 : 80;
+}
+
+bool isSameOrigin(const QUrl &base, const QUrl &resolved)
+{
+    return isHttpUrl(base)
+        && base.scheme().compare(resolved.scheme(), Qt::CaseInsensitive) == 0
+        && base.host().compare(resolved.host(), Qt::CaseInsensitive) == 0
+        && effectivePort(base) == effectivePort(resolved);
+}
+
+std::optional<QNetworkRequest> requestForSource(
+    AuthenticationService *authService,
+    const Bloom::ArtworkRef &artwork)
+{
+    if (!hasMatchingSession(authService, artwork)) {
+        return std::nullopt;
+    }
+
+    const auto url = resolveOpaqueUrl(authService->getServerUrl(), artwork.sourceUrl);
+    if (!url.has_value()) {
+        return std::nullopt;
+    }
+
+    const QUrl base(authService->getServerUrl().trimmed(), QUrl::StrictMode);
+    QNetworkRequest request;
+    if (isSameOrigin(base, *url)) {
+        request = authService->createRequest(QStringLiteral("/api/v1/catalog"));
+    }
+    request.setUrl(*url);
+    request.setRawHeader("Accept", "image/*");
+    return request;
+}
+
+QString identityString(const QJsonValue &value)
+{
+    if (value.isString()) {
+        return value.toString();
+    }
+    if (value.isDouble()) {
+        return QString::number(value.toVariant().toLongLong());
+    }
+    return {};
+}
+
+QString sourceForKind(const QJsonObject &object, Bloom::ArtworkKind kind)
+{
+    switch (kind) {
+    case Bloom::ArtworkKind::Primary:
+        return object.value(QStringLiteral("poster_url")).toString();
+    case Bloom::ArtworkKind::Thumb: {
+        const QString thumb = object.value(QStringLiteral("thumb_url")).toString();
+        return thumb.isEmpty()
+            ? object.value(QStringLiteral("thumbnail_url")).toString()
+            : thumb;
+    }
+    case Bloom::ArtworkKind::Backdrop:
+        return object.value(QStringLiteral("backdrop_url")).toString();
+    case Bloom::ArtworkKind::Logo:
+        return object.value(QStringLiteral("logo_url")).toString();
+    case Bloom::ArtworkKind::Chapter:
+        return object.value(QStringLiteral("thumbnail_url")).toString();
+    case Bloom::ArtworkKind::Person:
+        return object.value(QStringLiteral("photo_url")).toString();
+    case Bloom::ArtworkKind::Unknown:
+        return {};
+    }
+    return {};
+}
+
+QString chapterSource(const QJsonArray &chapters, int requestedIndex)
+{
+    for (qsizetype position = 0; position < chapters.size(); ++position) {
+        const QJsonObject chapter = chapters.at(position).toObject();
+        if (chapter.isEmpty()) {
+            continue;
+        }
+        const int index = chapter.value(QStringLiteral("index")).isDouble()
+            ? chapter.value(QStringLiteral("index")).toInt()
+            : static_cast<int>(position);
+        if (index == requestedIndex) {
+            return sourceForKind(chapter, Bloom::ArtworkKind::Chapter);
+        }
+    }
+    return {};
+}
+
+QString chapterSource(const QJsonObject &item,
+                      const Bloom::ArtworkRef &artwork)
+{
+    QString source = chapterSource(
+        item.value(QStringLiteral("chapters")).toArray(), artwork.index);
+    if (!source.isEmpty()) {
+        return source;
+    }
+
+    const QJsonArray versions = item.value(QStringLiteral("versions")).toArray();
+    for (const QJsonValue &value : versions) {
+        const QJsonObject version = value.toObject();
+        if (!artwork.tag.isEmpty()
+            && identityString(version.value(QStringLiteral("file_id"))) != artwork.tag) {
+            continue;
+        }
+        source = chapterSource(
+            version.value(QStringLiteral("chapters")).toArray(), artwork.index);
+        if (!source.isEmpty()) {
+            return source;
+        }
+    }
+    return {};
+}
+
+QJsonObject unwrappedObject(const QJsonObject &object, const QString &property)
+{
+    const QJsonObject nested = object.value(property).toObject();
+    return nested.isEmpty() ? object : nested;
+}
+
+QString refreshedSource(const QByteArray &payload,
+                        const Bloom::ArtworkRef &artwork)
+{
+    QJsonParseError parseError;
+    const QJsonDocument document = QJsonDocument::fromJson(payload, &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        return {};
+    }
+
+    switch (artwork.ownerKind) {
+    case Bloom::ArtworkOwnerKind::Library: {
+        QJsonArray libraries;
+        if (document.isArray()) {
+            libraries = document.array();
+        } else if (document.isObject()) {
+            const QJsonObject object = document.object();
+            libraries = object.value(QStringLiteral("libraries")).toArray();
+            if (libraries.isEmpty()) {
+                libraries = object.value(QStringLiteral("items")).toArray();
+            }
+        }
+        for (const QJsonValue &value : libraries) {
+            const QJsonObject library = value.toObject();
+            if (identityString(library.value(QStringLiteral("id"))) == artwork.itemId) {
+                return sourceForKind(library, artwork.kind);
+            }
+        }
+        return {};
+    }
+    case Bloom::ArtworkOwnerKind::Person:
+        if (!document.isObject()) {
+            return {};
+        }
+        return sourceForKind(
+            unwrappedObject(document.object(), QStringLiteral("person")), artwork.kind);
+    case Bloom::ArtworkOwnerKind::Chapter:
+        if (!document.isObject() || artwork.kind != Bloom::ArtworkKind::Chapter) {
+            return {};
+        }
+        return chapterSource(
+            unwrappedObject(document.object(), QStringLiteral("item")), artwork);
+    case Bloom::ArtworkOwnerKind::MediaItem:
+        if (!document.isObject()) {
+            return {};
+        }
+        return sourceForKind(
+            unwrappedObject(document.object(), QStringLiteral("item")), artwork.kind);
+    }
+    return {};
+}
+
+QString encodedIdentity(const QString &identity)
+{
+    return QString::fromLatin1(QUrl::toPercentEncoding(identity));
+}
+
+QString refreshEndpoint(const Bloom::ArtworkRef &artwork)
+{
+    switch (artwork.ownerKind) {
+    case Bloom::ArtworkOwnerKind::Library:
+        return artwork.kind == Bloom::ArtworkKind::Primary
+            ? QStringLiteral("/api/v1/user/libraries") : QString();
+    case Bloom::ArtworkOwnerKind::Person:
+        return artwork.kind == Bloom::ArtworkKind::Person
+            ? QStringLiteral("/api/v1/catalog/people/%1").arg(encodedIdentity(artwork.itemId))
+            : QString();
+    case Bloom::ArtworkOwnerKind::Chapter:
+        return artwork.kind == Bloom::ArtworkKind::Chapter
+            ? QStringLiteral("/api/v1/catalog/items/%1").arg(encodedIdentity(artwork.itemId))
+            : QString();
+    case Bloom::ArtworkOwnerKind::MediaItem:
+        switch (artwork.kind) {
+        case Bloom::ArtworkKind::Primary:
+        case Bloom::ArtworkKind::Thumb:
+        case Bloom::ArtworkKind::Backdrop:
+        case Bloom::ArtworkKind::Logo:
+            return QStringLiteral("/api/v1/catalog/items/%1")
+                .arg(encodedIdentity(artwork.itemId));
+        case Bloom::ArtworkKind::Chapter:
+        case Bloom::ArtworkKind::Person:
+        case Bloom::ArtworkKind::Unknown:
+            return {};
+        }
+    }
+    return {};
+}
+
+} // namespace
+
+SiloArtworkProvider::SiloArtworkProvider(AuthenticationService *authService)
+    : m_authService(authService)
+{
+}
+
+std::optional<QNetworkRequest> SiloArtworkProvider::resolveArtwork(
+    const Bloom::ArtworkRef &artwork) const
+{
+    return requestForSource(m_authService, artwork);
+}
+
+void SiloArtworkProvider::refreshArtwork(
+    const Bloom::ArtworkRef &artwork,
+    RefreshCallback callback) const
+{
+    if (!callback) {
+        return;
+    }
+
+    auto completion = std::make_shared<RefreshCompletion>(std::move(callback));
+    const QString endpoint = refreshEndpoint(artwork);
+    if (!hasMatchingSession(m_authService, artwork) || endpoint.isEmpty()) {
+        finishLater(completion);
+        return;
+    }
+
+    QPointer<AuthenticationService> authService(m_authService);
+    QPointer<HttpTransport> transport(m_authService->transport());
+    QPointer<QNetworkAccessManager> networkManager(m_authService->networkManager());
+    if (!transport || !networkManager) {
+        finishLater(completion);
+        return;
+    }
+
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+
+    HttpRequestHandle *handle = transport->sendWithRetry(
+        transport.data(),
+        endpoint,
+        [authService, networkManager, endpoint]() -> QNetworkReply * {
+            if (!authService || !networkManager) {
+                return nullptr;
+            }
+            const QNetworkRequest request = authService->createRequest(endpoint);
+            if (!request.url().isValid() || request.url().isEmpty()) {
+                return nullptr;
+            }
+            return networkManager->get(request);
+        },
+        [authService, artwork, completion](QNetworkReply *reply) {
+            if (!authService || !reply) {
+                completion->finish(std::nullopt);
+                return;
+            }
+            const QString source = refreshedSource(reply->readAll(), artwork);
+            if (source.isEmpty()) {
+                completion->finish(std::nullopt);
+                return;
+            }
+            Bloom::ArtworkRef refreshed = artwork;
+            refreshed.sourceUrl = source;
+            completion->finish(requestForSource(authService.data(), refreshed));
+        },
+        [completion](const NetworkError &) {
+            completion->finish(std::nullopt);
+        },
+        options);
+
+    if (!handle) {
+        finishLater(completion);
+        return;
+    }
+    QObject::connect(handle, &QObject::destroyed, [completion]() {
+        completion->finish(std::nullopt);
+    });
+}

--- a/src/providers/silo/SiloArtworkProvider.cpp
+++ b/src/providers/silo/SiloArtworkProvider.cpp
@@ -370,7 +370,7 @@ void SiloArtworkProvider::refreshArtwork(
     auto completion = std::make_shared<RefreshCompletion>(std::move(callback));
     const QString endpoint = refreshEndpoint(artwork);
     if (!hasMatchingSession(m_authService, artwork) || endpoint.isEmpty()) {
-        finishLater(completion, m_authService.data());
+        finishLater(completion);
         return;
     }
 
@@ -378,7 +378,7 @@ void SiloArtworkProvider::refreshArtwork(
     QPointer<HttpTransport> transport(m_authService->transport());
     QPointer<QNetworkAccessManager> networkManager(m_authService->networkManager());
     if (!transport || !networkManager) {
-        finishLater(completion, authService.data());
+        finishLater(completion);
         return;
     }
 
@@ -421,7 +421,7 @@ void SiloArtworkProvider::refreshArtwork(
         options);
 
     if (!handle) {
-        finishLater(completion, authService.data());
+        finishLater(completion);
         return;
     }
     QObject::connect(handle, &QObject::destroyed, [completion]() {

--- a/src/providers/silo/SiloArtworkProvider.h
+++ b/src/providers/silo/SiloArtworkProvider.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "providers/IArtworkProvider.h"
+
+class AuthenticationService;
+
+class SiloArtworkProvider final : public IArtworkProvider
+{
+public:
+    explicit SiloArtworkProvider(AuthenticationService *authService);
+
+    std::optional<QNetworkRequest> resolveArtwork(
+        const Bloom::ArtworkRef &artwork) const override;
+    void refreshArtwork(const Bloom::ArtworkRef &artwork,
+                        RefreshCallback callback) const override;
+
+private:
+    AuthenticationService *m_authService = nullptr;
+};

--- a/src/providers/silo/SiloArtworkProvider.h
+++ b/src/providers/silo/SiloArtworkProvider.h
@@ -2,6 +2,8 @@
 
 #include "providers/IArtworkProvider.h"
 
+#include <QPointer>
+
 class AuthenticationService;
 
 class SiloArtworkProvider final : public IArtworkProvider
@@ -15,5 +17,5 @@ public:
                         RefreshCallback callback) const override;
 
 private:
-    AuthenticationService *m_authService = nullptr;
+    QPointer<AuthenticationService> m_authService;
 };

--- a/src/providers/silo/SiloAuthenticator.h
+++ b/src/providers/silo/SiloAuthenticator.h
@@ -1,0 +1,315 @@
+#pragma once
+
+#include "providers/IProviderAuthenticator.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QStringList>
+#include <QUrl>
+
+#include <cmath>
+#include <limits>
+
+/** Provider-specific authentication failure codes carried by Silo error envelopes. */
+enum class SiloAuthenticationFailure {
+    None,
+    InvalidCredentials,
+    InvalidToken,
+    SessionRevoked,
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    BadRequest,
+    Other
+};
+
+struct SiloAuthenticationError {
+    SiloAuthenticationFailure failure = SiloAuthenticationFailure::None;
+    QString code;
+    QString message;
+
+    [[nodiscard]] bool isValid() const
+    {
+        return failure != SiloAuthenticationFailure::None && !code.isEmpty();
+    }
+
+    [[nodiscard]] bool isSessionRevoked() const
+    {
+        return failure == SiloAuthenticationFailure::SessionRevoked;
+    }
+};
+
+struct SiloAccountIdentity {
+    QString accountId;
+    QString username;
+    QString role;
+    QStringList permissions;
+    bool downloadAllowed = false;
+
+    [[nodiscard]] bool isValid() const
+    {
+        return !accountId.isEmpty() && !username.isEmpty();
+    }
+};
+
+/** Native Silo /api/v1 authentication wire contract. */
+class SiloAuthenticator final : public IProviderAuthenticator
+{
+public:
+    ProviderAuthenticationRequest createLoginRequest(const QString &username,
+                                                      const QString &password) const override
+    {
+        return createLoginRequest(username, password, {});
+    }
+
+    ProviderAuthenticationRequest createLoginRequest(const QString &username,
+                                                      const QString &password,
+                                                      const QString &provider) const
+    {
+        QJsonObject body{
+            {QStringLiteral("username"), username},
+            {QStringLiteral("password"), password}
+        };
+        if (!provider.trimmed().isEmpty()) {
+            body[QStringLiteral("provider")] = provider.trimmed();
+        }
+        return {
+            QStringLiteral("/api/v1/auth/login"),
+            QJsonDocument(body).toJson(QJsonDocument::Compact)
+        };
+    }
+
+    QString sessionValidationEndpoint(const QString &accountId) const override
+    {
+        Q_UNUSED(accountId)
+        return QStringLiteral("/api/v1/auth/me");
+    }
+
+    ProviderAuthenticationResult parseLoginResponse(const QByteArray &response) const override
+    {
+        const auto object = parseObject(response);
+        if (!object) {
+            return {};
+        }
+
+        const QJsonValue accessToken = object->value(QStringLiteral("access_token"));
+        const QJsonValue refreshToken = object->value(QStringLiteral("refresh_token"));
+        const qint64 expiresIn = positiveInteger(object->value(QStringLiteral("expires_in")));
+        const QJsonValue user = object->value(QStringLiteral("user"));
+        if (!accessToken.isString() || accessToken.toString().isEmpty()
+            || !refreshToken.isString() || refreshToken.toString().isEmpty()
+            || expiresIn <= 0 || !user.isObject()) {
+            return {};
+        }
+
+        const SiloAccountIdentity identity = accountIdentity(user.toObject(), false);
+        if (!identity.isValid()) {
+            return {};
+        }
+
+        ProviderAuthenticationResult result;
+        result.accessToken = accessToken.toString();
+        result.refreshToken = refreshToken.toString();
+        result.accountId = identity.accountId;
+        result.username = identity.username;
+        result.expiresInSeconds = expiresIn;
+        return result;
+    }
+
+    std::optional<ProviderAuthenticationRequest> createRefreshRequest(
+        const QString &refreshToken) const override
+    {
+        if (refreshToken.isEmpty()) {
+            return std::nullopt;
+        }
+        return ProviderAuthenticationRequest{
+            QStringLiteral("/api/v1/auth/refresh"),
+            QJsonDocument(QJsonObject{
+                {QStringLiteral("refresh_token"), refreshToken}
+            }).toJson(QJsonDocument::Compact),
+            refreshToken
+        };
+    }
+
+    ProviderAuthenticationResult parseRefreshResponse(const QByteArray &response) const override
+    {
+        const auto object = parseObject(response);
+        if (!object) {
+            return {};
+        }
+
+        const QJsonValue accessToken = object->value(QStringLiteral("access_token"));
+        const QJsonValue refreshToken = object->value(QStringLiteral("refresh_token"));
+        const qint64 expiresIn = positiveInteger(object->value(QStringLiteral("expires_in")));
+        if (!accessToken.isString() || accessToken.toString().isEmpty()
+            || !refreshToken.isString() || refreshToken.toString().isEmpty()
+            || expiresIn <= 0) {
+            return {};
+        }
+
+        ProviderAuthenticationResult result;
+        result.accessToken = accessToken.toString();
+        // Silo returns a replacement refresh token. Callers must persist this value.
+        result.refreshToken = refreshToken.toString();
+        result.expiresInSeconds = expiresIn;
+        return result;
+    }
+
+    std::optional<ProviderAuthenticationRequest> createProfileLoginRequest(
+        const QString &profileId, const QString &pin) const override
+    {
+        if (profileId.trimmed().isEmpty() || pin.isEmpty()) {
+            return std::nullopt;
+        }
+
+        const QString encodedProfileId = QString::fromLatin1(
+            QUrl::toPercentEncoding(profileId.trimmed()));
+        ProviderAuthenticationRequest request;
+        request.endpoint = QStringLiteral("/api/v1/profiles/%1/verify-pin")
+                               .arg(encodedProfileId);
+        request.body = QJsonDocument(QJsonObject{
+            {QStringLiteral("pin"), pin}
+        }).toJson(QJsonDocument::Compact);
+        request.profileId = profileId.trimmed();
+        return request;
+    }
+
+    ProviderProfileAuthenticationResult parseProfileLoginResponse(
+        const QByteArray &response) const override
+    {
+        const auto object = parseObject(response);
+        if (!object) {
+            return {};
+        }
+
+        const QJsonValue valid = object->value(QStringLiteral("valid"));
+        if (!valid.isBool()) {
+            return {};
+        }
+
+        ProviderProfileAuthenticationResult result;
+        result.responseParsed = true;
+        result.valid = valid.toBool();
+        if (!result.valid) {
+            return result;
+        }
+
+        const QJsonValue profileToken = object->value(QStringLiteral("profile_token"));
+        if (!profileToken.isString() || profileToken.toString().isEmpty()) {
+            return {};
+        }
+
+        result.profileToken = profileToken.toString();
+        return result;
+    }
+
+    SiloAccountIdentity parseSessionValidationResponse(const QByteArray &response) const
+    {
+        const auto object = parseObject(response);
+        return object ? accountIdentity(*object, true) : SiloAccountIdentity{};
+    }
+
+    SiloAuthenticationError parseErrorResponse(const QByteArray &response) const
+    {
+        const auto object = parseObject(response);
+        if (!object) {
+            return {};
+        }
+
+        const QJsonValue codeValue = object->value(QStringLiteral("error"));
+        const QJsonValue messageValue = object->value(QStringLiteral("message"));
+        if (!codeValue.isString() || codeValue.toString().isEmpty()
+            || !messageValue.isString()) {
+            return {};
+        }
+
+        SiloAuthenticationError result;
+        result.code = codeValue.toString();
+        result.message = messageValue.toString();
+        if (result.code == QStringLiteral("invalid_credentials")) {
+            result.failure = SiloAuthenticationFailure::InvalidCredentials;
+        } else if (result.code == QStringLiteral("invalid_token")) {
+            result.failure = SiloAuthenticationFailure::InvalidToken;
+        } else if (result.code == QStringLiteral("session_revoked")) {
+            result.failure = SiloAuthenticationFailure::SessionRevoked;
+        } else if (result.code == QStringLiteral("unauthorized")) {
+            result.failure = SiloAuthenticationFailure::Unauthorized;
+        } else if (result.code == QStringLiteral("forbidden")
+                   || result.code == QStringLiteral("user_disabled")) {
+            result.failure = SiloAuthenticationFailure::Forbidden;
+        } else if (result.code == QStringLiteral("not_found")) {
+            result.failure = SiloAuthenticationFailure::NotFound;
+        } else if (result.code == QStringLiteral("bad_request")) {
+            result.failure = SiloAuthenticationFailure::BadRequest;
+        } else {
+            result.failure = SiloAuthenticationFailure::Other;
+        }
+        return result;
+    }
+
+private:
+    static std::optional<QJsonObject> parseObject(const QByteArray &response)
+    {
+        QJsonParseError error;
+        const QJsonDocument document = QJsonDocument::fromJson(response, &error);
+        if (error.error != QJsonParseError::NoError || !document.isObject()) {
+            return std::nullopt;
+        }
+        return document.object();
+    }
+
+    static qint64 positiveInteger(const QJsonValue &value)
+    {
+        if (!value.isDouble()) {
+            return -1;
+        }
+        const double number = value.toDouble();
+        constexpr double maximumExactJsonInteger = 9007199254740991.0;
+        if (!std::isfinite(number) || number <= 0.0
+            || number > maximumExactJsonInteger || std::trunc(number) != number) {
+            return -1;
+        }
+        return static_cast<qint64>(number);
+    }
+
+    static SiloAccountIdentity accountIdentity(const QJsonObject &user,
+                                               bool requireAuthorizationFields)
+    {
+        const qint64 id = positiveInteger(user.value(QStringLiteral("id")));
+        const QJsonValue username = user.value(QStringLiteral("username"));
+        if (id <= 0 || !username.isString() || username.toString().isEmpty()) {
+            return {};
+        }
+
+        const QJsonValue role = user.value(QStringLiteral("role"));
+        const QJsonValue permissions = user.value(QStringLiteral("permissions"));
+        const QJsonValue downloadAllowed = user.value(QStringLiteral("download_allowed"));
+        if (requireAuthorizationFields
+            && (!role.isString() || !permissions.isArray() || !downloadAllowed.isBool())) {
+            return {};
+        }
+
+        SiloAccountIdentity result;
+        result.accountId = QString::number(id);
+        result.username = username.toString();
+        if (role.isString()) {
+            result.role = role.toString();
+        }
+        if (permissions.isArray()) {
+            for (const QJsonValue &permission : permissions.toArray()) {
+                if (!permission.isString()) {
+                    if (requireAuthorizationFields) {
+                        return {};
+                    }
+                    continue;
+                }
+                result.permissions.append(permission.toString());
+            }
+        }
+        if (downloadAllowed.isBool()) {
+            result.downloadAllowed = downloadAllowed.toBool();
+        }
+        return result;
+    }
+};

--- a/src/providers/silo/SiloAuthenticator.h
+++ b/src/providers/silo/SiloAuthenticator.h
@@ -196,7 +196,9 @@ public:
         }
 
         const QJsonValue profileToken = object->value(QStringLiteral("profile_token"));
-        if (!profileToken.isString() || profileToken.toString().isEmpty()) {
+        const QJsonValue expiresAt = object->value(QStringLiteral("expires_at"));
+        if (!profileToken.isString() || profileToken.toString().isEmpty()
+            || !expiresAt.isString() || expiresAt.toString().trimmed().isEmpty()) {
             return {};
         }
 

--- a/src/providers/silo/SiloAuthenticator.h
+++ b/src/providers/silo/SiloAuthenticator.h
@@ -65,7 +65,7 @@ public:
 
     ProviderAuthenticationRequest createLoginRequest(const QString &username,
                                                       const QString &password,
-                                                      const QString &provider) const
+                                                      const QString &provider) const override
     {
         QJsonObject body{
             {QStringLiteral("username"), username},
@@ -143,15 +143,17 @@ public:
         const QJsonValue refreshToken = object->value(QStringLiteral("refresh_token"));
         const qint64 expiresIn = positiveInteger(object->value(QStringLiteral("expires_in")));
         if (!accessToken.isString() || accessToken.toString().isEmpty()
-            || !refreshToken.isString() || refreshToken.toString().isEmpty()
-            || expiresIn <= 0) {
+            || expiresIn <= 0
+            || (!refreshToken.isUndefined()
+                && (!refreshToken.isString() || refreshToken.toString().isEmpty()))) {
             return {};
         }
 
         ProviderAuthenticationResult result;
         result.accessToken = accessToken.toString();
-        // Silo returns a replacement refresh token. Callers must persist this value.
-        result.refreshToken = refreshToken.toString();
+        if (!refreshToken.isUndefined()) {
+            result.refreshToken = refreshToken.toString();
+        }
         result.expiresInSeconds = expiresIn;
         return result;
     }
@@ -206,10 +208,23 @@ public:
         return result;
     }
 
-    SiloAccountIdentity parseSessionValidationResponse(const QByteArray &response) const
+    ProviderAuthenticationResult parseSessionValidationResponse(
+        const QByteArray &response) const override
     {
         const auto object = parseObject(response);
-        return object ? accountIdentity(*object, true) : SiloAccountIdentity{};
+        if (!object) {
+            return {};
+        }
+
+        const SiloAccountIdentity identity = accountIdentity(*object, true);
+        if (!identity.isValid()) {
+            return {};
+        }
+
+        ProviderAuthenticationResult result;
+        result.accountId = identity.accountId;
+        result.username = identity.username;
+        return result;
     }
 
     SiloAuthenticationError parseErrorResponse(const QByteArray &response) const

--- a/src/providers/silo/SiloCatalogProvider.h
+++ b/src/providers/silo/SiloCatalogProvider.h
@@ -605,10 +605,15 @@ private:
         if (!trimmedParentId.isEmpty()) {
             static_cast<void>(trimmedParentId.toInt(&libraryIdOk));
         }
-        if (!libraryIdOk && query.includeItemTypes.size() == 1) {
+        if (!libraryIdOk
+            && (query.includeItemTypes.isEmpty() || query.includeItemTypes.size() == 1)) {
             if (hasHierarchyModifiers(query)) {
                 return unsupported(QStringLiteral(
                     "Silo hierarchy routes do not support catalog filters or pagination"));
+            }
+            if (query.includeItemTypes.isEmpty()) {
+                return getWithContentId(QStringLiteral("/api/v1/catalog/series/%1/seasons"),
+                                        query.parentId);
             }
             const QString type = normalizedItemType(query.includeItemTypes.first());
             if (type == QStringLiteral("season")) {

--- a/src/providers/silo/SiloCatalogProvider.h
+++ b/src/providers/silo/SiloCatalogProvider.h
@@ -1,0 +1,767 @@
+#pragma once
+
+#include "providers/ICatalogProvider.h"
+#include "providers/silo/SiloModelMapper.h"
+
+#include <QJsonDocument>
+#include <QUrl>
+#include <QUrlQuery>
+#include <optional>
+#include <cmath>
+
+class SiloCatalogProvider final : public ICatalogProvider
+{
+public:
+    ProviderCatalogRequest createRequest(
+        ProviderCatalogOperation operation,
+        const ProviderCatalogQuery &query) const override
+    {
+        switch (operation) {
+        case ProviderCatalogOperation::Views:
+            return createViewsRequest(query);
+        case ProviderCatalogOperation::Items:
+            return createItemsRequest(query);
+        case ProviderCatalogOperation::FilterOptions:
+            return createFilterOptionsRequest(query);
+        case ProviderCatalogOperation::LatestMedia: {
+            ProviderCatalogQuery latest = query;
+            if (latest.sortBy.trimmed().isEmpty()) {
+                latest.sortBy = QStringLiteral("added_at");
+                latest.sortOrder = QStringLiteral("desc");
+            }
+            return createCatalogRequest(latest, false);
+        }
+        case ProviderCatalogOperation::Item:
+            return getWithContentId(QStringLiteral("/api/v1/catalog/items/%1"), query.itemId);
+        case ProviderCatalogOperation::Chapters:
+        case ProviderCatalogOperation::Versions:
+            return getWithContentId(QStringLiteral("/api/v1/catalog/items/%1/versions"),
+                                    query.itemId);
+        case ProviderCatalogOperation::ThemeSongs:
+            return unsupported(themeSongsUnsupportedReason());
+        case ProviderCatalogOperation::SimilarItems: {
+            if (query.limit < 0 || query.startIndex != 0
+                || !query.parentId.trimmed().isEmpty()
+                || !query.seriesId.trimmed().isEmpty()
+                || !query.searchTerm.trimmed().isEmpty()
+                || !query.genres.isEmpty() || !query.tags.isEmpty()
+                || !query.studios.isEmpty() || !query.years.isEmpty()
+                || !query.includeItemTypes.isEmpty()
+                || query.watched != ProviderCatalogTriState::Any
+                || query.favorite != ProviderCatalogTriState::Any
+                || query.unwatchedOnly) {
+                return unsupported(QStringLiteral(
+                    "Silo similar recommendations support only content_id and limit"));
+            }
+            ProviderCatalogRequest request = getWithContentId(
+                QStringLiteral("/api/v1/recommendations/similar/%1"), query.itemId);
+            if (!request.supported) {
+                return request;
+            }
+            QUrlQuery parameters;
+            appendLimit(parameters, query.limit);
+            request.relativeEndpoint = endpointWithQuery(request.relativeEndpoint, parameters);
+            return request;
+        }
+        case ProviderCatalogOperation::SetWatched:
+            return mutationWithContentId(query.stateValue ? ProviderHttpMethod::Post
+                                                          : ProviderHttpMethod::Delete,
+                                         QStringLiteral("/api/v1/watched/%1"),
+                                         query.itemId);
+        case ProviderCatalogOperation::SetFavorite:
+            return mutationWithContentId(query.stateValue ? ProviderHttpMethod::Put
+                                                          : ProviderHttpMethod::Delete,
+                                         QStringLiteral("/api/v1/favorites/%1"),
+                                         query.itemId);
+        case ProviderCatalogOperation::Search:
+            if (query.searchTerm.trimmed().isEmpty()) {
+                return unsupported(QStringLiteral("Silo search requires a non-empty search term"));
+            }
+            return createCatalogRequest(query, false);
+        case ProviderCatalogOperation::NextUp:
+            if (hasCatalogModifiers(query)
+                || !query.parentId.trimmed().isEmpty()
+                || !query.itemId.trimmed().isEmpty()) {
+                return unsupported(QStringLiteral(
+                    "Silo's Next Up home section does not accept catalog modifiers"));
+            }
+            return get(QStringLiteral("/api/v1/home/sections/system-next-up/items"));
+        case ProviderCatalogOperation::HomeBackdrops:
+        case ProviderCatalogOperation::ScreensaverItems:
+        case ProviderCatalogOperation::RandomItems:
+        case ProviderCatalogOperation::HeroItems:
+        case ProviderCatalogOperation::HeroOverviews:
+            return unsupported(QStringLiteral(
+                "Silo has no native endpoint with the requested selection semantics"));
+        case ProviderCatalogOperation::NextUnplayedEpisode:
+            return unsupported(QStringLiteral(
+                "Silo has no series-scoped next-unplayed-episode endpoint at revision 8044eb84"));
+        case ProviderCatalogOperation::ResolveLibrary:
+            return unsupported(QStringLiteral(
+                "Silo catalog resources do not expose an ancestor-to-library resolution route"));
+        }
+        return unsupported(QStringLiteral("Unsupported Silo catalog operation"));
+    }
+
+    ProviderCatalogResponse parseResponse(
+        ProviderCatalogOperation operation,
+        const QByteArray &body,
+        const QHash<QByteArray, QByteArray> &responseHeaders = {}) const override
+    {
+        if (operation == ProviderCatalogOperation::ThemeSongs) {
+            ProviderCatalogResponse response;
+            response.error = themeSongsUnsupportedReason();
+            return response;
+        }
+        return SiloModelMapper::catalogResponse(operation, body, responseHeaders);
+    }
+
+private:
+    struct Rule
+    {
+        QString field;
+        QString op;
+        QJsonValue value;
+    };
+
+    static QString themeSongsUnsupportedReason()
+    {
+        return QStringLiteral(
+            "Silo's native catalog contract has no theme-song endpoint");
+    }
+
+    static ProviderCatalogRequest get(const QString &endpoint)
+    {
+        ProviderCatalogRequest request;
+        request.method = ProviderHttpMethod::Get;
+        request.relativeEndpoint = endpoint;
+        request.supported = true;
+        return request;
+    }
+
+    static ProviderCatalogRequest unsupported(const QString &reason)
+    {
+        ProviderCatalogRequest request;
+        request.unsupportedReason = reason;
+        return request;
+    }
+
+    static QString encodedId(const QString &id)
+    {
+        return QString::fromLatin1(QUrl::toPercentEncoding(id.trimmed()));
+    }
+
+    static ProviderCatalogRequest getWithContentId(const QString &format,
+                                                   const QString &contentId)
+    {
+        const QString normalized = contentId.trimmed();
+        if (normalized.isEmpty()) {
+            return unsupported(QStringLiteral("Silo catalog operation requires a content_id"));
+        }
+        return get(format.arg(encodedId(normalized)));
+    }
+
+    static ProviderCatalogRequest mutationWithContentId(ProviderHttpMethod method,
+                                                        const QString &format,
+                                                        const QString &contentId)
+    {
+        ProviderCatalogRequest request = getWithContentId(format, contentId);
+        if (request.supported) {
+            request.method = method;
+        }
+        return request;
+    }
+
+    static QString endpointWithQuery(const QString &endpoint, const QUrlQuery &query)
+    {
+        if (query.isEmpty()) {
+            return endpoint;
+        }
+        return endpoint + QLatin1Char('?') + query.query(QUrl::FullyEncoded);
+    }
+
+    static void appendLimit(QUrlQuery &parameters, int limit)
+    {
+        if (limit > 0) {
+            parameters.addQueryItem(QStringLiteral("limit"), QString::number(qMin(limit, 100)));
+        }
+    }
+
+    static QString normalizedItemType(const QString &type)
+    {
+        const QString normalized = type.trimmed().toLower();
+        if (normalized == QStringLiteral("audio") || normalized == QStringLiteral("music")) {
+            return {};
+        }
+        if (normalized == QStringLiteral("audiobook")
+            || normalized == QStringLiteral("book")
+            || normalized == QStringLiteral("ebook")
+            || normalized == QStringLiteral("episode")
+            || normalized == QStringLiteral("manga")
+            || normalized == QStringLiteral("movie")
+            || normalized == QStringLiteral("series")
+            || normalized == QStringLiteral("show")) {
+            if (normalized == QStringLiteral("show")) {
+                return QStringLiteral("series");
+            }
+            if (normalized == QStringLiteral("book")) {
+                return QStringLiteral("ebook");
+            }
+            return normalized;
+        }
+        return {};
+    }
+
+    static std::optional<QString> normalizedSort(const QString &wireSort)
+    {
+        const QString sort = wireSort.trimmed().toLower();
+        if (sort.isEmpty()) {
+            return QString();
+        }
+        if (sort.contains(QLatin1Char(','))) {
+            return std::nullopt;
+        }
+        if (sort == QStringLiteral("sortname") || sort == QStringLiteral("sort_name")
+            || sort == QStringLiteral("title")) {
+            return QStringLiteral("title");
+        }
+        if (sort == QStringLiteral("datecreated") || sort == QStringLiteral("date_created")
+            || sort == QStringLiteral("added_at") || sort == QStringLiteral("recently_added")) {
+            return QStringLiteral("added_at");
+        }
+        if (sort == QStringLiteral("premieredate") || sort == QStringLiteral("premiere_date")
+            || sort == QStringLiteral("release_date")) {
+            return QStringLiteral("release_date");
+        }
+        if (sort == QStringLiteral("productionyear") || sort == QStringLiteral("production_year")
+            || sort == QStringLiteral("year")) {
+            return QStringLiteral("year");
+        }
+        if (sort == QStringLiteral("communityrating")
+            || sort == QStringLiteral("community_rating")
+            || sort == QStringLiteral("rating") || sort == QStringLiteral("rating_imdb")) {
+            return QStringLiteral("rating_imdb");
+        }
+        if (sort == QStringLiteral("runtime") || sort == QStringLiteral("content_rating")
+            || sort == QStringLiteral("last_air_date")
+            || sort == QStringLiteral("latest_episode_added")
+            || sort == QStringLiteral("resolution") || sort == QStringLiteral("bitrate")
+            || sort == QStringLiteral("progress") || sort == QStringLiteral("date_viewed")
+            || sort == QStringLiteral("plays") || sort == QStringLiteral("author")
+            || sort == QStringLiteral("narrator") || sort == QStringLiteral("series")) {
+            return sort;
+        }
+        return std::nullopt;
+    }
+
+    static QString validationError(const ProviderCatalogQuery &query)
+    {
+        if (query.startIndex < 0) {
+            return QStringLiteral("Silo catalog offset cannot be negative");
+        }
+        if (query.limit < 0) {
+            return QStringLiteral("Silo catalog limit cannot be negative");
+        }
+        if (!query.tags.isEmpty()) {
+            return QStringLiteral("Silo catalog does not support tag or keyword filtering");
+        }
+        if (!query.itemIds.isEmpty() || !query.parentIds.isEmpty()
+            || !query.seriesIds.isEmpty() || !query.excludeItemId.trimmed().isEmpty()) {
+            return QStringLiteral("Silo catalog does not support the requested ID-set filter semantics");
+        }
+        if (query.minDateLastSaved.isValid()) {
+            return QStringLiteral(
+                "Silo's added_at filter is exclusive and cannot represent Bloom's inclusive minimum date");
+        }
+        if (query.minPremiereDate.isValid() != query.maxPremiereDate.isValid()) {
+            return QStringLiteral(
+                "Silo supports an inclusive premiere-date range, but not either inclusive boundary alone");
+        }
+        if (query.minPremiereDate.isValid()
+            && query.minPremiereDate > query.maxPremiereDate) {
+            return QStringLiteral("Silo premiere-date range is reversed");
+        }
+        if (!std::isfinite(query.minCommunityRating)
+            || query.minCommunityRating < 0.0) {
+            return QStringLiteral(
+                "Silo minimum community rating must be finite and non-negative");
+        }
+        if (query.watched == ProviderCatalogTriState::Yes && query.unwatchedOnly) {
+            return QStringLiteral("Conflicting watched and unwatched filters");
+        }
+        if (!normalizedSort(query.sortBy).has_value()) {
+            return QStringLiteral("Silo does not support the requested catalog sort");
+        }
+        const QString order = query.sortOrder.trimmed().toLower();
+        if (!order.isEmpty() && order != QStringLiteral("asc") && order != QStringLiteral("desc")
+            && order != QStringLiteral("ascending") && order != QStringLiteral("descending")) {
+            return QStringLiteral("Silo catalog sort order must be ascending or descending");
+        }
+        for (int year : query.years) {
+            if (year <= 0) {
+                return QStringLiteral("Silo catalog years must be positive");
+            }
+        }
+        for (const QString &genre : query.genres) {
+            if (genre.trimmed().isEmpty()) {
+                return QStringLiteral("Silo catalog genres cannot be empty");
+            }
+        }
+        for (const QString &studio : query.studios) {
+            if (studio.trimmed().isEmpty()) {
+                return QStringLiteral("Silo catalog studios cannot be empty");
+            }
+        }
+        for (const QString &type : query.includeItemTypes) {
+            const QString normalized = normalizedItemType(type);
+            if (normalized.isEmpty()) {
+                return QStringLiteral("Silo does not support requested item type '%1'").arg(type);
+            }
+            if (normalized == QStringLiteral("season")
+                || normalized == QStringLiteral("episode")) {
+                return QStringLiteral(
+                    "Silo season and episode types require a content hierarchy route");
+            }
+        }
+        return {};
+    }
+
+    static QList<Rule> filterRules(const ProviderCatalogQuery &query)
+    {
+        QList<Rule> rules;
+        if (query.genres.size() == 1) {
+            rules.append({QStringLiteral("genre"), QStringLiteral("contains"),
+                          query.genres.first().trimmed()});
+        }
+        if (query.studios.size() == 1) {
+            rules.append({QStringLiteral("studio"), QStringLiteral("is"),
+                          query.studios.first().trimmed()});
+        }
+        if (query.minPremiereDate.isValid() && query.maxPremiereDate.isValid()) {
+            rules.append({QStringLiteral("release_date"), QStringLiteral("between"),
+                          QJsonArray{query.minPremiereDate.toString(Qt::ISODate),
+                                     query.maxPremiereDate.toString(Qt::ISODate)}});
+        }
+        if (query.minCommunityRating > 0.0) {
+            rules.append({QStringLiteral("rating_imdb"), QStringLiteral("gte"),
+                          query.minCommunityRating});
+        }
+        if (!query.years.isEmpty()) {
+            if (query.years.size() == 1) {
+                rules.append({QStringLiteral("year"), QStringLiteral("is"), query.years.first()});
+            }
+        }
+        if (query.watched != ProviderCatalogTriState::Any || query.unwatchedOnly) {
+            const bool watched = !query.unwatchedOnly
+                && query.watched == ProviderCatalogTriState::Yes;
+            rules.append({QStringLiteral("watched"), QStringLiteral("is"), watched});
+        }
+        if (query.favorite != ProviderCatalogTriState::Any) {
+            rules.append({QStringLiteral("favorited"), QStringLiteral("is"),
+                          query.favorite == ProviderCatalogTriState::Yes});
+        }
+        return rules;
+    }
+
+    static QJsonArray ruleArray(const ProviderCatalogQuery &query)
+    {
+        QJsonArray rules;
+        for (const Rule &rule : filterRules(query)) {
+            rules.append(QJsonObject{{QStringLiteral("field"), rule.field},
+                                     {QStringLiteral("op"), rule.op},
+                                     {QStringLiteral("value"), rule.value}});
+        }
+        if (query.genres.size() > 1) {
+            QJsonArray alternatives;
+            for (const QString &genre : query.genres) {
+                alternatives.append(
+                    QJsonObject{{QStringLiteral("field"), QStringLiteral("genre")},
+                                {QStringLiteral("op"), QStringLiteral("contains")},
+                                {QStringLiteral("value"), genre.trimmed()}});
+            }
+            rules.append(QJsonObject{{QStringLiteral("field"), QStringLiteral("__genre_any")},
+                                     {QStringLiteral("op"), QStringLiteral("__group")},
+                                     {QStringLiteral("value"), alternatives}});
+        }
+        if (query.studios.size() > 1) {
+            QJsonArray alternatives;
+            for (const QString &studio : query.studios) {
+                alternatives.append(
+                    QJsonObject{{QStringLiteral("field"), QStringLiteral("studio")},
+                                {QStringLiteral("op"), QStringLiteral("is")},
+                                {QStringLiteral("value"), studio.trimmed()}});
+            }
+            rules.append(QJsonObject{{QStringLiteral("field"), QStringLiteral("__studio_any")},
+                                     {QStringLiteral("op"), QStringLiteral("__group")},
+                                     {QStringLiteral("value"), alternatives}});
+        }
+        if (query.years.size() > 1) {
+            QJsonArray alternatives;
+            for (int year : query.years) {
+                alternatives.append(
+                    QJsonObject{{QStringLiteral("field"), QStringLiteral("year")},
+                                {QStringLiteral("op"), QStringLiteral("is")},
+                                {QStringLiteral("value"), year}});
+            }
+            rules.append(QJsonObject{{QStringLiteral("field"), QStringLiteral("__year_any")},
+                                     {QStringLiteral("op"), QStringLiteral("__group")},
+                                     {QStringLiteral("value"), alternatives}});
+        }
+        if (!query.includeItemTypes.isEmpty()) {
+            QStringList itemTypes;
+            for (const QString &type : query.includeItemTypes) {
+                const QString normalized = normalizedItemType(type);
+                if (!itemTypes.contains(normalized)) {
+                    itemTypes.append(normalized);
+                }
+            }
+            if (itemTypes.size() == 1) {
+                rules.append(QJsonObject{{QStringLiteral("field"), QStringLiteral("type")},
+                                         {QStringLiteral("op"), QStringLiteral("is")},
+                                         {QStringLiteral("value"), itemTypes.first()}});
+            } else {
+                QJsonArray alternatives;
+                for (const QString &type : itemTypes) {
+                    alternatives.append(
+                        QJsonObject{{QStringLiteral("field"), QStringLiteral("type")},
+                                    {QStringLiteral("op"), QStringLiteral("is")},
+                                    {QStringLiteral("value"), type}});
+                }
+                rules.append(
+                    QJsonObject{{QStringLiteral("field"), QStringLiteral("__type_any")},
+                                {QStringLiteral("op"), QStringLiteral("__group")},
+                                {QStringLiteral("value"), alternatives}});
+            }
+        }
+        return rules;
+    }
+
+    static QJsonArray groupsForPost(const ProviderCatalogQuery &query)
+    {
+        QJsonArray groups;
+        QJsonArray allRules;
+        const QJsonArray encoded = ruleArray(query);
+        for (const QJsonValue &value : encoded) {
+            const QJsonObject rule = value.toObject();
+            if (rule.value(QStringLiteral("op")).toString() == QStringLiteral("__group")) {
+                groups.append(QJsonObject{{QStringLiteral("match"), QStringLiteral("any")},
+                                          {QStringLiteral("rules"), rule.value(QStringLiteral("value"))}});
+            } else {
+                allRules.append(rule);
+            }
+        }
+        if (!allRules.isEmpty()) {
+            groups.prepend(QJsonObject{{QStringLiteral("match"), QStringLiteral("all")},
+                                       {QStringLiteral("rules"), allRules}});
+        }
+        return groups;
+    }
+
+    static void appendGroupsForGet(QUrlQuery &parameters,
+                                   const ProviderCatalogQuery &query)
+    {
+        const QJsonArray groups = groupsForPost(query);
+        for (qsizetype groupIndex = 0; groupIndex < groups.size(); ++groupIndex) {
+            const QJsonObject group = groups.at(groupIndex).toObject();
+            const QString groupPrefix = QStringLiteral("groups[%1]").arg(groupIndex);
+            parameters.addQueryItem(groupPrefix + QStringLiteral("[match]"),
+                                    group.value(QStringLiteral("match")).toString());
+            const QJsonArray rules = group.value(QStringLiteral("rules")).toArray();
+            for (qsizetype ruleIndex = 0; ruleIndex < rules.size(); ++ruleIndex) {
+                const QJsonObject rule = rules.at(ruleIndex).toObject();
+                const QString prefix = groupPrefix
+                    + QStringLiteral("[rules][%1]").arg(ruleIndex);
+                parameters.addQueryItem(prefix + QStringLiteral("[field]"),
+                                        rule.value(QStringLiteral("field")).toString());
+                parameters.addQueryItem(prefix + QStringLiteral("[op]"),
+                                        rule.value(QStringLiteral("op")).toString());
+                const QJsonValue value = rule.value(QStringLiteral("value"));
+                if (value.isArray()) {
+                    const QJsonArray values = value.toArray();
+                    for (qsizetype valueIndex = 0; valueIndex < values.size(); ++valueIndex) {
+                        parameters.addQueryItem(
+                            prefix + QStringLiteral("[value][%1]").arg(valueIndex),
+                            values.at(valueIndex).toVariant().toString());
+                    }
+                } else {
+                    parameters.addQueryItem(prefix + QStringLiteral("[value]"),
+                                            value.toVariant().toString());
+                }
+            }
+        }
+    }
+
+    static ProviderCatalogRequest createViewsRequest(const ProviderCatalogQuery &query)
+    {
+        if (query.parentId.trimmed().isEmpty()) {
+            if (hasCatalogModifiers(query) || !query.itemId.trimmed().isEmpty()) {
+                return unsupported(QStringLiteral(
+                    "Silo library discovery does not support catalog modifiers"));
+            }
+            return get(QStringLiteral("/api/v1/user/libraries"));
+        }
+        if (query.parentId.trimmed().compare(
+                QStringLiteral("home"), Qt::CaseInsensitive) == 0) {
+            if (hasCatalogModifiers(query) || !query.itemId.trimmed().isEmpty()) {
+                return unsupported(QStringLiteral(
+                    "Silo home section discovery does not support catalog modifiers"));
+            }
+            return get(QStringLiteral("/api/v1/home/sections"));
+        }
+        bool libraryIdOk = false;
+        const int libraryId = query.parentId.trimmed().toInt(&libraryIdOk);
+        if (!libraryIdOk || libraryId <= 0 || hasCatalogModifiers(query)
+            || !query.itemId.trimmed().isEmpty()) {
+            return unsupported(QStringLiteral(
+                "Silo library section discovery requires only a positive numeric library ID"));
+        }
+        return get(QStringLiteral("/api/v1/library/%1/sections").arg(libraryId));
+    }
+
+    static ProviderCatalogRequest createItemsRequest(const ProviderCatalogQuery &query)
+    {
+        if (query.parentId.trimmed().compare(
+                QStringLiteral("home"), Qt::CaseInsensitive) == 0
+            && !query.itemId.trimmed().isEmpty()) {
+            if (hasCatalogModifiers(query)) {
+                return unsupported(QStringLiteral(
+                    "Silo home section items do not support catalog modifiers"));
+            }
+            return get(QStringLiteral("/api/v1/home/sections/%1/items")
+                           .arg(encodedId(query.itemId)));
+        }
+        bool sectionLibraryIdOk = false;
+        const int sectionLibraryId =
+            query.parentId.trimmed().toInt(&sectionLibraryIdOk);
+        if (sectionLibraryIdOk && sectionLibraryId > 0
+            && !query.itemId.trimmed().isEmpty()) {
+            if (hasCatalogModifiers(query)) {
+                return unsupported(QStringLiteral(
+                    "Silo library section items do not support catalog modifiers"));
+            }
+            return get(QStringLiteral("/api/v1/library/%1/sections/%2/items")
+                           .arg(sectionLibraryId)
+                           .arg(encodedId(query.itemId)));
+        }
+        if (!query.seriesId.trimmed().isEmpty()) {
+            if (hasHierarchyModifiers(query)) {
+                return unsupported(QStringLiteral(
+                    "Silo hierarchy routes do not support catalog filters or pagination"));
+            }
+            if (!query.includeItemTypes.isEmpty()) {
+                const QString expectedType = query.parentId.trimmed().isEmpty()
+                    ? QStringLiteral("season") : QStringLiteral("episode");
+                if (query.includeItemTypes.size() != 1
+                    || normalizedItemType(query.includeItemTypes.first())
+                        != expectedType) {
+                    return unsupported(QStringLiteral(
+                        "Silo hierarchy item type does not match the requested resource"));
+                }
+            }
+            if (!query.parentId.trimmed().isEmpty()) {
+                return getWithContentId(QStringLiteral("/api/v1/catalog/items/%1/episodes"),
+                                        query.parentId);
+            }
+            return getWithContentId(QStringLiteral("/api/v1/catalog/series/%1/seasons"),
+                                    query.seriesId);
+        }
+
+        bool libraryIdOk = true;
+        if (!query.parentId.trimmed().isEmpty()) {
+            query.parentId.trimmed().toInt(&libraryIdOk);
+        }
+        if (!libraryIdOk && query.includeItemTypes.size() == 1) {
+            if (hasHierarchyModifiers(query)) {
+                return unsupported(QStringLiteral(
+                    "Silo hierarchy routes do not support catalog filters or pagination"));
+            }
+            const QString type = normalizedItemType(query.includeItemTypes.first());
+            if (type == QStringLiteral("season")) {
+                return getWithContentId(QStringLiteral("/api/v1/catalog/series/%1/seasons"),
+                                        query.parentId);
+            }
+            if (type == QStringLiteral("episode")) {
+                return getWithContentId(QStringLiteral("/api/v1/catalog/items/%1/episodes"),
+                                        query.parentId);
+            }
+        }
+        return createCatalogRequest(query, true);
+    }
+
+    static bool hasCatalogModifiers(const ProviderCatalogQuery &query)
+    {
+        return query.startIndex != 0 || query.limit > 0
+            || !query.searchTerm.trimmed().isEmpty()
+            || !query.genres.isEmpty() || !query.tags.isEmpty()
+            || !query.studios.isEmpty()
+            || query.minPremiereDate.isValid() || query.maxPremiereDate.isValid()
+            || query.minDateLastSaved.isValid() || query.minCommunityRating > 0.0
+            || !query.years.isEmpty() || !query.sortBy.trimmed().isEmpty()
+            || !query.includeItemTypes.isEmpty()
+            || !query.seriesId.trimmed().isEmpty()
+            || !query.excludeItemId.trimmed().isEmpty()
+            || !query.itemIds.isEmpty() || !query.parentIds.isEmpty()
+            || !query.seriesIds.isEmpty()
+            || query.watched != ProviderCatalogTriState::Any
+            || query.favorite != ProviderCatalogTriState::Any || query.unwatchedOnly;
+    }
+
+    static bool hasHierarchyModifiers(const ProviderCatalogQuery &query)
+    {
+        return query.startIndex != 0 || query.limit > 0
+            || !query.searchTerm.trimmed().isEmpty()
+            || !query.genres.isEmpty() || !query.tags.isEmpty()
+            || !query.studios.isEmpty()
+            || query.minPremiereDate.isValid() || query.maxPremiereDate.isValid()
+            || query.minDateLastSaved.isValid() || query.minCommunityRating > 0.0
+            || !query.years.isEmpty() || !query.sortBy.trimmed().isEmpty()
+            || query.watched != ProviderCatalogTriState::Any
+            || query.favorite != ProviderCatalogTriState::Any || query.unwatchedOnly;
+    }
+
+    static ProviderCatalogRequest createCatalogRequest(const ProviderCatalogQuery &query,
+                                                        bool allowPost)
+    {
+        const QString error = validationError(query);
+        if (!error.isEmpty()) {
+            return unsupported(error);
+        }
+
+        bool libraryIdOk = true;
+        const int libraryId = query.parentId.trimmed().isEmpty()
+            ? 0 : query.parentId.trimmed().toInt(&libraryIdOk);
+        if (!libraryIdOk
+            || (!query.parentId.trimmed().isEmpty() && libraryId <= 0)) {
+            return unsupported(QStringLiteral(
+                "Silo library catalog scope requires a positive numeric library ID"));
+        }
+
+        const QJsonArray groups = groupsForPost(query);
+        const bool hasStructuredFilters = !groups.isEmpty();
+        const bool usePost = allowPost && hasStructuredFilters
+            && query.searchTerm.trimmed().isEmpty() && query.includeHeavyFields;
+        const std::optional<QString> sort = normalizedSort(query.sortBy);
+        QString order = query.sortOrder.trimmed().toLower();
+        if (order == QStringLiteral("ascending")) order = QStringLiteral("asc");
+        if (order == QStringLiteral("descending")) order = QStringLiteral("desc");
+
+        if (usePost) {
+            QJsonObject body{{QStringLiteral("match"), QStringLiteral("all")},
+                             {QStringLiteral("groups"), groups},
+                             {QStringLiteral("library_id"), libraryId},
+                             {QStringLiteral("offset"), query.startIndex}};
+            if (query.limit > 0) {
+                body.insert(QStringLiteral("limit"), qMin(query.limit, 100));
+            }
+            if (sort && !sort->isEmpty()) {
+                body.insert(QStringLiteral("sort"), *sort);
+            }
+            if (!order.isEmpty()) {
+                body.insert(QStringLiteral("order"), order);
+            }
+            ProviderCatalogRequest request;
+            request.method = ProviderHttpMethod::Post;
+            request.relativeEndpoint = QStringLiteral("/api/v1/catalog/query");
+            request.body = QJsonDocument(body).toJson(QJsonDocument::Compact);
+            request.extraHeaders.insert(QByteArrayLiteral("Content-Type"),
+                                        QByteArrayLiteral("application/json"));
+            request.supported = true;
+            return request;
+        }
+
+        QUrlQuery parameters;
+        parameters.addQueryItem(QStringLiteral("source"), QStringLiteral("query"));
+        parameters.addQueryItem(
+            QStringLiteral("include_technical"),
+            query.includeHeavyFields ? QStringLiteral("true") : QStringLiteral("false"));
+        if (libraryId > 0) {
+            parameters.addQueryItem(QStringLiteral("library_id"), QString::number(libraryId));
+        }
+        if (query.startIndex > 0) {
+            parameters.addQueryItem(QStringLiteral("offset"), QString::number(query.startIndex));
+        }
+        appendLimit(parameters, query.limit);
+        if (!query.searchTerm.trimmed().isEmpty()) {
+            parameters.addQueryItem(QStringLiteral("q"), query.searchTerm.trimmed());
+        }
+        if (sort && !sort->isEmpty()) {
+            parameters.addQueryItem(QStringLiteral("sort"), *sort);
+        }
+        if (!order.isEmpty()) {
+            parameters.addQueryItem(QStringLiteral("order"), order);
+        }
+        appendGroupsForGet(parameters, query);
+
+        ProviderCatalogRequest request = get(
+            endpointWithQuery(QStringLiteral("/api/v1/catalog"), parameters));
+        if (query.useCacheValidation) {
+            if (!query.etag.isEmpty()) {
+                request.extraHeaders.insert(QByteArrayLiteral("If-None-Match"), query.etag);
+            }
+            if (!query.lastModified.isEmpty()) {
+                request.extraHeaders.insert(QByteArrayLiteral("If-Modified-Since"),
+                                            query.lastModified);
+            }
+        }
+        return request;
+    }
+
+    static ProviderCatalogRequest createFilterOptionsRequest(
+        const ProviderCatalogQuery &query)
+    {
+        const QString error = validationError(query);
+        if (!error.isEmpty()) {
+            return unsupported(error);
+        }
+        bool libraryIdOk = true;
+        const int libraryId = query.parentId.trimmed().isEmpty()
+            ? 0 : query.parentId.trimmed().toInt(&libraryIdOk);
+        if (!libraryIdOk
+            || (!query.parentId.trimmed().isEmpty() && libraryId <= 0)) {
+            return unsupported(QStringLiteral(
+                "Silo filter scope requires a positive numeric library ID"));
+        }
+
+        QUrlQuery parameters;
+        parameters.addQueryItem(QStringLiteral("source"), QStringLiteral("query"));
+        if (libraryId > 0) {
+            parameters.addQueryItem(QStringLiteral("library_id"), QString::number(libraryId));
+        }
+        appendGroupsForGet(parameters, query);
+        if (!query.searchTerm.trimmed().isEmpty()) {
+            parameters.addQueryItem(QStringLiteral("q"), query.searchTerm.trimmed());
+        }
+        parameters.addQueryItem(QStringLiteral("include_technical"),
+                                query.includeHeavyFields ? QStringLiteral("true")
+                                                         : QStringLiteral("false"));
+
+        QString endpoint = QStringLiteral("/api/v1/catalog/filters");
+        QString facet = query.filterFacet.trimmed().toLower();
+        static const QHash<QString, QString> facetAliases{
+            {QStringLiteral("genres"), QStringLiteral("genre")},
+            {QStringLiteral("studios"), QStringLiteral("studio")},
+            {QStringLiteral("networks"), QStringLiteral("network")},
+            {QStringLiteral("countries"), QStringLiteral("country")},
+            {QStringLiteral("authors"), QStringLiteral("author")},
+            {QStringLiteral("narrators"), QStringLiteral("narrator")},
+            {QStringLiteral("original_languages"), QStringLiteral("original_language")},
+            {QStringLiteral("content_ratings"), QStringLiteral("content_rating")}};
+        facet = facetAliases.value(facet, facet);
+        if (!facet.isEmpty()) {
+            static const QStringList supportedFacets{
+                QStringLiteral("author"), QStringLiteral("narrator"),
+                QStringLiteral("series"), QStringLiteral("genre"),
+                QStringLiteral("studio"), QStringLiteral("network"),
+                QStringLiteral("country"), QStringLiteral("original_language"),
+                QStringLiteral("content_rating")};
+            if (!supportedFacets.contains(facet)) {
+                return unsupported(QStringLiteral("Silo does not support filter facet '%1'")
+                                       .arg(query.filterFacet));
+            }
+            endpoint += QStringLiteral("/search");
+            parameters.addQueryItem(QStringLiteral("facet"), facet);
+            appendLimit(parameters, query.limit);
+        }
+        return get(endpointWithQuery(endpoint, parameters));
+    }
+};

--- a/src/providers/silo/SiloCatalogProvider.h
+++ b/src/providers/silo/SiloCatalogProvider.h
@@ -12,6 +12,7 @@
 class SiloCatalogProvider final : public ICatalogProvider
 {
 public:
+    using ICatalogProvider::parseResponse;
     ProviderCatalogRequest createRequest(
         ProviderCatalogOperation operation,
         const ProviderCatalogQuery &query) const override
@@ -110,7 +111,7 @@ public:
     ProviderCatalogResponse parseResponse(
         ProviderCatalogOperation operation,
         const QByteArray &body,
-        const QHash<QByteArray, QByteArray> &responseHeaders = {}) const override
+        const QHash<QByteArray, QByteArray> &responseHeaders) const override
     {
         if (operation == ProviderCatalogOperation::ThemeSongs) {
             ProviderCatalogResponse response;
@@ -214,12 +215,10 @@ private:
         if (normalized == QStringLiteral("audio") || normalized == QStringLiteral("music")) {
             return {};
         }
-        if (normalized == QStringLiteral("audiobook")
-            || normalized == QStringLiteral("book")
-            || normalized == QStringLiteral("ebook")
-            || normalized == QStringLiteral("episode")
+        if (normalized == QStringLiteral("episode")
             || normalized == QStringLiteral("manga")
             || normalized == QStringLiteral("movie")
+            || normalized == QStringLiteral("season")
             || normalized == QStringLiteral("series")
             || normalized == QStringLiteral("show")) {
             if (normalized == QStringLiteral("show")) {
@@ -600,9 +599,10 @@ private:
                                     query.seriesId);
         }
 
+        const QString trimmedParentId = query.parentId.trimmed();
         bool libraryIdOk = true;
-        if (!query.parentId.trimmed().isEmpty()) {
-            query.parentId.trimmed().toInt(&libraryIdOk);
+        if (!trimmedParentId.isEmpty()) {
+            static_cast<void>(trimmedParentId.toInt(&libraryIdOk));
         }
         if (!libraryIdOk && query.includeItemTypes.size() == 1) {
             if (hasHierarchyModifiers(query)) {
@@ -666,19 +666,22 @@ private:
                 "Silo catalog does not expose a recursive-scope switch"));
         }
 
+        const QString trimmedParentId = query.parentId.trimmed();
         bool libraryIdOk = true;
-        const int libraryId = query.parentId.trimmed().isEmpty()
-            ? 0 : query.parentId.trimmed().toInt(&libraryIdOk);
+        const int libraryId = trimmedParentId.isEmpty()
+            ? 0 : trimmedParentId.toInt(&libraryIdOk);
         if (!libraryIdOk
-            || (!query.parentId.trimmed().isEmpty() && libraryId <= 0)) {
+            || (!trimmedParentId.isEmpty() && libraryId <= 0)) {
             return unsupported(QStringLiteral(
                 "Silo library catalog scope requires a positive numeric library ID"));
         }
 
         const QJsonArray groups = groupsForPost(query);
         const bool hasStructuredFilters = !groups.isEmpty();
+        const bool hasSnapshot = query.snapshot.has_value() && !query.snapshot->isEmpty();
         const bool usePost = allowPost && hasStructuredFilters
-            && query.searchTerm.trimmed().isEmpty() && query.includeHeavyFields;
+            && query.searchTerm.trimmed().isEmpty() && query.includeHeavyFields
+            && !hasSnapshot;
         const std::optional<QString> sort = normalizedSort(query.sortBy);
         QString order = query.sortOrder.trimmed().toLower();
         if (order == QStringLiteral("ascending")) order = QStringLiteral("asc");
@@ -687,8 +690,10 @@ private:
         if (usePost) {
             QJsonObject body{{QStringLiteral("match"), QStringLiteral("all")},
                              {QStringLiteral("groups"), groups},
-                             {QStringLiteral("library_id"), libraryId},
                              {QStringLiteral("offset"), query.startIndex}};
+            if (libraryId > 0) {
+                body.insert(QStringLiteral("library_id"), libraryId);
+            }
             if (query.limit > 0) {
                 body.insert(QStringLiteral("limit"), qMin(query.limit, 100));
             }
@@ -715,6 +720,9 @@ private:
             query.includeHeavyFields ? QStringLiteral("true") : QStringLiteral("false"));
         if (libraryId > 0) {
             parameters.addQueryItem(QStringLiteral("library_id"), QString::number(libraryId));
+        }
+        if (query.snapshot.has_value() && !query.snapshot->isEmpty()) {
+            parameters.addQueryItem(QStringLiteral("snapshot"), *query.snapshot);
         }
         if (query.startIndex > 0) {
             parameters.addQueryItem(QStringLiteral("offset"), QString::number(query.startIndex));

--- a/src/providers/silo/SiloCatalogProvider.h
+++ b/src/providers/silo/SiloCatalogProvider.h
@@ -220,7 +220,8 @@ private:
             || normalized == QStringLiteral("movie")
             || normalized == QStringLiteral("season")
             || normalized == QStringLiteral("series")
-            || normalized == QStringLiteral("show")) {
+            || normalized == QStringLiteral("show")
+            || normalized == QStringLiteral("book")) {
             if (normalized == QStringLiteral("show")) {
                 return QStringLiteral("series");
             }

--- a/src/providers/silo/SiloCatalogProvider.h
+++ b/src/providers/silo/SiloCatalogProvider.h
@@ -49,7 +49,11 @@ public:
                 || !query.includeItemTypes.isEmpty()
                 || query.watched != ProviderCatalogTriState::Any
                 || query.favorite != ProviderCatalogTriState::Any
-                || query.unwatchedOnly) {
+                || query.unwatchedOnly
+                || query.minPremiereDate.isValid() || query.maxPremiereDate.isValid()
+                || query.minDateLastSaved.isValid() || query.minCommunityRating > 0.0
+                || !query.sortBy.trimmed().isEmpty()
+                || !query.sortOrder.trimmed().isEmpty()) {
                 return unsupported(QStringLiteral(
                     "Silo similar recommendations support only content_id and limit"));
             }
@@ -111,6 +115,23 @@ public:
         if (operation == ProviderCatalogOperation::ThemeSongs) {
             ProviderCatalogResponse response;
             response.error = themeSongsUnsupportedReason();
+            return response;
+        }
+
+        // The native numeric-season detail endpoint returns {"season": {...}},
+        // unlike the Items operation's array/envelope responses. Parse that
+        // envelope as an item even when the request originated as Items.
+        const QJsonDocument document = QJsonDocument::fromJson(body);
+        if (document.isObject()
+            && document.object().value(QStringLiteral("season")).isObject()) {
+            ProviderCatalogResponse response = SiloModelMapper::catalogResponse(
+                ProviderCatalogOperation::Item, body, responseHeaders);
+            if (response.valid) {
+                response.rawItem =
+                    document.object().value(QStringLiteral("season")).toObject();
+                response.capabilityMetadata.insert(
+                    QStringLiteral("envelope"), QStringLiteral("season"));
+            }
             return response;
         }
         return SiloModelMapper::catalogResponse(operation, body, responseHeaders);
@@ -282,9 +303,10 @@ private:
             return QStringLiteral("Silo premiere-date range is reversed");
         }
         if (!std::isfinite(query.minCommunityRating)
-            || query.minCommunityRating < 0.0) {
+            || query.minCommunityRating < 0.0
+            || query.minCommunityRating > 10.0) {
             return QStringLiteral(
-                "Silo minimum community rating must be finite and non-negative");
+                "Silo minimum community rating must be finite and between zero and ten");
         }
         if (query.watched == ProviderCatalogTriState::Yes && query.unwatchedOnly) {
             return QStringLiteral("Conflicting watched and unwatched filters");
@@ -548,19 +570,31 @@ private:
                 return unsupported(QStringLiteral(
                     "Silo hierarchy routes do not support catalog filters or pagination"));
             }
+            const QString parent = query.parentId.trimmed();
             if (!query.includeItemTypes.isEmpty()) {
-                const QString expectedType = query.parentId.trimmed().isEmpty()
-                    ? QStringLiteral("season") : QStringLiteral("episode");
+                const QString expectedType = parent.isEmpty()
+                    ? QStringLiteral("season")
+                    : QStringLiteral("episode");
                 if (query.includeItemTypes.size() != 1
-                    || normalizedItemType(query.includeItemTypes.first())
-                        != expectedType) {
+                    || normalizedItemType(query.includeItemTypes.first()) != expectedType) {
                     return unsupported(QStringLiteral(
                         "Silo hierarchy item type does not match the requested resource"));
                 }
             }
-            if (!query.parentId.trimmed().isEmpty()) {
+            if (!parent.isEmpty()) {
+                bool seasonNumberOk = false;
+                const int seasonNumber = parent.toInt(&seasonNumberOk);
+                if (seasonNumberOk && seasonNumber >= 0) {
+                    const QString route = query.includeItemTypes.isEmpty()
+                        || normalizedItemType(query.includeItemTypes.first())
+                               == QStringLiteral("season")
+                        ? QStringLiteral("/api/v1/catalog/series/%1/seasons/%2")
+                        : QStringLiteral("/api/v1/catalog/series/%1/seasons/%2/episodes");
+                    return get(
+                        route.arg(encodedId(query.seriesId), QString::number(seasonNumber)));
+                }
                 return getWithContentId(QStringLiteral("/api/v1/catalog/items/%1/episodes"),
-                                        query.parentId);
+                                        parent);
             }
             return getWithContentId(QStringLiteral("/api/v1/catalog/series/%1/seasons"),
                                     query.seriesId);
@@ -587,7 +621,6 @@ private:
         }
         return createCatalogRequest(query, true);
     }
-
     static bool hasCatalogModifiers(const ProviderCatalogQuery &query)
     {
         return query.startIndex != 0 || query.limit > 0
@@ -597,6 +630,7 @@ private:
             || query.minPremiereDate.isValid() || query.maxPremiereDate.isValid()
             || query.minDateLastSaved.isValid() || query.minCommunityRating > 0.0
             || !query.years.isEmpty() || !query.sortBy.trimmed().isEmpty()
+            || !query.sortOrder.trimmed().isEmpty() || query.recursive
             || !query.includeItemTypes.isEmpty()
             || !query.seriesId.trimmed().isEmpty()
             || !query.excludeItemId.trimmed().isEmpty()
@@ -615,6 +649,7 @@ private:
             || query.minPremiereDate.isValid() || query.maxPremiereDate.isValid()
             || query.minDateLastSaved.isValid() || query.minCommunityRating > 0.0
             || !query.years.isEmpty() || !query.sortBy.trimmed().isEmpty()
+            || !query.sortOrder.trimmed().isEmpty() || query.recursive
             || query.watched != ProviderCatalogTriState::Any
             || query.favorite != ProviderCatalogTriState::Any || query.unwatchedOnly;
     }
@@ -625,6 +660,10 @@ private:
         const QString error = validationError(query);
         if (!error.isEmpty()) {
             return unsupported(error);
+        }
+        if (query.recursive) {
+            return unsupported(QStringLiteral(
+                "Silo catalog does not expose a recursive-scope switch"));
         }
 
         bool libraryIdOk = true;

--- a/src/providers/silo/SiloModelMapper.cpp
+++ b/src/providers/silo/SiloModelMapper.cpp
@@ -1,0 +1,1255 @@
+#include "SiloModelMapper.h"
+
+#include <QDateTime>
+#include <QJsonDocument>
+#include <QJsonParseError>
+#include <QSet>
+
+#include <cmath>
+#include <limits>
+#include <utility>
+
+namespace {
+QString identityString(const QJsonValue &value)
+{
+    if (value.isString()) {
+        return value.toString();
+    }
+    if (!value.isDouble()) {
+        return {};
+    }
+    const double number = value.toDouble();
+    constexpr double maximumExactJsonInteger = 9007199254740991.0;
+    if (!std::isfinite(number) || std::trunc(number) != number
+        || std::abs(number) > maximumExactJsonInteger) {
+        return {};
+    }
+    return QString::number(static_cast<qint64>(number));
+}
+
+QStringList stringList(const QJsonValue &value)
+{
+    QStringList result;
+    if (!value.isArray()) {
+        return result;
+    }
+    const QJsonArray values = value.toArray();
+    result.reserve(values.size());
+    for (const QJsonValue &entry : values) {
+        if (entry.isString()) {
+            result.append(entry.toString());
+        }
+    }
+    return result;
+}
+
+qint64 jsonInteger(const QJsonValue &value, qint64 fallback = 0)
+{
+    if (!value.isDouble()) {
+        return fallback;
+    }
+    const double number = value.toDouble();
+    if (!std::isfinite(number) || std::trunc(number) != number
+        || number < static_cast<double>(std::numeric_limits<qint64>::min())
+        || number > static_cast<double>(std::numeric_limits<qint64>::max())) {
+        return fallback;
+    }
+    return static_cast<qint64>(number);
+}
+
+qint64 isoDateMilliseconds(const QJsonValue &value)
+{
+    if (!value.isString() || value.toString().isEmpty()) {
+        return -1;
+    }
+    QDateTime date = QDateTime::fromString(value.toString(), Qt::ISODateWithMs);
+    if (!date.isValid()) {
+        date = QDateTime::fromString(value.toString(), Qt::ISODate);
+    }
+    return date.isValid() ? date.toMSecsSinceEpoch() : -1;
+}
+
+QString canonicalMediaType(const QString &wireType)
+{
+    const QString type = wireType.trimmed().toLower();
+    if (type == QStringLiteral("movie")) return QStringLiteral("Movie");
+    if (type == QStringLiteral("series") || type == QStringLiteral("show")) {
+        return QStringLiteral("Series");
+    }
+    if (type == QStringLiteral("season")) return QStringLiteral("Season");
+    if (type == QStringLiteral("episode")) return QStringLiteral("Episode");
+    if (type == QStringLiteral("person")) return QStringLiteral("Person");
+    if (type == QStringLiteral("audiobook")) return QStringLiteral("AudioBook");
+    if (type == QStringLiteral("ebook")) return QStringLiteral("Book");
+    if (type == QStringLiteral("music") || type == QStringLiteral("audio")) {
+        return QStringLiteral("Audio");
+    }
+    return wireType;
+}
+
+QVariantMap providerIds(const QJsonObject &wire)
+{
+    QVariantMap result;
+    const QJsonObject nested = wire.value(QStringLiteral("provider_ids")).toObject();
+    const auto add = [&result, &wire, &nested](const QString &canonical,
+                                               const QString &snakeCase,
+                                               const QString &shortName) {
+        QString value = identityString(wire.value(snakeCase));
+        if (value.isEmpty()) {
+            value = identityString(nested.value(snakeCase));
+        }
+        if (value.isEmpty()) {
+            value = identityString(nested.value(canonical));
+        }
+        if (value.isEmpty()) {
+            value = identityString(nested.value(shortName));
+        }
+        if (!value.isEmpty()) {
+            result.insert(canonical, value);
+        }
+    };
+    add(QStringLiteral("Imdb"), QStringLiteral("imdb_id"), QStringLiteral("imdb"));
+    add(QStringLiteral("Tmdb"), QStringLiteral("tmdb_id"), QStringLiteral("tmdb"));
+    add(QStringLiteral("Tvdb"), QStringLiteral("tvdb_id"), QStringLiteral("tvdb"));
+    add(QStringLiteral("Plex"), QStringLiteral("plex_guid"), QStringLiteral("plex"));
+    return result;
+}
+
+void appendArtwork(QVariantList &all,
+                   QVariantMap &owner,
+                   const QString &property,
+                   const QString &urlProperty,
+                   const QString &connectionId,
+                   const QString &itemId,
+                   Bloom::ArtworkKind kind,
+                   const QString &url,
+                   int index = 0,
+                   Bloom::ArtworkOwnerKind ownerKind = Bloom::ArtworkOwnerKind::MediaItem)
+{
+    if (url.isEmpty() || connectionId.isEmpty() || itemId.isEmpty()) {
+        return;
+    }
+    Bloom::ArtworkRef artwork;
+    artwork.connectionId = connectionId;
+    artwork.itemId = itemId;
+    artwork.kind = kind;
+    artwork.ownerKind = ownerKind;
+    artwork.index = qMax(0, index);
+    artwork.sourceUrl = url;
+    const QVariantMap ref = artwork.toVariantMap();
+    if (!owner.contains(property)) {
+        owner.insert(property, ref);
+        owner.insert(urlProperty, url);
+    }
+    all.append(ref);
+}
+
+QVariantList people(const QJsonObject &wireItem, const QString &connectionId)
+{
+    QVariantList result;
+    const auto append = [&result, &connectionId](const QJsonArray &credits,
+                                                  const QString &kind,
+                                                  const QString &roleKey) {
+        for (const QJsonValue &value : credits) {
+            if (!value.isObject()) {
+                continue;
+            }
+            const QJsonObject wire = value.toObject();
+            const QString name = wire.value(QStringLiteral("name")).toString();
+            if (name.isEmpty()) {
+                continue;
+            }
+            const QString personId = identityString(wire.value(QStringLiteral("person_id")));
+            Bloom::Person person;
+            person.media = {connectionId, personId};
+            person.name = name;
+            person.role = wire.value(roleKey).toString();
+            person.kind = kind;
+            const QString photoUrl = wire.value(QStringLiteral("photo_url")).toString();
+            if (!personId.isEmpty() && !photoUrl.isEmpty()) {
+                person.artwork.connectionId = connectionId;
+                person.artwork.itemId = personId;
+                person.artwork.kind = Bloom::ArtworkKind::Person;
+                person.artwork.ownerKind = Bloom::ArtworkOwnerKind::Person;
+                person.artwork.sourceUrl = photoUrl;
+            }
+            QVariantMap mapped = person.toVariantMap();
+            mapped[QStringLiteral("providerIds")] = providerIds(wire);
+            if (!photoUrl.isEmpty()) {
+                mapped[QStringLiteral("artworkUrl")] = photoUrl;
+            }
+            const QString thumbhash = wire.value(QStringLiteral("photo_thumbhash")).toString();
+            if (!thumbhash.isEmpty()) {
+                mapped[QStringLiteral("artworkThumbhash")] = thumbhash;
+            }
+            result.append(mapped);
+        }
+    };
+    append(wireItem.value(QStringLiteral("cast")).toArray(),
+           QStringLiteral("Actor"), QStringLiteral("character"));
+    append(wireItem.value(QStringLiteral("crew")).toArray(),
+           QStringLiteral("Crew"), QStringLiteral("job"));
+    return result;
+}
+
+double frameRate(const QString &value)
+{
+    const QStringList parts = value.split(QLatin1Char('/'));
+    bool numeratorOk = false;
+    const double numerator = parts.value(0).toDouble(&numeratorOk);
+    if (!numeratorOk) {
+        return 0.0;
+    }
+    if (parts.size() == 1) {
+        return numerator;
+    }
+    bool denominatorOk = false;
+    const double denominator = parts.value(1).toDouble(&denominatorOk);
+    return denominatorOk && denominator != 0.0 ? numerator / denominator : 0.0;
+}
+
+QVariantList tracks(const QJsonArray &wireTracks,
+                    const QString &kind,
+                    int initialIndex,
+                    QVariantList *mediaStreams)
+{
+    QVariantList result;
+    result.reserve(wireTracks.size());
+    for (qsizetype offset = 0; offset < wireTracks.size(); ++offset) {
+        if (!wireTracks.at(offset).isObject()) {
+            continue;
+        }
+        const QJsonObject wire = wireTracks.at(offset).toObject();
+        const int index = wire.contains(QStringLiteral("index"))
+            ? wire.value(QStringLiteral("index")).toInt(initialIndex + static_cast<int>(offset))
+            : initialIndex + static_cast<int>(offset);
+        MediaStreamInfo stream = SiloModelMapper::mediaStream(wire, kind, index);
+        QVariantMap mapped = stream.toVariantMap();
+        if (kind.compare(QStringLiteral("Video"), Qt::CaseInsensitive) == 0) {
+            mapped[QStringLiteral("dolbyVision")] = wire.value(QStringLiteral("dolby_vision")).toString();
+            mapped[QStringLiteral("hdr10Plus")] = wire.value(QStringLiteral("hdr10_plus")).toBool();
+            mapped[QStringLiteral("bitDepth")] = wire.value(QStringLiteral("bit_depth")).toInt();
+            mapped[QStringLiteral("pixelFormat")] = wire.value(QStringLiteral("pixel_format")).toString();
+            mapped[QStringLiteral("aspectRatio")] = wire.value(QStringLiteral("aspect_ratio")).toString();
+        } else if (kind.compare(QStringLiteral("Audio"), Qt::CaseInsensitive) == 0) {
+            mapped[QStringLiteral("sampleRate")] = wire.value(QStringLiteral("sample_rate")).toInt();
+            mapped[QStringLiteral("bitDepth")] = wire.value(QStringLiteral("bit_depth")).toInt();
+        } else {
+            mapped[QStringLiteral("resolution")] = wire.value(QStringLiteral("resolution")).toString();
+            mapped[QStringLiteral("fileName")] = wire.value(QStringLiteral("file_name")).toString();
+        }
+        result.append(mapped);
+        if (mediaStreams) {
+            mediaStreams->append(stream.toVariantMap());
+        }
+    }
+    return result;
+}
+
+QVariantMap markerVariant(const QString &name, const QJsonObject &wire)
+{
+    const QJsonValue start = wire.contains(QStringLiteral("start_seconds"))
+        ? wire.value(QStringLiteral("start_seconds"))
+        : wire.value(QStringLiteral("start"));
+    const QJsonValue end = wire.contains(QStringLiteral("end_seconds"))
+        ? wire.value(QStringLiteral("end_seconds"))
+        : wire.value(QStringLiteral("end"));
+    if (!start.isDouble() || !end.isDouble()
+        || !std::isfinite(start.toDouble()) || !std::isfinite(end.toDouble())
+        || start.toDouble() < 0.0 || end.toDouble() <= start.toDouble()) {
+        return {};
+    }
+    return {
+        {QStringLiteral("type"), name},
+        {QStringLiteral("startMs"), SiloModelMapper::secondsToMilliseconds(start.toDouble())},
+        {QStringLiteral("endMs"), SiloModelMapper::secondsToMilliseconds(end.toDouble())},
+        {QStringLiteral("source"), wire.value(QStringLiteral("source")).toString()},
+        {QStringLiteral("provider"), wire.value(QStringLiteral("provider")).toString()},
+        {QStringLiteral("confidence"), wire.value(QStringLiteral("confidence")).toDouble()},
+        {QStringLiteral("algorithm"), wire.value(QStringLiteral("algorithm")).toString()},
+        {QStringLiteral("detectedAt"), wire.value(QStringLiteral("detected_at")).toString()}
+    };
+}
+
+QVariantList markerVariants(const QJsonObject &wire)
+{
+    QVariantList result;
+    for (const QString &name : {QStringLiteral("intro"), QStringLiteral("credits"),
+                                QStringLiteral("recap"), QStringLiteral("preview")}) {
+        if (!wire.value(name).isObject()) {
+            continue;
+        }
+        const QVariantMap marker = markerVariant(name, wire.value(name).toObject());
+        if (!marker.isEmpty()) {
+            result.append(marker);
+        }
+    }
+    return result;
+}
+
+QVariantList subtitles(const QJsonArray &wireSubtitles)
+{
+    return tracks(wireSubtitles, QStringLiteral("Subtitle"), 0, nullptr);
+}
+
+QVariantList playbackVariants(const QJsonArray &wireVariants,
+                              const QString &connectionId,
+                              const QString &itemId)
+{
+    QVariantList result;
+    result.reserve(wireVariants.size());
+    for (const QJsonValue &value : wireVariants) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const QJsonObject wire = value.toObject();
+        QVariantList parts;
+        for (const QJsonValue &partValue : wire.value(QStringLiteral("parts")).toArray()) {
+            if (!partValue.isObject()) {
+                continue;
+            }
+            const QJsonObject part = partValue.toObject();
+            parts.append(QVariantMap{
+                {QStringLiteral("partIndex"), part.value(QStringLiteral("part_index")).toInt()},
+                {QStringLiteral("defaultFileId"), identityString(part.value(QStringLiteral("default_file_id")))},
+                {QStringLiteral("totalDurationMs"), SiloModelMapper::secondsToMilliseconds(
+                     part.value(QStringLiteral("total_duration")).toDouble())},
+                {QStringLiteral("versions"), SiloModelMapper::mediaVersions(
+                     part.value(QStringLiteral("versions")).toArray(), connectionId, itemId)}
+            });
+        }
+        result.append(QVariantMap{
+            {QStringLiteral("variantId"), wire.value(QStringLiteral("variant_id")).toString()},
+            {QStringLiteral("edition"), wire.value(QStringLiteral("edition_raw")).toString()},
+            {QStringLiteral("editionKey"), wire.value(QStringLiteral("edition_key")).toString()},
+            {QStringLiteral("presentationKind"), wire.value(QStringLiteral("presentation_kind")).toString()},
+            {QStringLiteral("presentationGroupKey"), wire.value(QStringLiteral("presentation_group_key")).toString()},
+            {QStringLiteral("partCount"), wire.value(QStringLiteral("part_count")).toInt()},
+            {QStringLiteral("totalDurationMs"), SiloModelMapper::secondsToMilliseconds(
+                 wire.value(QStringLiteral("total_duration")).toDouble())},
+            {QStringLiteral("defaultFileId"), identityString(wire.value(QStringLiteral("default_file_id")))},
+            {QStringLiteral("parts"), parts}
+        });
+    }
+    return result;
+}
+} // namespace
+
+qint64 SiloModelMapper::secondsToMilliseconds(double seconds)
+{
+    if (!std::isfinite(seconds) || seconds <= 0.0
+        || seconds >= static_cast<double>(std::numeric_limits<qint64>::max()) / 1000.0) {
+        return 0;
+    }
+    return static_cast<qint64>(std::llround(seconds * 1000.0));
+}
+
+ParsedItemsResult SiloModelMapper::itemsResponse(const QByteArray &wireResponse,
+                                                 const QString &parentId)
+{
+    ParsedItemsResult result;
+    result.parentId = parentId;
+    result.queryKey = parentId;
+
+    QJsonParseError error;
+    const QJsonDocument document = QJsonDocument::fromJson(wireResponse, &error);
+    if (error.error != QJsonParseError::NoError) {
+        return result;
+    }
+    if (document.isArray()) {
+        result.items = document.array();
+        result.totalRecordCount = 0;
+        result.success = true;
+        return result;
+    }
+    if (!document.isObject()) {
+        return result;
+    }
+
+    const QJsonObject object = document.object();
+    if (!object.value(QStringLiteral("items")).isArray()) {
+        return result;
+    }
+    result.items = object.value(QStringLiteral("items")).toArray();
+    result.totalRecordCount = object.value(QStringLiteral("total")).isDouble()
+        ? qMax(0, object.value(QStringLiteral("total")).toInt())
+        : 0;
+    result.success = true;
+    return result;
+}
+
+ProviderCatalogResponse SiloModelMapper::catalogResponse(
+    ProviderCatalogOperation operation,
+    const QByteArray &wireResponse,
+    const QHash<QByteArray, QByteArray> &responseHeaders)
+{
+    ProviderCatalogResponse result;
+    const QByteArray trimmed = wireResponse.trimmed();
+    if (trimmed.isEmpty()) {
+        if (operation == ProviderCatalogOperation::SetFavorite) {
+            result.valid = true;
+        } else {
+            result.error = QStringLiteral("Silo returned an empty catalog response");
+        }
+        return result;
+    }
+
+    QJsonParseError error;
+    const QJsonDocument document = QJsonDocument::fromJson(trimmed, &error);
+    if (error.error != QJsonParseError::NoError) {
+        result.error = error.errorString();
+        return result;
+    }
+
+    const auto responseHeader = [&responseHeaders](const QByteArray &name) {
+        for (auto it = responseHeaders.constBegin(); it != responseHeaders.constEnd(); ++it) {
+            if (it.key().compare(name, Qt::CaseInsensitive) == 0) {
+                return it.value();
+            }
+        }
+        return QByteArray();
+    };
+    const QByteArray etag = responseHeader(QByteArrayLiteral("ETag"));
+    const QByteArray lastModified = responseHeader(QByteArrayLiteral("Last-Modified"));
+    if (!etag.isEmpty()) {
+        result.snapshot.insert(QStringLiteral("etag"), QString::fromUtf8(etag));
+    }
+    if (!lastModified.isEmpty()) {
+        result.snapshot.insert(QStringLiteral("lastModified"),
+                               QString::fromUtf8(lastModified));
+    }
+
+    if (document.isArray()) {
+        switch (operation) {
+        case ProviderCatalogOperation::Views:
+        case ProviderCatalogOperation::Items:
+            result.rawItems = document.array();
+            result.valid = true;
+            return result;
+        case ProviderCatalogOperation::Chapters:
+        case ProviderCatalogOperation::Versions:
+            result.rawItems = document.array();
+            result.rawItem.insert(QStringLiteral("versions"), result.rawItems);
+            result.valid = true;
+            return result;
+        default:
+            result.error = QStringLiteral("Unexpected Silo array response");
+            return result;
+        }
+    }
+    if (!document.isObject()) {
+        result.error = QStringLiteral("Unexpected Silo catalog response type");
+        return result;
+    }
+
+    const QJsonObject object = document.object();
+    if (object.value(QStringLiteral("error")).isString()) {
+        result.error = object.value(QStringLiteral("message")).toString(
+            object.value(QStringLiteral("error")).toString());
+        return result;
+    }
+
+    if (object.value(QStringLiteral("total")).isDouble()) {
+        const qint64 total = jsonInteger(object.value(QStringLiteral("total")), -1);
+        if (total >= 0 && total <= std::numeric_limits<int>::max()) {
+            result.total = static_cast<int>(total);
+            result.capabilityMetadata.insert(QStringLiteral("totalPresent"), true);
+        }
+    }
+    if (object.value(QStringLiteral("total_exact")).isBool()) {
+        result.capabilityMetadata.insert(
+            QStringLiteral("totalExact"),
+            object.value(QStringLiteral("total_exact")).toBool());
+    }
+    if (object.value(QStringLiteral("has_more")).isBool()) {
+        result.hasMore = object.value(QStringLiteral("has_more")).toBool();
+        result.capabilityMetadata.insert(QStringLiteral("hasMorePresent"), true);
+    }
+    if (object.value(QStringLiteral("snapshot")).isString()) {
+        result.snapshot.insert(QStringLiteral("snapshot"),
+                               object.value(QStringLiteral("snapshot")).toString());
+    }
+    if (object.value(QStringLiteral("search_diagnostics")).isObject()) {
+        result.capabilityMetadata.insert(
+            QStringLiteral("searchDiagnostics"),
+            object.value(QStringLiteral("search_diagnostics")).toObject().toVariantMap());
+    }
+
+    if ((operation == ProviderCatalogOperation::NextUp
+         || operation == ProviderCatalogOperation::Items)
+        && object.value(QStringLiteral("section")).isObject()) {
+        result.rawItem = object.value(QStringLiteral("section")).toObject();
+        if (!result.rawItem.value(QStringLiteral("items")).isArray()) {
+            result.error = QStringLiteral("Silo section response has no items array");
+            return result;
+        }
+        result.rawItems = result.rawItem.value(QStringLiteral("items")).toArray();
+        result.capabilityMetadata.insert(
+            QStringLiteral("section"),
+            result.rawItem.toVariantMap());
+        if (result.rawItem.value(QStringLiteral("total_count")).isDouble()) {
+            const qint64 sectionTotal = jsonInteger(
+                result.rawItem.value(QStringLiteral("total_count")), -1);
+            if (sectionTotal >= 0
+                && sectionTotal <= std::numeric_limits<int>::max()) {
+                result.total = static_cast<int>(sectionTotal);
+                result.capabilityMetadata.insert(
+                    QStringLiteral("totalPresent"), true);
+            }
+        }
+        result.valid = true;
+        return result;
+    }
+
+    if (operation == ProviderCatalogOperation::FilterOptions) {
+        result.rawItem = object;
+        result.filterMetadata = filterOptions(object);
+        if (object.value(QStringLiteral("matches")).isArray()) {
+            result.filterMetadata.insert(QStringLiteral("namedItems"),
+                                         namedItems(object));
+        }
+        result.valid = true;
+        return result;
+    }
+    if (operation == ProviderCatalogOperation::Item
+        || operation == ProviderCatalogOperation::SetWatched
+        || operation == ProviderCatalogOperation::SetFavorite) {
+        result.rawItem = object;
+        result.valid = true;
+        return result;
+    }
+
+    for (const QString &key : {QStringLiteral("items"), QStringLiteral("sections"),
+                               QStringLiteral("seasons"), QStringLiteral("episodes"),
+                               QStringLiteral("versions")}) {
+        if (object.value(key).isArray()) {
+            result.rawItems = object.value(key).toArray();
+            if (key == QStringLiteral("seasons")
+                || key == QStringLiteral("episodes")
+                || (operation == ProviderCatalogOperation::SimilarItems
+                    && key == QStringLiteral("items"))) {
+                QJsonArray normalizedItems;
+                for (const QJsonValue &value : result.rawItems) {
+                    if (!value.isObject()) {
+                        continue;
+                    }
+                    QJsonObject item = value.toObject();
+                    if (key == QStringLiteral("seasons")
+                        && !item.value(QStringLiteral("type")).isString()) {
+                        item.insert(QStringLiteral("type"), QStringLiteral("season"));
+                    } else if (key == QStringLiteral("episodes")
+                               && !item.value(QStringLiteral("type")).isString()) {
+                        item.insert(QStringLiteral("type"), QStringLiteral("episode"));
+                    }
+                    if (operation == ProviderCatalogOperation::SimilarItems
+                        && !item.value(QStringLiteral("content_id")).isString()) {
+                        item.insert(QStringLiteral("content_id"),
+                                    item.value(QStringLiteral("media_item_id")));
+                    }
+                    normalizedItems.append(item);
+                }
+                result.rawItems = normalizedItems;
+            }
+            result.capabilityMetadata.insert(QStringLiteral("envelope"), key);
+            result.valid = true;
+            return result;
+        }
+    }
+
+    result.error = QStringLiteral("Silo catalog response did not contain the expected resource");
+    return result;
+}
+
+QVariantMap SiloModelMapper::library(const QJsonObject &wireLibrary,
+                                     const QString &connectionId)
+{
+    const QString libraryId = identityString(wireLibrary.value(QStringLiteral("id")));
+    const QString name = wireLibrary.value(QStringLiteral("name")).toString();
+    if (libraryId.isEmpty() || name.isEmpty()) {
+        return {};
+    }
+
+    QVariantMap result{
+        {QStringLiteral("media"), Bloom::MediaRef{connectionId, libraryId}.toVariantMap()},
+        {QStringLiteral("connectionId"), connectionId},
+        {QStringLiteral("itemId"), libraryId},
+        {QStringLiteral("libraryId"), libraryId},
+        {QStringLiteral("name"), name},
+        {QStringLiteral("sortName"), name},
+        {QStringLiteral("mediaType"), QStringLiteral("CollectionFolder")},
+        {QStringLiteral("collectionType"), wireLibrary.value(QStringLiteral("type")).toString()},
+        {QStringLiteral("sortOrder"), wireLibrary.value(QStringLiteral("sort_order")).toInt()}
+    };
+    QVariantList artwork;
+    appendArtwork(artwork, result, QStringLiteral("primaryArtwork"),
+                  QStringLiteral("primaryArtworkUrl"), connectionId, libraryId,
+                  Bloom::ArtworkKind::Primary,
+                  wireLibrary.value(QStringLiteral("poster_url")).toString(),
+                  0, Bloom::ArtworkOwnerKind::Library);
+    result[QStringLiteral("artwork")] = artwork;
+    return result;
+}
+
+QVariantList SiloModelMapper::libraries(const QJsonArray &wireLibraries,
+                                        const QString &connectionId)
+{
+    QVariantList result;
+    result.reserve(wireLibraries.size());
+    for (const QJsonValue &value : wireLibraries) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const QVariantMap mapped = library(value.toObject(), connectionId);
+        if (!mapped.isEmpty()) {
+            result.append(mapped);
+        }
+    }
+    return result;
+}
+
+MediaStreamInfo SiloModelMapper::mediaStream(const QJsonObject &wireTrack,
+                                             const QString &kind,
+                                             int index)
+{
+    MediaStreamInfo result;
+    result.index = index;
+    result.type = kind;
+    result.codec = wireTrack.value(QStringLiteral("codec")).toString();
+    result.language = wireTrack.value(QStringLiteral("language")).toString();
+    result.title = wireTrack.value(QStringLiteral("title")).toString();
+    if (result.title.isEmpty()) {
+        result.title = wireTrack.value(QStringLiteral("embedded_title")).toString();
+    }
+    result.displayTitle = result.title;
+    result.isDefault = wireTrack.value(QStringLiteral("default")).toBool();
+    result.isForced = wireTrack.value(QStringLiteral("forced")).toBool();
+    result.isExternal = wireTrack.value(QStringLiteral("external")).toBool();
+    result.isHearingImpaired = wireTrack.value(QStringLiteral("hearing_impaired")).toBool();
+    result.channels = wireTrack.value(QStringLiteral("channels")).toInt();
+    result.channelLayout = wireTrack.value(QStringLiteral("layout")).toString();
+    result.bitRate = wireTrack.value(QStringLiteral("bitrate")).toInt();
+    result.width = wireTrack.value(QStringLiteral("width")).toInt();
+    result.height = wireTrack.value(QStringLiteral("height")).toInt();
+    result.averageFrameRate = frameRate(wireTrack.value(QStringLiteral("frame_rate")).toString());
+    result.realFrameRate = result.averageFrameRate;
+    result.profile = wireTrack.value(QStringLiteral("profile")).toString();
+    result.videoRange = wireTrack.value(QStringLiteral("video_range")).toString();
+    result.videoRangeType = wireTrack.value(QStringLiteral("video_range_type")).toString();
+    result.dolbyVisionProfile = wireTrack.value(QStringLiteral("dv_profile")).toInt();
+    result.dolbyVisionBlSignalCompatibilityId =
+        wireTrack.value(QStringLiteral("dv_bl_compat_id")).toInt();
+    return result;
+}
+
+QVariantMap SiloModelMapper::mediaVersion(const QJsonObject &wireVersion,
+                                          const QString &connectionId,
+                                          const QString &itemId)
+{
+    const QString fileId = identityString(wireVersion.value(QStringLiteral("file_id")));
+    if (fileId.isEmpty()) {
+        return {};
+    }
+
+    QVariantList mediaStreams;
+    const QVariantList videoTracks = tracks(wireVersion.value(QStringLiteral("video_tracks")).toArray(),
+                                            QStringLiteral("Video"), 0, &mediaStreams);
+    const QVariantList audioTracks = tracks(wireVersion.value(QStringLiteral("audio_tracks")).toArray(),
+                                            QStringLiteral("Audio"), 0, &mediaStreams);
+    const QVariantList subtitleTracks = tracks(
+        wireVersion.value(QStringLiteral("subtitle_tracks")).toArray(),
+        QStringLiteral("Subtitle"), 0, &mediaStreams);
+
+    QVariantMap result{
+        {QStringLiteral("id"), fileId},
+        {QStringLiteral("fileId"), fileId},
+        {QStringLiteral("mediaVersionId"), fileId},
+        {QStringLiteral("fileName"), wireVersion.value(QStringLiteral("file_name")).toString()},
+        {QStringLiteral("resolution"), wireVersion.value(QStringLiteral("resolution")).toString()},
+        {QStringLiteral("videoCodec"), wireVersion.value(QStringLiteral("codec_video")).toString()},
+        {QStringLiteral("audioCodec"), wireVersion.value(QStringLiteral("codec_audio")).toString()},
+        {QStringLiteral("hdr"), wireVersion.value(QStringLiteral("hdr")).toBool()},
+        {QStringLiteral("container"), wireVersion.value(QStringLiteral("container")).toString()},
+        {QStringLiteral("fileSize"), jsonInteger(wireVersion.value(QStringLiteral("file_size")))},
+        {QStringLiteral("durationMs"), secondsToMilliseconds(
+             wireVersion.value(QStringLiteral("duration")).toDouble())},
+        {QStringLiteral("bitrate"), wireVersion.value(QStringLiteral("bitrate")).toInt()},
+        {QStringLiteral("addedAt"), wireVersion.value(QStringLiteral("added_at")).toString()},
+        {QStringLiteral("edition"), wireVersion.value(QStringLiteral("edition_raw")).toString()},
+        {QStringLiteral("editionKey"), wireVersion.value(QStringLiteral("edition_key")).toString()},
+        {QStringLiteral("presentationKind"), wireVersion.value(QStringLiteral("presentation_kind")).toString()},
+        {QStringLiteral("presentationGroupKey"), wireVersion.value(QStringLiteral("presentation_group_key")).toString()},
+        {QStringLiteral("presentationPartIndex"), wireVersion.value(QStringLiteral("presentation_part_index")).toInt()},
+        {QStringLiteral("presentationPartTotal"), wireVersion.value(QStringLiteral("presentation_part_total")).toInt()},
+        {QStringLiteral("multiEpisodeStart"), wireVersion.value(QStringLiteral("multi_episode_start")).toInt()},
+        {QStringLiteral("multiEpisodeEnd"), wireVersion.value(QStringLiteral("multi_episode_end")).toInt()},
+        {QStringLiteral("effectiveAudioTrackIndex"), wireVersion.value(QStringLiteral("effective_audio_track_index")).toInt(-1)},
+        {QStringLiteral("effectiveAudioLanguage"), wireVersion.value(QStringLiteral("effective_audio_language")).toString()},
+        {QStringLiteral("videoTracks"), videoTracks},
+        {QStringLiteral("audioTracks"), audioTracks},
+        {QStringLiteral("subtitleTracks"), subtitleTracks},
+        {QStringLiteral("mediaStreams"), mediaStreams},
+        {QStringLiteral("chapters"), chapters(
+             wireVersion.value(QStringLiteral("chapters")).toArray(), connectionId, itemId, fileId)},
+        {QStringLiteral("markers"), markerVariants(wireVersion)}
+    };
+    if (wireVersion.value(QStringLiteral("file_path")).isString()) {
+        result[QStringLiteral("filePath")] = wireVersion.value(QStringLiteral("file_path")).toString();
+    }
+    return result;
+}
+
+QVariantList SiloModelMapper::mediaVersions(const QJsonArray &wireVersions,
+                                            const QString &connectionId,
+                                            const QString &itemId)
+{
+    QVariantList result;
+    result.reserve(wireVersions.size());
+    for (const QJsonValue &value : wireVersions) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const QVariantMap mapped = mediaVersion(value.toObject(), connectionId, itemId);
+        if (!mapped.isEmpty()) {
+            result.append(mapped);
+        }
+    }
+    return result;
+}
+
+QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
+                                       const QString &connectionId)
+{
+    QString itemId = identityString(wireItem.value(QStringLiteral("content_id")));
+    if (itemId.isEmpty()) {
+        itemId = identityString(wireItem.value(QStringLiteral("media_item_id")));
+    }
+    if (itemId.isEmpty()
+        && wireItem.value(QStringLiteral("id")).isString()
+        && wireItem.value(QStringLiteral("section_type")).isString()) {
+        const QString sectionId =
+            identityString(wireItem.value(QStringLiteral("id")));
+        const QString title = wireItem.value(QStringLiteral("title")).toString();
+        if (sectionId.isEmpty() || title.isEmpty()) {
+            return {};
+        }
+        return {
+            {QStringLiteral("media"),
+             Bloom::MediaRef{connectionId, sectionId}.toVariantMap()},
+            {QStringLiteral("connectionId"), connectionId},
+            {QStringLiteral("itemId"), sectionId},
+            {QStringLiteral("sectionId"), sectionId},
+            {QStringLiteral("name"), title},
+            {QStringLiteral("sortName"), title},
+            {QStringLiteral("mediaType"), QStringLiteral("CollectionFolder")},
+            {QStringLiteral("collectionType"),
+             wireItem.value(QStringLiteral("section_type")).toString()},
+            {QStringLiteral("featured"),
+             wireItem.value(QStringLiteral("featured")).toBool()},
+            {QStringLiteral("itemLimit"),
+             wireItem.value(QStringLiteral("item_limit")).toInt()},
+            {QStringLiteral("isCustom"),
+             wireItem.value(QStringLiteral("is_custom")).toBool()},
+            {QStringLiteral("customized"),
+             wireItem.value(QStringLiteral("customized")).toBool()}
+        };
+    }
+    if (itemId.isEmpty() && wireItem.contains(QStringLiteral("id"))
+        && wireItem.contains(QStringLiteral("name"))) {
+        return library(wireItem, connectionId);
+    }
+    if (itemId.isEmpty()) {
+        return {};
+    }
+
+    const QJsonObject userData = wireItem.value(QStringLiteral("user_data")).isObject()
+        ? wireItem.value(QStringLiteral("user_data")).toObject()
+        : wireItem.value(QStringLiteral("user_state")).toObject();
+    Bloom::UserMediaState state;
+    state.watched = userData.value(QStringLiteral("played")).toBool();
+    state.favorite = userData.contains(QStringLiteral("is_favorite"))
+        ? userData.value(QStringLiteral("is_favorite")).toBool()
+        : userData.value(QStringLiteral("favorite")).toBool();
+    const QJsonValue positionSeconds = userData.value(QStringLiteral("position_seconds")).isDouble()
+        ? userData.value(QStringLiteral("position_seconds"))
+        : wireItem.value(QStringLiteral("position_seconds"));
+    state.positionMs = secondsToMilliseconds(positionSeconds.toDouble());
+    state.unplayedItemCount = userData.value(QStringLiteral("unplayed_count")).toInt();
+    state.lastPlayedAt = userData.value(QStringLiteral("last_played_at")).toString(
+        wireItem.value(QStringLiteral("progress_updated_at")).toString());
+
+    const QJsonArray wireVersions = wireItem.value(QStringLiteral("versions")).isArray()
+        ? wireItem.value(QStringLiteral("versions")).toArray()
+        : wireItem.value(QStringLiteral("files")).toArray();
+    const QVariantList versions = mediaVersions(wireVersions, connectionId, itemId);
+    qint64 durationMs = 0;
+    if (wireItem.value(QStringLiteral("duration_seconds")).isDouble()) {
+        durationMs = secondsToMilliseconds(
+            wireItem.value(QStringLiteral("duration_seconds")).toDouble());
+    } else if (userData.value(QStringLiteral("duration_seconds")).isDouble()) {
+        durationMs = secondsToMilliseconds(
+            userData.value(QStringLiteral("duration_seconds")).toDouble());
+    } else if (!versions.isEmpty()) {
+        durationMs = versions.first().toMap().value(QStringLiteral("durationMs")).toLongLong();
+    } else if (wireItem.value(QStringLiteral("runtime")).isDouble()) {
+        durationMs = secondsToMilliseconds(
+            wireItem.value(QStringLiteral("runtime")).toDouble() * 60.0);
+    }
+
+    double communityRating = 0.0;
+    if (wireItem.value(QStringLiteral("rating_imdb")).isDouble()) {
+        communityRating = wireItem.value(QStringLiteral("rating_imdb")).toDouble();
+    } else if (wireItem.value(QStringLiteral("rating_tmdb")).isDouble()) {
+        communityRating = wireItem.value(QStringLiteral("rating_tmdb")).toDouble();
+    }
+
+    const QString seriesId = identityString(wireItem.value(QStringLiteral("series_id")));
+    QVariantMap result{
+        {QStringLiteral("media"), Bloom::MediaRef{connectionId, itemId}.toVariantMap()},
+        {QStringLiteral("connectionId"), connectionId},
+        {QStringLiteral("itemId"), itemId},
+        {QStringLiteral("name"), wireItem.value(QStringLiteral("title")).toString()},
+        {QStringLiteral("sortName"), wireItem.value(QStringLiteral("sort_title")).toString()},
+        {QStringLiteral("originalTitle"), wireItem.value(QStringLiteral("original_title")).toString()},
+        {QStringLiteral("mediaType"), canonicalMediaType(
+             wireItem.value(QStringLiteral("type")).toString())},
+        {QStringLiteral("parentId"), identityString(wireItem.value(QStringLiteral("parent_id")))},
+        {QStringLiteral("seriesId"), seriesId},
+        {QStringLiteral("seasonId"), identityString(wireItem.value(QStringLiteral("season_id")))},
+        {QStringLiteral("seriesName"), wireItem.value(QStringLiteral("series_title")).toString()},
+        {QStringLiteral("indexNumber"), wireItem.value(QStringLiteral("episode_number")).toInt(-1)},
+        {QStringLiteral("parentIndexNumber"), wireItem.value(QStringLiteral("season_number")).toInt(-1)},
+        {QStringLiteral("overview"), wireItem.value(QStringLiteral("overview")).toString()},
+        {QStringLiteral("tagline"), wireItem.value(QStringLiteral("tagline")).toString()},
+        {QStringLiteral("productionYear"), wireItem.value(QStringLiteral("year")).toInt()},
+        {QStringLiteral("premiereDate"),
+         wireItem.value(QStringLiteral("release_date")).toString(
+             wireItem.value(QStringLiteral("air_date")).toString())},
+        {QStringLiteral("endDate"), wireItem.value(QStringLiteral("last_air_date")).toString()},
+        {QStringLiteral("officialRating"), wireItem.value(QStringLiteral("content_rating")).toString()},
+        {QStringLiteral("communityRating"), communityRating},
+        {QStringLiteral("durationMs"), durationMs},
+        {QStringLiteral("runtimeMinutes"), wireItem.value(QStringLiteral("runtime")).toInt()},
+        {QStringLiteral("status"), wireItem.value(QStringLiteral("show_status")).toString(
+             wireItem.value(QStringLiteral("status")).toString())},
+        {QStringLiteral("genres"), stringList(wireItem.value(QStringLiteral("genres")))},
+        {QStringLiteral("studios"), stringList(wireItem.value(QStringLiteral("studios")))},
+        {QStringLiteral("networks"), stringList(wireItem.value(QStringLiteral("networks")))},
+        {QStringLiteral("tags"), stringList(wireItem.value(QStringLiteral("keywords")))},
+        {QStringLiteral("providerIds"), providerIds(wireItem)},
+        {QStringLiteral("userState"), state.toVariantMap()},
+        {QStringLiteral("watched"), state.watched},
+        {QStringLiteral("favorite"), state.favorite},
+        {QStringLiteral("positionMs"), state.positionMs},
+        {QStringLiteral("unplayedItemCount"), state.unplayedItemCount},
+        {QStringLiteral("isInProgress"),
+         userData.contains(QStringLiteral("is_in_progress"))
+             ? userData.value(QStringLiteral("is_in_progress")).toBool()
+             : wireItem.value(QStringLiteral("position_seconds")).toDouble() > 0.0},
+        {QStringLiteral("people"), people(wireItem, connectionId)},
+        {QStringLiteral("versions"), versions},
+        {QStringLiteral("playbackVariants"), playbackVariants(
+             wireItem.value(QStringLiteral("playback_variants")).toArray(), connectionId, itemId)},
+        {QStringLiteral("subtitles"), subtitles(wireItem.value(QStringLiteral("subtitles")).toArray())},
+        {QStringLiteral("markers"), markerVariants(wireItem)}
+    };
+    if (wireItem.value(QStringLiteral("score")).isDouble()) {
+        result[QStringLiteral("recommendationScore")] =
+            wireItem.value(QStringLiteral("score")).toDouble();
+    }
+    if (wireItem.value(QStringLiteral("reason")).isString()) {
+        result[QStringLiteral("recommendationReason")] =
+            wireItem.value(QStringLiteral("reason")).toString();
+    }
+    if (wireItem.value(QStringLiteral("reason_detail")).isString()) {
+        result[QStringLiteral("recommendationReasonDetail")] =
+            wireItem.value(QStringLiteral("reason_detail")).toString();
+    }
+    if (result.value(QStringLiteral("parentId")).toString().isEmpty()) {
+        result[QStringLiteral("parentId")] = seriesId;
+    }
+    if (wireItem.contains(QStringLiteral("season_count"))) {
+        result[QStringLiteral("seasonCount")] = wireItem.value(QStringLiteral("season_count")).toInt();
+        result[QStringLiteral("childCount")] = wireItem.value(QStringLiteral("season_count")).toInt();
+    }
+    if (wireItem.contains(QStringLiteral("episode_count"))) {
+        result[QStringLiteral("episodeCount")] = wireItem.value(QStringLiteral("episode_count")).toInt();
+        result[QStringLiteral("childCount")] = wireItem.value(QStringLiteral("episode_count")).toInt();
+    }
+    result[QStringLiteral("ratings")] = QVariantMap{
+        {QStringLiteral("imdb"), wireItem.value(QStringLiteral("rating_imdb")).toDouble()},
+        {QStringLiteral("tmdb"), wireItem.value(QStringLiteral("rating_tmdb")).toDouble()},
+        {QStringLiteral("rottenTomatoesCritic"), wireItem.value(QStringLiteral("rating_rt_critic")).toInt()},
+        {QStringLiteral("rottenTomatoesAudience"), wireItem.value(QStringLiteral("rating_rt_audience")).toInt()}
+    };
+    if (wireItem.value(QStringLiteral("restrictions")).isObject()) {
+        result[QStringLiteral("restrictions")] =
+            wireItem.value(QStringLiteral("restrictions")).toObject().toVariantMap();
+    } else if (wireItem.value(QStringLiteral("access_restrictions")).isObject()) {
+        result[QStringLiteral("restrictions")] =
+            wireItem.value(QStringLiteral("access_restrictions")).toObject().toVariantMap();
+    } else if (wireItem.value(QStringLiteral("restrictions")).isArray()) {
+        result[QStringLiteral("restrictions")] =
+            wireItem.value(QStringLiteral("restrictions")).toArray().toVariantList();
+    }
+    if (wireItem.value(QStringLiteral("restricted")).isBool()) {
+        result[QStringLiteral("restricted")] =
+            wireItem.value(QStringLiteral("restricted")).toBool();
+    }
+
+    const QString primaryArtworkUrl =
+        wireItem.value(QStringLiteral("poster_url")).toString(
+            wireItem.value(QStringLiteral("still_url")).toString());
+    const QString primaryThumbhash =
+        wireItem.value(QStringLiteral("poster_thumbhash")).toString(
+            wireItem.value(QStringLiteral("still_thumbhash")).toString());
+    QVariantList artwork;
+    appendArtwork(artwork, result, QStringLiteral("primaryArtwork"),
+                  QStringLiteral("primaryArtworkUrl"), connectionId, itemId,
+                  Bloom::ArtworkKind::Primary,
+                  primaryArtworkUrl);
+    appendArtwork(artwork, result, QStringLiteral("backdropArtwork"),
+                  QStringLiteral("backdropArtworkUrl"), connectionId, itemId,
+                  Bloom::ArtworkKind::Backdrop,
+                  wireItem.value(QStringLiteral("backdrop_url")).toString());
+    appendArtwork(artwork, result, QStringLiteral("logoArtwork"),
+                  QStringLiteral("logoArtworkUrl"), connectionId, itemId,
+                  Bloom::ArtworkKind::Logo,
+                  wireItem.value(QStringLiteral("logo_url")).toString());
+    result[QStringLiteral("artwork")] = artwork;
+    result[QStringLiteral("artworkThumbhashes")] = QVariantMap{
+        {QStringLiteral("poster"), primaryThumbhash},
+        {QStringLiteral("backdrop"), wireItem.value(QStringLiteral("backdrop_thumbhash")).toString()}
+    };
+    QVariantMap artworkExpiresAt;
+    for (const auto &[kind, field] : {
+             std::pair{QStringLiteral("primary"),
+                       wireItem.value(QStringLiteral("poster_url")).isString()
+                           ? QStringLiteral("poster_url_expires_at")
+                           : QStringLiteral("still_url_expires_at")},
+             std::pair{QStringLiteral("backdrop"), QStringLiteral("backdrop_url_expires_at")},
+             std::pair{QStringLiteral("logo"), QStringLiteral("logo_url_expires_at")}}) {
+        if (wireItem.value(field).isString()) {
+            artworkExpiresAt.insert(kind, wireItem.value(field).toString());
+        }
+    }
+    if (!artworkExpiresAt.isEmpty()) {
+        result[QStringLiteral("artworkExpiresAt")] = artworkExpiresAt;
+    }
+    return result;
+}
+
+QVariantList SiloModelMapper::mediaItems(const QJsonArray &wireItems,
+                                         const QString &connectionId)
+{
+    QVariantList result;
+    result.reserve(wireItems.size());
+    for (const QJsonValue &value : wireItems) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const QVariantMap mapped = mediaItem(value.toObject(), connectionId);
+        if (!mapped.isEmpty()) {
+            result.append(mapped);
+        }
+    }
+    return result;
+}
+
+QVariantMap SiloModelMapper::chapter(const QJsonObject &wireChapter,
+                                     const QString &connectionId,
+                                     const QString &itemId,
+                                     const QString &fileId,
+                                     int fallbackIndex)
+{
+    if (!wireChapter.value(QStringLiteral("start_seconds")).isDouble()) {
+        return {};
+    }
+    const int index = wireChapter.contains(QStringLiteral("index"))
+        ? wireChapter.value(QStringLiteral("index")).toInt(fallbackIndex)
+        : fallbackIndex;
+    QVariantMap result{
+        {QStringLiteral("name"), wireChapter.value(QStringLiteral("title")).toString()},
+        {QStringLiteral("index"), index},
+        {QStringLiteral("fileId"), fileId},
+        {QStringLiteral("startMs"), secondsToMilliseconds(
+             wireChapter.value(QStringLiteral("start_seconds")).toDouble())},
+        {QStringLiteral("endMs"), secondsToMilliseconds(
+             wireChapter.value(QStringLiteral("end_seconds")).toDouble())},
+        {QStringLiteral("source"), wireChapter.value(QStringLiteral("source")).toString()},
+        {QStringLiteral("thumbnailUrl"), wireChapter.value(QStringLiteral("thumbnail_url")).toString()},
+        {QStringLiteral("thumbnailThumbhash"), wireChapter.value(QStringLiteral("thumbnail_thumbhash")).toString()}
+    };
+    if (!result.value(QStringLiteral("thumbnailUrl")).toString().isEmpty()
+        && !connectionId.isEmpty() && !itemId.isEmpty()) {
+        Bloom::ArtworkRef artwork;
+        artwork.connectionId = connectionId;
+        artwork.itemId = itemId;
+        artwork.kind = Bloom::ArtworkKind::Chapter;
+        artwork.tag = fileId;
+        artwork.ownerKind = Bloom::ArtworkOwnerKind::Chapter;
+        artwork.index = qMax(0, index);
+        artwork.sourceUrl = result.value(QStringLiteral("thumbnailUrl")).toString();
+        result[QStringLiteral("artwork")] = artwork.toVariantMap();
+    }
+    return result;
+}
+
+QVariantList SiloModelMapper::chapters(const QJsonArray &wireChapters,
+                                       const QString &connectionId,
+                                       const QString &itemId,
+                                       const QString &fileId)
+{
+    QVariantList result;
+    result.reserve(wireChapters.size());
+    for (qsizetype index = 0; index < wireChapters.size(); ++index) {
+        if (!wireChapters.at(index).isObject()) {
+            continue;
+        }
+        const QVariantMap mapped = chapter(wireChapters.at(index).toObject(), connectionId,
+                                           itemId, fileId, static_cast<int>(index));
+        if (!mapped.isEmpty()) {
+            result.append(mapped);
+        }
+    }
+    return result;
+}
+
+QVariantList SiloModelMapper::chaptersFromItem(const QJsonObject &wireItem,
+                                               const QString &connectionId,
+                                               const QString &itemId)
+{
+    QVariantList result;
+    QSet<QString> seen;
+    const auto appendChapters = [&result, &seen, &connectionId, &itemId](
+                                    const QJsonObject &version) {
+        const QString fileId = identityString(version.value(QStringLiteral("file_id")));
+        const QVariantList mapped = chapters(version.value(QStringLiteral("chapters")).toArray(),
+                                              connectionId, itemId, fileId);
+        for (const QVariant &entry : mapped) {
+            const QVariantMap chapterMap = entry.toMap();
+            const QString key = fileId + QLatin1Char(':')
+                + QString::number(chapterMap.value(QStringLiteral("index")).toInt())
+                + QLatin1Char(':')
+                + QString::number(chapterMap.value(QStringLiteral("startMs")).toLongLong());
+            if (!seen.contains(key)) {
+                seen.insert(key);
+                result.append(entry);
+            }
+        }
+    };
+
+    if (wireItem.value(QStringLiteral("chapters")).isArray()) {
+        QJsonObject direct;
+        direct.insert(QStringLiteral("file_id"), wireItem.value(QStringLiteral("file_id")));
+        direct.insert(QStringLiteral("chapters"), wireItem.value(QStringLiteral("chapters")));
+        appendChapters(direct);
+    }
+    for (const QJsonValue &value : wireItem.value(QStringLiteral("versions")).toArray()) {
+        if (value.isObject()) {
+            appendChapters(value.toObject());
+        }
+    }
+    for (const QJsonValue &variantValue :
+         wireItem.value(QStringLiteral("playback_variants")).toArray()) {
+        if (!variantValue.isObject()) {
+            continue;
+        }
+        for (const QJsonValue &partValue :
+             variantValue.toObject().value(QStringLiteral("parts")).toArray()) {
+            if (!partValue.isObject()) {
+                continue;
+            }
+            for (const QJsonValue &versionValue :
+                 partValue.toObject().value(QStringLiteral("versions")).toArray()) {
+                if (versionValue.isObject()) {
+                    appendChapters(versionValue.toObject());
+                }
+            }
+        }
+    }
+    return result;
+}
+
+QVariantMap SiloModelMapper::filterOptions(const QJsonObject &wireFilters)
+{
+    return {
+        {QStringLiteral("genres"), stringList(wireFilters.value(QStringLiteral("genres")))},
+        {QStringLiteral("studios"), stringList(wireFilters.value(QStringLiteral("studios")))},
+        {QStringLiteral("networks"), stringList(wireFilters.value(QStringLiteral("networks")))},
+        {QStringLiteral("countries"), stringList(wireFilters.value(QStringLiteral("countries")))},
+        {QStringLiteral("originalLanguages"), stringList(wireFilters.value(QStringLiteral("original_languages")))},
+        {QStringLiteral("contentRatings"), stringList(wireFilters.value(QStringLiteral("content_ratings")))},
+        {QStringLiteral("authors"), stringList(wireFilters.value(QStringLiteral("authors")))},
+        {QStringLiteral("narrators"), stringList(wireFilters.value(QStringLiteral("narrators")))},
+        {QStringLiteral("series"), stringList(wireFilters.value(QStringLiteral("series")))},
+        {QStringLiteral("resolutions"), stringList(wireFilters.value(QStringLiteral("resolutions")))},
+        {QStringLiteral("audioLanguages"), stringList(wireFilters.value(QStringLiteral("audio_languages")))},
+        {QStringLiteral("subtitleLanguages"), stringList(wireFilters.value(QStringLiteral("subtitle_languages")))}
+    };
+}
+
+QStringList SiloModelMapper::namedItems(const QJsonObject &wireItems)
+{
+    QStringList result;
+    const QJsonArray items = wireItems.value(QStringLiteral("items")).isArray()
+        ? wireItems.value(QStringLiteral("items")).toArray()
+        : wireItems.value(QStringLiteral("matches")).toArray();
+    result.reserve(items.size());
+    for (const QJsonValue &value : items) {
+        if (value.isString()) {
+            result.append(value.toString());
+        } else if (value.isObject()) {
+            const QJsonObject object = value.toObject();
+            const QString name = object.value(QStringLiteral("name")).toString(
+                object.value(QStringLiteral("title")).toString());
+            if (!name.isEmpty()) {
+                result.append(name);
+            }
+        }
+    }
+    return result;
+}
+
+QList<ProviderProfile> SiloModelMapper::profiles(const QJsonArray &wireProfiles)
+{
+    QList<ProviderProfile> result;
+    result.reserve(wireProfiles.size());
+    for (const QJsonValue &value : wireProfiles) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const QJsonObject wire = value.toObject();
+        ProviderProfile profile;
+        profile.id = wire.value(QStringLiteral("id")).toString();
+        profile.name = wire.value(QStringLiteral("name")).toString();
+        profile.avatarUrl = wire.value(QStringLiteral("avatar_url")).toString();
+        profile.hasPin = wire.value(QStringLiteral("has_pin")).toBool();
+        profile.isChild = wire.value(QStringLiteral("is_child")).toBool();
+        profile.isPrimary = wire.value(QStringLiteral("is_primary")).toBool();
+        if (profile.isValid() && !profile.name.isEmpty()) {
+            result.append(profile);
+        }
+    }
+    return result;
+}
+
+QList<ProviderAuthSession> SiloModelMapper::authSessions(const QJsonArray &wireSessions)
+{
+    QList<ProviderAuthSession> result;
+    result.reserve(wireSessions.size());
+    for (const QJsonValue &value : wireSessions) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const QJsonObject wire = value.toObject();
+        ProviderAuthSession session;
+        session.id = wire.value(QStringLiteral("id")).toString();
+        session.deviceName = wire.value(QStringLiteral("device_name")).toString();
+        session.ipAddress = wire.value(QStringLiteral("ip_address")).toString();
+        session.createdAt = isoDateMilliseconds(wire.value(QStringLiteral("created_at")));
+        session.expiresAt = isoDateMilliseconds(wire.value(QStringLiteral("expires_at")));
+        session.revokedAt = isoDateMilliseconds(wire.value(QStringLiteral("revoked_at")));
+        session.isCurrent = wire.value(QStringLiteral("is_current")).toBool();
+        if (session.isValid()) {
+            result.append(session);
+        }
+    }
+    return result;
+}
+
+QVariantMap SiloModelMapper::nativeState(const QJsonObject &wireState,
+                                         const QString &connectionId)
+{
+    const QJsonObject state = wireState.value(QStringLiteral("user_data")).isObject()
+        ? wireState.value(QStringLiteral("user_data")).toObject()
+        : (wireState.value(QStringLiteral("user_state")).isObject()
+               ? wireState.value(QStringLiteral("user_state")).toObject()
+               : wireState);
+    const bool recognized = state.contains(QStringLiteral("played"))
+        || state.contains(QStringLiteral("is_favorite"))
+        || state.contains(QStringLiteral("favorite"))
+        || state.contains(QStringLiteral("position_seconds"))
+        || state.contains(QStringLiteral("is_in_progress"));
+    if (!recognized) {
+        return {};
+    }
+
+    Bloom::UserMediaState userState;
+    userState.watched = state.value(QStringLiteral("played")).toBool();
+    userState.favorite = state.contains(QStringLiteral("is_favorite"))
+        ? state.value(QStringLiteral("is_favorite")).toBool()
+        : state.value(QStringLiteral("favorite")).toBool();
+    const QJsonValue position = state.value(QStringLiteral("position_seconds")).isDouble()
+        ? state.value(QStringLiteral("position_seconds"))
+        : wireState.value(QStringLiteral("position_seconds"));
+    userState.positionMs = secondsToMilliseconds(position.toDouble());
+    userState.unplayedItemCount = state.value(QStringLiteral("unplayed_count")).toInt();
+    userState.lastPlayedAt = state.value(QStringLiteral("last_played_at")).toString(
+        wireState.value(QStringLiteral("progress_updated_at")).toString());
+    return {
+        {QStringLiteral("connectionId"), connectionId},
+        {QStringLiteral("itemId"), identityString(
+             wireState.value(QStringLiteral("content_id")).isUndefined()
+                 ? state.value(QStringLiteral("content_id"))
+                 : wireState.value(QStringLiteral("content_id")))},
+        {QStringLiteral("userState"), userState.toVariantMap()},
+        {QStringLiteral("watched"), userState.watched},
+        {QStringLiteral("favorite"), userState.favorite},
+        {QStringLiteral("positionMs"), userState.positionMs},
+        {QStringLiteral("durationMs"), secondsToMilliseconds(
+             (state.value(QStringLiteral("duration_seconds")).isDouble()
+                  ? state.value(QStringLiteral("duration_seconds"))
+                  : wireState.value(QStringLiteral("duration_seconds"))).toDouble())},
+        {QStringLiteral("isInProgress"), state.value(QStringLiteral("is_in_progress")).toBool()},
+        {QStringLiteral("watchedCount"), state.value(QStringLiteral("watched_count")).toInt()},
+        {QStringLiteral("unplayedItemCount"), userState.unplayedItemCount},
+        {QStringLiteral("inProgressCount"), state.value(QStringLiteral("in_progress_count")).toInt()},
+        {QStringLiteral("lastFileId"), identityString(state.value(QStringLiteral("last_file_id")))}
+    };
+}
+
+QList<MediaSegmentInfo> SiloModelMapper::mediaSegments(const QString &itemId,
+                                                       const QJsonObject &wireSegments)
+{
+    QList<MediaSegmentInfo> result;
+    const QString fileId = identityString(wireSegments.value(QStringLiteral("file_id")));
+    for (const QString &name : {QStringLiteral("intro"), QStringLiteral("credits"),
+                                QStringLiteral("recap"), QStringLiteral("preview")}) {
+        if (!wireSegments.value(name).isObject()) {
+            continue;
+        }
+        const QJsonObject wire = wireSegments.value(name).toObject();
+        const QJsonValue start = wire.contains(QStringLiteral("start_seconds"))
+            ? wire.value(QStringLiteral("start_seconds")) : wire.value(QStringLiteral("start"));
+        const QJsonValue end = wire.contains(QStringLiteral("end_seconds"))
+            ? wire.value(QStringLiteral("end_seconds")) : wire.value(QStringLiteral("end"));
+        if (!start.isDouble() || !end.isDouble()
+            || !std::isfinite(start.toDouble()) || !std::isfinite(end.toDouble())
+            || start.toDouble() < 0.0 || end.toDouble() <= start.toDouble()) {
+            continue;
+        }
+
+        MediaSegmentInfo segment;
+        segment.id = fileId.isEmpty() ? QString() : fileId + QLatin1Char(':') + name;
+        segment.itemId = itemId;
+        segment.startMs = secondsToMilliseconds(start.toDouble());
+        segment.endMs = secondsToMilliseconds(end.toDouble());
+        segment.source = wire.value(QStringLiteral("source")).toString();
+        segment.confidence = wire.value(QStringLiteral("confidence")).toDouble();
+        if (name == QStringLiteral("intro")) {
+            segment.type = MediaSegmentType::Intro;
+            segment.typeString = QStringLiteral("Intro");
+        } else if (name == QStringLiteral("credits")) {
+            segment.type = MediaSegmentType::Outro;
+            segment.typeString = QStringLiteral("Outro");
+        } else if (name == QStringLiteral("recap")) {
+            segment.type = MediaSegmentType::Recap;
+            segment.typeString = QStringLiteral("Recap");
+        } else {
+            segment.type = MediaSegmentType::Preview;
+            segment.typeString = QStringLiteral("Preview");
+        }
+        result.append(segment);
+    }
+    return result;
+}

--- a/src/providers/silo/SiloModelMapper.cpp
+++ b/src/providers/silo/SiloModelMapper.cpp
@@ -51,7 +51,7 @@ qint64 jsonInteger(const QJsonValue &value, qint64 fallback = 0)
     const double number = value.toDouble();
     if (!std::isfinite(number) || std::trunc(number) != number
         || number < static_cast<double>(std::numeric_limits<qint64>::min())
-        || number > static_cast<double>(std::numeric_limits<qint64>::max())) {
+        || number >= static_cast<double>(std::numeric_limits<qint64>::max())) {
         return fallback;
     }
     return static_cast<qint64>(number);
@@ -361,22 +361,19 @@ ParsedItemsResult SiloModelMapper::itemsResponse(const QByteArray &wireResponse,
     }
     if (document.isArray()) {
         result.items = document.array();
-        result.totalRecordCount = 0;
+        result.totalRecordCount = static_cast<int>(result.items.size());
         result.success = true;
         return result;
     }
     if (!document.isObject()) {
         return result;
     }
-
     const QJsonObject object = document.object();
-    if (!object.value(QStringLiteral("items")).isArray()) {
-        return result;
-    }
+
     result.items = object.value(QStringLiteral("items")).toArray();
     result.totalRecordCount = object.value(QStringLiteral("total")).isDouble()
         ? qMax(0, object.value(QStringLiteral("total")).toInt())
-        : 0;
+        : static_cast<int>(result.items.size());
     result.success = true;
     return result;
 }
@@ -431,6 +428,7 @@ ProviderCatalogResponse SiloModelMapper::catalogResponse(
         case ProviderCatalogOperation::SimilarItems:
         case ProviderCatalogOperation::Search:
             result.rawItems = document.array();
+            result.total = static_cast<int>(result.rawItems.size());
             result.valid = true;
             return result;
         case ProviderCatalogOperation::Chapters:
@@ -521,6 +519,9 @@ ProviderCatalogResponse SiloModelMapper::catalogResponse(
                     QStringLiteral("totalPresent"), true);
             }
         }
+        if (!result.capabilityMetadata.value(QStringLiteral("totalPresent")).toBool()) {
+            result.total = static_cast<int>(result.rawItems.size());
+        }
         result.valid = true;
         return result;
     }
@@ -583,6 +584,9 @@ ProviderCatalogResponse SiloModelMapper::catalogResponse(
                     normalizedItems.append(item);
                 }
                 result.rawItems = normalizedItems;
+            }
+            if (!result.capabilityMetadata.value(QStringLiteral("totalPresent")).toBool()) {
+                result.total = static_cast<int>(result.rawItems.size());
             }
             result.capabilityMetadata.insert(QStringLiteral("envelope"), key);
             result.valid = true;
@@ -798,19 +802,24 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
 
     const QJsonObject userData = wireItem.value(QStringLiteral("user_data")).isObject()
         ? wireItem.value(QStringLiteral("user_data")).toObject()
-        : wireItem.value(QStringLiteral("user_state")).toObject();
+        : (wireItem.value(QStringLiteral("user_state")).isObject()
+               ? wireItem.value(QStringLiteral("user_state")).toObject()
+               : (wireItem.value(QStringLiteral("state")).isObject()
+                      ? wireItem.value(QStringLiteral("state")).toObject()
+                      : QJsonObject{}));
+    const auto stateValue = [&userData, &wireItem](const QString &key) {
+        return userData.contains(key) ? userData.value(key) : wireItem.value(key);
+    };
     Bloom::UserMediaState state;
-    state.watched = userData.value(QStringLiteral("played")).toBool();
-    state.favorite = userData.contains(QStringLiteral("is_favorite"))
-        ? userData.value(QStringLiteral("is_favorite")).toBool()
-        : userData.value(QStringLiteral("favorite")).toBool();
-    const QJsonValue positionSeconds = userData.value(QStringLiteral("position_seconds")).isDouble()
-        ? userData.value(QStringLiteral("position_seconds"))
-        : wireItem.value(QStringLiteral("position_seconds"));
-    state.positionMs = secondsToMilliseconds(positionSeconds.toDouble());
-    state.unplayedItemCount = userData.value(QStringLiteral("unplayed_count")).toInt();
-    state.lastPlayedAt = userData.value(QStringLiteral("last_played_at")).toString(
-        wireItem.value(QStringLiteral("progress_updated_at")).toString());
+    state.watched = stateValue(QStringLiteral("played")).toBool();
+    state.favorite = stateValue(QStringLiteral("is_favorite")).isBool()
+        ? stateValue(QStringLiteral("is_favorite")).toBool()
+        : stateValue(QStringLiteral("favorite")).toBool();
+    state.positionMs = secondsToMilliseconds(
+        stateValue(QStringLiteral("position_seconds")).toDouble());
+    state.unplayedItemCount = stateValue(QStringLiteral("unplayed_count")).toInt();
+    state.lastPlayedAt = stateValue(QStringLiteral("last_played_at")).toString(
+        stateValue(QStringLiteral("progress_updated_at")).toString());
 
     const QJsonArray wireVersions = wireItem.value(QStringLiteral("versions")).isArray()
         ? wireItem.value(QStringLiteral("versions")).toArray()
@@ -885,9 +894,8 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
         {QStringLiteral("positionMs"), state.positionMs},
         {QStringLiteral("unplayedItemCount"), state.unplayedItemCount},
         {QStringLiteral("isInProgress"),
-         userData.contains(QStringLiteral("is_in_progress"))
-             ? userData.value(QStringLiteral("is_in_progress")).toBool()
-             : state.positionMs > 0},
+         state.positionMs > 0
+             || stateValue(QStringLiteral("is_in_progress")).toBool()},
         {QStringLiteral("people"), people(wireItem, connectionId)},
         {QStringLiteral("versions"), versions},
         {QStringLiteral("playbackVariants"), playbackVariants(
@@ -895,10 +903,6 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
         {QStringLiteral("subtitles"), subtitles(wireItem.value(QStringLiteral("subtitles")).toArray())},
         {QStringLiteral("markers"), markerVariants(wireItem)}
     };
-    if (wireItem.value(QStringLiteral("score")).isDouble()) {
-        result[QStringLiteral("recommendationScore")] =
-            wireItem.value(QStringLiteral("score")).toDouble();
-    }
     if (wireItem.value(QStringLiteral("reason")).isString()) {
         result[QStringLiteral("recommendationReason")] =
             wireItem.value(QStringLiteral("reason")).toString();
@@ -939,12 +943,15 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
             wireItem.value(QStringLiteral("restricted")).toBool();
     }
 
-    const QString primaryArtworkUrl =
-        wireItem.value(QStringLiteral("poster_url")).toString(
-            wireItem.value(QStringLiteral("still_url")).toString());
+    const QString posterUrl = wireItem.value(QStringLiteral("poster_url")).toString();
+    const QString stillUrl = wireItem.value(QStringLiteral("still_url")).toString();
+    const QString primaryArtworkUrl = posterUrl.isEmpty() ? stillUrl : posterUrl;
+    const QString posterThumbhash =
+        wireItem.value(QStringLiteral("poster_thumbhash")).toString();
+    const QString stillThumbhash =
+        wireItem.value(QStringLiteral("still_thumbhash")).toString();
     const QString primaryThumbhash =
-        wireItem.value(QStringLiteral("poster_thumbhash")).toString(
-            wireItem.value(QStringLiteral("still_thumbhash")).toString());
+        posterThumbhash.isEmpty() ? stillThumbhash : posterThumbhash;
     QVariantList artwork;
     appendArtwork(artwork, result, QStringLiteral("primaryArtwork"),
                   QStringLiteral("primaryArtworkUrl"), connectionId, itemId,
@@ -966,7 +973,7 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
     QVariantMap artworkExpiresAt;
     for (const auto &[kind, field] : {
              std::pair{QStringLiteral("primary"),
-                       wireItem.value(QStringLiteral("poster_url")).isString()
+                       !posterUrl.isEmpty()
                            ? QStringLiteral("poster_url_expires_at")
                            : QStringLiteral("still_url_expires_at")},
              std::pair{QStringLiteral("backdrop"), QStringLiteral("backdrop_url_expires_at")},
@@ -1006,9 +1013,12 @@ QVariantMap SiloModelMapper::chapter(const QJsonObject &wireChapter,
 {
     const QJsonValue startValue = wireChapter.value(QStringLiteral("start_seconds"));
     const QJsonValue endValue = wireChapter.value(QStringLiteral("end_seconds"));
-    if (!startValue.isDouble() || !endValue.isDouble()
-        || !std::isfinite(startValue.toDouble()) || !std::isfinite(endValue.toDouble())
-        || startValue.toDouble() < 0.0 || endValue.toDouble() <= startValue.toDouble()) {
+    if (!startValue.isDouble() || !std::isfinite(startValue.toDouble())
+        || startValue.toDouble() < 0.0) {
+        return {};
+    }
+    const bool hasEnd = endValue.isDouble() && std::isfinite(endValue.toDouble());
+    if (hasEnd && endValue.toDouble() < startValue.toDouble()) {
         return {};
     }
     const int index = wireChapter.contains(QStringLiteral("index"))
@@ -1020,8 +1030,9 @@ QVariantMap SiloModelMapper::chapter(const QJsonObject &wireChapter,
         {QStringLiteral("fileId"), fileId},
         {QStringLiteral("startMs"), secondsToMilliseconds(
              wireChapter.value(QStringLiteral("start_seconds")).toDouble())},
-        {QStringLiteral("endMs"), secondsToMilliseconds(
-             wireChapter.value(QStringLiteral("end_seconds")).toDouble())},
+        {QStringLiteral("endMs"), hasEnd
+             ? secondsToMilliseconds(wireChapter.value(QStringLiteral("end_seconds")).toDouble())
+             : -1},
         {QStringLiteral("source"), wireChapter.value(QStringLiteral("source")).toString()},
         {QStringLiteral("thumbnailUrl"), wireChapter.value(QStringLiteral("thumbnail_url")).toString()},
         {QStringLiteral("thumbnailThumbhash"), wireChapter.value(QStringLiteral("thumbnail_thumbhash")).toString()}
@@ -1212,41 +1223,49 @@ QList<ProviderAuthSession> SiloModelMapper::authSessions(const QJsonArray &wireS
 QVariantMap SiloModelMapper::nativeState(const QJsonObject &wireState,
                                          const QString &connectionId)
 {
-    const QJsonObject state = wireState.value(QStringLiteral("user_data")).isObject()
+    QJsonObject state = wireState.value(QStringLiteral("user_data")).isObject()
         ? wireState.value(QStringLiteral("user_data")).toObject()
         : (wireState.value(QStringLiteral("user_state")).isObject()
                ? wireState.value(QStringLiteral("user_state")).toObject()
-               : wireState);
-    const bool recognized = state.contains(QStringLiteral("played"))
-        || state.contains(QStringLiteral("is_favorite"))
-        || state.contains(QStringLiteral("favorite"))
-        || state.contains(QStringLiteral("position_seconds"))
-        || state.contains(QStringLiteral("is_in_progress"));
+               : (wireState.value(QStringLiteral("state")).isObject()
+                      ? wireState.value(QStringLiteral("state")).toObject()
+                      : wireState));
+    if (state.value(QStringLiteral("user_data")).isObject()) {
+        state = state.value(QStringLiteral("user_data")).toObject();
+    } else if (state.value(QStringLiteral("user_state")).isObject()) {
+        state = state.value(QStringLiteral("user_state")).toObject();
+    }
+    const auto value = [&state, &wireState](const QString &key) {
+        return state.contains(key) ? state.value(key) : wireState.value(key);
+    };
+    const bool recognized = value(QStringLiteral("played")).isBool()
+        || value(QStringLiteral("is_favorite")).isBool()
+        || value(QStringLiteral("favorite")).isBool()
+        || value(QStringLiteral("position_seconds")).isDouble()
+        || value(QStringLiteral("is_in_progress")).isBool();
     if (!recognized) {
         return {};
     }
 
     Bloom::UserMediaState userState;
-    userState.watched = state.value(QStringLiteral("played")).toBool();
-    userState.favorite = state.contains(QStringLiteral("is_favorite"))
-        ? state.value(QStringLiteral("is_favorite")).toBool()
-        : state.value(QStringLiteral("favorite")).toBool();
-    const QJsonValue position = state.value(QStringLiteral("position_seconds")).isDouble()
-        ? state.value(QStringLiteral("position_seconds"))
-        : wireState.value(QStringLiteral("position_seconds"));
-    userState.positionMs = secondsToMilliseconds(position.toDouble());
-    userState.unplayedItemCount = state.value(QStringLiteral("unplayed_count")).toInt();
-    userState.lastPlayedAt = state.value(QStringLiteral("last_played_at")).toString(
-        wireState.value(QStringLiteral("progress_updated_at")).toString());
+    userState.watched = value(QStringLiteral("played")).toBool();
+    userState.favorite = value(QStringLiteral("is_favorite")).isBool()
+        ? value(QStringLiteral("is_favorite")).toBool()
+        : value(QStringLiteral("favorite")).toBool();
+    userState.positionMs = secondsToMilliseconds(
+        value(QStringLiteral("position_seconds")).toDouble());
+    userState.unplayedItemCount = value(QStringLiteral("unplayed_count")).toInt();
+    userState.lastPlayedAt = value(QStringLiteral("last_played_at")).toString(
+        value(QStringLiteral("progress_updated_at")).toString());
     QString contentId = identityString(wireState.value(QStringLiteral("content_id")));
     if (contentId.isEmpty()) {
-        contentId = identityString(state.value(QStringLiteral("content_id")));
+        contentId = identityString(value(QStringLiteral("content_id")));
     }
     if (contentId.isEmpty()) {
         contentId = identityString(wireState.value(QStringLiteral("media_item_id")));
     }
     if (contentId.isEmpty()) {
-        contentId = identityString(state.value(QStringLiteral("media_item_id")));
+        contentId = identityString(value(QStringLiteral("media_item_id")));
     }
     return {
         {QStringLiteral("connectionId"), connectionId},
@@ -1256,15 +1275,12 @@ QVariantMap SiloModelMapper::nativeState(const QJsonObject &wireState,
         {QStringLiteral("favorite"), userState.favorite},
         {QStringLiteral("positionMs"), userState.positionMs},
         {QStringLiteral("durationMs"), secondsToMilliseconds(
-             (state.value(QStringLiteral("duration_seconds")).isDouble()
-                  ? state.value(QStringLiteral("duration_seconds"))
-                  : wireState.value(QStringLiteral("duration_seconds"))).toDouble())},
-        {QStringLiteral("watchedCount"), state.value(QStringLiteral("watched_count")).toInt()},
+             value(QStringLiteral("duration_seconds")).toDouble())},
+        {QStringLiteral("watchedCount"), value(QStringLiteral("watched_count")).toInt()},
         {QStringLiteral("isInProgress"),
-         state.contains(QStringLiteral("is_in_progress"))
-             ? state.value(QStringLiteral("is_in_progress")).toBool()
-             : userState.positionMs > 0},
-        {QStringLiteral("lastFileId"), identityString(state.value(QStringLiteral("last_file_id")))}
+         userState.positionMs > 0
+             || value(QStringLiteral("is_in_progress")).toBool()},
+        {QStringLiteral("lastFileId"), identityString(value(QStringLiteral("last_file_id")))}
     };
 }
 

--- a/src/providers/silo/SiloModelMapper.cpp
+++ b/src/providers/silo/SiloModelMapper.cpp
@@ -69,6 +69,15 @@ qint64 isoDateMilliseconds(const QJsonValue &value)
     return date.isValid() ? date.toMSecsSinceEpoch() : -1;
 }
 
+bool secondsToMillisecondsRepresentable(double seconds)
+{
+    if (!std::isfinite(seconds) || seconds < 0.0) {
+        return false;
+    }
+    const long double milliseconds = static_cast<long double>(seconds) * 1000.0L;
+    return milliseconds <= static_cast<long double>(std::numeric_limits<qint64>::max());
+}
+
 QString canonicalMediaType(const QString &wireType)
 {
     const QString type = wireType.trimmed().toLower();
@@ -340,12 +349,12 @@ QVariantList playbackVariants(const QJsonArray &wireVariants,
 
 qint64 SiloModelMapper::secondsToMilliseconds(double seconds)
 {
-    if (!std::isfinite(seconds) || seconds <= 0.0
-        || seconds >= static_cast<double>(std::numeric_limits<qint64>::max()) / 1000.0) {
+    if (!secondsToMillisecondsRepresentable(seconds) || seconds <= 0.0) {
         return 0;
     }
     return static_cast<qint64>(std::llround(seconds * 1000.0));
 }
+
 
 ParsedItemsResult SiloModelMapper::itemsResponse(const QByteArray &wireResponse,
                                                  const QString &parentId)
@@ -912,8 +921,10 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
             wireItem.value(QStringLiteral("reason_detail")).toString();
     }
     if (result.value(QStringLiteral("parentId")).toString().isEmpty()) {
-        result[QStringLiteral("parentId")] = seriesId;
+        const QString seasonId = result.value(QStringLiteral("seasonId")).toString();
+        result[QStringLiteral("parentId")] = seasonId.isEmpty() ? seriesId : seasonId;
     }
+
     if (wireItem.contains(QStringLiteral("season_count"))) {
         result[QStringLiteral("seasonCount")] = wireItem.value(QStringLiteral("season_count")).toInt();
         result[QStringLiteral("childCount")] = wireItem.value(QStringLiteral("season_count")).toInt();
@@ -1013,14 +1024,15 @@ QVariantMap SiloModelMapper::chapter(const QJsonObject &wireChapter,
 {
     const QJsonValue startValue = wireChapter.value(QStringLiteral("start_seconds"));
     const QJsonValue endValue = wireChapter.value(QStringLiteral("end_seconds"));
-    if (!startValue.isDouble() || !std::isfinite(startValue.toDouble())
-        || startValue.toDouble() < 0.0) {
+    if (!startValue.isDouble() || !secondsToMillisecondsRepresentable(startValue.toDouble())) {
         return {};
     }
     const bool hasEnd = endValue.isDouble() && std::isfinite(endValue.toDouble());
-    if (hasEnd && endValue.toDouble() < startValue.toDouble()) {
+    if (hasEnd && (!secondsToMillisecondsRepresentable(endValue.toDouble())
+                   || endValue.toDouble() < startValue.toDouble())) {
         return {};
     }
+
     const int index = wireChapter.contains(QStringLiteral("index"))
         ? wireChapter.value(QStringLiteral("index")).toInt(fallbackIndex)
         : fallbackIndex;
@@ -1300,8 +1312,9 @@ QList<MediaSegmentInfo> SiloModelMapper::mediaSegments(const QString &itemId,
         const QJsonValue end = wire.contains(QStringLiteral("end_seconds"))
             ? wire.value(QStringLiteral("end_seconds")) : wire.value(QStringLiteral("end"));
         if (!start.isDouble() || !end.isDouble()
-            || !std::isfinite(start.toDouble()) || !std::isfinite(end.toDouble())
-            || start.toDouble() < 0.0 || end.toDouble() <= start.toDouble()) {
+            || !secondsToMillisecondsRepresentable(start.toDouble())
+            || !secondsToMillisecondsRepresentable(end.toDouble())
+            || end.toDouble() <= start.toDouble()) {
             continue;
         }
 

--- a/src/providers/silo/SiloModelMapper.cpp
+++ b/src/providers/silo/SiloModelMapper.cpp
@@ -96,6 +96,9 @@ QVariantMap providerIds(const QJsonObject &wire)
                                                const QString &shortName) {
         QString value = identityString(wire.value(snakeCase));
         if (value.isEmpty()) {
+            value = identityString(wire.value(shortName));
+        }
+        if (value.isEmpty()) {
             value = identityString(nested.value(snakeCase));
         }
         if (value.isEmpty()) {
@@ -386,7 +389,8 @@ ProviderCatalogResponse SiloModelMapper::catalogResponse(
     ProviderCatalogResponse result;
     const QByteArray trimmed = wireResponse.trimmed();
     if (trimmed.isEmpty()) {
-        if (operation == ProviderCatalogOperation::SetFavorite) {
+        if (operation == ProviderCatalogOperation::SetWatched
+            || operation == ProviderCatalogOperation::SetFavorite) {
             result.valid = true;
         } else {
             result.error = QStringLiteral("Silo returned an empty catalog response");
@@ -418,11 +422,14 @@ ProviderCatalogResponse SiloModelMapper::catalogResponse(
         result.snapshot.insert(QStringLiteral("lastModified"),
                                QString::fromUtf8(lastModified));
     }
-
     if (document.isArray()) {
         switch (operation) {
         case ProviderCatalogOperation::Views:
         case ProviderCatalogOperation::Items:
+        case ProviderCatalogOperation::NextUp:
+        case ProviderCatalogOperation::LatestMedia:
+        case ProviderCatalogOperation::SimilarItems:
+        case ProviderCatalogOperation::Search:
             result.rawItems = document.array();
             result.valid = true;
             return result;
@@ -464,10 +471,27 @@ ProviderCatalogResponse SiloModelMapper::catalogResponse(
     if (object.value(QStringLiteral("has_more")).isBool()) {
         result.hasMore = object.value(QStringLiteral("has_more")).toBool();
         result.capabilityMetadata.insert(QStringLiteral("hasMorePresent"), true);
+    } else if (object.value(QStringLiteral("hasMore")).isBool()) {
+        result.hasMore = object.value(QStringLiteral("hasMore")).toBool();
+        result.capabilityMetadata.insert(QStringLiteral("hasMorePresent"), true);
     }
     if (object.value(QStringLiteral("snapshot")).isString()) {
         result.snapshot.insert(QStringLiteral("snapshot"),
                                object.value(QStringLiteral("snapshot")).toString());
+    } else if (object.value(QStringLiteral("snapshot")).isObject()) {
+        result.snapshot.insert(QStringLiteral("snapshot"),
+                               object.value(QStringLiteral("snapshot")).toObject().toVariantMap());
+    }
+    for (const QString &key : {QStringLiteral("cursor"), QStringLiteral("next_cursor"),
+                               QStringLiteral("nextCursor")}) {
+        if (object.value(key).isString()) {
+            result.snapshot.insert(key, object.value(key).toString());
+        }
+    }
+    for (const QString &key : {QStringLiteral("offset"), QStringLiteral("limit")}) {
+        if (object.value(key).isDouble()) {
+            result.capabilityMetadata.insert(key, jsonInteger(object.value(key)));
+        }
     }
     if (object.value(QStringLiteral("search_diagnostics")).isObject()) {
         result.capabilityMetadata.insert(
@@ -504,9 +528,19 @@ ProviderCatalogResponse SiloModelMapper::catalogResponse(
     if (operation == ProviderCatalogOperation::FilterOptions) {
         result.rawItem = object;
         result.filterMetadata = filterOptions(object);
-        if (object.value(QStringLiteral("matches")).isArray()) {
+        if (object.value(QStringLiteral("matches")).isArray()
+            || object.value(QStringLiteral("items")).isArray()) {
             result.filterMetadata.insert(QStringLiteral("namedItems"),
                                          namedItems(object));
+        }
+        result.valid = true;
+        return result;
+    }
+    if (operation == ProviderCatalogOperation::Chapters
+        || operation == ProviderCatalogOperation::Versions) {
+        result.rawItem = object;
+        if (object.value(QStringLiteral("versions")).isArray()) {
+            result.rawItems = object.value(QStringLiteral("versions")).toArray();
         }
         result.valid = true;
         return result;
@@ -724,11 +758,12 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
         itemId = identityString(wireItem.value(QStringLiteral("media_item_id")));
     }
     if (itemId.isEmpty()
-        && wireItem.value(QStringLiteral("id")).isString()
+        && wireItem.contains(QStringLiteral("id"))
         && wireItem.value(QStringLiteral("section_type")).isString()) {
         const QString sectionId =
             identityString(wireItem.value(QStringLiteral("id")));
-        const QString title = wireItem.value(QStringLiteral("title")).toString();
+        const QString title = wireItem.value(QStringLiteral("title")).toString(
+            wireItem.value(QStringLiteral("name")).toString());
         if (sectionId.isEmpty() || title.isEmpty()) {
             return {};
         }
@@ -794,6 +829,10 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
         durationMs = secondsToMilliseconds(
             wireItem.value(QStringLiteral("runtime")).toDouble() * 60.0);
     }
+    QString defaultFileId = identityString(wireItem.value(QStringLiteral("default_file_id")));
+    if (defaultFileId.isEmpty()) {
+        defaultFileId = identityString(wireItem.value(QStringLiteral("file_id")));
+    }
 
     double communityRating = 0.0;
     if (wireItem.value(QStringLiteral("rating_imdb")).isDouble()) {
@@ -807,8 +846,12 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
         {QStringLiteral("media"), Bloom::MediaRef{connectionId, itemId}.toVariantMap()},
         {QStringLiteral("connectionId"), connectionId},
         {QStringLiteral("itemId"), itemId},
-        {QStringLiteral("name"), wireItem.value(QStringLiteral("title")).toString()},
-        {QStringLiteral("sortName"), wireItem.value(QStringLiteral("sort_title")).toString()},
+        {QStringLiteral("defaultFileId"), defaultFileId},
+        {QStringLiteral("name"), wireItem.value(QStringLiteral("title")).toString(
+             wireItem.value(QStringLiteral("name")).toString())},
+        {QStringLiteral("sortName"), wireItem.value(QStringLiteral("sort_title")).toString(
+             wireItem.value(QStringLiteral("title")).toString(
+                 wireItem.value(QStringLiteral("name")).toString()))},
         {QStringLiteral("originalTitle"), wireItem.value(QStringLiteral("original_title")).toString()},
         {QStringLiteral("mediaType"), canonicalMediaType(
              wireItem.value(QStringLiteral("type")).toString())},
@@ -844,7 +887,7 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
         {QStringLiteral("isInProgress"),
          userData.contains(QStringLiteral("is_in_progress"))
              ? userData.value(QStringLiteral("is_in_progress")).toBool()
-             : wireItem.value(QStringLiteral("position_seconds")).toDouble() > 0.0},
+             : state.positionMs > 0},
         {QStringLiteral("people"), people(wireItem, connectionId)},
         {QStringLiteral("versions"), versions},
         {QStringLiteral("playbackVariants"), playbackVariants(
@@ -961,7 +1004,11 @@ QVariantMap SiloModelMapper::chapter(const QJsonObject &wireChapter,
                                      const QString &fileId,
                                      int fallbackIndex)
 {
-    if (!wireChapter.value(QStringLiteral("start_seconds")).isDouble()) {
+    const QJsonValue startValue = wireChapter.value(QStringLiteral("start_seconds"));
+    const QJsonValue endValue = wireChapter.value(QStringLiteral("end_seconds"));
+    if (!startValue.isDouble() || !endValue.isDouble()
+        || !std::isfinite(startValue.toDouble()) || !std::isfinite(endValue.toDouble())
+        || startValue.toDouble() < 0.0 || endValue.toDouble() <= startValue.toDouble()) {
         return {};
     }
     const int index = wireChapter.contains(QStringLiteral("index"))
@@ -1045,6 +1092,11 @@ QVariantList SiloModelMapper::chaptersFromItem(const QJsonObject &wireItem,
         appendChapters(direct);
     }
     for (const QJsonValue &value : wireItem.value(QStringLiteral("versions")).toArray()) {
+        if (value.isObject()) {
+            appendChapters(value.toObject());
+        }
+    }
+    for (const QJsonValue &value : wireItem.value(QStringLiteral("files")).toArray()) {
         if (value.isObject()) {
             appendChapters(value.toObject());
         }
@@ -1186,12 +1238,19 @@ QVariantMap SiloModelMapper::nativeState(const QJsonObject &wireState,
     userState.unplayedItemCount = state.value(QStringLiteral("unplayed_count")).toInt();
     userState.lastPlayedAt = state.value(QStringLiteral("last_played_at")).toString(
         wireState.value(QStringLiteral("progress_updated_at")).toString());
+    QString contentId = identityString(wireState.value(QStringLiteral("content_id")));
+    if (contentId.isEmpty()) {
+        contentId = identityString(state.value(QStringLiteral("content_id")));
+    }
+    if (contentId.isEmpty()) {
+        contentId = identityString(wireState.value(QStringLiteral("media_item_id")));
+    }
+    if (contentId.isEmpty()) {
+        contentId = identityString(state.value(QStringLiteral("media_item_id")));
+    }
     return {
         {QStringLiteral("connectionId"), connectionId},
-        {QStringLiteral("itemId"), identityString(
-             wireState.value(QStringLiteral("content_id")).isUndefined()
-                 ? state.value(QStringLiteral("content_id"))
-                 : wireState.value(QStringLiteral("content_id")))},
+        {QStringLiteral("itemId"), contentId},
         {QStringLiteral("userState"), userState.toVariantMap()},
         {QStringLiteral("watched"), userState.watched},
         {QStringLiteral("favorite"), userState.favorite},
@@ -1200,10 +1259,11 @@ QVariantMap SiloModelMapper::nativeState(const QJsonObject &wireState,
              (state.value(QStringLiteral("duration_seconds")).isDouble()
                   ? state.value(QStringLiteral("duration_seconds"))
                   : wireState.value(QStringLiteral("duration_seconds"))).toDouble())},
-        {QStringLiteral("isInProgress"), state.value(QStringLiteral("is_in_progress")).toBool()},
         {QStringLiteral("watchedCount"), state.value(QStringLiteral("watched_count")).toInt()},
-        {QStringLiteral("unplayedItemCount"), userState.unplayedItemCount},
-        {QStringLiteral("inProgressCount"), state.value(QStringLiteral("in_progress_count")).toInt()},
+        {QStringLiteral("isInProgress"),
+         state.contains(QStringLiteral("is_in_progress"))
+             ? state.value(QStringLiteral("is_in_progress")).toBool()
+             : userState.positionMs > 0},
         {QStringLiteral("lastFileId"), identityString(state.value(QStringLiteral("last_file_id")))}
     };
 }

--- a/src/providers/silo/SiloModelMapper.h
+++ b/src/providers/silo/SiloModelMapper.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "models/MediaModels.h"
+#include "network/Types.h"
+#include "providers/ICatalogProvider.h"
+#include "providers/ServerConnection.h"
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QVariantList>
+#include <QVariantMap>
+
+class SiloModelMapper
+{
+public:
+    static qint64 secondsToMilliseconds(double seconds);
+
+    static ParsedItemsResult itemsResponse(const QByteArray &wireResponse,
+                                           const QString &parentId);
+    static ProviderCatalogResponse catalogResponse(
+        ProviderCatalogOperation operation,
+        const QByteArray &wireResponse,
+        const QHash<QByteArray, QByteArray> &responseHeaders = {});
+    static QVariantMap library(const QJsonObject &wireLibrary,
+                               const QString &connectionId);
+    static QVariantList libraries(const QJsonArray &wireLibraries,
+                                  const QString &connectionId);
+
+    static MediaStreamInfo mediaStream(const QJsonObject &wireTrack,
+                                       const QString &kind,
+                                       int index);
+    static QVariantMap mediaVersion(const QJsonObject &wireVersion,
+                                    const QString &connectionId,
+                                    const QString &itemId);
+    static QVariantList mediaVersions(const QJsonArray &wireVersions,
+                                      const QString &connectionId,
+                                      const QString &itemId);
+    static QVariantMap mediaItem(const QJsonObject &wireItem,
+                                 const QString &connectionId);
+    static QVariantList mediaItems(const QJsonArray &wireItems,
+                                   const QString &connectionId);
+
+    static QVariantMap chapter(const QJsonObject &wireChapter,
+                               const QString &connectionId,
+                               const QString &itemId,
+                               const QString &fileId,
+                               int fallbackIndex);
+    static QVariantList chapters(const QJsonArray &wireChapters,
+                                 const QString &connectionId,
+                                 const QString &itemId,
+                                 const QString &fileId = {});
+    static QVariantList chaptersFromItem(const QJsonObject &wireItem,
+                                         const QString &connectionId,
+                                         const QString &itemId);
+
+    static QVariantMap filterOptions(const QJsonObject &wireFilters);
+    static QStringList namedItems(const QJsonObject &wireItems);
+    static QList<ProviderProfile> profiles(const QJsonArray &wireProfiles);
+    static QList<ProviderAuthSession> authSessions(const QJsonArray &wireSessions);
+    static QVariantMap nativeState(const QJsonObject &wireState,
+                                   const QString &connectionId);
+    static QList<MediaSegmentInfo> mediaSegments(const QString &itemId,
+                                                 const QJsonObject &wireSegments);
+};

--- a/src/providers/silo/SiloProviderAdapter.h
+++ b/src/providers/silo/SiloProviderAdapter.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include "providers/IProviderAdapter.h"
+#include "providers/silo/SiloAuthenticator.h"
+#include "providers/silo/SiloCatalogProvider.h"
+#include "providers/silo/SiloModelMapper.h"
+#include "providers/silo/SiloRequestFactory.h"
+
+#include <QUrl>
+
+class SiloProviderAdapter final : public IProviderAdapter
+{
+public:
+    ProviderKind providerKind() const override { return ProviderKind::Silo; }
+    ProtocolMode protocolMode() const override { return ProtocolMode::Native; }
+    const IProviderAuthenticator *authenticator() const override { return &m_authenticator; }
+    const IProviderRequestFactory *requestFactory() const override { return &m_requestFactory; }
+
+    // Native playback is intentionally not advertised until the dedicated playback phase.
+    const IPlaybackProvider *playbackProvider() const override { return nullptr; }
+    const ICatalogProvider *catalogProvider() const override { return &m_catalogProvider; }
+
+    PlaybackInfoResponse mapPlaybackInfo(const QJsonObject &wirePlaybackInfo) const override
+    {
+        Q_UNUSED(wirePlaybackInfo)
+        return {};
+    }
+
+    ProviderItemsResponseParser itemsResponseParser() const override
+    {
+        return [](const QByteArray &wireResponse, const QString &parentId) {
+            return SiloModelMapper::itemsResponse(wireResponse, parentId);
+        };
+    }
+
+    TrickplayTileInfoMap mapTrickplayInfo(const QJsonObject &wireItem) const override
+    {
+        Q_UNUSED(wireItem)
+        // The pinned native API has no trickplay route or tile contract.
+        return {};
+    }
+
+    QList<MediaSegmentInfo> mapIntroSkipperSegments(
+        const QString &itemId, const QJsonObject &wireSegments) const override
+    {
+        return SiloModelMapper::mediaSegments(itemId, wireSegments);
+    }
+
+    QVariantList mapRemoteSessions(const QJsonArray &wireSessions,
+                                   const QString &connectionId) const override
+    {
+        Q_UNUSED(wireSessions)
+        Q_UNUSED(connectionId)
+        // Auth sessions are mapped through mapAuthSessions; playback sessions are unsupported.
+        return {};
+    }
+
+    QString mapLibraryIdFromAncestors(const QJsonArray &wireAncestors) const override
+    {
+        Q_UNUSED(wireAncestors)
+        return {};
+    }
+
+    QVariantMap mapFilterOptions(const QJsonObject &wireFilters) const override
+    {
+        return SiloModelMapper::filterOptions(wireFilters);
+    }
+
+    QStringList mapNamedItems(const QJsonObject &wireItems) const override
+    {
+        return SiloModelMapper::namedItems(wireItems);
+    }
+
+    QVariantMap mapMediaItem(const QJsonObject &wireItem,
+                             const QString &connectionId) const override
+    {
+        return SiloModelMapper::mediaItem(wireItem, connectionId);
+    }
+
+    QVariantList mapMediaItems(const QJsonArray &wireItems,
+                               const QString &connectionId) const override
+    {
+        return SiloModelMapper::mediaItems(wireItems, connectionId);
+    }
+
+    QVariantList mapChaptersFromItem(const QJsonObject &wireItem,
+                                     const QString &connectionId,
+                                     const QString &itemId) const override
+    {
+        return SiloModelMapper::chaptersFromItem(wireItem, connectionId, itemId);
+    }
+
+    bool supportsCapability(ProviderCapability capability) const override
+    {
+        switch (capability) {
+        case ProviderCapability::RefreshAuthentication:
+        case ProviderCapability::Profiles:
+        case ProviderCapability::ProfilePin:
+        case ProviderCapability::AuthSessions:
+        case ProviderCapability::Catalog:
+        case ProviderCapability::NativeState:
+        case ProviderCapability::MediaSegments:
+            return true;
+        case ProviderCapability::Playback:
+        case ProviderCapability::PlaybackReporting:
+            return false;
+        }
+        return false;
+    }
+
+    std::optional<QString> endpointFor(
+        ProviderRoute route, const ProviderRouteContext &context = {}) const override
+    {
+        switch (route) {
+        case ProviderRoute::Profiles:
+            return QStringLiteral("/api/v1/profiles");
+        case ProviderRoute::VerifyProfilePin:
+            return endpointWithId(QStringLiteral("/api/v1/profiles/%1/verify-pin"),
+                                  context.profileId);
+        case ProviderRoute::AuthSessions:
+            return QStringLiteral("/api/v1/auth/sessions");
+        case ProviderRoute::RevokeAuthSession:
+            return endpointWithId(QStringLiteral("/api/v1/auth/sessions/%1"),
+                                  context.sessionId);
+        case ProviderRoute::CatalogItems:
+            return QStringLiteral("/api/v1/catalog");
+        case ProviderRoute::CatalogItem:
+            return endpointWithId(QStringLiteral("/api/v1/catalog/items/%1"),
+                                  context.itemId);
+        case ProviderRoute::NativeState:
+            // Detail is the authoritative profile-scoped read for user state.
+            return endpointWithId(QStringLiteral("/api/v1/catalog/items/%1"),
+                                  context.itemId);
+        case ProviderRoute::UpdateNativeState:
+            return endpointWithId(QStringLiteral("/api/v1/watched/%1"),
+                                  context.itemId);
+        case ProviderRoute::MediaSegments:
+            return endpointWithId(QStringLiteral("/api/v1/markers/items/%1"),
+                                  context.itemId);
+        case ProviderRoute::PlaybackInfo:
+        case ProviderRoute::PlaybackCapability:
+            return std::nullopt;
+        }
+        return std::nullopt;
+    }
+
+    std::optional<ProviderDetectionResult> mapDetectionResult(
+        const QJsonObject &wireResult) const override
+    {
+        const QJsonValue status = wireResult.value(QStringLiteral("status"));
+        if (!status.isString() || status.toString() != QStringLiteral("ok")) {
+            return std::nullopt;
+        }
+
+        const QJsonValue serverIdValue = wireResult.value(QStringLiteral("server_id"));
+        const QJsonValue serverNameValue = wireResult.value(QStringLiteral("server_name"));
+        if ((!serverIdValue.isUndefined() && !serverIdValue.isString())
+            || (!serverNameValue.isUndefined() && !serverNameValue.isString())) {
+            return std::nullopt;
+        }
+        QString serverId = serverIdValue.toString().trimmed();
+        // This is Silo 8044eb84's configured deterministic default. It cannot identify
+        // an installation, so leaving it empty forces connection identity to stay URL-scoped.
+        if (serverId.compare(QStringLiteral("b2d9e6c9-1237-5add-a687-5dae547ece33"),
+                             Qt::CaseInsensitive) == 0) {
+            serverId.clear();
+        }
+
+        ProviderDetectionResult result;
+        result.providerKind = ProviderKind::Silo;
+        result.protocolMode = ProtocolMode::Native;
+        result.serverId = serverId;
+        result.serverName = serverNameValue.toString().trimmed();
+        result.capabilities = implementedCapabilities();
+        return result;
+    }
+
+    std::optional<QList<ProviderProfile>> mapProfiles(
+        const QJsonArray &wireProfiles) const override
+    {
+        return SiloModelMapper::profiles(wireProfiles);
+    }
+
+    std::optional<QList<ProviderAuthSession>> mapAuthSessions(
+        const QJsonArray &wireSessions) const override
+    {
+        return SiloModelMapper::authSessions(wireSessions);
+    }
+
+    std::optional<QVariantMap> mapNativeState(
+        const QJsonObject &wireState, const QString &connectionId) const override
+    {
+        const QVariantMap state = SiloModelMapper::nativeState(wireState, connectionId);
+        return state.isEmpty() ? std::nullopt : std::optional<QVariantMap>(state);
+    }
+
+    std::optional<QList<MediaSegmentInfo>> mapMediaSegments(
+        const QString &itemId, const QJsonObject &wireSegments) const override
+    {
+        return SiloModelMapper::mediaSegments(itemId, wireSegments);
+    }
+
+private:
+    static ProviderCapabilities implementedCapabilities()
+    {
+        ProviderCapabilities capabilities;
+        capabilities |= ProviderCapability::RefreshAuthentication;
+        capabilities |= ProviderCapability::Profiles;
+        capabilities |= ProviderCapability::ProfilePin;
+        capabilities |= ProviderCapability::AuthSessions;
+        capabilities |= ProviderCapability::Catalog;
+        capabilities |= ProviderCapability::NativeState;
+        capabilities |= ProviderCapability::MediaSegments;
+        return capabilities;
+    }
+
+    static std::optional<QString> endpointWithId(const QString &format,
+                                                 const QString &id)
+    {
+        const QString normalized = id.trimmed();
+        if (normalized.isEmpty()) {
+            return std::nullopt;
+        }
+        return format.arg(QString::fromLatin1(QUrl::toPercentEncoding(normalized)));
+    }
+
+    SiloAuthenticator m_authenticator;
+    SiloCatalogProvider m_catalogProvider;
+    SiloRequestFactory m_requestFactory;
+};

--- a/src/providers/silo/SiloProviderAdapter.h
+++ b/src/providers/silo/SiloProviderAdapter.h
@@ -11,6 +11,7 @@
 class SiloProviderAdapter final : public IProviderAdapter
 {
 public:
+    using IProviderAdapter::endpointFor;
     ProviderKind providerKind() const override { return ProviderKind::Silo; }
     ProtocolMode protocolMode() const override { return ProtocolMode::Native; }
     const IProviderAuthenticator *authenticator() const override { return &m_authenticator; }
@@ -92,26 +93,17 @@ public:
 
     bool supportsCapability(ProviderCapability capability) const override
     {
-        switch (capability) {
-        case ProviderCapability::RefreshAuthentication:
-        case ProviderCapability::Profiles:
-        case ProviderCapability::ProfilePin:
-        case ProviderCapability::AuthSessions:
-        case ProviderCapability::Catalog:
-        case ProviderCapability::NativeState:
-        case ProviderCapability::MediaSegments:
-            return true;
-        case ProviderCapability::Playback:
-        case ProviderCapability::PlaybackReporting:
-            return false;
-        }
-        return false;
+        return implementedCapabilities().testFlag(capability);
     }
 
     std::optional<QString> endpointFor(
-        ProviderRoute route, const ProviderRouteContext &context = {}) const override
+        ProviderRoute route, const ProviderRouteContext &context) const override
     {
         switch (route) {
+        case ProviderRoute::Health:
+            return QStringLiteral("/api/v1/health");
+        case ProviderRoute::CallerLogout:
+            return QStringLiteral("/api/v1/auth/logout");
         case ProviderRoute::Profiles:
             return QStringLiteral("/api/v1/profiles");
         case ProviderRoute::VerifyProfilePin:

--- a/src/providers/silo/SiloRequestFactory.h
+++ b/src/providers/silo/SiloRequestFactory.h
@@ -21,16 +21,22 @@ public:
         const bool publicAuthenticationRoute =
             path.endsWith(QStringLiteral("/api/v1/auth/login"))
             || path.endsWith(QStringLiteral("/api/v1/auth/refresh"))
-            || path.endsWith(QStringLiteral("/api/v1/auth/providers"));
+            || path.endsWith(QStringLiteral("/api/v1/auth/providers"))
+            || path.endsWith(QStringLiteral("/api/v1/health"));
+        const bool profileVerificationRoute =
+            path.contains(QStringLiteral("/api/v1/profiles/"))
+            && path.endsWith(QStringLiteral("/verify-pin"));
         if (sameOrigin(context.baseUrl, request.url())) {
             if (!publicAuthenticationRoute && !context.accessToken.isEmpty()) {
                 request.setRawHeader("Authorization",
                                      QByteArrayLiteral("Bearer ") + context.accessToken.toUtf8());
             }
-            if (!authenticationRoute && !context.profileId.isEmpty()) {
+            if (!authenticationRoute && !profileVerificationRoute
+                && !publicAuthenticationRoute && !context.profileId.isEmpty()) {
                 request.setRawHeader("X-Profile-Id", context.profileId.toUtf8());
             }
-            if (!authenticationRoute && !context.profileToken.isEmpty()) {
+            if (!authenticationRoute && !profileVerificationRoute
+                && !publicAuthenticationRoute && !context.profileToken.isEmpty()) {
                 request.setRawHeader("X-Profile-Token", context.profileToken.toUtf8());
             }
 

--- a/src/providers/silo/SiloRequestFactory.h
+++ b/src/providers/silo/SiloRequestFactory.h
@@ -18,8 +18,9 @@ public:
         const QString path = request.url().path();
         const bool authenticationRoute =
             path.contains(QStringLiteral("/api/v1/auth/"));
+        const bool loginRoute = path.endsWith(QStringLiteral("/api/v1/auth/login"));
         const bool publicAuthenticationRoute =
-            path.endsWith(QStringLiteral("/api/v1/auth/login"))
+            loginRoute
             || path.endsWith(QStringLiteral("/api/v1/auth/refresh"))
             || path.endsWith(QStringLiteral("/api/v1/auth/providers"))
             || path.endsWith(QStringLiteral("/api/v1/health"));
@@ -47,7 +48,7 @@ public:
             setHeaderIfPresent(request, "X-Silo-Device-Platform", context.devicePlatform);
 
             // Silo records the login request's User-Agent as the auth-session device name.
-            if (!context.deviceName.isEmpty()) {
+            if (loginRoute && !context.deviceName.isEmpty()) {
                 request.setRawHeader("User-Agent", context.deviceName.toUtf8());
             }
         }
@@ -98,12 +99,12 @@ public:
 private:
     static QUrl resolveEndpoint(const QString &baseUrl, const QString &endpoint)
     {
-        const QUrl direct(endpoint);
+        const QUrl direct = QUrl::fromEncoded(endpoint.toUtf8(), QUrl::StrictMode);
         if (!direct.isRelative() && !direct.scheme().isEmpty()) {
             return direct;
         }
 
-        QUrl base(baseUrl.trimmed());
+        QUrl base(baseUrl.trimmed(), QUrl::StrictMode);
         QString path = base.path();
         while (path.endsWith(QLatin1Char('/'))) {
             path.chop(1);
@@ -115,7 +116,7 @@ private:
         while (relative.startsWith(QLatin1Char('/'))) {
             relative.remove(0, 1);
         }
-        return base.resolved(QUrl(relative));
+        return base.resolved(QUrl::fromEncoded(relative.toUtf8(), QUrl::StrictMode));
     }
 
     static bool sameOrigin(const QString &baseUrl, const QUrl &resolved)
@@ -153,6 +154,11 @@ private:
             || normalized == QStringLiteral("signature")
             || normalized == QStringLiteral("x-amz-signature")
             || normalized == QStringLiteral("x-goog-signature")
+            || normalized == QStringLiteral("key")
+            || normalized == QStringLiteral("api_key")
+            || normalized == QStringLiteral("secret")
+            || normalized == QStringLiteral("password")
+            || normalized.contains(QStringLiteral("session"))
             || normalized.contains(QStringLiteral("token"));
     }
 };

--- a/src/providers/silo/SiloRequestFactory.h
+++ b/src/providers/silo/SiloRequestFactory.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include "providers/IProviderRequestFactory.h"
+
+#include <QByteArray>
+#include <QUrl>
+
+class SiloRequestFactory final : public IProviderRequestFactory
+{
+public:
+    QNetworkRequest createRequest(const ProviderRequestContext &context,
+                                  const QString &endpoint) const override
+    {
+        QNetworkRequest request(resolveEndpoint(context.baseUrl, endpoint));
+        request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));
+        request.setRawHeader("Accept", "application/json");
+
+        const QString path = request.url().path();
+        const bool authenticationRoute =
+            path.contains(QStringLiteral("/api/v1/auth/"));
+        const bool publicAuthenticationRoute =
+            path.endsWith(QStringLiteral("/api/v1/auth/login"))
+            || path.endsWith(QStringLiteral("/api/v1/auth/refresh"))
+            || path.endsWith(QStringLiteral("/api/v1/auth/providers"));
+        if (sameOrigin(context.baseUrl, request.url())) {
+            if (!publicAuthenticationRoute && !context.accessToken.isEmpty()) {
+                request.setRawHeader("Authorization",
+                                     QByteArrayLiteral("Bearer ") + context.accessToken.toUtf8());
+            }
+            if (!authenticationRoute && !context.profileId.isEmpty()) {
+                request.setRawHeader("X-Profile-Id", context.profileId.toUtf8());
+            }
+            if (!authenticationRoute && !context.profileToken.isEmpty()) {
+                request.setRawHeader("X-Profile-Token", context.profileToken.toUtf8());
+            }
+
+            setHeaderIfPresent(request, "X-Silo-Client", context.clientName);
+            setHeaderIfPresent(request, "X-Silo-Client-Version", context.clientVersion);
+            setHeaderIfPresent(request, "X-Silo-Device-Id", context.deviceId);
+            setHeaderIfPresent(request, "X-Silo-Device-Name", context.deviceName);
+            setHeaderIfPresent(request, "X-Silo-Device-Platform", context.devicePlatform);
+
+            // Silo records the login request's User-Agent as the auth-session device name.
+            if (!context.deviceName.isEmpty()) {
+                request.setRawHeader("User-Agent", context.deviceName.toUtf8());
+            }
+        }
+        return request;
+    }
+
+    QString redactedUrl(const QUrl &url) const override
+    {
+        QUrl withoutCredentials = url;
+        withoutCredentials.setUserName({});
+        withoutCredentials.setPassword({});
+
+        QByteArray encoded = withoutCredentials.toEncoded(QUrl::FullyEncoded);
+        const qsizetype queryStart = encoded.indexOf('?');
+        if (queryStart < 0) {
+            return QString::fromUtf8(encoded);
+        }
+
+        const qsizetype fragmentStart = encoded.indexOf('#', queryStart + 1);
+        const qsizetype queryEnd = fragmentStart < 0 ? encoded.size() : fragmentStart;
+        QByteArray query = encoded.mid(queryStart + 1, queryEnd - queryStart - 1);
+
+        qsizetype itemStart = 0;
+        while (itemStart <= query.size()) {
+            qsizetype itemEnd = query.indexOf('&', itemStart);
+            if (itemEnd < 0) {
+                itemEnd = query.size();
+            }
+            const qsizetype equals = query.indexOf('=', itemStart);
+            const qsizetype nameEnd = equals >= itemStart && equals < itemEnd ? equals : itemEnd;
+            const QByteArray encodedName = query.mid(itemStart, nameEnd - itemStart);
+            const QString decodedName = QUrl::fromPercentEncoding(encodedName);
+            if (isSensitiveQueryItem(decodedName) && equals >= itemStart && equals < itemEnd) {
+                static const QByteArray redaction = QByteArrayLiteral("%5BREDACTED%5D");
+                query.replace(equals + 1, itemEnd - equals - 1, redaction);
+                itemEnd = equals + 1 + redaction.size();
+            }
+            if (itemEnd >= query.size()) {
+                break;
+            }
+            itemStart = itemEnd + 1;
+        }
+
+        encoded.replace(queryStart + 1, queryEnd - queryStart - 1, query);
+        return QString::fromUtf8(encoded);
+    }
+
+private:
+    static QUrl resolveEndpoint(const QString &baseUrl, const QString &endpoint)
+    {
+        const QUrl direct(endpoint);
+        if (!direct.isRelative() && !direct.scheme().isEmpty()) {
+            return direct;
+        }
+
+        QUrl base(baseUrl.trimmed());
+        QString path = base.path();
+        while (path.endsWith(QLatin1Char('/'))) {
+            path.chop(1);
+        }
+        path += QLatin1Char('/');
+        base.setPath(path);
+
+        QString relative = endpoint;
+        while (relative.startsWith(QLatin1Char('/'))) {
+            relative.remove(0, 1);
+        }
+        return base.resolved(QUrl(relative));
+    }
+
+    static bool sameOrigin(const QString &baseUrl, const QUrl &resolved)
+    {
+        const QUrl base(baseUrl.trimmed());
+        if (!base.isValid() || !resolved.isValid()
+            || base.scheme().compare(resolved.scheme(), Qt::CaseInsensitive) != 0
+            || base.host().compare(resolved.host(), Qt::CaseInsensitive) != 0) {
+            return false;
+        }
+        const auto effectivePort = [](const QUrl &url) {
+            if (url.port() >= 0) {
+                return url.port();
+            }
+            return url.scheme().compare(QStringLiteral("https"), Qt::CaseInsensitive) == 0
+                ? 443 : 80;
+        };
+        return effectivePort(base) == effectivePort(resolved);
+    }
+
+    static void setHeaderIfPresent(QNetworkRequest &request,
+                                   const QByteArray &name,
+                                   const QString &value)
+    {
+        if (!value.isEmpty()) {
+            request.setRawHeader(name, value.toUtf8());
+        }
+    }
+
+    static bool isSensitiveQueryItem(const QString &name)
+    {
+        const QString normalized = name.trimmed().toLower();
+        return normalized == QStringLiteral("st")
+            || normalized == QStringLiteral("sig")
+            || normalized == QStringLiteral("signature")
+            || normalized == QStringLiteral("x-amz-signature")
+            || normalized == QStringLiteral("x-goog-signature")
+            || normalized.contains(QStringLiteral("token"));
+    }
+};

--- a/src/ui/ImageCacheProvider.cpp
+++ b/src/ui/ImageCacheProvider.cpp
@@ -18,6 +18,7 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QImageWriter>
+#include <QPointer>
 #include <utility>
 #include "../utils/BloomLogging.h"
 
@@ -202,11 +203,34 @@ void CachedImageResponse::onNetworkReplyFinished()
         return;
     }
     
-    if (m_reply->error() != QNetworkReply::NoError) {
-        QString error = m_reply->errorString();
+    const int httpStatus = m_reply->attribute(
+        QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const bool refreshableStatus = httpStatus == 401 || httpStatus == 403;
+    if (refreshableStatus) {
+        const QString error = m_reply->error() == QNetworkReply::NoError
+            ? QStringLiteral("HTTP error: %1").arg(httpStatus)
+            : QStringLiteral("Network error: %1").arg(m_reply->errorString());
         m_reply->deleteLater();
         m_reply = nullptr;
-        finishWithError("Network error: " + error);
+
+        if (!m_refreshAttempted
+            && m_url.startsWith(QStringLiteral("artwork:"))
+            && m_provider->m_artworkProvider) {
+            m_refreshAttempted = true;
+            locker.unlock();
+            refreshArtworkRequest(error);
+            return;
+        }
+
+        finishWithError(error);
+        return;
+    }
+
+    if (m_reply->error() != QNetworkReply::NoError) {
+        const QString error = m_reply->errorString();
+        m_reply->deleteLater();
+        m_reply = nullptr;
+        finishWithError(QStringLiteral("Network error: %1").arg(error));
         return;
     }
     
@@ -248,6 +272,49 @@ void CachedImageResponse::onNetworkReplyFinished()
     }
     
     finishWithImage(image);
+}
+
+void CachedImageResponse::refreshArtworkRequest(const QString &networkError)
+{
+    const Bloom::ArtworkRef artwork = Bloom::ArtworkRef::fromCacheKey(m_url);
+    IArtworkProvider *artworkProvider = m_provider->m_artworkProvider;
+    if (!artwork.isValid() || !artworkProvider) {
+        finishWithError(networkError);
+        return;
+    }
+
+    const QPointer<CachedImageResponse> guard(this);
+    artworkProvider->refreshArtwork(
+        artwork,
+        [guard, networkError](std::optional<QNetworkRequest> refreshedRequest) {
+            if (!guard) {
+                return;
+            }
+
+            QMetaObject::invokeMethod(
+                guard.data(),
+                [guard, networkError,
+                 refreshedRequest = std::move(refreshedRequest)]() mutable {
+                    if (!guard) {
+                        return;
+                    }
+
+                    QMutexLocker locker(&guard->m_mutex);
+                    if (guard->m_cancelled) {
+                        guard->finishWithError(QStringLiteral("Request cancelled"));
+                        return;
+                    }
+                    if (!refreshedRequest.has_value()) {
+                        guard->finishWithError(networkError);
+                        return;
+                    }
+
+                    guard->m_resolvedRequest = std::move(refreshedRequest);
+                    locker.unlock();
+                    guard->fetchFromNetwork();
+                },
+                Qt::QueuedConnection);
+        });
 }
 
 void CachedImageResponse::saveToCache(const QByteArray &data)

--- a/src/ui/ImageCacheProvider.cpp
+++ b/src/ui/ImageCacheProvider.cpp
@@ -276,7 +276,8 @@ void CachedImageResponse::onNetworkReplyFinished()
 
 void CachedImageResponse::refreshArtworkRequest(const QString &networkError)
 {
-    const Bloom::ArtworkRef artwork = Bloom::ArtworkRef::fromCacheKey(m_url);
+    Bloom::ArtworkRef artwork = Bloom::ArtworkRef::fromCacheKey(m_url);
+    artwork.sourceUrl = Bloom::ArtworkRef::transientSourceUrlForCacheKey(m_url);
     IArtworkProvider *artworkProvider = m_provider->m_artworkProvider;
     if (!artwork.isValid() || !artworkProvider) {
         finishWithError(networkError);
@@ -722,12 +723,12 @@ std::optional<QNetworkRequest> ImageCacheProvider::resolveRequest(const QString 
                                   Qt::BlockingQueuedConnection);
         return resolved;
     }
-
     if (cacheKey.startsWith(QStringLiteral("artwork:"))) {
         if (!m_artworkProvider) {
             return std::nullopt;
         }
-        const Bloom::ArtworkRef artwork = Bloom::ArtworkRef::fromCacheKey(cacheKey);
+        Bloom::ArtworkRef artwork = Bloom::ArtworkRef::fromCacheKey(cacheKey);
+        artwork.sourceUrl = Bloom::ArtworkRef::transientSourceUrlForCacheKey(cacheKey);
         if (!artwork.isValid()) {
             return std::nullopt;
         }

--- a/src/ui/ImageCacheProvider.h
+++ b/src/ui/ImageCacheProvider.h
@@ -215,12 +215,18 @@ private:
     void evictIfNeeded();
     
     /**
-     * @brief Generate cache file name from URL
+     * @brief Generate a cache filename from a token-free identity.
      */
     QString hashUrl(const QString &url) const;
     QString safeCacheLabel(const QString &cacheKey) const;
+
+    /**
+     * @brief Resolve a transient artwork source without persisting credentials.
+     *
+     * ArtworkRef keeps the signed source URL in a bounded in-process registry;
+     * only the opaque identity key is used by the disk cache.
+     */
     std::optional<QNetworkRequest> resolveRequest(const QString &cacheKey) const;
-    
     /**
      * @brief Construct a stable key for a rounded variant.
      */

--- a/src/ui/ImageCacheProvider.h
+++ b/src/ui/ImageCacheProvider.h
@@ -59,6 +59,7 @@ private slots:
 private:
     void loadFromCache();
     void fetchFromNetwork();
+    void refreshArtworkRequest(const QString &networkError);
     void saveToCache(const QByteArray &data);
     void finishWithImage(const QImage &image);
     
@@ -70,6 +71,7 @@ private:
     bool m_cancelled = false;
     QNetworkReply *m_reply = nullptr;
     std::optional<QNetworkRequest> m_resolvedRequest;
+    bool m_refreshAttempted = false;
     QMutex m_mutex;
 };
 

--- a/src/ui/LoginScreen.qml
+++ b/src/ui/LoginScreen.qml
@@ -95,6 +95,22 @@ FocusScope {
         return !!(profile && (profile.hasPin || profile.has_pin || profile.pinRequired))
     }
 
+    function syncSelectedProfile() {
+        if (authenticationStep === "pin" && selectedProfileId.length === 0) {
+            var profile = null
+            if (availableProfiles.length === 1) {
+                profile = availableProfiles[0]
+            } else if (profileList.currentIndex >= 0 && profileList.currentIndex < availableProfiles.length) {
+                profile = availableProfiles[profileList.currentIndex]
+            }
+            if (profile) {
+                selectedProfileId = profileId(profile)
+                selectedProfileName = profileName(profile)
+                selectedProfileAvatar = profileAvatar(profile)
+            }
+        }
+    }
+
     function chooseProfile(profile) {
         const id = profileId(profile)
         if (id.length === 0)
@@ -108,6 +124,9 @@ FocusScope {
     }
 
     function submitPin() {
+        if (selectedProfileId.length === 0) {
+            syncSelectedProfile()
+        }
         if (selectedProfileId.length === 0) {
             setStatus(qsTr("Choose a profile before entering a PIN."), true)
             cancelAuthentication()
@@ -132,7 +151,11 @@ FocusScope {
         serviceLoginReported = false
         completionEmitted = false
         clearStatus()
-        AuthenticationService.logout()
+        if (AuthenticationService.authenticated) {
+            AuthenticationService.logout()
+        } else if (authenticationStep === "pin" || authenticationStep === "profiles") {
+            AuthenticationService.clearProfileState()
+        }
         Qt.callLater(restoreStepFocus)
     }
 
@@ -155,12 +178,14 @@ FocusScope {
                     profilesBackButton.forceActiveFocus()
                 }
             } else if (authenticationStep === "pin") {
+                syncSelectedProfile()
                 pinField.forceActiveFocus()
             } else {
                 selectedProviderButton().forceActiveFocus()
             }
         })
     }
+
 
     function restoreRetryFocus() {
         Qt.callLater(function() {
@@ -605,7 +630,11 @@ FocusScope {
                             MouseArea {
                                 anchors.fill: parent
                                 hoverEnabled: true
-                                onEntered: profileList.currentIndex = index
+                                onEntered: {
+                                    if (typeof InputModeManager === "undefined" || InputModeManager.pointerActive) {
+                                        profileList.currentIndex = index
+                                    }
+                                }
                                 onClicked: {
                                     profileList.currentIndex = index
                                     profileList.forceActiveFocus()
@@ -678,6 +707,7 @@ FocusScope {
                         }
 
                         Text {
+                            parent: profileList
                             anchors.centerIn: parent
                             visible: profileList.count === 0
                             text: qsTr("Loading profiles…")
@@ -697,6 +727,20 @@ FocusScope {
                         KeyNavigation.down: profileList
                         KeyNavigation.tab: profileList
                         KeyNavigation.backtab: profileList
+                        Keys.onUpPressed: function(event) {
+                            if (profileList.count > 0) {
+                                profileList.currentIndex = profileList.count - 1
+                                profileList.forceActiveFocus()
+                            }
+                            event.accepted = true
+                        }
+                        Keys.onDownPressed: function(event) {
+                            if (profileList.count > 0) {
+                                profileList.currentIndex = 0
+                                profileList.forceActiveFocus()
+                            }
+                            event.accepted = true
+                        }
                         onClicked: root.cancelAuthentication()
                         background: Rectangle {
                             radius: Theme.radiusSmall
@@ -878,16 +922,20 @@ FocusScope {
 
         function onProfilesChanged() {
             Qt.callLater(function() {
-                if (root.authenticationStep !== "profiles")
+                if (root.authenticationStep !== "profiles" && root.authenticationStep !== "pin")
                     return
                 profileList.currentIndex = root.availableProfiles.length > 0 ? 0 : -1
+                if (root.authenticationStep === "pin")
+                    root.syncSelectedProfile()
                 root.restoreStepFocus()
             })
         }
 
         function onAuthenticationStepChanged() {
-            if (root.authenticationStep === "pin")
+            if (root.authenticationStep === "pin") {
                 pinField.clear()
+                root.syncSelectedProfile()
+            }
             if (root.authenticationStep !== "authenticated")
                 root.clearStatus()
             root.restoreStepFocus()

--- a/src/ui/LoginScreen.qml
+++ b/src/ui/LoginScreen.qml
@@ -5,9 +5,185 @@ import BloomUI
 
 FocusScope {
     id: root
+    objectName: "loginScreen"
     focus: true
 
     signal loginSuccess()
+
+    readonly property string authenticationStep: AuthenticationService.authenticationStep
+    readonly property string providerSelection: AuthenticationService.providerSelection
+    readonly property var availableProfiles: AuthenticationService.profiles || []
+    property string selectedProfileName: ""
+    property string selectedProfileAvatar: ""
+    property string selectedProfileId: ""
+    property bool serviceLoginReported: false
+    property bool completionEmitted: false
+    property string statusMessage: ""
+    property bool statusIsError: false
+
+    function providerTitle() {
+        if (providerSelection === "jellyfin")
+            return qsTr("Sign in to Jellyfin")
+        if (providerSelection === "silo")
+            return qsTr("Sign in to Silo")
+        return qsTr("Connect your media server")
+    }
+
+    function providerDescription() {
+        if (providerSelection === "jellyfin")
+            return qsTr("Connect directly to your Jellyfin server.")
+        if (providerSelection === "silo")
+            return qsTr("Sign in to your Silo account, then choose a household profile.")
+        return qsTr("Bloom will detect whether this server uses Jellyfin or Silo.")
+    }
+
+    function selectedProviderButton() {
+        if (providerSelection === "jellyfin")
+            return jellyfinButton
+        if (providerSelection === "silo")
+            return siloButton
+        return autoButton
+    }
+
+    function setStatus(message, isError) {
+        statusMessage = message
+        statusIsError = isError
+    }
+
+    function clearStatus() {
+        setStatus("", false)
+    }
+
+    function selectProvider(provider) {
+        clearStatus()
+        AuthenticationService.setProviderSelection(provider)
+        Qt.callLater(function() {
+            selectedProviderButton().forceActiveFocus()
+        })
+    }
+
+    function submitCredentials() {
+        if (serverField.text.trim().length === 0) {
+            setStatus(qsTr("Enter your server URL."), true)
+            serverField.forceActiveFocus()
+            return
+        }
+
+        setStatus(qsTr("Signing in…"), false)
+        AuthenticationService.authenticate(serverField.text.trim(), userField.text, passField.text)
+    }
+
+    function profileId(profile) {
+        if (!profile)
+            return ""
+        return profile.id || profile.profileId || profile.profile_id || ""
+    }
+
+    function profileName(profile) {
+        if (!profile)
+            return qsTr("Profile")
+        return profile.name || profile.displayName || qsTr("Profile")
+    }
+
+    function profileAvatar(profile) {
+        if (!profile)
+            return ""
+        return profile.avatarUrl || profile.avatar_url || profile.imageUrl || ""
+    }
+
+    function profileHasPin(profile) {
+        return !!(profile && (profile.hasPin || profile.has_pin || profile.pinRequired))
+    }
+
+    function chooseProfile(profile) {
+        const id = profileId(profile)
+        if (id.length === 0)
+            return
+
+        selectedProfileId = id
+        selectedProfileName = profileName(profile)
+        selectedProfileAvatar = profileAvatar(profile)
+        clearStatus()
+        AuthenticationService.selectProfile(id)
+    }
+
+    function submitPin() {
+        if (selectedProfileId.length === 0) {
+            setStatus(qsTr("Choose a profile before entering a PIN."), true)
+            cancelAuthentication()
+            return
+        }
+        if (pinField.text.length === 0) {
+            setStatus(qsTr("Enter the profile PIN."), true)
+            pinField.forceActiveFocus()
+            return
+        }
+
+        setStatus(qsTr("Checking PIN…"), false)
+        AuthenticationService.verifyProfilePin(selectedProfileId, pinField.text)
+    }
+
+    function cancelAuthentication() {
+        passField.clear()
+        pinField.clear()
+        selectedProfileName = ""
+        selectedProfileId = ""
+        selectedProfileAvatar = ""
+        serviceLoginReported = false
+        completionEmitted = false
+        clearStatus()
+        AuthenticationService.logout()
+        Qt.callLater(restoreStepFocus)
+    }
+
+    function restoreStepFocus() {
+        Qt.callLater(function() {
+            if (!root.visible)
+                return
+
+            if (authenticationStep === "profiles") {
+                if (availableProfiles.length > 0) {
+                    profileList.currentIndex = Math.max(0, Math.min(profileList.currentIndex,
+                                                                      availableProfiles.length - 1))
+                    profileList.forceActiveFocus()
+                } else {
+                    profilesBackButton.forceActiveFocus()
+                }
+            } else if (authenticationStep === "pin") {
+                pinField.forceActiveFocus()
+            } else if (authenticationStep === "credentials") {
+                selectedProviderButton().forceActiveFocus()
+            }
+        })
+    }
+
+    function restoreRetryFocus() {
+        Qt.callLater(function() {
+            if (authenticationStep === "pin") {
+                pinField.selectAll()
+                pinField.forceActiveFocus()
+            } else if (authenticationStep === "profiles") {
+                profileList.forceActiveFocus()
+            } else {
+                passField.selectAll()
+                passField.forceActiveFocus()
+            }
+        })
+    }
+
+    function maybeEmitLoginSuccess() {
+        if (!serviceLoginReported || completionEmitted || authenticationStep !== "authenticated")
+            return
+        completionEmitted = true
+        loginSuccess()
+    }
+
+    Keys.onEscapePressed: function(event) {
+        if (authenticationStep !== "authenticated") {
+            cancelAuthentication()
+            event.accepted = true
+        }
+    }
 
     Image {
         anchors.fill: parent
@@ -19,277 +195,676 @@ FocusScope {
 
     Rectangle {
         anchors.fill: parent
-        color: Qt.rgba(0.01, 0.04, 0.10, 0.55)
+        color: Theme.overlayDark
     }
 
     Rectangle {
-        anchors.fill: parent
-        gradient: Gradient {
-            orientation: Gradient.Vertical
-            GradientStop { position: 0.0; color: Qt.rgba(0.02, 0.06, 0.12, 0.30) }
-            GradientStop { position: 0.45; color: Qt.rgba(0.02, 0.05, 0.12, 0.62) }
-            GradientStop { position: 1.0; color: Qt.rgba(0.01, 0.02, 0.07, 0.88) }
-        }
-    }
+        id: loginCard
+        anchors.centerIn: parent
+        width: Math.min(Math.round(720 * Theme.layoutScale), parent.width - Theme.spacingLarge * 2)
+        height: Math.min(Math.round(660 * Theme.layoutScale), parent.height - Theme.spacingLarge * 2)
+        radius: Theme.radiusXLarge
+        color: Theme.backgroundGlass
+        border.color: Theme.borderLight
+        border.width: Theme.borderWidth
 
-    Item {
-        anchors.fill: parent
+        ColumnLayout {
+            id: cardContent
+            anchors.fill: parent
+            anchors.margins: Theme.spacingLarge
+            spacing: Theme.spacingSmall
 
-        Rectangle {
-            id: loginCard
-            anchors.centerIn: parent
-            width: Math.min(Math.round(560 * Theme.layoutScale), parent.width * 0.92)
-            radius: Theme.radiusXLarge
-            color: Qt.rgba(0.07, 0.12, 0.20, 0.48)
-            border.color: Qt.rgba(1, 1, 1, 0.28)
-            border.width: 1
-            implicitHeight: cardContent.implicitHeight + Math.round(54 * Theme.layoutScale) * 2
-
-            Rectangle {
-                anchors.fill: parent
-                radius: parent.radius
-                color: "transparent"
-                border.color: Qt.rgba(1, 1, 1, 0.12)
-                border.width: 1
-                opacity: 0.8
+            Image {
+                source: "qrc:/images/app/logo_trans.svg"
+                Layout.alignment: Qt.AlignHCenter
+                Layout.preferredHeight: Math.round(54 * Theme.layoutScale)
+                Layout.preferredWidth: Math.round(180 * Theme.layoutScale)
+                fillMode: Image.PreserveAspectFit
+                sourceSize.height: Math.round(96 * Theme.layoutScale)
+                mipmap: true
             }
 
-            Rectangle {
-                anchors {
-                    left: parent.left
-                    right: parent.right
-                    top: parent.top
-                }
-                height: Math.round(parent.height * 0.52)
-                radius: parent.radius
-                gradient: Gradient {
-                    orientation: Gradient.Vertical
-                    GradientStop { position: 0.0; color: Qt.rgba(1, 1, 1, 0.16) }
-                    GradientStop { position: 0.55; color: Qt.rgba(1, 1, 1, 0.07) }
-                    GradientStop { position: 1.0; color: Qt.rgba(1, 1, 1, 0.0) }
-                }
+            Text {
+                text: authenticationStep === "profiles" ? qsTr("Who’s watching?")
+                      : authenticationStep === "pin" ? qsTr("Enter profile PIN")
+                      : providerTitle()
+                color: Theme.textPrimary
+                font.family: Theme.fontPrimary
+                font.pixelSize: Theme.fontSizeHeader
+                font.bold: true
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.Wrap
+                Layout.fillWidth: true
             }
 
-            ColumnLayout {
-                id: cardContent
-                anchors {
-                    fill: parent
-                    margins: Math.round(54 * Theme.layoutScale)
-                }
-                spacing: Theme.spacingMedium
+            Text {
+                text: authenticationStep === "profiles"
+                      ? qsTr("Choose a Silo profile to continue.")
+                      : authenticationStep === "pin"
+                        ? (selectedProfileName.length > 0
+                           ? qsTr("Unlock %1 to continue.").arg(selectedProfileName)
+                           : qsTr("Unlock this profile to continue."))
+                        : providerDescription()
+                color: Theme.textSecondary
+                font.family: Theme.fontPrimary
+                font.pixelSize: Theme.fontSizeSmall
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.Wrap
+                Layout.fillWidth: true
+            }
 
-                Image {
-                    source: "qrc:/images/app/logo_trans.svg"
-                    Layout.alignment: Qt.AlignHCenter
-                    Layout.preferredHeight: Math.round(86 * Theme.layoutScale)
-                    fillMode: Image.PreserveAspectFit
-                    sourceSize.height: Math.round(120 * Theme.layoutScale)
-                    mipmap: true
-                }
+            StackLayout {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                currentIndex: authenticationStep === "profiles" ? 1
+                              : authenticationStep === "pin" ? 2 : 0
 
-                Text {
-                    text: qsTr("Bloom")
-                    font.pixelSize: Theme.fontSizeHeader
-                    font.family: Theme.fontPrimary
-                    font.bold: true
-                    color: Theme.textPrimary
-                    Layout.alignment: Qt.AlignHCenter
-                }
+                ColumnLayout {
+                    spacing: Theme.spacingSmall
 
-                Text {
-                    text: qsTr("Sign in to Jellyfin to watch your media.")
-                    color: Theme.textSecondary
-                    font.pixelSize: Theme.fontSizeSmall
-                    font.family: Theme.fontPrimary
-                    Layout.alignment: Qt.AlignHCenter
-                    horizontalAlignment: Text.AlignHCenter
-                    wrapMode: Text.Wrap
-                    Layout.fillWidth: true
-                }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.spacingSmall
 
-                Item {
-                    Layout.preferredHeight: Theme.spacingSmall
-                }
-
-                TextField {
-                    id: serverField
-                    focus: true
-                    placeholderText: qsTr("http://localhost:8096")
-                    placeholderTextColor: Theme.textSecondary
-                    Layout.fillWidth: true
-                    font.pixelSize: Theme.fontSizeBody
-                    font.family: Theme.fontPrimary
-                    color: Theme.textPrimary
-
-                    background: Rectangle {
-                        color: Theme.inputBackground
-                        radius: Theme.radiusSmall
-                        border.color: serverField.activeFocus ? Theme.focusBorder : Theme.inputBorder
-                        border.width: Theme.borderWidth
-                    }
-
-                    KeyNavigation.up: connectButton
-                    KeyNavigation.down: userField
-                    onAccepted: userField.forceActiveFocus()
-                    Keys.onReturnPressed: (event) => { userField.forceActiveFocus(); event.accepted = true }
-                    Keys.onEnterPressed: (event) => { userField.forceActiveFocus(); event.accepted = true }
-                }
-
-                TextField {
-                    id: userField
-                    placeholderText: qsTr("Username")
-                    placeholderTextColor: Theme.textSecondary
-                    Layout.fillWidth: true
-                    font.pixelSize: Theme.fontSizeBody
-                    font.family: Theme.fontPrimary
-                    color: Theme.textPrimary
-
-                    background: Rectangle {
-                        color: Theme.inputBackground
-                        radius: Theme.radiusSmall
-                        border.color: userField.activeFocus ? Theme.focusBorder : Theme.inputBorder
-                        border.width: Theme.borderWidth
-                    }
-
-                    KeyNavigation.up: serverField
-                    KeyNavigation.down: passField
-                    onAccepted: passField.forceActiveFocus()
-                    Keys.onReturnPressed: (event) => { passField.forceActiveFocus(); event.accepted = true }
-                    Keys.onEnterPressed: (event) => { passField.forceActiveFocus(); event.accepted = true }
-                }
-
-                TextField {
-                    id: passField
-                    placeholderText: qsTr("Password")
-                    placeholderTextColor: Theme.textSecondary
-                    echoMode: TextInput.Password
-                    Layout.fillWidth: true
-                    font.pixelSize: Theme.fontSizeBody
-                    font.family: Theme.fontPrimary
-                    color: Theme.textPrimary
-
-                    background: Rectangle {
-                        color: Theme.inputBackground
-                        radius: Theme.radiusSmall
-                        border.color: passField.activeFocus ? Theme.focusBorder : Theme.inputBorder
-                        border.width: Theme.borderWidth
-                    }
-
-                    KeyNavigation.up: userField
-                    KeyNavigation.down: connectButton
-                    onAccepted: connectButton.clicked()
-                    Keys.onReturnPressed: (event) => {
-                        if (event.isAutoRepeat) {
-                            event.accepted = true
-                            return
+                        Button {
+                            id: autoButton
+                            text: qsTr("Auto")
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: Theme.buttonHeightMedium
+                            focusPolicy: Qt.StrongFocus
+                            KeyNavigation.left: siloButton
+                            KeyNavigation.right: jellyfinButton
+                            KeyNavigation.up: credentialCancelButton
+                            KeyNavigation.down: serverField
+                            KeyNavigation.tab: jellyfinButton
+                            KeyNavigation.backtab: credentialCancelButton
+                            onClicked: root.selectProvider("auto")
+                            background: Rectangle {
+                                radius: Theme.radiusSmall
+                                color: root.providerSelection === "auto" ? Theme.accentPrimary : Theme.backgroundSecondary
+                                border.color: autoButton.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                                border.width: autoButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+                            }
+                            contentItem: Text {
+                                text: autoButton.text
+                                color: root.providerSelection === "auto" ? Theme.textOnAccent : Theme.textPrimary
+                                font.family: Theme.fontPrimary
+                                font.pixelSize: Theme.fontSizeSmall
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                            }
                         }
-                        connectButton.clicked()
-                        event.accepted = true
-                    }
-                    Keys.onEnterPressed: (event) => {
-                        if (event.isAutoRepeat) {
-                            event.accepted = true
-                            return
+
+                        Button {
+                            id: jellyfinButton
+                            text: qsTr("Jellyfin")
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: Theme.buttonHeightMedium
+                            focusPolicy: Qt.StrongFocus
+                            KeyNavigation.left: autoButton
+                            KeyNavigation.right: siloButton
+                            KeyNavigation.up: credentialCancelButton
+                            KeyNavigation.down: serverField
+                            KeyNavigation.tab: siloButton
+                            KeyNavigation.backtab: autoButton
+                            onClicked: root.selectProvider("jellyfin")
+                            background: Rectangle {
+                                radius: Theme.radiusSmall
+                                color: root.providerSelection === "jellyfin" ? Theme.accentPrimary : Theme.backgroundSecondary
+                                border.color: jellyfinButton.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                                border.width: jellyfinButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+                            }
+                            contentItem: Text {
+                                text: jellyfinButton.text
+                                color: root.providerSelection === "jellyfin" ? Theme.textOnAccent : Theme.textPrimary
+                                font.family: Theme.fontPrimary
+                                font.pixelSize: Theme.fontSizeSmall
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                            }
                         }
-                        connectButton.clicked()
-                        event.accepted = true
-                    }
-                }
 
-                Button {
-                    id: connectButton
-                    text: qsTr("Connect")
-                    enabled: serverField.text.length > 0
-                    font.pixelSize: Theme.fontSizeTitle
-                    font.family: Theme.fontPrimary
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: Theme.buttonHeightLarge
-
-                    background: Rectangle {
-                        color: parent.activeFocus ? Theme.accentPrimary : Theme.backgroundSecondary
-                        radius: Theme.radiusSmall
-                        border.color: parent.activeFocus ? Theme.textPrimary : "transparent"
-                        border.width: Theme.buttonFocusBorderWidth
-                    }
-
-                    contentItem: Text {
-                        text: parent.text
-                        font: parent.font
-                        color: Theme.textPrimary
-                        horizontalAlignment: Text.AlignHCenter
-                        verticalAlignment: Text.AlignVCenter
-                    }
-
-                    onClicked: {
-                        console.log("=== LoginScreen: Connect button clicked ===")
-                        console.log("LoginScreen: server=", serverField.text, "user=", userField.text)
-                        statusText.text = qsTr("Connecting...")
-                        statusText.color = Theme.textPrimary
-                        AuthenticationService.authenticate(serverField.text, userField.text, passField.text)
-                        console.log("LoginScreen: authenticate() called")
-                    }
-
-                    KeyNavigation.up: passField
-                    KeyNavigation.down: serverField
-                    Keys.onReturnPressed: (event) => {
-                        if (event.isAutoRepeat) {
-                            event.accepted = true
-                            return
+                        Button {
+                            id: siloButton
+                            text: qsTr("Silo")
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: Theme.buttonHeightMedium
+                            focusPolicy: Qt.StrongFocus
+                            KeyNavigation.left: jellyfinButton
+                            KeyNavigation.right: autoButton
+                            KeyNavigation.up: credentialCancelButton
+                            KeyNavigation.down: serverField
+                            KeyNavigation.tab: serverField
+                            KeyNavigation.backtab: jellyfinButton
+                            onClicked: root.selectProvider("silo")
+                            background: Rectangle {
+                                radius: Theme.radiusSmall
+                                color: root.providerSelection === "silo" ? Theme.accentPrimary : Theme.backgroundSecondary
+                                border.color: siloButton.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                                border.width: siloButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+                            }
+                            contentItem: Text {
+                                text: siloButton.text
+                                color: root.providerSelection === "silo" ? Theme.textOnAccent : Theme.textPrimary
+                                font.family: Theme.fontPrimary
+                                font.pixelSize: Theme.fontSizeSmall
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                            }
                         }
-                        clicked()
-                        event.accepted = true
                     }
-                    Keys.onEnterPressed: (event) => {
-                        if (event.isAutoRepeat) {
-                            event.accepted = true
-                            return
-                        }
-                        clicked()
-                        event.accepted = true
-                    }
-                }
-
-                Rectangle {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: Math.max(Math.round(40 * Theme.layoutScale), statusText.implicitHeight + Math.round(12 * Theme.layoutScale))
-                    radius: Theme.radiusSmall
-                    color: statusText.text.length > 0 ? Qt.rgba(1, 1, 1, 0.12) : "transparent"
-                    border.color: statusText.text.length > 0 ? Qt.rgba(1, 1, 1, 0.16) : "transparent"
-                    border.width: 1
-                    visible: statusText.text.length > 0
 
                     Text {
-                        id: statusText
-                        anchors.centerIn: parent
-                        text: ""
-                        color: Theme.textPrimary
-                        font.pixelSize: Theme.fontSizeSmall
+                        text: qsTr("Server type")
+                        color: Theme.textSecondary
                         font.family: Theme.fontPrimary
+                        font.pixelSize: Theme.fontSizeCaption
+                        Layout.fillWidth: true
+                        horizontalAlignment: Text.AlignHCenter
                     }
+
+                    TextField {
+                        id: serverField
+                        placeholderText: qsTr("https://media.example.com")
+                        placeholderTextColor: Theme.textSecondary
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Theme.buttonHeightMedium
+                        font.pixelSize: Theme.fontSizeBody
+                        font.family: Theme.fontPrimary
+                        color: Theme.textPrimary
+                        KeyNavigation.up: root.selectedProviderButton()
+                        KeyNavigation.down: userField
+                        KeyNavigation.tab: userField
+                        KeyNavigation.backtab: siloButton
+                        onAccepted: userField.forceActiveFocus()
+                        background: Rectangle {
+                            color: Theme.inputBackground
+                            radius: Theme.radiusSmall
+                            border.color: serverField.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                            border.width: serverField.activeFocus ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+                        }
+                    }
+
+                    Text {
+                        text: qsTr("Enter the full server URL. A custom port is optional.")
+                        color: Theme.textSecondary
+                        font.family: Theme.fontPrimary
+                        font.pixelSize: Theme.fontSizeCaption
+                        Layout.fillWidth: true
+                        wrapMode: Text.Wrap
+                    }
+
+                    TextField {
+                        id: userField
+                        placeholderText: root.providerSelection === "silo" ? qsTr("Silo account username") : qsTr("Username")
+                        placeholderTextColor: Theme.textSecondary
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Theme.buttonHeightMedium
+                        font.pixelSize: Theme.fontSizeBody
+                        font.family: Theme.fontPrimary
+                        color: Theme.textPrimary
+                        KeyNavigation.up: serverField
+                        KeyNavigation.down: passField
+                        KeyNavigation.tab: passField
+                        KeyNavigation.backtab: serverField
+                        onAccepted: passField.forceActiveFocus()
+                        background: Rectangle {
+                            color: Theme.inputBackground
+                            radius: Theme.radiusSmall
+                            border.color: userField.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                            border.width: userField.activeFocus ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+                        }
+                    }
+
+                    TextField {
+                        id: passField
+                        placeholderText: qsTr("Password")
+                        placeholderTextColor: Theme.textSecondary
+                        echoMode: TextInput.Password
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Theme.buttonHeightMedium
+                        font.pixelSize: Theme.fontSizeBody
+                        font.family: Theme.fontPrimary
+                        color: Theme.textPrimary
+                        KeyNavigation.up: userField
+                        KeyNavigation.down: connectButton
+                        KeyNavigation.tab: connectButton
+                        KeyNavigation.backtab: userField
+                        onAccepted: root.submitCredentials()
+                        background: Rectangle {
+                            color: Theme.inputBackground
+                            radius: Theme.radiusSmall
+                            border.color: passField.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                            border.width: passField.activeFocus ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.spacingSmall
+
+                        Button {
+                            id: credentialCancelButton
+                            text: qsTr("Reset")
+                            Layout.preferredWidth: Math.round(160 * Theme.layoutScale)
+                            Layout.preferredHeight: Theme.buttonHeightLarge
+                            focusPolicy: Qt.StrongFocus
+                            KeyNavigation.up: connectButton
+                            KeyNavigation.down: autoButton
+                            KeyNavigation.left: connectButton
+                            KeyNavigation.right: connectButton
+                            KeyNavigation.tab: autoButton
+                            KeyNavigation.backtab: connectButton
+                            onClicked: {
+                                serverField.clear()
+                                userField.clear()
+                                root.cancelAuthentication()
+                            }
+                            background: Rectangle {
+                                radius: Theme.radiusSmall
+                                color: Theme.backgroundSecondary
+                                border.color: credentialCancelButton.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                                border.width: credentialCancelButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+                            }
+                            contentItem: Text {
+                                text: credentialCancelButton.text
+                                color: Theme.textPrimary
+                                font.family: Theme.fontPrimary
+                                font.pixelSize: Theme.fontSizeSmall
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                        }
+
+                        Button {
+                            id: connectButton
+                            text: qsTr("Sign in")
+                            enabled: serverField.text.trim().length > 0
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: Theme.buttonHeightLarge
+                            focusPolicy: Qt.StrongFocus
+                            KeyNavigation.up: passField
+                            KeyNavigation.down: credentialCancelButton
+                            KeyNavigation.left: credentialCancelButton
+                            KeyNavigation.right: credentialCancelButton
+                            KeyNavigation.tab: credentialCancelButton
+                            KeyNavigation.backtab: passField
+                            onClicked: root.submitCredentials()
+                            background: Rectangle {
+                                radius: Theme.radiusSmall
+                                color: connectButton.enabled ? Theme.accentPrimary : Theme.backgroundSecondary
+                                border.color: connectButton.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                                border.width: connectButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+                            }
+                            contentItem: Text {
+                                text: connectButton.text
+                                color: connectButton.enabled ? Theme.textOnAccent : Theme.textDisabled
+                                font.family: Theme.fontPrimary
+                                font.pixelSize: Theme.fontSizeTitle
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                        }
+                    }
+                }
+
+                ColumnLayout {
+                    spacing: Theme.spacingSmall
+
+                    ListView {
+                        id: profileList
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        clip: true
+                        spacing: Theme.spacingSmall
+                        model: root.availableProfiles
+                        currentIndex: root.availableProfiles.length > 0 ? 0 : -1
+                        focus: false
+                        activeFocusOnTab: true
+                        KeyNavigation.up: profilesBackButton
+                        KeyNavigation.down: profilesBackButton
+                        KeyNavigation.tab: profilesBackButton
+                        KeyNavigation.backtab: profilesBackButton
+
+                        Keys.onUpPressed: function(event) {
+                            if (count > 0)
+                                currentIndex = (currentIndex - 1 + count) % count
+                            event.accepted = true
+                        }
+                        Keys.onDownPressed: function(event) {
+                            if (count > 0)
+                                currentIndex = (currentIndex + 1) % count
+                            event.accepted = true
+                        }
+                        Keys.onReturnPressed: function(event) {
+                            if (!event.isAutoRepeat && currentIndex >= 0)
+                                root.chooseProfile(root.availableProfiles[currentIndex])
+                            event.accepted = true
+                        }
+                        Keys.onEnterPressed: function(event) {
+                            if (!event.isAutoRepeat && currentIndex >= 0)
+                                root.chooseProfile(root.availableProfiles[currentIndex])
+                            event.accepted = true
+                        }
+
+                        delegate: Rectangle {
+                            required property int index
+                            required property var modelData
+                            width: profileList.width
+                            height: Math.round(88 * Theme.layoutScale)
+                            radius: Theme.radiusMedium
+                            color: profileList.currentIndex === index ? Theme.accentPrimary : Theme.backgroundSecondary
+                            border.color: profileList.activeFocus && profileList.currentIndex === index
+                                          ? Theme.focusBorder : Theme.inputBorder
+                            border.width: profileList.activeFocus && profileList.currentIndex === index
+                                          ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+
+                            MouseArea {
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onEntered: profileList.currentIndex = index
+                                onClicked: {
+                                    profileList.currentIndex = index
+                                    profileList.forceActiveFocus()
+                                    root.chooseProfile(modelData)
+                                }
+                            }
+
+                            RowLayout {
+                                anchors.fill: parent
+                                anchors.margins: Theme.spacingSmall
+                                spacing: Theme.spacingMedium
+
+                                Rectangle {
+                                    Layout.preferredWidth: Math.round(64 * Theme.layoutScale)
+                                    Layout.preferredHeight: Math.round(64 * Theme.layoutScale)
+                                    radius: width / 2
+                                    color: Theme.inputBackground
+                                    clip: true
+
+                                    Text {
+                                        anchors.centerIn: parent
+                                        text: root.profileName(modelData).charAt(0).toUpperCase()
+                                        color: profileList.currentIndex === index ? Theme.textOnAccent : Theme.textPrimary
+                                        font.family: Theme.fontPrimary
+                                        font.pixelSize: Theme.fontSizeTitle
+                                        font.bold: true
+                                        visible: root.profileAvatar(modelData).length === 0
+                                    }
+
+                                    Image {
+                                        anchors.fill: parent
+                                        source: root.profileAvatar(modelData)
+                                        fillMode: Image.PreserveAspectCrop
+                                        asynchronous: true
+                                        cache: true
+                                        visible: source.toString().length > 0
+                                    }
+                                }
+
+                                ColumnLayout {
+                                    Layout.fillWidth: true
+                                    spacing: Theme.spacingXSmall
+
+                                    Text {
+                                        text: root.profileName(modelData)
+                                        color: profileList.currentIndex === index ? Theme.textOnAccent : Theme.textPrimary
+                                        font.family: Theme.fontPrimary
+                                        font.pixelSize: Theme.fontSizeBody
+                                        font.bold: true
+                                        elide: Text.ElideRight
+                                        Layout.fillWidth: true
+                                    }
+
+                                    Text {
+                                        text: root.profileHasPin(modelData) ? qsTr("PIN required") : qsTr("No PIN required")
+                                        color: profileList.currentIndex === index ? Theme.textOnAccent : Theme.textSecondary
+                                        font.family: Theme.fontPrimary
+                                        font.pixelSize: Theme.fontSizeCaption
+                                        Layout.fillWidth: true
+                                    }
+                                }
+
+                                Text {
+                                    text: root.profileHasPin(modelData) ? "lock" : "arrow_forward"
+                                    color: profileList.currentIndex === index ? Theme.textOnAccent : Theme.textPrimary
+                                    font.family: "Material Symbols Outlined"
+                                    font.pixelSize: Theme.fontSizeIcon
+                                }
+                            }
+                        }
+
+                        Text {
+                            anchors.centerIn: parent
+                            visible: profileList.count === 0
+                            text: qsTr("Loading profiles…")
+                            color: Theme.textSecondary
+                            font.family: Theme.fontPrimary
+                            font.pixelSize: Theme.fontSizeBody
+                        }
+                    }
+
+                    Button {
+                        id: profilesBackButton
+                        text: qsTr("Back to sign in")
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Theme.buttonHeightMedium
+                        focusPolicy: Qt.StrongFocus
+                        KeyNavigation.up: profileList
+                        KeyNavigation.down: profileList
+                        KeyNavigation.tab: profileList
+                        KeyNavigation.backtab: profileList
+                        onClicked: root.cancelAuthentication()
+                        background: Rectangle {
+                            radius: Theme.radiusSmall
+                            color: Theme.backgroundSecondary
+                            border.color: profilesBackButton.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                            border.width: profilesBackButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+                        }
+                        contentItem: Text {
+                            text: profilesBackButton.text
+                            color: Theme.textPrimary
+                            font.family: Theme.fontPrimary
+                            font.pixelSize: Theme.fontSizeSmall
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+                }
+
+                ColumnLayout {
+                    spacing: Theme.spacingMedium
+
+                    Item { Layout.fillHeight: true }
+
+                    Rectangle {
+                        Layout.alignment: Qt.AlignHCenter
+                        Layout.preferredWidth: Math.round(104 * Theme.layoutScale)
+                        Layout.preferredHeight: Math.round(104 * Theme.layoutScale)
+                        radius: width / 2
+                        color: Theme.inputBackground
+                        clip: true
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: root.selectedProfileName.length > 0
+                                  ? root.selectedProfileName.charAt(0).toUpperCase() : "lock"
+                            color: Theme.textPrimary
+                            font.family: root.selectedProfileName.length > 0
+                                         ? Theme.fontPrimary : "Material Symbols Outlined"
+                            font.pixelSize: Theme.fontSizeHeader
+                            font.bold: true
+                            visible: root.selectedProfileAvatar.length === 0
+                        }
+
+                        Image {
+                            anchors.fill: parent
+                            source: root.selectedProfileAvatar
+                            fillMode: Image.PreserveAspectCrop
+                            asynchronous: true
+                            cache: true
+                            visible: source.toString().length > 0
+                        }
+                    }
+
+                    TextField {
+                        id: pinField
+                        placeholderText: qsTr("Profile PIN")
+                        placeholderTextColor: Theme.textSecondary
+                        echoMode: TextInput.Password
+                        inputMethodHints: Qt.ImhDigitsOnly | Qt.ImhSensitiveData | Qt.ImhNoPredictiveText
+                        horizontalAlignment: TextInput.AlignHCenter
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Theme.buttonHeightLarge
+                        font.pixelSize: Theme.fontSizeTitle
+                        font.family: Theme.fontPrimary
+                        color: Theme.textPrimary
+                        KeyNavigation.up: pinCancelButton
+                        KeyNavigation.down: verifyPinButton
+                        KeyNavigation.tab: verifyPinButton
+                        KeyNavigation.backtab: pinCancelButton
+                        onAccepted: root.submitPin()
+                        background: Rectangle {
+                            color: Theme.inputBackground
+                            radius: Theme.radiusSmall
+                            border.color: pinField.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                            border.width: pinField.activeFocus ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+                        }
+                    }
+
+                    Button {
+                        id: verifyPinButton
+                        text: qsTr("Unlock profile")
+                        enabled: pinField.text.length > 0
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Theme.buttonHeightLarge
+                        focusPolicy: Qt.StrongFocus
+                        KeyNavigation.up: pinField
+                        KeyNavigation.down: pinCancelButton
+                        KeyNavigation.tab: pinCancelButton
+                        KeyNavigation.backtab: pinField
+                        onClicked: root.submitPin()
+                        background: Rectangle {
+                            radius: Theme.radiusSmall
+                            color: verifyPinButton.enabled ? Theme.accentPrimary : Theme.backgroundSecondary
+                            border.color: verifyPinButton.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                            border.width: verifyPinButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+                        }
+                        contentItem: Text {
+                            text: verifyPinButton.text
+                            color: verifyPinButton.enabled ? Theme.textOnAccent : Theme.textDisabled
+                            font.family: Theme.fontPrimary
+                            font.pixelSize: Theme.fontSizeTitle
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+
+                    Button {
+                        id: pinCancelButton
+                        text: qsTr("Cancel and return to sign in")
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Theme.buttonHeightMedium
+                        focusPolicy: Qt.StrongFocus
+                        KeyNavigation.up: verifyPinButton
+                        KeyNavigation.down: pinField
+                        KeyNavigation.tab: pinField
+                        KeyNavigation.backtab: verifyPinButton
+                        onClicked: root.cancelAuthentication()
+                        background: Rectangle {
+                            radius: Theme.radiusSmall
+                            color: Theme.backgroundSecondary
+                            border.color: pinCancelButton.activeFocus ? Theme.focusBorder : Theme.inputBorder
+                            border.width: pinCancelButton.activeFocus ? Theme.buttonFocusBorderWidth : Theme.borderWidth
+                        }
+                        contentItem: Text {
+                            text: pinCancelButton.text
+                            color: Theme.textPrimary
+                            font.family: Theme.fontPrimary
+                            font.pixelSize: Theme.fontSizeSmall
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+
+                    Item { Layout.fillHeight: true }
+                }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: statusMessage.length > 0
+                                        ? Math.max(Theme.buttonHeightSmall, statusLabel.implicitHeight + Theme.spacingSmall * 2)
+                                        : 0
+                visible: statusMessage.length > 0
+                radius: Theme.radiusSmall
+                color: Theme.inputBackground
+                border.color: statusIsError ? Theme.errorColor : Theme.borderLight
+                border.width: Theme.borderWidth
+
+                Text {
+                    id: statusLabel
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingSmall
+                    text: root.statusMessage
+                    color: root.statusIsError ? Theme.errorColor : Theme.textPrimary
+                    font.pixelSize: Theme.fontSizeSmall
+                    font.family: Theme.fontPrimary
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    wrapMode: Text.Wrap
                 }
             }
         }
     }
 
-    Component.onCompleted: Qt.callLater(function() {
-        serverField.forceActiveFocus()
-    })
+    Component.onCompleted: restoreStepFocus()
+
+    onVisibleChanged: {
+        if (visible)
+            restoreStepFocus()
+    }
 
     Connections {
         target: AuthenticationService
-        function onLoginSuccess(userId, accessToken, username) {
-            console.log("=== LoginScreen: onLoginSuccess received ===")
-            console.log("LoginScreen: userId=", userId, "username=", username)
-            statusText.text = qsTr("Connected!")
-            statusText.color = "#8AEFC1"
-            console.log("LoginScreen: About to emit root.loginSuccess()")
-            root.loginSuccess()
-            console.log("LoginScreen: root.loginSuccess() emitted")
+        ignoreUnknownSignals: true
+
+        function onProviderSelectionChanged() {
+            Qt.callLater(root.restoreStepFocus)
         }
+
+        function onProfilesChanged() {
+            Qt.callLater(function() {
+                if (root.authenticationStep !== "profiles")
+                    return
+                profileList.currentIndex = root.availableProfiles.length > 0 ? 0 : -1
+                root.restoreStepFocus()
+            })
+        }
+
+        function onAuthenticationStepChanged() {
+            if (root.authenticationStep === "pin")
+                pinField.clear()
+            if (root.authenticationStep !== "authenticated")
+                root.clearStatus()
+            root.restoreStepFocus()
+            root.maybeEmitLoginSuccess()
+        }
+
+        function onLoginSuccess(userId, accessToken, username) {
+            root.serviceLoginReported = true
+            Qt.callLater(root.maybeEmitLoginSuccess)
+        }
+
         function onLoginError(error) {
-            console.log("=== LoginScreen: onLoginError received ===", error)
-            statusText.text = qsTr("Error: ") + error
-            statusText.color = "#FF8A95"
+            root.setStatus(error, true)
+            root.restoreRetryFocus()
+        }
+
+        function onLoggedOut() {
+            root.serviceLoginReported = false
+            root.completionEmitted = false
+            root.restoreStepFocus()
         }
     }
 }

--- a/src/ui/LoginScreen.qml
+++ b/src/ui/LoginScreen.qml
@@ -141,9 +141,14 @@ FocusScope {
             if (!root.visible)
                 return
 
+            if (typeof InputModeManager !== "undefined" && !InputModeManager.pointerActive) {
+                InputModeManager.setNavigationMode("keyboard")
+                InputModeManager.hideCursor(true)
+            }
+
             if (authenticationStep === "profiles") {
                 if (availableProfiles.length > 0) {
-                    profileList.currentIndex = Math.max(0, Math.min(profileList.currentIndex,
+                    profileList.currentIndex = Math.max(0, Math.min(profileList.currentIndex >= 0 ? profileList.currentIndex : 0,
                                                                       availableProfiles.length - 1))
                     profileList.forceActiveFocus()
                 } else {
@@ -151,7 +156,7 @@ FocusScope {
                 }
             } else if (authenticationStep === "pin") {
                 pinField.forceActiveFocus()
-            } else if (authenticationStep === "credentials") {
+            } else {
                 selectedProviderButton().forceActiveFocus()
             }
         })
@@ -159,11 +164,23 @@ FocusScope {
 
     function restoreRetryFocus() {
         Qt.callLater(function() {
+            if (!root.visible)
+                return
+
+            if (typeof InputModeManager !== "undefined" && !InputModeManager.pointerActive) {
+                InputModeManager.setNavigationMode("keyboard")
+                InputModeManager.hideCursor(true)
+            }
+
             if (authenticationStep === "pin") {
                 pinField.selectAll()
                 pinField.forceActiveFocus()
             } else if (authenticationStep === "profiles") {
-                profileList.forceActiveFocus()
+                if (profileList.count > 0) {
+                    profileList.forceActiveFocus()
+                } else {
+                    profilesBackButton.forceActiveFocus()
+                }
             } else {
                 passField.selectAll()
                 passField.forceActiveFocus()
@@ -178,6 +195,11 @@ FocusScope {
         loginSuccess()
     }
 
+    onActiveFocusChanged: {
+        if (activeFocus)
+            restoreStepFocus()
+    }
+
     Keys.onEscapePressed: function(event) {
         if (authenticationStep !== "authenticated") {
             cancelAuthentication()
@@ -185,6 +207,12 @@ FocusScope {
         }
     }
 
+    Keys.onBackPressed: function(event) {
+        if (authenticationStep !== "authenticated") {
+            cancelAuthentication()
+            event.accepted = true
+        }
+    }
     Image {
         anchors.fill: parent
         source: "qrc:/images/app/login.jpg"
@@ -375,7 +403,7 @@ FocusScope {
                         KeyNavigation.up: root.selectedProviderButton()
                         KeyNavigation.down: userField
                         KeyNavigation.tab: userField
-                        KeyNavigation.backtab: siloButton
+                        KeyNavigation.backtab: root.selectedProviderButton()
                         onAccepted: userField.forceActiveFocus()
                         background: Rectangle {
                             color: Theme.inputBackground
@@ -449,15 +477,16 @@ FocusScope {
                             Layout.preferredWidth: Math.round(160 * Theme.layoutScale)
                             Layout.preferredHeight: Theme.buttonHeightLarge
                             focusPolicy: Qt.StrongFocus
-                            KeyNavigation.up: connectButton
-                            KeyNavigation.down: autoButton
+                            KeyNavigation.up: passField
+                            KeyNavigation.down: root.selectedProviderButton()
                             KeyNavigation.left: connectButton
                             KeyNavigation.right: connectButton
-                            KeyNavigation.tab: autoButton
-                            KeyNavigation.backtab: connectButton
+                            KeyNavigation.tab: root.selectedProviderButton()
+                            KeyNavigation.backtab: passField
                             onClicked: {
                                 serverField.clear()
                                 userField.clear()
+                                passField.clear()
                                 root.cancelAuthentication()
                             }
                             background: Rectangle {
@@ -484,7 +513,7 @@ FocusScope {
                             Layout.preferredHeight: Theme.buttonHeightLarge
                             focusPolicy: Qt.StrongFocus
                             KeyNavigation.up: passField
-                            KeyNavigation.down: credentialCancelButton
+                            KeyNavigation.down: root.selectedProviderButton()
                             KeyNavigation.left: credentialCancelButton
                             KeyNavigation.right: credentialCancelButton
                             KeyNavigation.tab: credentialCancelButton
@@ -519,7 +548,7 @@ FocusScope {
                         spacing: Theme.spacingSmall
                         model: root.availableProfiles
                         currentIndex: root.availableProfiles.length > 0 ? 0 : -1
-                        focus: false
+                        focus: true
                         activeFocusOnTab: true
                         KeyNavigation.up: profilesBackButton
                         KeyNavigation.down: profilesBackButton
@@ -527,22 +556,36 @@ FocusScope {
                         KeyNavigation.backtab: profilesBackButton
 
                         Keys.onUpPressed: function(event) {
-                            if (count > 0)
-                                currentIndex = (currentIndex - 1 + count) % count
+                            if (count > 0) {
+                                if (currentIndex > 0) {
+                                    currentIndex = currentIndex - 1
+                                } else {
+                                    profilesBackButton.forceActiveFocus()
+                                }
+                            } else {
+                                profilesBackButton.forceActiveFocus()
+                            }
                             event.accepted = true
                         }
                         Keys.onDownPressed: function(event) {
-                            if (count > 0)
-                                currentIndex = (currentIndex + 1) % count
+                            if (count > 0) {
+                                if (currentIndex < count - 1) {
+                                    currentIndex = currentIndex + 1
+                                } else {
+                                    profilesBackButton.forceActiveFocus()
+                                }
+                            } else {
+                                profilesBackButton.forceActiveFocus()
+                            }
                             event.accepted = true
                         }
                         Keys.onReturnPressed: function(event) {
-                            if (!event.isAutoRepeat && currentIndex >= 0)
+                            if (!event.isAutoRepeat && currentIndex >= 0 && currentIndex < count)
                                 root.chooseProfile(root.availableProfiles[currentIndex])
                             event.accepted = true
                         }
                         Keys.onEnterPressed: function(event) {
-                            if (!event.isAutoRepeat && currentIndex >= 0)
+                            if (!event.isAutoRepeat && currentIndex >= 0 && currentIndex < count)
                                 root.chooseProfile(root.availableProfiles[currentIndex])
                             event.accepted = true
                         }

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -64,6 +64,7 @@ Window {
     /// Whether the user is logged in (controls sidebar visibility)
     property bool isLoggedIn: false
     property var sidebarProxy: sidebarLoader.item || sidebarStub
+    property bool pendingAuthenticatedNavigation: false
     
     /// Sidebar overlay mode threshold (narrow screens use overlay)
     readonly property int overlayThreshold: 960
@@ -122,6 +123,28 @@ Window {
         Qt.callLater(function() {
             if (dialog.primaryButton) {
                 dialog.primaryButton.forceActiveFocus()
+            }
+        })
+    }
+
+    function showLoginScreen() {
+        pendingAuthenticatedNavigation = false
+        sidebarProxy.close()
+        isLoggedIn = false
+
+        var current = stackView.currentItem
+        if (!current || current.objectName !== "loginScreen") {
+            stackView.clear()
+            current = stackView.push("LoginScreen.qml")
+        }
+
+        window.requestActivate()
+        Qt.callLater(function() {
+            var loginScreen = stackView.currentItem
+            if (loginScreen && loginScreen.objectName === "loginScreen") {
+                loginScreen.forceActiveFocus()
+            } else {
+                mainContentArea.forceActiveFocus()
             }
         })
     }
@@ -1173,28 +1196,37 @@ Window {
         target: AuthenticationService
         
         function onSessionExpiredAfterPlayback() {
-            console.log("Main.qml: Session expired after playback, showing toast")
-            // Show toast explaining what happened
             toast.show(qsTr("Your session has expired. Please log in again."))
+            window.showLoginScreen()
+        }
+
+        function onSessionExpired() {
+            toast.show(qsTr("Your session has expired. Please log in again."))
+            window.showLoginScreen()
+        }
+
+        function onAuthenticationStepChanged() {
+            if (window.pendingAuthenticatedNavigation
+                    && AuthenticationService.authenticationStep === "authenticated") {
+                onLoginSuccess("", "", "")
+            }
         }
         
         function onLoginSuccess(userId, accessToken, username) {
-            console.log("=== Main.qml: onLoginSuccess CALLED ===")
-            console.log("Main.qml: userId=", userId, "username=", username)
-            console.log("Main.qml: stackView.depth before replace:", stackView.depth)
-            console.log("Main.qml: stackView.currentItem before replace:", stackView.currentItem)
-            
-            // Mark as logged in to show sidebar
+            window.pendingAuthenticatedNavigation = true
+            if (AuthenticationService.authenticationStep !== "authenticated"
+                    || !AuthenticationService.authenticated) {
+                return
+            }
+            if (window.isLoggedIn) {
+                window.pendingAuthenticatedNavigation = false
+                return
+            }
+
+            window.pendingAuthenticatedNavigation = false
             window.isLoggedIn = true
-            console.log("Main.qml: isLoggedIn set to true")
-            
-            // Replace instead of push to prevent going back to login
-            console.log("Main.qml: About to call stackView.replace with HomeScreen.qml")
+
             var homeScreen = stackView.replace("HomeScreen.qml")
-            console.log("Main.qml: stackView.replace returned:", homeScreen)
-            console.log("Main.qml: stackView.depth after replace:", stackView.depth)
-            console.log("Main.qml: stackView.currentItem after replace:", stackView.currentItem)
-            
             if (homeScreen) {
                 console.log("Main.qml: homeScreen is valid, connecting signals...")
                 // Connect navigateToLibrary signal
@@ -1299,17 +1331,7 @@ Window {
         }
         
         function onLoggedOut() {
-            console.log("Main.qml: Logged out, returning to login screen")
-            
-            // Close sidebar if open
-            sidebarProxy.close()
-
-            // Mark as logged out to hide sidebar
-            window.isLoggedIn = false
-
-            // Clear all screens and go back to login
-            stackView.clear()
-            stackView.push("LoginScreen.qml")
+            window.showLoginScreen()
         }
         
         ignoreUnknownSignals: true

--- a/src/ui/Main.qml
+++ b/src/ui/Main.qml
@@ -12,6 +12,123 @@ Window {
     title: "Bloom"
     color: Theme.backgroundPrimary
     
+    function navigateToAuthenticatedHome(userId, accessToken, username) {
+            window.pendingAuthenticatedNavigation = true
+            if (AuthenticationService.authenticationStep !== "authenticated"
+                    || !AuthenticationService.authenticated) {
+                return
+            }
+            if (window.isLoggedIn) {
+                window.pendingAuthenticatedNavigation = false
+                return
+            }
+
+            window.pendingAuthenticatedNavigation = false
+            window.isLoggedIn = true
+
+            var homeScreen = stackView.replace("HomeScreen.qml")
+            if (homeScreen) {
+                console.log("Main.qml: homeScreen is valid, connecting signals...")
+                // Connect navigateToLibrary signal
+                homeScreen.navigateToLibrary.connect(function(libraryId, libraryName) {
+                    playPointerSelectSound()
+                    stackView.push("LibraryScreen.qml", {
+                        currentParentId: libraryId,
+                        currentLibraryId: libraryId,
+                        currentLibraryName: libraryName
+                    })
+                })
+                
+                // Connect navigateToMovie signal - show movie details view
+                homeScreen.navigateToMovie.connect(function(movieData, libraryId, libraryName) {
+                    playPointerSelectSound()
+                    stackView.push("LibraryScreen.qml", {
+                        currentParentId: libraryId,
+                        currentLibraryId: libraryId,
+                        currentLibraryName: libraryName,
+                        directNavigationMode: true,
+                        returnToHomeOnDirectBack: true
+                    })
+                    // Defer calling showMovieDetailsView until screen is ready
+                    Qt.callLater(function() {
+                        var screen = stackView.currentItem
+                        if (screen && typeof screen["showMovieDetailsView"] === "function") {
+                            screen["showMovieDetailsView"](movieData)
+                        }
+                    })
+                })
+                
+                // Connect navigateToEpisode signal - show episode view
+                homeScreen.navigateToEpisode.connect(function(episodeData, seriesId, libraryId, libraryName) {
+                    playPointerSelectSound()
+                    stackView.push("LibraryScreen.qml", {
+                        currentParentId: libraryId,
+                        currentLibraryId: libraryId,
+                        currentLibraryName: libraryName,
+                        currentSeriesId: seriesId,
+                        directNavigationMode: true,
+                        returnToHomeOnDirectBack: true
+                    })
+                    // Need to load series details first for context, then show episode
+                    LibraryService.getSeriesDetails(seriesId)
+                    // Defer calling showEpisodeDetails until screen is ready
+                    Qt.callLater(function() {
+                        var screen = stackView.currentItem
+                        if (screen && typeof screen["showEpisodeDetails"] === "function") {
+                            screen["showEpisodeDetails"](episodeData)
+                        }
+                    })
+                })
+                
+                // Connect navigateToSeason signal - show season view
+                homeScreen.navigateToSeason.connect(function(seasonId, seasonNumber, seriesId, libraryId, libraryName) {
+                    playPointerSelectSound()
+                    stackView.push("LibraryScreen.qml", {
+                        currentParentId: libraryId,
+                        currentLibraryId: libraryId,
+                        currentLibraryName: libraryName,
+                        currentSeriesId: seriesId,
+                        currentSeasonId: seasonId,
+                        currentSeasonNumber: seasonNumber,
+                        showSeasonView: true,
+                        directNavigationMode: true,
+                        returnToHomeOnDirectBack: true
+                    })
+                    // Load series details for logo/poster context
+                    LibraryService.getSeriesDetails(seriesId)
+                    // Load season episodes
+                    SeriesDetailsViewModel.loadSeasonEpisodes(seasonId)
+                })
+                
+                // Connect navigateToSeries signal - show series details view
+                homeScreen.navigateToSeries.connect(function(seriesId, libraryId, libraryName) {
+                    playPointerSelectSound()
+                    stackView.push("LibraryScreen.qml", {
+                        currentParentId: libraryId,
+                        currentLibraryId: libraryId,
+                        currentLibraryName: libraryName,
+                        currentSeriesId: seriesId,
+                        showSeriesDetails: true,
+                        directNavigationMode: true,
+                        returnToHomeOnDirectBack: true
+                    })
+                    // Load series details, seasons, and next episode
+                    LibraryService.getSeriesDetails(seriesId)
+                    LibraryService.getItems(seriesId, 0, 0)  // Load seasons
+                    LibraryService.getNextUnplayedEpisode(seriesId)
+                })
+            }
+            updateSidebarNavigation()
+
+            if (pendingStartupUpdatePopup) {
+                Qt.callLater(function() {
+                    if (window.isLoggedIn) {
+                        pendingStartupUpdatePopup = false
+                        openStartupUpdateDialog()
+                    }
+                })
+            }
+        }
     Component.onCompleted: {
         console.log("=== Main.qml: Window Component.onCompleted ===")
         console.log("Main.qml: AuthenticationService =", AuthenticationService)
@@ -26,6 +143,9 @@ Window {
         }
 
         startupUpdateTimer.start()
+        if (AuthenticationService.authenticated && AuthenticationService.authenticationStep === "authenticated") {
+            window.navigateToAuthenticatedHome("", "", "")
+        }
     }
 
     Binding {
@@ -1206,129 +1326,17 @@ Window {
         }
 
         function onAuthenticationStepChanged() {
-            if (window.pendingAuthenticatedNavigation
-                    && AuthenticationService.authenticationStep === "authenticated") {
-                onLoginSuccess("", "", "")
+            if ((window.pendingAuthenticatedNavigation || !window.isLoggedIn)
+                    && AuthenticationService.authenticationStep === "authenticated"
+                    && AuthenticationService.authenticated) {
+                window.navigateToAuthenticatedHome("", "", "")
             }
+        }
+
+        function onLoginSuccess(userId, accessToken, username) {
+            window.navigateToAuthenticatedHome(userId, accessToken, username)
         }
         
-        function onLoginSuccess(userId, accessToken, username) {
-            window.pendingAuthenticatedNavigation = true
-            if (AuthenticationService.authenticationStep !== "authenticated"
-                    || !AuthenticationService.authenticated) {
-                return
-            }
-            if (window.isLoggedIn) {
-                window.pendingAuthenticatedNavigation = false
-                return
-            }
-
-            window.pendingAuthenticatedNavigation = false
-            window.isLoggedIn = true
-
-            var homeScreen = stackView.replace("HomeScreen.qml")
-            if (homeScreen) {
-                console.log("Main.qml: homeScreen is valid, connecting signals...")
-                // Connect navigateToLibrary signal
-                homeScreen.navigateToLibrary.connect(function(libraryId, libraryName) {
-                    playPointerSelectSound()
-                    stackView.push("LibraryScreen.qml", {
-                        currentParentId: libraryId,
-                        currentLibraryId: libraryId,
-                        currentLibraryName: libraryName
-                    })
-                })
-                
-                // Connect navigateToMovie signal - show movie details view
-                homeScreen.navigateToMovie.connect(function(movieData, libraryId, libraryName) {
-                    playPointerSelectSound()
-                    stackView.push("LibraryScreen.qml", {
-                        currentParentId: libraryId,
-                        currentLibraryId: libraryId,
-                        currentLibraryName: libraryName,
-                        directNavigationMode: true,
-                        returnToHomeOnDirectBack: true
-                    })
-                    // Defer calling showMovieDetailsView until screen is ready
-                    Qt.callLater(function() {
-                        var screen = stackView.currentItem
-                        if (screen && typeof screen["showMovieDetailsView"] === "function") {
-                            screen["showMovieDetailsView"](movieData)
-                        }
-                    })
-                })
-                
-                // Connect navigateToEpisode signal - show episode view
-                homeScreen.navigateToEpisode.connect(function(episodeData, seriesId, libraryId, libraryName) {
-                    playPointerSelectSound()
-                    stackView.push("LibraryScreen.qml", {
-                        currentParentId: libraryId,
-                        currentLibraryId: libraryId,
-                        currentLibraryName: libraryName,
-                        currentSeriesId: seriesId,
-                        directNavigationMode: true,
-                        returnToHomeOnDirectBack: true
-                    })
-                    // Need to load series details first for context, then show episode
-                    LibraryService.getSeriesDetails(seriesId)
-                    // Defer calling showEpisodeDetails until screen is ready
-                    Qt.callLater(function() {
-                        var screen = stackView.currentItem
-                        if (screen && typeof screen["showEpisodeDetails"] === "function") {
-                            screen["showEpisodeDetails"](episodeData)
-                        }
-                    })
-                })
-                
-                // Connect navigateToSeason signal - show season view
-                homeScreen.navigateToSeason.connect(function(seasonId, seasonNumber, seriesId, libraryId, libraryName) {
-                    playPointerSelectSound()
-                    stackView.push("LibraryScreen.qml", {
-                        currentParentId: libraryId,
-                        currentLibraryId: libraryId,
-                        currentLibraryName: libraryName,
-                        currentSeriesId: seriesId,
-                        currentSeasonId: seasonId,
-                        currentSeasonNumber: seasonNumber,
-                        showSeasonView: true,
-                        directNavigationMode: true,
-                        returnToHomeOnDirectBack: true
-                    })
-                    // Load series details for logo/poster context
-                    LibraryService.getSeriesDetails(seriesId)
-                    // Load season episodes
-                    SeriesDetailsViewModel.loadSeasonEpisodes(seasonId)
-                })
-                
-                // Connect navigateToSeries signal - show series details view
-                homeScreen.navigateToSeries.connect(function(seriesId, libraryId, libraryName) {
-                    playPointerSelectSound()
-                    stackView.push("LibraryScreen.qml", {
-                        currentParentId: libraryId,
-                        currentLibraryId: libraryId,
-                        currentLibraryName: libraryName,
-                        currentSeriesId: seriesId,
-                        showSeriesDetails: true,
-                        directNavigationMode: true,
-                        returnToHomeOnDirectBack: true
-                    })
-                    // Load series details, seasons, and next episode
-                    LibraryService.getSeriesDetails(seriesId)
-                    LibraryService.getItems(seriesId, 0, 0)  // Load seasons
-                    LibraryService.getNextUnplayedEpisode(seriesId)
-                })
-            }
-            updateSidebarNavigation()
-
-            if (pendingStartupUpdatePopup) {
-                Qt.callLater(function() {
-                    if (window.isLoggedIn) {
-                        pendingStartupUpdatePopup = false
-                        openStartupUpdateDialog()
-                    }
-                })
-            }
-        }
         
         function onLoggedOut() {
             window.showLoginScreen()

--- a/src/ui/WindowManager.cpp
+++ b/src/ui/WindowManager.cpp
@@ -18,8 +18,7 @@
 #include "viewmodels/MovieDetailsViewModel.h"
 #include "viewmodels/UpNextRecommendationsViewModel.h"
 #include "network/AuthenticationService.h"
-#include "providers/IArtworkProvider.h"
-#include "providers/jellyfin/JellyfinArtworkProvider.h"
+#include "providers/ActiveArtworkProvider.h"
 #include "network/LibraryService.h"
 #include "network/PlaybackService.h"
 #include "network/SeerrService.h"
@@ -67,7 +66,7 @@ WindowManager::~WindowManager()
 void WindowManager::setup(ConfigManager* configManager)
 {
     // ImageCacheProvider
-    m_artworkProvider = std::make_unique<JellyfinArtworkProvider>(
+    m_artworkProvider = std::make_unique<ActiveArtworkProvider>(
         ServiceLocator::get<AuthenticationService>());
     m_imageCacheProvider = new ImageCacheProvider(configManager->getImageCacheSizeMB(),
                                                    m_artworkProvider.get());

--- a/tests/ArtworkRefreshTest.cpp
+++ b/tests/ArtworkRefreshTest.cpp
@@ -109,6 +109,29 @@ private:
     ScriptedHttpServer *m_server;
 };
 
+class MissingArtworkProvider final : public IArtworkProvider
+{
+public:
+    std::optional<QNetworkRequest> resolveArtwork(
+        const Bloom::ArtworkRef &) const override
+    {
+        ++resolveCount;
+        return std::nullopt;
+    }
+
+    void refreshArtwork(const Bloom::ArtworkRef &,
+                        RefreshCallback callback) const override
+    {
+        ++refreshCount;
+        if (callback) {
+            callback(std::nullopt);
+        }
+    }
+
+    mutable int resolveCount = 0;
+    mutable int refreshCount = 0;
+};
+
 class ScopedConfigIsolation
 {
 public:
@@ -189,11 +212,32 @@ class ArtworkRefreshTest : public QObject
     Q_OBJECT
 
 private slots:
+    void missingArtworkDegradesWithoutRefresh();
     void signedUrlIsNotPartOfCacheIdentity();
     void authorizationFailureRefreshesExactlyOnce_data();
     void authorizationFailureRefreshesExactlyOnce();
     void jellyfinRefreshKeepsExistingResolvedRequest();
 };
+void ArtworkRefreshTest::missingArtworkDegradesWithoutRefresh()
+{
+    MissingArtworkProvider artworkProvider;
+    ImageCacheProvider cache(1, &artworkProvider);
+    cache.setRoundedPreprocessEnabled(false);
+
+    const Bloom::ArtworkRef artwork = artworkRef();
+    QPointer<QQuickImageResponse> response(
+        cache.requestImageResponse(artwork.cacheKey(), QSize()));
+    QVERIFY(response);
+    QSignalSpy finishedSpy(response, &QQuickImageResponse::finished);
+    QVERIFY(finishedSpy.isValid());
+
+    QTRY_COMPARE_WITH_TIMEOUT(finishedSpy.count(), 1, 3000);
+    QCOMPARE(artworkProvider.resolveCount, 1);
+    QCOMPARE(artworkProvider.refreshCount, 0);
+    QVERIFY(!response->errorString().isEmpty());
+
+    delete response;
+}
 
 void ArtworkRefreshTest::signedUrlIsNotPartOfCacheIdentity()
 {
@@ -252,16 +296,11 @@ void ArtworkRefreshTest::authorizationFailureRefreshesExactlyOnce()
     QCOMPARE(artworkProvider.refreshedArtwork.connectionId, artwork.connectionId);
     QCOMPARE(artworkProvider.refreshedArtwork.itemId, artwork.itemId);
     QCOMPARE(server.requestTargets.size(), 2);
-    QVERIFY(server.requestTargets.at(0).startsWith(
-        QStringLiteral("/old.jpg?X-Amz-Signature=expired")));
-    QVERIFY(server.requestTargets.at(1).startsWith(
-        QStringLiteral("/new.jpg?X-Amz-Signature=fresh")));
     QVERIFY(!response->errorString().isEmpty());
-
-    QTest::qWait(20);
-    QCOMPARE(artworkProvider.refreshCount, 1);
-    QCOMPARE(finishedSpy.count(), 1);
-
+    QCOMPARE(server.requestTargets.at(0),
+             QStringLiteral("/old.jpg?X-Amz-Signature=expired&X-Amz-Expires=1"));
+    QCOMPARE(server.requestTargets.at(1),
+             QStringLiteral("/new.jpg?X-Amz-Signature=fresh&X-Amz-Expires=900"));
     delete response;
 }
 

--- a/tests/ArtworkRefreshTest.cpp
+++ b/tests/ArtworkRefreshTest.cpp
@@ -1,0 +1,333 @@
+#include <QtTest/QtTest>
+
+#include <QDir>
+#include <QHostAddress>
+#include <QNetworkRequest>
+#include <QPointer>
+#include <QQuickImageResponse>
+#include <QSignalSpy>
+#include <QStandardPaths>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QTemporaryDir>
+#include <QUrlQuery>
+#include <QUuid>
+
+#include "network/AuthenticationService.h"
+#include "network/HttpTransport.h"
+#include "models/MediaModels.h"
+#include "providers/IArtworkProvider.h"
+#include "providers/ServerConnection.h"
+#include "providers/jellyfin/JellyfinArtworkProvider.h"
+#include "providers/jellyfin/JellyfinProviderAdapter.h"
+#include "ui/ImageCacheProvider.h"
+#include "utils/ConfigManager.h"
+
+namespace {
+
+class ScriptedHttpServer final : public QTcpServer
+{
+public:
+    QList<int> statuses;
+    QStringList requestTargets;
+
+    bool start()
+    {
+        connect(this, &QTcpServer::newConnection, this, [this]() {
+            while (hasPendingConnections()) {
+                QTcpSocket *socket = nextPendingConnection();
+                connect(socket, &QTcpSocket::readyRead, socket, [this, socket]() {
+                    if (socket->property("responded").toBool()) {
+                        socket->readAll();
+                        return;
+                    }
+                    QByteArray request = socket->property("requestBuffer").toByteArray();
+                    request += socket->readAll();
+                    if (!request.contains(QByteArrayLiteral("\r\n\r\n"))) {
+                        socket->setProperty("requestBuffer", request);
+                        return;
+                    }
+                    socket->setProperty("responded", true);
+                    const qsizetype lineEnd = request.indexOf("\r\n");
+                    const QList<QByteArray> requestLine = request.left(lineEnd).split(' ');
+                    if (requestLine.size() >= 2) {
+                        requestTargets.append(QString::fromUtf8(requestLine.at(1)));
+                    }
+                    const int status = statuses.isEmpty() ? 500 : statuses.takeFirst();
+                    const QByteArray reason = status == 401
+                        ? QByteArrayLiteral("Unauthorized")
+                        : (status == 403 ? QByteArrayLiteral("Forbidden")
+                                         : QByteArrayLiteral("Internal Server Error"));
+                    socket->write(QByteArrayLiteral("HTTP/1.1 ")
+                                  + QByteArray::number(status) + QByteArrayLiteral(" ")
+                                  + reason
+                                  + QByteArrayLiteral("\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"));
+                    socket->disconnectFromHost();
+                });
+            }
+        });
+        return listen(QHostAddress::LocalHost, 0);
+    }
+
+    QUrl url(const QString &target) const
+    {
+        return QUrl(QStringLiteral("http://127.0.0.1:%1%2")
+                        .arg(serverPort()).arg(target));
+    }
+};
+
+class RefreshingArtworkProvider final : public IArtworkProvider
+{
+public:
+    explicit RefreshingArtworkProvider(ScriptedHttpServer *server)
+        : m_server(server)
+    {
+    }
+
+    std::optional<QNetworkRequest> resolveArtwork(
+        const Bloom::ArtworkRef &artwork) const override
+    {
+        resolvedArtwork = artwork;
+        return QNetworkRequest(m_server->url(
+            QStringLiteral("/old.jpg?X-Amz-Signature=expired&X-Amz-Expires=1")));
+    }
+
+    void refreshArtwork(const Bloom::ArtworkRef &artwork,
+                        RefreshCallback callback) const override
+    {
+        ++refreshCount;
+        refreshedArtwork = artwork;
+        callback(QNetworkRequest(m_server->url(
+            QStringLiteral("/new.jpg?X-Amz-Signature=fresh&X-Amz-Expires=900"))));
+    }
+
+    mutable int refreshCount = 0;
+    mutable Bloom::ArtworkRef resolvedArtwork;
+    mutable Bloom::ArtworkRef refreshedArtwork;
+
+private:
+    ScriptedHttpServer *m_server;
+};
+
+class ScopedConfigIsolation
+{
+public:
+    explicit ScopedConfigIsolation(const QString &path)
+        : m_previousConfigHome(qgetenv("XDG_CONFIG_HOME"))
+        , m_previousAppData(qgetenv("APPDATA"))
+        , m_previousHome(qgetenv("HOME"))
+        , m_hadConfigHome(!m_previousConfigHome.isNull())
+        , m_hadAppData(!m_previousAppData.isNull())
+        , m_hadHome(!m_previousHome.isNull())
+    {
+        QStandardPaths::setTestModeEnabled(true);
+        qputenv("XDG_CONFIG_HOME", path.toUtf8());
+        qputenv("APPDATA", path.toUtf8());
+        qputenv("HOME", path.toUtf8());
+        QDir().mkpath(path + QStringLiteral("/Library/Preferences"));
+    }
+
+    ~ScopedConfigIsolation()
+    {
+        restore("XDG_CONFIG_HOME", m_previousConfigHome, m_hadConfigHome);
+        restore("APPDATA", m_previousAppData, m_hadAppData);
+        restore("HOME", m_previousHome, m_hadHome);
+        QStandardPaths::setTestModeEnabled(false);
+    }
+
+private:
+    static void restore(const char *name, const QByteArray &value, bool existed)
+    {
+        if (existed) {
+            qputenv(name, value);
+        } else {
+            qunsetenv(name);
+        }
+    }
+
+    QByteArray m_previousConfigHome;
+    QByteArray m_previousAppData;
+    QByteArray m_previousHome;
+    bool m_hadConfigHome;
+    bool m_hadAppData;
+    bool m_hadHome;
+};
+
+class ExposedJellyfinAuthenticationService final : public AuthenticationService
+{
+public:
+    ExposedJellyfinAuthenticationService(HttpTransport *transport,
+                                         IProviderAdapter *adapter)
+        : AuthenticationService(nullptr, transport, adapter)
+    {
+    }
+
+    void seed()
+    {
+        seedSession(QStringLiteral("https://jellyfin.example.test"),
+                    QStringLiteral("user-1"),
+                    QStringLiteral("token-1"),
+                    QStringLiteral("Alice"));
+    }
+};
+
+Bloom::ArtworkRef artworkRef()
+{
+    Bloom::ArtworkRef artwork;
+    artwork.connectionId = QStringLiteral("connection-silo");
+    artwork.itemId = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    artwork.kind = Bloom::ArtworkKind::Primary;
+    artwork.ownerKind = Bloom::ArtworkOwnerKind::MediaItem;
+    artwork.requestedWidth = 640;
+    return artwork;
+}
+
+} // namespace
+
+class ArtworkRefreshTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void signedUrlIsNotPartOfCacheIdentity();
+    void authorizationFailureRefreshesExactlyOnce_data();
+    void authorizationFailureRefreshesExactlyOnce();
+    void jellyfinRefreshKeepsExistingResolvedRequest();
+};
+
+void ArtworkRefreshTest::signedUrlIsNotPartOfCacheIdentity()
+{
+    Bloom::ArtworkRef first = artworkRef();
+    first.sourceUrl = QStringLiteral(
+        "https://images.example.test/poster.jpg?X-Amz-Signature=old&X-Amz-Expires=1");
+    Bloom::ArtworkRef refreshed = first;
+    refreshed.sourceUrl = QStringLiteral(
+        "https://images.example.test/poster.jpg?X-Amz-Signature=new&X-Amz-Expires=900");
+
+    QCOMPARE(first.cacheKey(), refreshed.cacheKey());
+    QCOMPARE(first, refreshed);
+    QVERIFY(!first.cacheKey().contains(QStringLiteral("Signature")));
+    QVERIFY(!first.cacheKey().contains(QStringLiteral("images.example.test")));
+
+    const Bloom::ArtworkRef decoded = Bloom::ArtworkRef::fromCacheKey(first.cacheKey());
+    QVERIFY(decoded.isValid());
+    QCOMPARE(decoded.connectionId, first.connectionId);
+    QCOMPARE(decoded.itemId, first.itemId);
+    QCOMPARE(decoded.kind, first.kind);
+    QCOMPARE(decoded.ownerKind, first.ownerKind);
+    QCOMPARE(decoded.requestedWidth, first.requestedWidth);
+    QVERIFY(decoded.sourceUrl.isEmpty());
+}
+
+void ArtworkRefreshTest::authorizationFailureRefreshesExactlyOnce_data()
+{
+    QTest::addColumn<int>("status");
+    QTest::newRow("unauthorized") << 401;
+    QTest::newRow("forbidden") << 403;
+}
+
+void ArtworkRefreshTest::authorizationFailureRefreshesExactlyOnce()
+{
+    QFETCH(int, status);
+
+    ScriptedHttpServer server;
+    server.statuses = {status, status};
+    QVERIFY(server.start());
+
+    RefreshingArtworkProvider artworkProvider(&server);
+    ImageCacheProvider cache(1, &artworkProvider);
+    cache.setRoundedPreprocessEnabled(false);
+
+    const Bloom::ArtworkRef artwork = artworkRef();
+    QPointer<QQuickImageResponse> response(
+        cache.requestImageResponse(artwork.cacheKey(), QSize()));
+    QVERIFY(response);
+    QSignalSpy finishedSpy(response, &QQuickImageResponse::finished);
+    QVERIFY(finishedSpy.isValid());
+
+    QTRY_COMPARE_WITH_TIMEOUT(finishedSpy.count(), 1, 3000);
+    QCOMPARE(artworkProvider.refreshCount, 1);
+    QCOMPARE(artworkProvider.resolvedArtwork.connectionId, artwork.connectionId);
+    QCOMPARE(artworkProvider.resolvedArtwork.itemId, artwork.itemId);
+    QCOMPARE(artworkProvider.refreshedArtwork.connectionId, artwork.connectionId);
+    QCOMPARE(artworkProvider.refreshedArtwork.itemId, artwork.itemId);
+    QCOMPARE(server.requestTargets.size(), 2);
+    QVERIFY(server.requestTargets.at(0).startsWith(
+        QStringLiteral("/old.jpg?X-Amz-Signature=expired")));
+    QVERIFY(server.requestTargets.at(1).startsWith(
+        QStringLiteral("/new.jpg?X-Amz-Signature=fresh")));
+    QVERIFY(!response->errorString().isEmpty());
+
+    QTest::qWait(20);
+    QCOMPARE(artworkProvider.refreshCount, 1);
+    QCOMPARE(finishedSpy.count(), 1);
+
+    delete response;
+}
+
+void ArtworkRefreshTest::jellyfinRefreshKeepsExistingResolvedRequest()
+{
+    QTemporaryDir temporaryDirectory;
+    QVERIFY(temporaryDirectory.isValid());
+    ScopedConfigIsolation isolation(temporaryDirectory.path());
+
+    ConfigManager config;
+    ServerConnection connection;
+    connection.connectionId = QStringLiteral("connection-jellyfin");
+    connection.providerKind = ProviderKind::Jellyfin;
+    connection.protocolMode = ProtocolMode::Native;
+    connection.baseUrl = QStringLiteral("https://jellyfin.example.test");
+    connection.accountId = QStringLiteral("user-1");
+    connection.credentialReference = QStringLiteral("credential-jellyfin");
+    QVERIFY(connection.isValid());
+    config.upsertConnection(connection, true);
+
+    HttpTransport transport;
+    JellyfinProviderAdapter adapter;
+    ExposedJellyfinAuthenticationService auth(&transport, &adapter);
+    auth.initialize(&config);
+    auth.seed();
+    QVERIFY(auth.isAuthenticated());
+
+    JellyfinArtworkProvider provider(&auth);
+    Bloom::ArtworkRef artwork;
+    artwork.connectionId = connection.connectionId;
+    artwork.itemId = QStringLiteral("item-1");
+    artwork.kind = Bloom::ArtworkKind::Primary;
+    artwork.ownerKind = Bloom::ArtworkOwnerKind::MediaItem;
+    artwork.requestedWidth = 640;
+    artwork.tag = QStringLiteral("stable-tag");
+
+    const auto directlyResolved = provider.resolveArtwork(artwork);
+    QVERIFY(directlyResolved.has_value());
+    QCOMPARE(directlyResolved->url().path(),
+             QStringLiteral("/Items/item-1/Images/Primary"));
+    const QUrlQuery directQuery(directlyResolved->url());
+    QCOMPARE(directQuery.queryItemValue(QStringLiteral("fillWidth")),
+             QStringLiteral("640"));
+    QCOMPARE(directQuery.queryItemValue(QStringLiteral("quality")),
+             QStringLiteral("95"));
+    QCOMPARE(directQuery.queryItemValue(QStringLiteral("tag")),
+             QStringLiteral("stable-tag"));
+    QVERIFY(directlyResolved->rawHeader("Authorization").contains(
+        QByteArrayLiteral("Token=\"token-1\"")));
+
+    int callbacks = 0;
+    std::optional<QNetworkRequest> refreshed;
+    provider.refreshArtwork(
+        artwork,
+        [&](std::optional<QNetworkRequest> request) {
+            ++callbacks;
+            refreshed = std::move(request);
+        });
+
+    QCOMPARE(callbacks, 0);
+    QTRY_COMPARE_WITH_TIMEOUT(callbacks, 1, 1000);
+    QVERIFY(refreshed.has_value());
+    QCOMPARE(refreshed->url(), directlyResolved->url());
+    QCOMPARE(refreshed->rawHeader("Authorization"),
+             directlyResolved->rawHeader("Authorization"));
+}
+
+QTEST_MAIN(ArtworkRefreshTest)
+#include "ArtworkRefreshTest.moc"

--- a/tests/ArtworkRefreshTest.cpp
+++ b/tests/ArtworkRefreshTest.cpp
@@ -1,12 +1,10 @@
 #include <QtTest/QtTest>
 
-#include <QDir>
 #include <QHostAddress>
 #include <QNetworkRequest>
 #include <QPointer>
 #include <QQuickImageResponse>
 #include <QSignalSpy>
-#include <QStandardPaths>
 #include <QTcpServer>
 #include <QTcpSocket>
 #include <QTemporaryDir>
@@ -22,6 +20,8 @@
 #include "providers/jellyfin/JellyfinProviderAdapter.h"
 #include "ui/ImageCacheProvider.h"
 #include "utils/ConfigManager.h"
+
+#include "TestConfigIsolation.h"
 
 namespace {
 
@@ -132,50 +132,6 @@ public:
     mutable int refreshCount = 0;
 };
 
-class ScopedConfigIsolation
-{
-public:
-    explicit ScopedConfigIsolation(const QString &path)
-        : m_previousConfigHome(qgetenv("XDG_CONFIG_HOME"))
-        , m_previousAppData(qgetenv("APPDATA"))
-        , m_previousHome(qgetenv("HOME"))
-        , m_hadConfigHome(!m_previousConfigHome.isNull())
-        , m_hadAppData(!m_previousAppData.isNull())
-        , m_hadHome(!m_previousHome.isNull())
-    {
-        QStandardPaths::setTestModeEnabled(true);
-        qputenv("XDG_CONFIG_HOME", path.toUtf8());
-        qputenv("APPDATA", path.toUtf8());
-        qputenv("HOME", path.toUtf8());
-        QDir().mkpath(path + QStringLiteral("/Library/Preferences"));
-    }
-
-    ~ScopedConfigIsolation()
-    {
-        restore("XDG_CONFIG_HOME", m_previousConfigHome, m_hadConfigHome);
-        restore("APPDATA", m_previousAppData, m_hadAppData);
-        restore("HOME", m_previousHome, m_hadHome);
-        QStandardPaths::setTestModeEnabled(false);
-    }
-
-private:
-    static void restore(const char *name, const QByteArray &value, bool existed)
-    {
-        if (existed) {
-            qputenv(name, value);
-        } else {
-            qunsetenv(name);
-        }
-    }
-
-    QByteArray m_previousConfigHome;
-    QByteArray m_previousAppData;
-    QByteArray m_previousHome;
-    bool m_hadConfigHome;
-    bool m_hadAppData;
-    bool m_hadHome;
-};
-
 class ExposedJellyfinAuthenticationService final : public AuthenticationService
 {
 public:
@@ -213,6 +169,7 @@ class ArtworkRefreshTest : public QObject
 
 private slots:
     void missingArtworkDegradesWithoutRefresh();
+    void tokenFreeCacheMissRetainsTransientSourceUrl();
     void signedUrlIsNotPartOfCacheIdentity();
     void authorizationFailureRefreshesExactlyOnce_data();
     void authorizationFailureRefreshesExactlyOnce();
@@ -239,6 +196,35 @@ void ArtworkRefreshTest::missingArtworkDegradesWithoutRefresh()
     delete response;
 }
 
+void ArtworkRefreshTest::tokenFreeCacheMissRetainsTransientSourceUrl()
+{
+    ScriptedHttpServer server;
+    server.statuses = {500};
+    QVERIFY(server.start());
+
+    RefreshingArtworkProvider artworkProvider(&server);
+    ImageCacheProvider cache(1, &artworkProvider);
+    cache.setRoundedPreprocessEnabled(false);
+
+    Bloom::ArtworkRef artwork = artworkRef();
+    artwork.sourceUrl = server.url(
+        QStringLiteral("/artwork/poster.jpg?X-Amz-Signature=transient")).toString();
+    const QVariantMap emitted = artwork.toVariantMap();
+    QVERIFY(!emitted.contains(QStringLiteral("sourceUrl")));
+    QVERIFY(!artwork.cacheKey().contains(QStringLiteral("X-Amz-Signature")));
+
+    QPointer<QQuickImageResponse> response(
+        cache.requestImageResponse(artwork.cacheKey(), QSize()));
+    QVERIFY(response);
+    QCOMPARE(artworkProvider.resolvedArtwork.sourceUrl, artwork.sourceUrl);
+
+    QSignalSpy finishedSpy(response, &QQuickImageResponse::finished);
+    QVERIFY(finishedSpy.isValid());
+    QTRY_COMPARE_WITH_TIMEOUT(finishedSpy.count(), 1, 3000);
+    QVERIFY(!response->errorString().isEmpty());
+    delete response;
+}
+
 void ArtworkRefreshTest::signedUrlIsNotPartOfCacheIdentity()
 {
     Bloom::ArtworkRef first = artworkRef();
@@ -261,6 +247,10 @@ void ArtworkRefreshTest::signedUrlIsNotPartOfCacheIdentity()
     QCOMPARE(decoded.ownerKind, first.ownerKind);
     QCOMPARE(decoded.requestedWidth, first.requestedWidth);
     QVERIFY(decoded.sourceUrl.isEmpty());
+    QCOMPARE(Bloom::artworkOwnerKindFromName(QStringLiteral("mediaItem")),
+             Bloom::ArtworkOwnerKind::MediaItem);
+    QCOMPARE(Bloom::artworkOwnerKindFromName(QStringLiteral("unknown-owner")),
+             Bloom::ArtworkOwnerKind::MediaItem);
 }
 
 void ArtworkRefreshTest::authorizationFailureRefreshesExactlyOnce_data()

--- a/tests/ArtworkRefreshTest.cpp
+++ b/tests/ArtworkRefreshTest.cpp
@@ -15,7 +15,7 @@
 #include "network/HttpTransport.h"
 #include "models/MediaModels.h"
 #include "providers/IArtworkProvider.h"
-#include "providers/ServerConnection.h"
+#include "providers/silo/SiloArtworkProvider.h"
 #include "providers/jellyfin/JellyfinArtworkProvider.h"
 #include "providers/jellyfin/JellyfinProviderAdapter.h"
 #include "ui/ImageCacheProvider.h"
@@ -174,6 +174,7 @@ private slots:
     void authorizationFailureRefreshesExactlyOnce_data();
     void authorizationFailureRefreshesExactlyOnce();
     void jellyfinRefreshKeepsExistingResolvedRequest();
+    void siloRefreshCompletesAfterAuthenticationServiceDestruction();
 };
 void ArtworkRefreshTest::missingArtworkDegradesWithoutRefresh()
 {
@@ -356,6 +357,25 @@ void ArtworkRefreshTest::jellyfinRefreshKeepsExistingResolvedRequest()
     QCOMPARE(refreshed->url(), directlyResolved->url());
     QCOMPARE(refreshed->rawHeader("Authorization"),
              directlyResolved->rawHeader("Authorization"));
+}
+void ArtworkRefreshTest::siloRefreshCompletesAfterAuthenticationServiceDestruction()
+{
+    auto *auth = new AuthenticationService;
+    SiloArtworkProvider provider(auth);
+
+    int callbacks = 0;
+    bool receivedEmptyRequest = false;
+    provider.refreshArtwork(
+        artworkRef(),
+        [&callbacks, &receivedEmptyRequest](std::optional<QNetworkRequest> request) {
+            ++callbacks;
+            receivedEmptyRequest = !request.has_value();
+        });
+
+    QCOMPARE(callbacks, 0);
+    delete auth;
+    QTRY_COMPARE_WITH_TIMEOUT(callbacks, 1, 1000);
+    QVERIFY(receivedEmptyRequest);
 }
 
 QTEST_MAIN(ArtworkRefreshTest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -259,6 +259,113 @@ target_link_libraries(ProviderTransportTest
 
 add_test(NAME ProviderTransportTest COMMAND ProviderTransportTest)
 
+add_executable(SiloAuthenticationTest
+    SiloAuthenticationTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloModelMapper.cpp
+    ${TEST_PROVIDER_BOUNDARY_SOURCES}
+    ${TEST_CONFIG_SOURCES}
+    ${CMAKE_SOURCE_DIR}/src/resources/mpv-shaders.qrc
+)
+
+target_include_directories(SiloAuthenticationTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+target_link_libraries(SiloAuthenticationTest
+    PRIVATE
+        Qt6::Core
+        Qt6::Concurrent
+        Qt6::Network
+        Qt6::Test
+)
+
+add_test(NAME SiloAuthenticationTest COMMAND SiloAuthenticationTest)
+
+add_executable(ProviderCatalogTest
+    ProviderCatalogTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/models/MediaModels.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinAuthenticator.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinModelMapper.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinPlaybackProvider.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinRequestFactory.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloModelMapper.cpp
+    ${TEST_LOGGING_SOURCES}
+)
+
+target_include_directories(ProviderCatalogTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+target_link_libraries(ProviderCatalogTest
+    PRIVATE
+        Qt6::Core
+        Qt6::Network
+        Qt6::Test
+)
+
+add_test(NAME ProviderCatalogTest COMMAND ProviderCatalogTest)
+
+add_executable(SiloCatalogServiceTest
+    SiloCatalogServiceTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloModelMapper.cpp
+    ${TEST_PROVIDER_BOUNDARY_SOURCES}
+    ${TEST_CONFIG_SOURCES}
+    ${CMAKE_SOURCE_DIR}/src/resources/mpv-shaders.qrc
+)
+
+target_include_directories(SiloCatalogServiceTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+target_link_libraries(SiloCatalogServiceTest
+    PRIVATE
+        Qt6::Core
+        Qt6::Concurrent
+        Qt6::Network
+        Qt6::Test
+)
+
+add_test(NAME SiloCatalogServiceTest COMMAND SiloCatalogServiceTest)
+
+add_executable(ArtworkRefreshTest
+    ArtworkRefreshTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloModelMapper.cpp
+    ${CMAKE_SOURCE_DIR}/src/ui/ImageCacheProvider.cpp
+    ${TEST_PROVIDER_BOUNDARY_SOURCES}
+    ${TEST_CONFIG_SOURCES}
+    ${CMAKE_SOURCE_DIR}/src/resources/mpv-shaders.qrc
+)
+
+target_include_directories(ArtworkRefreshTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+target_link_libraries(ArtworkRefreshTest
+    PRIVATE
+        Qt6::Core
+        Qt6::Concurrent
+        Qt6::Gui
+        Qt6::Network
+        Qt6::Quick
+        Qt6::Sql
+        Qt6::Test
+)
+
+add_test(NAME ArtworkRefreshTest COMMAND ArtworkRefreshTest)
+
 add_executable(CanonicalModelsTest
     CanonicalModelsTest.cpp
     ${CMAKE_SOURCE_DIR}/src/models/MediaModels.cpp
@@ -620,6 +727,9 @@ qt_add_executable(VisualRegressionTest
     # Network sources
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
     ${TEST_PROVIDER_BOUNDARY_SOURCES}
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloModelMapper.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/ActiveArtworkProvider.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloArtworkProvider.cpp
     ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/network/PlaybackService.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -198,6 +198,7 @@ add_test(NAME ConfigManagerThemeTest COMMAND ConfigManagerThemeTest)
 
 add_executable(ConnectionPersistenceTest
     ConnectionPersistenceTest.cpp
+    TestConfigIsolation.h
     ${CMAKE_SOURCE_DIR}/src/network/SessionManager.cpp
     ${TEST_CONFIG_SOURCES}
     ${CMAKE_SOURCE_DIR}/src/resources/mpv-shaders.qrc
@@ -312,6 +313,7 @@ add_test(NAME ProviderCatalogTest COMMAND ProviderCatalogTest)
 
 add_executable(SiloCatalogServiceTest
     SiloCatalogServiceTest.cpp
+    TestConfigIsolation.h
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
@@ -339,6 +341,7 @@ add_test(NAME SiloCatalogServiceTest COMMAND SiloCatalogServiceTest)
 
 add_executable(ArtworkRefreshTest
     ArtworkRefreshTest.cpp
+    TestConfigIsolation.h
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloModelMapper.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -345,6 +345,7 @@ add_executable(ArtworkRefreshTest
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
     ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloModelMapper.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloArtworkProvider.cpp
     ${CMAKE_SOURCE_DIR}/src/ui/ImageCacheProvider.cpp
     ${TEST_PROVIDER_BOUNDARY_SOURCES}
     ${TEST_CONFIG_SOURCES}

--- a/tests/ConnectionPersistenceTest.cpp
+++ b/tests/ConnectionPersistenceTest.cpp
@@ -168,6 +168,26 @@ ServerConnection jellyfinConnection()
     return connection;
 }
 
+ServerConnection siloConnection(const QString &connectionId,
+                                const QString &baseUrl,
+                                const QString &accountId,
+                                const QString &profileId,
+                                const QString &serverId = QString())
+{
+    ServerConnection connection;
+    connection.connectionId = connectionId;
+    connection.providerKind = ProviderKind::Silo;
+    connection.protocolMode = ProtocolMode::Native;
+    connection.baseUrl = baseUrl;
+    connection.serverId = serverId;
+    connection.accountId = accountId;
+    connection.profileId = profileId;
+    connection.username = accountId;
+    connection.displayName = profileId;
+    connection.credentialReference = ServerConnection::createCredentialReference(connectionId);
+    return connection;
+}
+
 } // namespace
 
 class ConnectionPersistenceTest : public QObject
@@ -188,6 +208,9 @@ private slots:
     void connectionPersistenceSupportsMultipleServers();
     void connectionScopedSettingsPreventRemoteIdCollisions();
     void preActivationConnectionStateIsAdopted();
+    void siloConnectionsDoNotMergeOnMissingOrDefaultServerIdentity();
+    void siloAccountAndProfileSwitchesKeepStateIsolated();
+    void siloCredentialsAreKindAndConnectionScoped();
     void reservedConnectionScopeIdsAreRejected();
     void inactiveSoleConnectionReceivesV28StateMigration();
     void credentialStoreMigratesLegacyEntryAfterVerifiedCopy();
@@ -528,6 +551,120 @@ void ConnectionPersistenceTest::connectionScopedSettingsPreventRemoteIdCollision
     QVERIFY(config.setActiveConnection(second.connectionId));
     QCOMPARE(config.getLibraryProfile(QStringLiteral("shared-library")),
              QStringLiteral("Medium Quality"));
+}
+
+void ConnectionPersistenceTest::siloConnectionsDoNotMergeOnMissingOrDefaultServerIdentity()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    {
+        ConfigManager config;
+        config.load();
+        config.upsertConnection(siloConnection(QStringLiteral("silo-one"),
+                                               QStringLiteral("https://one.example.test"),
+                                               QStringLiteral("account-1"),
+                                               QStringLiteral("profile-1")));
+        config.upsertConnection(siloConnection(QStringLiteral("silo-two"),
+                                               QStringLiteral("https://two.example.test"),
+                                               QStringLiteral("account-2"),
+                                               QStringLiteral("profile-2"),
+                                               QStringLiteral("b2d9e6c9-1237-5add-a687-5dae547ece33")));
+        config.upsertConnection(siloConnection(QStringLiteral("silo-three"),
+                                               QStringLiteral("https://three.example.test"),
+                                               QStringLiteral("account-3"),
+                                               QStringLiteral("profile-3"),
+                                               QStringLiteral("b2d9e6c9-1237-5add-a687-5dae547ece33")));
+
+        QCOMPARE(config.getConnections().size(), 3);
+        QVERIFY(config.getConnection(QStringLiteral("silo-one")).has_value());
+        QVERIFY(config.getConnection(QStringLiteral("silo-two")).has_value());
+        QVERIFY(config.getConnection(QStringLiteral("silo-three")).has_value());
+    }
+
+    ConfigManager reloaded;
+    reloaded.load();
+    QCOMPARE(reloaded.getConnections().size(), 3);
+    QVERIFY(reloaded.getConnection(QStringLiteral("silo-one"))->serverId.isEmpty());
+    QCOMPARE(reloaded.getConnection(QStringLiteral("silo-two"))->serverId,
+             QStringLiteral("b2d9e6c9-1237-5add-a687-5dae547ece33"));
+    QCOMPARE(reloaded.getConnection(QStringLiteral("silo-three"))->serverId,
+             QStringLiteral("b2d9e6c9-1237-5add-a687-5dae547ece33"));
+}
+
+void ConnectionPersistenceTest::siloAccountAndProfileSwitchesKeepStateIsolated()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    const ServerConnection adult = siloConnection(QStringLiteral("silo-adult"),
+                                                  QStringLiteral("https://silo.example.test"),
+                                                  QStringLiteral("account-1"),
+                                                  QStringLiteral("profile-adult"));
+    const ServerConnection child = siloConnection(QStringLiteral("silo-child"),
+                                                  QStringLiteral("https://silo.example.test"),
+                                                  QStringLiteral("account-1"),
+                                                  QStringLiteral("profile-child"));
+
+    config.upsertConnection(adult);
+    config.setLibraryProfile(QStringLiteral("shared-library"), QStringLiteral("Adult Quality"));
+    config.upsertConnection(child);
+    QVERIFY(config.getLibraryProfile(QStringLiteral("shared-library")).isEmpty());
+    config.setLibraryProfile(QStringLiteral("shared-library"), QStringLiteral("Child Quality"));
+
+    QVERIFY(config.setActiveConnection(adult.connectionId));
+    QCOMPARE(config.getActiveConnection()->profileId, QStringLiteral("profile-adult"));
+    QCOMPARE(config.getLibraryProfile(QStringLiteral("shared-library")),
+             QStringLiteral("Adult Quality"));
+    QVERIFY(config.setActiveConnection(child.connectionId));
+    QCOMPARE(config.getActiveConnection()->profileId, QStringLiteral("profile-child"));
+    QCOMPARE(config.getLibraryProfile(QStringLiteral("shared-library")),
+             QStringLiteral("Child Quality"));
+}
+
+void ConnectionPersistenceTest::siloCredentialsAreKindAndConnectionScoped()
+{
+    FakeSecretStore secretStore;
+    CredentialStore credentials(&secretStore);
+    const ServerConnection adult = siloConnection(QStringLiteral("silo-adult"),
+                                                  QStringLiteral("https://silo.example.test"),
+                                                  QStringLiteral("account-1"),
+                                                  QStringLiteral("profile-adult"));
+    const ServerConnection child = siloConnection(QStringLiteral("silo-child"),
+                                                  QStringLiteral("https://silo.example.test"),
+                                                  QStringLiteral("account-1"),
+                                                  QStringLiteral("profile-child"));
+
+    QVERIFY(credentials.write(adult, CredentialKind::AccessToken, QStringLiteral("adult-access")));
+    QVERIFY(credentials.write(adult, CredentialKind::RefreshToken, QStringLiteral("adult-refresh")));
+    QVERIFY(credentials.write(adult, CredentialKind::ProfileToken, QStringLiteral("adult-profile")));
+    QVERIFY(credentials.write(child, CredentialKind::AccessToken, QStringLiteral("child-access")));
+    QVERIFY(credentials.write(child, CredentialKind::RefreshToken, QStringLiteral("child-refresh")));
+    QVERIFY(credentials.write(child, CredentialKind::ProfileToken, QStringLiteral("child-profile")));
+
+    QCOMPARE(credentials.read(adult, CredentialKind::AccessToken), QStringLiteral("adult-access"));
+    QCOMPARE(credentials.read(adult, CredentialKind::RefreshToken), QStringLiteral("adult-refresh"));
+    QCOMPARE(credentials.read(adult, CredentialKind::ProfileToken), QStringLiteral("adult-profile"));
+    QCOMPARE(credentials.read(child, CredentialKind::AccessToken), QStringLiteral("child-access"));
+    QCOMPARE(credentials.read(child, CredentialKind::RefreshToken), QStringLiteral("child-refresh"));
+    QCOMPARE(credentials.read(child, CredentialKind::ProfileToken), QStringLiteral("child-profile"));
+
+    QVERIFY(credentials.remove(adult, CredentialKind::ProfileToken));
+    QVERIFY(credentials.read(adult, CredentialKind::ProfileToken).isEmpty());
+    QCOMPARE(credentials.read(adult, CredentialKind::AccessToken), QStringLiteral("adult-access"));
+    QCOMPARE(credentials.read(adult, CredentialKind::RefreshToken), QStringLiteral("adult-refresh"));
+    QCOMPARE(credentials.read(child, CredentialKind::ProfileToken), QStringLiteral("child-profile"));
+
+    QVERIFY(credentials.removeAll(adult, QStringLiteral("device-1")));
+    QVERIFY(credentials.read(adult, CredentialKind::AccessToken).isEmpty());
+    QVERIFY(credentials.read(adult, CredentialKind::RefreshToken).isEmpty());
+    QCOMPARE(credentials.read(child, CredentialKind::AccessToken), QStringLiteral("child-access"));
+    QCOMPARE(credentials.read(child, CredentialKind::RefreshToken), QStringLiteral("child-refresh"));
+    QCOMPARE(credentials.read(child, CredentialKind::ProfileToken), QStringLiteral("child-profile"));
 }
 
 void ConnectionPersistenceTest::preActivationConnectionStateIsAdopted()

--- a/tests/ConnectionPersistenceTest.cpp
+++ b/tests/ConnectionPersistenceTest.cpp
@@ -203,6 +203,7 @@ private slots:
     void jellyfinFacadeUpsertsStableConnectionWithoutPersistingToken();
     void pendingLegacyTokenIsNotAttachedToAnotherActiveAccount();
     void loggingOutAnotherAccountRetainsPendingLegacyMigration();
+    void siloLogoutRetainsPendingLegacyJellyfinMigration();
     void loggingOutMatchingAccountClearsPendingLegacyMigration();
     void jellyfinFacadeDoesNotOverwriteAnotherServerOrAccount();
     void connectionPersistenceSupportsMultipleServers();
@@ -432,6 +433,29 @@ void ConnectionPersistenceTest::loggingOutAnotherAccountRetainsPendingLegacyMigr
     QCOMPARE(config.getPendingLegacyJellyfinSession().accessToken,
              QStringLiteral("alice-token"));
 }
+void ConnectionPersistenceTest::siloLogoutRetainsPendingLegacyJellyfinMigration()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation isolation(tempDir.path());
+    writeConfig(legacyV27Config(QStringLiteral("alice-token")));
+
+    ConfigManager config;
+    config.load();
+    ServerConnection silo = siloConnection(QStringLiteral("silo-connection"),
+                                           QStringLiteral("https://silo.example.test"),
+                                           QStringLiteral("account-silo"),
+                                           QStringLiteral("profile-silo"));
+    config.upsertConnection(silo);
+
+    config.clearActiveConnection();
+
+    QVERIFY(!config.getActiveConnection().has_value());
+    QVERIFY(config.hasPendingLegacyJellyfinMigration());
+    QCOMPARE(config.getPendingLegacyJellyfinSession().accessToken,
+             QStringLiteral("alice-token"));
+}
+
 
 void ConnectionPersistenceTest::loggingOutMatchingAccountClearsPendingLegacyMigration()
 {

--- a/tests/ConnectionPersistenceTest.cpp
+++ b/tests/ConnectionPersistenceTest.cpp
@@ -5,7 +5,6 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QStandardPaths>
 #include <QTemporaryDir>
 
 #include "network/SessionManager.h"
@@ -14,51 +13,9 @@
 #include "security/ISecretStore.h"
 #include "utils/ConfigManager.h"
 
+#include "TestConfigIsolation.h"
+
 namespace {
-
-class ScopedConfigIsolation
-{
-public:
-    explicit ScopedConfigIsolation(const QString &path)
-        : m_previousConfigHome(qgetenv("XDG_CONFIG_HOME"))
-        , m_previousAppData(qgetenv("APPDATA"))
-        , m_previousHome(qgetenv("HOME"))
-        , m_hadPreviousConfigHome(!m_previousConfigHome.isNull())
-        , m_hadPreviousAppData(!m_previousAppData.isNull())
-        , m_hadPreviousHome(!m_previousHome.isNull())
-    {
-        QStandardPaths::setTestModeEnabled(true);
-        qputenv("XDG_CONFIG_HOME", path.toUtf8());
-        qputenv("APPDATA", path.toUtf8());
-        qputenv("HOME", path.toUtf8());
-        QDir().mkpath(path + QStringLiteral("/Library/Preferences"));
-    }
-
-    ~ScopedConfigIsolation()
-    {
-        restore("XDG_CONFIG_HOME", m_previousConfigHome, m_hadPreviousConfigHome);
-        restore("APPDATA", m_previousAppData, m_hadPreviousAppData);
-        restore("HOME", m_previousHome, m_hadPreviousHome);
-        QStandardPaths::setTestModeEnabled(false);
-    }
-
-private:
-    static void restore(const char *name, const QByteArray &value, bool hadPrevious)
-    {
-        if (hadPrevious) {
-            qputenv(name, value);
-        } else {
-            qunsetenv(name);
-        }
-    }
-
-    QByteArray m_previousConfigHome;
-    QByteArray m_previousAppData;
-    QByteArray m_previousHome;
-    bool m_hadPreviousConfigHome;
-    bool m_hadPreviousAppData;
-    bool m_hadPreviousHome;
-};
 
 class FakeSecretStore : public ISecretStore
 {
@@ -318,11 +275,13 @@ void ConnectionPersistenceTest::v27MigrationUsesStableConnectionIdentityBeforeFi
 
     ConfigManager firstLoad;
     firstLoad.load();
+    QVERIFY(firstLoad.getActiveConnection().has_value());
     const QString firstId = firstLoad.getActiveConnection()->connectionId;
 
     writeConfig(legacy);
     ConfigManager secondLoad;
     secondLoad.load();
+    QVERIFY(secondLoad.getActiveConnection().has_value());
     QCOMPARE(secondLoad.getActiveConnection()->connectionId, firstId);
 }
 
@@ -362,6 +321,7 @@ void ConnectionPersistenceTest::jellyfinFacadeUpsertsStableConnectionWithoutPers
                                QStringLiteral("user-1"),
                                QStringLiteral("must-not-be-persisted"),
                                QStringLiteral("Alice"));
+    QVERIFY(config.getActiveConnection().has_value());
     const QString connectionId = config.getActiveConnection()->connectionId;
 
     config.setJellyfinSession(QStringLiteral("https://media.example.test"),
@@ -370,6 +330,7 @@ void ConnectionPersistenceTest::jellyfinFacadeUpsertsStableConnectionWithoutPers
                                QStringLiteral("Alice Updated"));
 
     QCOMPARE(config.getConnections().size(), 1);
+    QVERIFY(config.getActiveConnection().has_value());
     QCOMPARE(config.getActiveConnection()->connectionId, connectionId);
     QCOMPARE(config.getActiveConnection()->accountId, QStringLiteral("user-1"));
     QCOMPARE(config.getActiveConnection()->username, QStringLiteral("Alice Updated"));
@@ -484,6 +445,7 @@ void ConnectionPersistenceTest::jellyfinFacadeDoesNotOverwriteAnotherServerOrAcc
                               QStringLiteral("user-1"),
                               QString(),
                               QStringLiteral("Alice"));
+    QVERIFY(config.getActiveConnection().has_value());
     const QString firstId = config.getActiveConnection()->connectionId;
 
     config.setJellyfinSession(QStringLiteral("https://two.example.test"),
@@ -492,13 +454,15 @@ void ConnectionPersistenceTest::jellyfinFacadeDoesNotOverwriteAnotherServerOrAcc
                               QStringLiteral("Bob"));
     QCOMPARE(config.getConnections().size(), 2);
     QVERIFY(config.getConnection(firstId).has_value());
-    QVERIFY(config.getActiveConnection()->connectionId != firstId);
+    QVERIFY(config.getActiveConnection().has_value());
+    QCOMPARE(config.getActiveConnection()->connectionId != firstId, true);
 
     config.setJellyfinSession(QStringLiteral("https://two.example.test"),
                               QStringLiteral("user-3"),
                               QString(),
                               QStringLiteral("Carol"));
     QCOMPARE(config.getConnections().size(), 3);
+    QVERIFY(config.getConnection(firstId).has_value());
     QCOMPARE(config.getConnection(firstId)->username, QStringLiteral("Alice"));
 }
 
@@ -520,8 +484,10 @@ void ConnectionPersistenceTest::connectionPersistenceSupportsMultipleServers()
     config.upsertConnection(second);
 
     QCOMPARE(config.getConnections().size(), 2);
+    QVERIFY(config.getActiveConnection().has_value());
     QCOMPARE(config.getActiveConnection()->connectionId, QStringLiteral("connection-2"));
     QVERIFY(config.setActiveConnection(first.connectionId));
+    QVERIFY(config.getActiveConnection().has_value());
     QCOMPARE(config.getActiveConnection()->connectionId, first.connectionId);
     config.clearActiveConnection();
     QVERIFY(!config.getActiveConnection().has_value());
@@ -550,6 +516,7 @@ void ConnectionPersistenceTest::connectionScopedSettingsPreventRemoteIdCollision
 
     ConfigManager config;
     config.load();
+    QVERIFY(config.getActiveConnection().has_value());
     const ServerConnection first = *config.getActiveConnection();
     QCOMPARE(config.getLibraryProfile(QStringLiteral("shared-library")),
              QStringLiteral("High Quality"));
@@ -610,10 +577,16 @@ void ConnectionPersistenceTest::siloConnectionsDoNotMergeOnMissingOrDefaultServe
     ConfigManager reloaded;
     reloaded.load();
     QCOMPARE(reloaded.getConnections().size(), 3);
-    QVERIFY(reloaded.getConnection(QStringLiteral("silo-one"))->serverId.isEmpty());
-    QCOMPARE(reloaded.getConnection(QStringLiteral("silo-two"))->serverId,
+    const auto siloOne = reloaded.getConnection(QStringLiteral("silo-one"));
+    const auto siloTwo = reloaded.getConnection(QStringLiteral("silo-two"));
+    const auto siloThree = reloaded.getConnection(QStringLiteral("silo-three"));
+    QVERIFY(siloOne.has_value());
+    QVERIFY(siloTwo.has_value());
+    QVERIFY(siloThree.has_value());
+    QVERIFY(siloOne->serverId.isEmpty());
+    QCOMPARE(siloTwo->serverId,
              QStringLiteral("b2d9e6c9-1237-5add-a687-5dae547ece33"));
-    QCOMPARE(reloaded.getConnection(QStringLiteral("silo-three"))->serverId,
+    QCOMPARE(siloThree->serverId,
              QStringLiteral("b2d9e6c9-1237-5add-a687-5dae547ece33"));
 }
 
@@ -641,10 +614,12 @@ void ConnectionPersistenceTest::siloAccountAndProfileSwitchesKeepStateIsolated()
     config.setLibraryProfile(QStringLiteral("shared-library"), QStringLiteral("Child Quality"));
 
     QVERIFY(config.setActiveConnection(adult.connectionId));
+    QVERIFY(config.getActiveConnection().has_value());
     QCOMPARE(config.getActiveConnection()->profileId, QStringLiteral("profile-adult"));
     QCOMPARE(config.getLibraryProfile(QStringLiteral("shared-library")),
              QStringLiteral("Adult Quality"));
     QVERIFY(config.setActiveConnection(child.connectionId));
+    QVERIFY(config.getActiveConnection().has_value());
     QCOMPARE(config.getActiveConnection()->profileId, QStringLiteral("profile-child"));
     QCOMPARE(config.getLibraryProfile(QStringLiteral("shared-library")),
              QStringLiteral("Child Quality"));
@@ -995,6 +970,7 @@ void ConnectionPersistenceTest::deviceRotationMigratesLegacyConfigFallback()
 
     QVERIFY(sessionManager.rotateDeviceId());
     CredentialStore credentials(&secretStore);
+    QVERIFY(config.getActiveConnection().has_value());
     QCOMPARE(credentials.read(*config.getActiveConnection(), CredentialKind::AccessToken),
              QStringLiteral("legacy-config-token"));
 }

--- a/tests/LibraryItemQueryTest.cpp
+++ b/tests/LibraryItemQueryTest.cpp
@@ -10,6 +10,7 @@ private slots:
     void cacheKeySeparatesSearchFilterAndSort();
     void cacheKeySeparatesPaginationAndHeavyFields();
     void artworkSourcePreservesConnectionIdentity();
+    void providerSnapshotCarriesAcrossPages();
 };
 
 void LibraryItemQueryTest::cacheKeySeparatesSearchFilterAndSort()
@@ -58,6 +59,20 @@ void LibraryItemQueryTest::cacheKeySeparatesPaginationAndHeavyFields()
     QVERIFY(firstPage.cacheKey() != unpaged.cacheKey());
     QVERIFY(firstPage.cacheKey() != differentLimit.cacheKey());
     QVERIFY(firstPage.cacheKey() != lightFields.cacheKey());
+}
+
+void LibraryItemQueryTest::providerSnapshotCarriesAcrossPages()
+{
+    ProviderCatalogQuery firstPage;
+    firstPage.startIndex = 0;
+    firstPage.limit = 250;
+    firstPage.snapshot = QStringLiteral("catalog-snapshot-1");
+
+    ProviderCatalogQuery nextPage = firstPage;
+    nextPage.startIndex = 250;
+
+    QVERIFY(nextPage.snapshot.has_value());
+    QCOMPARE(*nextPage.snapshot, QStringLiteral("catalog-snapshot-1"));
 }
 
 void LibraryItemQueryTest::artworkSourcePreservesConnectionIdentity()

--- a/tests/ProviderCatalogTest.cpp
+++ b/tests/ProviderCatalogTest.cpp
@@ -1,9 +1,11 @@
 #include <QtTest/QtTest>
 
 #include <QJsonArray>
+#include <QJsonDocument>
 #include <QJsonObject>
 #include <QUrl>
 #include <QUrlQuery>
+#include <limits>
 
 #include "providers/ICatalogProvider.h"
 #include "providers/jellyfin/JellyfinProviderAdapter.h"
@@ -20,7 +22,9 @@ private slots:
     void jellyfinMutationsAndPaginationRemainCompatible();
     void siloCanonicalIdentityVersionsMultipartAndStateUseMilliseconds();
     void canonicalArtworkAndPlaybackChapterMetadataRemainProviderNeutral();
+    void siloEpisodeParentAndBoundedTimes();
     void siloNumericSeasonRoutesAndEnvelopeOperation();
+
 };
 
 void ProviderCatalogTest::jellyfinItemsRequestRetainsNativeContract()
@@ -366,6 +370,67 @@ void ProviderCatalogTest::canonicalArtworkAndPlaybackChapterMetadataRemainProvid
     QCOMPARE(descriptorMap.value(QStringLiteral("chapters")).toList().first().toMap()
                  .value(QStringLiteral("startMs")).toLongLong(), 1250);
 }
+
+void ProviderCatalogTest::siloEpisodeParentAndBoundedTimes()
+{
+    const QJsonObject episode{
+        {QStringLiteral("content_id"), QStringLiteral("episode-1")},
+        {QStringLiteral("type"), QStringLiteral("episode")},
+        {QStringLiteral("series_id"), QStringLiteral("series-1")},
+        {QStringLiteral("season_id"), QStringLiteral("season-1")}
+    };
+    const QVariantMap mapped = SiloModelMapper::mediaItem(episode, QStringLiteral("silo"));
+    QCOMPARE(mapped.value(QStringLiteral("parentId")).toString(),
+             QStringLiteral("season-1"));
+
+    const QVariantMap seriesFallback = SiloModelMapper::mediaItem(
+        QJsonObject{
+            {QStringLiteral("content_id"), QStringLiteral("episode-2")},
+            {QStringLiteral("type"), QStringLiteral("episode")},
+            {QStringLiteral("series_id"), QStringLiteral("series-1")}
+        },
+        QStringLiteral("silo"));
+    QCOMPARE(seriesFallback.value(QStringLiteral("parentId")).toString(),
+             QStringLiteral("series-1"));
+
+    const QVariantMap zeroChapter = SiloModelMapper::chapter(
+        QJsonObject{
+            {QStringLiteral("start_seconds"), 0.0},
+            {QStringLiteral("end_seconds"), 0.0}
+        },
+        QStringLiteral("silo"), QStringLiteral("episode-1"), QStringLiteral("file-1"), 0);
+    QVERIFY(!zeroChapter.isEmpty());
+    QCOMPARE(zeroChapter.value(QStringLiteral("startMs")).toLongLong(), 0);
+    QCOMPARE(zeroChapter.value(QStringLiteral("endMs")).toLongLong(), 0);
+
+    const QVariantMap oversizedChapter = SiloModelMapper::chapter(
+        QJsonObject{{QStringLiteral("start_seconds"),
+                     std::numeric_limits<double>::max()}},
+        QStringLiteral("silo"), QStringLiteral("episode-1"), QStringLiteral("file-1"), 0);
+    QVERIFY(oversizedChapter.isEmpty());
+
+    const QList<MediaSegmentInfo> validSegments = SiloModelMapper::mediaSegments(
+        QStringLiteral("episode-1"),
+        QJsonObject{
+            {QStringLiteral("file_id"), QStringLiteral("file-1")},
+            {QStringLiteral("intro"), QJsonObject{
+                 {QStringLiteral("start_seconds"), 0.0},
+                 {QStringLiteral("end_seconds"), 1.0}}}
+        });
+    QCOMPARE(validSegments.size(), 1);
+    QCOMPARE(validSegments.first().startMs, 0);
+
+    const QList<MediaSegmentInfo> oversizedSegments = SiloModelMapper::mediaSegments(
+        QStringLiteral("episode-1"),
+        QJsonObject{
+            {QStringLiteral("file_id"), QStringLiteral("file-1")},
+            {QStringLiteral("intro"), QJsonObject{
+                 {QStringLiteral("start_seconds"), 0.0},
+                 {QStringLiteral("end_seconds"), std::numeric_limits<double>::max()}}}
+        });
+    QVERIFY(oversizedSegments.isEmpty());
+}
+
 
 void ProviderCatalogTest::siloNumericSeasonRoutesAndEnvelopeOperation()
 {

--- a/tests/ProviderCatalogTest.cpp
+++ b/tests/ProviderCatalogTest.cpp
@@ -1,0 +1,249 @@
+#include <QtTest/QtTest>
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QUrl>
+#include <QUrlQuery>
+
+#include "providers/ICatalogProvider.h"
+#include "providers/jellyfin/JellyfinProviderAdapter.h"
+#include "providers/silo/SiloModelMapper.h"
+
+class ProviderCatalogTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void jellyfinItemsRequestRetainsNativeContract();
+    void jellyfinMutationsAndPaginationRemainCompatible();
+    void siloCanonicalIdentityVersionsMultipartAndStateUseMilliseconds();
+};
+
+void ProviderCatalogTest::jellyfinItemsRequestRetainsNativeContract()
+{
+    JellyfinProviderAdapter adapter;
+    const ICatalogProvider *catalog = adapter.catalogProvider();
+    QVERIFY(catalog);
+
+    ProviderCatalogQuery query;
+    query.userId = QStringLiteral("user-1");
+    query.parentId = QStringLiteral("library-1");
+    query.startIndex = 20;
+    query.limit = 25;
+    query.searchTerm = QStringLiteral("Alien");
+    query.genres = {QStringLiteral("Science Fiction"), QStringLiteral("Drama")};
+    query.includeItemTypes = {QStringLiteral("Movie")};
+    query.sortBy = QStringLiteral("PremiereDate");
+    query.sortOrder = QStringLiteral("Descending");
+    query.watched = ProviderCatalogTriState::No;
+    query.recursive = true;
+    query.useCacheValidation = true;
+    query.etag = QByteArrayLiteral("\"catalog-v2\"");
+    query.lastModified = QByteArrayLiteral("Fri, 07 Aug 2026 10:00:00 GMT");
+
+    const ProviderCatalogRequest request = catalog->createRequest(
+        ProviderCatalogOperation::Items, query);
+    QVERIFY(request.supported);
+    QCOMPARE(request.method, ProviderHttpMethod::Get);
+    QVERIFY(request.body.isEmpty());
+    QCOMPARE(request.extraHeaders.value(QByteArrayLiteral("If-None-Match")),
+             QByteArrayLiteral("\"catalog-v2\""));
+    QCOMPARE(request.extraHeaders.value(QByteArrayLiteral("If-Modified-Since")),
+             QByteArrayLiteral("Fri, 07 Aug 2026 10:00:00 GMT"));
+
+    const QUrl url(request.relativeEndpoint);
+    const QUrlQuery parameters(url);
+    QCOMPARE(url.path(), QStringLiteral("/Users/user-1/Items"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("ParentId")),
+             QStringLiteral("library-1"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("StartIndex")),
+             QStringLiteral("20"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("Limit")),
+             QStringLiteral("25"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("SearchTerm")),
+             QStringLiteral("Alien"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("Genres")),
+             QStringLiteral("Drama,Science Fiction"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("IncludeItemTypes")),
+             QStringLiteral("Movie"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("SortBy")),
+             QStringLiteral("PremiereDate"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("SortOrder")),
+             QStringLiteral("Descending"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("IsPlayed")),
+             QStringLiteral("false"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("Recursive")),
+             QStringLiteral("true"));
+    QVERIFY(parameters.queryItemValue(QStringLiteral("Fields"))
+                .contains(QStringLiteral("MediaSources")));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("EnableImageTypes")),
+             QStringLiteral("Primary,Backdrop,Thumb,Logo"));
+}
+
+void ProviderCatalogTest::jellyfinMutationsAndPaginationRemainCompatible()
+{
+    JellyfinProviderAdapter adapter;
+    const ICatalogProvider *catalog = adapter.catalogProvider();
+    QVERIFY(catalog);
+
+    ProviderCatalogQuery query;
+    query.userId = QStringLiteral("user-1");
+    query.itemId = QStringLiteral("item-9");
+    query.stateValue = true;
+
+    const ProviderCatalogRequest markWatched = catalog->createRequest(
+        ProviderCatalogOperation::SetWatched, query);
+    QVERIFY(markWatched.supported);
+    QCOMPARE(markWatched.method, ProviderHttpMethod::Post);
+    QCOMPARE(markWatched.relativeEndpoint,
+             QStringLiteral("/Users/user-1/PlayedItems/item-9"));
+    QCOMPARE(markWatched.extraHeaders.value(QByteArrayLiteral("Content-Type")),
+             QByteArrayLiteral("application/json"));
+
+    query.stateValue = false;
+    const ProviderCatalogRequest clearFavorite = catalog->createRequest(
+        ProviderCatalogOperation::SetFavorite, query);
+    QVERIFY(clearFavorite.supported);
+    QCOMPARE(clearFavorite.method, ProviderHttpMethod::Delete);
+    QCOMPARE(clearFavorite.relativeEndpoint,
+             QStringLiteral("/Users/user-1/FavoriteItems/item-9"));
+
+    const ProviderCatalogResponse response = catalog->parseResponse(
+        ProviderCatalogOperation::Items,
+        QByteArrayLiteral(
+            R"({"Items":[{"Id":"item-21"},{"Id":"item-22"}],"StartIndex":20,"TotalRecordCount":23})"),
+        {{QByteArrayLiteral("etag"), QByteArrayLiteral("\"items-v3\"")},
+         {QByteArrayLiteral("LAST-MODIFIED"),
+          QByteArrayLiteral("Fri, 07 Aug 2026 11:00:00 GMT")}});
+    QVERIFY(response.valid);
+    QCOMPARE(response.rawItems.size(), 2);
+    QCOMPARE(response.total, 23);
+    QVERIFY(response.hasMore);
+    QCOMPARE(response.snapshot.value(QStringLiteral("etag")).toString(),
+             QStringLiteral("\"items-v3\""));
+    QCOMPARE(response.snapshot.value(QStringLiteral("lastModified")).toString(),
+             QStringLiteral("Fri, 07 Aug 2026 11:00:00 GMT"));
+}
+
+void ProviderCatalogTest::siloCanonicalIdentityVersionsMultipartAndStateUseMilliseconds()
+{
+    const QJsonObject version{
+        {QStringLiteral("file_id"), QStringLiteral("file-99")},
+        {QStringLiteral("file_name"), QStringLiteral("movie.mkv")},
+        {QStringLiteral("duration"), 123.456},
+        {QStringLiteral("edition_raw"), QStringLiteral("Director's Cut")},
+        {QStringLiteral("presentation_part_index"), 1},
+        {QStringLiteral("presentation_part_total"), 2},
+        {QStringLiteral("chapters"), QJsonArray{
+             QJsonObject{
+                 {QStringLiteral("index"), 3},
+                 {QStringLiteral("title"), QStringLiteral("Arrival")},
+                 {QStringLiteral("start_seconds"), 1.25},
+                 {QStringLiteral("end_seconds"), 4.75}
+             }
+         }}
+    };
+    const QJsonObject item{
+        {QStringLiteral("content_id"), QStringLiteral("content-42")},
+        {QStringLiteral("file_id"), QStringLiteral("wrong-item-identity")},
+        {QStringLiteral("type"), QStringLiteral("movie")},
+        {QStringLiteral("title"), QStringLiteral("Example")},
+        {QStringLiteral("provider_ids"), QJsonObject{
+             {QStringLiteral("imdb_id"), QStringLiteral("tt1234567")},
+             {QStringLiteral("Tmdb"), 7654}
+         }},
+        {QStringLiteral("user_data"), QJsonObject{
+             {QStringLiteral("played"), false},
+             {QStringLiteral("is_favorite"), true},
+             {QStringLiteral("position_seconds"), 12.345},
+             {QStringLiteral("duration_seconds"), 123.456},
+             {QStringLiteral("is_in_progress"), true}
+         }},
+        {QStringLiteral("versions"), QJsonArray{version}},
+        {QStringLiteral("playback_variants"), QJsonArray{
+             QJsonObject{
+                 {QStringLiteral("variant_id"), QStringLiteral("variant-main")},
+                 {QStringLiteral("part_count"), 2},
+                 {QStringLiteral("total_duration"), 246.912},
+                 {QStringLiteral("default_file_id"), QStringLiteral("file-99")},
+                 {QStringLiteral("parts"), QJsonArray{
+                      QJsonObject{
+                          {QStringLiteral("part_index"), 1},
+                          {QStringLiteral("default_file_id"), QStringLiteral("file-99")},
+                          {QStringLiteral("total_duration"), 123.456},
+                          {QStringLiteral("versions"), QJsonArray{version}}
+                      }
+                  }}
+             }
+         }}
+    };
+
+    const QVariantMap mapped = SiloModelMapper::mediaItem(
+        item, QStringLiteral("connection-silo"));
+    QCOMPARE(mapped.value(QStringLiteral("itemId")).toString(),
+             QStringLiteral("content-42"));
+    QVERIFY(mapped.value(QStringLiteral("itemId")).toString()
+            != QStringLiteral("file-99"));
+    QCOMPARE(mapped.value(QStringLiteral("providerIds")).toMap()
+                 .value(QStringLiteral("Imdb")).toString(),
+             QStringLiteral("tt1234567"));
+    QCOMPARE(mapped.value(QStringLiteral("providerIds")).toMap()
+                 .value(QStringLiteral("Tmdb")).toString(),
+             QStringLiteral("7654"));
+    QCOMPARE(mapped.value(QStringLiteral("positionMs")).toLongLong(), 12345);
+    QCOMPARE(mapped.value(QStringLiteral("durationMs")).toLongLong(), 123456);
+    QVERIFY(mapped.value(QStringLiteral("favorite")).toBool());
+    QVERIFY(mapped.value(QStringLiteral("isInProgress")).toBool());
+
+    const QVariantMap mappedVersion = mapped.value(QStringLiteral("versions"))
+                                          .toList().constFirst().toMap();
+    QCOMPARE(mappedVersion.value(QStringLiteral("fileId")).toString(),
+             QStringLiteral("file-99"));
+    QCOMPARE(mappedVersion.value(QStringLiteral("durationMs")).toLongLong(), 123456);
+    QCOMPARE(mappedVersion.value(QStringLiteral("presentationPartIndex")).toInt(), 1);
+    QCOMPARE(mappedVersion.value(QStringLiteral("presentationPartTotal")).toInt(), 2);
+    const QVariantMap chapter = mappedVersion.value(QStringLiteral("chapters"))
+                                    .toList().constFirst().toMap();
+    QCOMPARE(chapter.value(QStringLiteral("fileId")).toString(),
+             QStringLiteral("file-99"));
+    QCOMPARE(chapter.value(QStringLiteral("startMs")).toLongLong(), 1250);
+    QCOMPARE(chapter.value(QStringLiteral("endMs")).toLongLong(), 4750);
+
+    const QVariantMap playbackVariant = mapped.value(QStringLiteral("playbackVariants"))
+                                            .toList().constFirst().toMap();
+    QCOMPARE(playbackVariant.value(QStringLiteral("defaultFileId")).toString(),
+             QStringLiteral("file-99"));
+    QCOMPARE(playbackVariant.value(QStringLiteral("partCount")).toInt(), 2);
+    QCOMPARE(playbackVariant.value(QStringLiteral("totalDurationMs")).toLongLong(),
+             246912);
+    const QVariantMap part = playbackVariant.value(QStringLiteral("parts"))
+                                 .toList().constFirst().toMap();
+    QCOMPARE(part.value(QStringLiteral("partIndex")).toInt(), 1);
+    QCOMPARE(part.value(QStringLiteral("defaultFileId")).toString(),
+             QStringLiteral("file-99"));
+    QCOMPARE(part.value(QStringLiteral("versions")).toList()
+                 .constFirst().toMap().value(QStringLiteral("fileId")).toString(),
+             QStringLiteral("file-99"));
+
+    const QVariantMap state = SiloModelMapper::nativeState(
+        QJsonObject{
+            {QStringLiteral("content_id"), QStringLiteral("content-42")},
+            {QStringLiteral("user_state"), QJsonObject{
+                 {QStringLiteral("played"), true},
+                 {QStringLiteral("position_seconds"), 98.765},
+                 {QStringLiteral("duration_seconds"), 123.456},
+                 {QStringLiteral("last_file_id"), QStringLiteral("file-99")}
+             }}
+        },
+        QStringLiteral("connection-silo"));
+    QCOMPARE(state.value(QStringLiteral("itemId")).toString(),
+             QStringLiteral("content-42"));
+    QCOMPARE(state.value(QStringLiteral("lastFileId")).toString(),
+             QStringLiteral("file-99"));
+    QCOMPARE(state.value(QStringLiteral("positionMs")).toLongLong(), 98765);
+    QCOMPARE(state.value(QStringLiteral("durationMs")).toLongLong(), 123456);
+    QVERIFY(state.value(QStringLiteral("watched")).toBool());
+}
+
+QTEST_MAIN(ProviderCatalogTest)
+#include "ProviderCatalogTest.moc"

--- a/tests/ProviderCatalogTest.cpp
+++ b/tests/ProviderCatalogTest.cpp
@@ -435,6 +435,14 @@ void ProviderCatalogTest::siloEpisodeParentAndBoundedTimes()
 void ProviderCatalogTest::siloNumericSeasonRoutesAndEnvelopeOperation()
 {
     SiloCatalogProvider provider;
+    ProviderCatalogQuery parentOnlyQuery;
+    parentOnlyQuery.parentId = QStringLiteral("series/one");
+    const ProviderCatalogRequest seasonsRequest =
+        provider.createRequest(ProviderCatalogOperation::Items, parentOnlyQuery);
+    QVERIFY(seasonsRequest.supported);
+    QCOMPARE(seasonsRequest.relativeEndpoint,
+             QStringLiteral("/api/v1/catalog/series/series%2Fone/seasons"));
+
     ProviderCatalogQuery query;
     query.seriesId = QStringLiteral("series/one");
     query.parentId = QStringLiteral("0");

--- a/tests/ProviderCatalogTest.cpp
+++ b/tests/ProviderCatalogTest.cpp
@@ -8,6 +8,7 @@
 #include "providers/ICatalogProvider.h"
 #include "providers/jellyfin/JellyfinProviderAdapter.h"
 #include "providers/silo/SiloModelMapper.h"
+#include "providers/silo/SiloCatalogProvider.h"
 
 class ProviderCatalogTest : public QObject
 {
@@ -17,6 +18,8 @@ private slots:
     void jellyfinItemsRequestRetainsNativeContract();
     void jellyfinMutationsAndPaginationRemainCompatible();
     void siloCanonicalIdentityVersionsMultipartAndStateUseMilliseconds();
+    void canonicalArtworkAndPlaybackChapterMetadataRemainProviderNeutral();
+    void siloNumericSeasonRoutesAndEnvelopeOperation();
 };
 
 void ProviderCatalogTest::jellyfinItemsRequestRetainsNativeContract()
@@ -243,6 +246,107 @@ void ProviderCatalogTest::siloCanonicalIdentityVersionsMultipartAndStateUseMilli
     QCOMPARE(state.value(QStringLiteral("positionMs")).toLongLong(), 98765);
     QCOMPARE(state.value(QStringLiteral("durationMs")).toLongLong(), 123456);
     QVERIFY(state.value(QStringLiteral("watched")).toBool());
+}
+
+void ProviderCatalogTest::canonicalArtworkAndPlaybackChapterMetadataRemainProviderNeutral()
+{
+    Bloom::ArtworkRef artwork;
+    artwork.connectionId = QStringLiteral("silo-connection");
+    artwork.itemId = QStringLiteral("content-42");
+    artwork.kind = Bloom::ArtworkKind::Chapter;
+    artwork.ownerKind = Bloom::ArtworkOwnerKind::Chapter;
+    artwork.index = 4;
+    artwork.tag = QStringLiteral("file-99");
+    artwork.requestedWidth = 640;
+    artwork.sourceUrl = QStringLiteral(
+        "https://silo.example.test/api/v1/artwork/file-99/4?signature=rotating");
+
+    const QString cacheKey = artwork.cacheKey();
+    const Bloom::ArtworkRef restored = Bloom::ArtworkRef::fromCacheKey(cacheKey);
+    QVERIFY(restored.isValid());
+    QVERIFY(restored == artwork);
+    QCOMPARE(restored.ownerKind, Bloom::ArtworkOwnerKind::Chapter);
+    QVERIFY(restored.sourceUrl.isEmpty());
+    QVERIFY(!cacheKey.contains(QStringLiteral("signature")));
+
+    Bloom::Chapter chapter;
+    chapter.name = QStringLiteral("Arrival");
+    chapter.startMs = 1250;
+    chapter.artwork = artwork;
+    chapter.index = 3;
+    chapter.fileId = QStringLiteral("file-99");
+    chapter.endMs = 4750;
+    chapter.source = QStringLiteral("embedded");
+    chapter.thumbnailThumbhash = QStringLiteral("thumbhash");
+    const QVariantMap chapterMap = chapter.toVariantMap();
+    QCOMPARE(chapterMap.value(QStringLiteral("name")).toString(),
+             QStringLiteral("Arrival"));
+    QCOMPARE(chapterMap.value(QStringLiteral("startMs")).toLongLong(), 1250);
+    QCOMPARE(chapterMap.value(QStringLiteral("index")).toInt(), 3);
+    QCOMPARE(chapterMap.value(QStringLiteral("fileId")).toString(),
+             QStringLiteral("file-99"));
+    QCOMPARE(chapterMap.value(QStringLiteral("endMs")).toLongLong(), 4750);
+    QCOMPARE(chapterMap.value(QStringLiteral("source")).toString(),
+             QStringLiteral("embedded"));
+    QCOMPARE(chapterMap.value(QStringLiteral("thumbnailThumbhash")).toString(),
+             QStringLiteral("thumbhash"));
+    QCOMPARE(chapterMap.value(QStringLiteral("artwork")).toMap()
+                 .value(QStringLiteral("ownerKind")).toString(),
+             QStringLiteral("chapter"));
+
+    Bloom::PlaybackDescriptor descriptor;
+    descriptor.media = {QStringLiteral("silo-connection"), QStringLiteral("content-42")};
+    descriptor.mediaVersionId = QStringLiteral("file-99");
+    descriptor.durationMs = 123456;
+    descriptor.startPositionMs = 98765;
+    descriptor.stream.url = QUrl(QStringLiteral(
+        "https://silo.example.test/api/v1/playback/file-99"));
+    descriptor.stream.method = Bloom::PlaybackMethod::DirectPlay;
+    descriptor.chapters.append(chapter);
+    QVERIFY(descriptor.isValid());
+    const QVariantMap descriptorMap = descriptor.toVariantMap();
+    QCOMPARE(descriptorMap.value(QStringLiteral("mediaVersionId")).toString(),
+             QStringLiteral("file-99"));
+    QCOMPARE(descriptorMap.value(QStringLiteral("durationMs")).toLongLong(), 123456);
+    QCOMPARE(descriptorMap.value(QStringLiteral("startPositionMs")).toLongLong(), 98765);
+    QCOMPARE(descriptorMap.value(QStringLiteral("chapters")).toList().size(), 1);
+    QCOMPARE(descriptorMap.value(QStringLiteral("chapters")).toList().first().toMap()
+                 .value(QStringLiteral("startMs")).toLongLong(), 1250);
+}
+
+void ProviderCatalogTest::siloNumericSeasonRoutesAndEnvelopeOperation()
+{
+    SiloCatalogProvider provider;
+    ProviderCatalogQuery query;
+    query.seriesId = QStringLiteral("series/one");
+    query.parentId = QStringLiteral("0");
+
+    ProviderCatalogRequest request =
+        provider.createRequest(ProviderCatalogOperation::Items, query);
+    QVERIFY(request.supported);
+    QCOMPARE(request.relativeEndpoint,
+             QStringLiteral("/api/v1/catalog/series/series%2Fone/seasons/0"));
+
+    const ProviderCatalogResponse season = provider.parseResponse(
+        ProviderCatalogOperation::Items,
+        QByteArrayLiteral(
+            R"({"season":{"content_id":"series/one-S00","season_number":0,"title":"Specials"}})"));
+    QVERIFY(season.valid);
+    QCOMPARE(season.rawItem.value(QStringLiteral("content_id")).toString(),
+             QStringLiteral("series/one-S00"));
+    QCOMPARE(season.capabilityMetadata.value(QStringLiteral("envelope")).toString(),
+             QStringLiteral("season"));
+
+    query.includeItemTypes = {QStringLiteral("Episode")};
+    request = provider.createRequest(ProviderCatalogOperation::Items, query);
+    QVERIFY(request.supported);
+    QCOMPARE(request.relativeEndpoint,
+             QStringLiteral("/api/v1/catalog/series/series%2Fone/seasons/0/episodes"));
+
+    query.includeItemTypes = {QStringLiteral("Movie")};
+    request = provider.createRequest(ProviderCatalogOperation::Items, query);
+    QVERIFY(!request.supported);
+    QVERIFY(!request.unsupportedReason.isEmpty());
 }
 
 QTEST_MAIN(ProviderCatalogTest)

--- a/tests/ProviderCatalogTest.cpp
+++ b/tests/ProviderCatalogTest.cpp
@@ -16,6 +16,7 @@ class ProviderCatalogTest : public QObject
 
 private slots:
     void jellyfinItemsRequestRetainsNativeContract();
+    void jellyfinReservedIdentifiersAndLimitsRemainOpaque();
     void jellyfinMutationsAndPaginationRemainCompatible();
     void siloCanonicalIdentityVersionsMultipartAndStateUseMilliseconds();
     void canonicalArtworkAndPlaybackChapterMetadataRemainProviderNeutral();
@@ -81,6 +82,52 @@ void ProviderCatalogTest::jellyfinItemsRequestRetainsNativeContract()
                 .contains(QStringLiteral("MediaSources")));
     QCOMPARE(parameters.queryItemValue(QStringLiteral("EnableImageTypes")),
              QStringLiteral("Primary,Backdrop,Thumb,Logo"));
+}
+
+void ProviderCatalogTest::jellyfinReservedIdentifiersAndLimitsRemainOpaque()
+{
+    JellyfinProviderAdapter adapter;
+    const ICatalogProvider *catalog = adapter.catalogProvider();
+    QVERIFY(catalog);
+
+    ProviderCatalogQuery query;
+    query.userId = QStringLiteral("user/&?=");
+    query.parentId = QStringLiteral("parent&next=bad");
+    query.itemId = QStringLiteral("item/child?x=1");
+    query.seriesId = QStringLiteral("series#fragment");
+
+    const ProviderCatalogRequest items = catalog->createRequest(
+        ProviderCatalogOperation::Items, query);
+    QVERIFY(items.supported);
+    QVERIFY(items.relativeEndpoint.contains(QStringLiteral("user%2F%26%3F%3D")));
+    const QUrl itemsUrl(items.relativeEndpoint);
+    QCOMPARE(itemsUrl.path(QUrl::FullyEncoded),
+             QStringLiteral("/Users/user%2F%26%3F%3D/Items"));
+    QCOMPARE(QUrlQuery(itemsUrl).queryItemValue(QStringLiteral("ParentId")),
+             query.parentId);
+
+    const ProviderCatalogRequest item = catalog->createRequest(
+        ProviderCatalogOperation::Item, query);
+    QVERIFY(item.supported);
+    QVERIFY(item.relativeEndpoint.contains(QStringLiteral("item%2Fchild%3Fx%3D1")));
+    QCOMPARE(QUrl(item.relativeEndpoint).path(QUrl::FullyEncoded),
+             QStringLiteral("/Users/user%2F%26%3F%3D/Items/item%2Fchild%3Fx%3D1"));
+
+    query.limit = 0;
+    const ProviderCatalogRequest searchDefault = catalog->createRequest(
+        ProviderCatalogOperation::Search, query);
+    QVERIFY(searchDefault.supported);
+    QCOMPARE(QUrlQuery(QUrl(searchDefault.relativeEndpoint))
+                 .queryItemValue(QStringLiteral("Limit")),
+             QStringLiteral("50"));
+
+    query.limit = -7;
+    const ProviderCatalogRequest randomDefault = catalog->createRequest(
+        ProviderCatalogOperation::RandomItems, query);
+    QVERIFY(randomDefault.supported);
+    QCOMPARE(QUrlQuery(QUrl(randomDefault.relativeEndpoint))
+                 .queryItemValue(QStringLiteral("Limit")),
+             QStringLiteral("50"));
 }
 
 void ProviderCatalogTest::jellyfinMutationsAndPaginationRemainCompatible()
@@ -198,34 +245,40 @@ void ProviderCatalogTest::siloCanonicalIdentityVersionsMultipartAndStateUseMilli
     QVERIFY(mapped.value(QStringLiteral("favorite")).toBool());
     QVERIFY(mapped.value(QStringLiteral("isInProgress")).toBool());
 
-    const QVariantMap mappedVersion = mapped.value(QStringLiteral("versions"))
-                                          .toList().constFirst().toMap();
+    const QVariantList mappedVersions = mapped.value(QStringLiteral("versions")).toList();
+    QCOMPARE(mappedVersions.size(), 1);
+    const QVariantMap mappedVersion = mappedVersions.constFirst().toMap();
     QCOMPARE(mappedVersion.value(QStringLiteral("fileId")).toString(),
              QStringLiteral("file-99"));
     QCOMPARE(mappedVersion.value(QStringLiteral("durationMs")).toLongLong(), 123456);
     QCOMPARE(mappedVersion.value(QStringLiteral("presentationPartIndex")).toInt(), 1);
     QCOMPARE(mappedVersion.value(QStringLiteral("presentationPartTotal")).toInt(), 2);
-    const QVariantMap chapter = mappedVersion.value(QStringLiteral("chapters"))
-                                    .toList().constFirst().toMap();
+    const QVariantList mappedChapters = mappedVersion.value(QStringLiteral("chapters")).toList();
+    QCOMPARE(mappedChapters.size(), 1);
+    const QVariantMap chapter = mappedChapters.constFirst().toMap();
     QCOMPARE(chapter.value(QStringLiteral("fileId")).toString(),
              QStringLiteral("file-99"));
     QCOMPARE(chapter.value(QStringLiteral("startMs")).toLongLong(), 1250);
     QCOMPARE(chapter.value(QStringLiteral("endMs")).toLongLong(), 4750);
 
-    const QVariantMap playbackVariant = mapped.value(QStringLiteral("playbackVariants"))
-                                            .toList().constFirst().toMap();
+    const QVariantList playbackVariants = mapped.value(QStringLiteral("playbackVariants"))
+                                              .toList();
+    QCOMPARE(playbackVariants.size(), 1);
+    const QVariantMap playbackVariant = playbackVariants.constFirst().toMap();
     QCOMPARE(playbackVariant.value(QStringLiteral("defaultFileId")).toString(),
              QStringLiteral("file-99"));
     QCOMPARE(playbackVariant.value(QStringLiteral("partCount")).toInt(), 2);
     QCOMPARE(playbackVariant.value(QStringLiteral("totalDurationMs")).toLongLong(),
              246912);
-    const QVariantMap part = playbackVariant.value(QStringLiteral("parts"))
-                                 .toList().constFirst().toMap();
+    const QVariantList parts = playbackVariant.value(QStringLiteral("parts")).toList();
+    QCOMPARE(parts.size(), 1);
+    const QVariantMap part = parts.constFirst().toMap();
     QCOMPARE(part.value(QStringLiteral("partIndex")).toInt(), 1);
     QCOMPARE(part.value(QStringLiteral("defaultFileId")).toString(),
              QStringLiteral("file-99"));
-    QCOMPARE(part.value(QStringLiteral("versions")).toList()
-                 .constFirst().toMap().value(QStringLiteral("fileId")).toString(),
+    const QVariantList partVersions = part.value(QStringLiteral("versions")).toList();
+    QCOMPARE(partVersions.size(), 1);
+    QCOMPARE(partVersions.constFirst().toMap().value(QStringLiteral("fileId")).toString(),
              QStringLiteral("file-99"));
 
     const QVariantMap state = SiloModelMapper::nativeState(

--- a/tests/ProviderTransportTest.cpp
+++ b/tests/ProviderTransportTest.cpp
@@ -127,9 +127,14 @@ void ProviderTransportTest::jellyfinRequestFactoryBuildsHeaderWithAndWithoutToke
     QVERIFY(!anonymousHeader.contains("Token="));
 
     context.accessToken = QStringLiteral("secret-token");
+    context.profileId = QStringLiteral("silo-profile-must-not-leak");
+    context.profileToken = QStringLiteral("silo-profile-token-must-not-leak");
     const QNetworkRequest authenticated = factory.createRequest(context, QStringLiteral("/Users/user-1"));
     QCOMPARE(authenticated.url(), QUrl(QStringLiteral("https://media.example.test/Users/user-1")));
     QVERIFY(authenticated.rawHeader("Authorization").contains("Token=\"secret-token\""));
+    QVERIFY(authenticated.rawHeader("Authorization").startsWith("MediaBrowser "));
+    QVERIFY(!authenticated.hasRawHeader("X-Profile-Id"));
+    QVERIFY(!authenticated.hasRawHeader("X-Profile-Token"));
 }
 
 void ProviderTransportTest::jellyfinRequestFactoryNormalizesUrlAndRedactsSecrets()
@@ -170,6 +175,12 @@ void ProviderTransportTest::jellyfinAuthenticatorOwnsLoginAndValidationWireContr
     QCOMPARE(result.accessToken, QStringLiteral("token-1"));
     QCOMPARE(result.accountId, QStringLiteral("user-1"));
     QCOMPARE(result.username, QStringLiteral("Alice"));
+
+    QVERIFY(!authenticator.createRefreshRequest(QStringLiteral("refresh-token")).has_value());
+    QVERIFY(!authenticator.parseLoginResponse(QByteArrayLiteral("not-json")).isValid());
+    QVERIFY(!authenticator.parseLoginResponse(
+                 QByteArrayLiteral(R"({"AccessToken":"token-only","User":{}})"))
+                 .isValid());
 }
 
 void ProviderTransportTest::transportRetriesTransientFailures()

--- a/tests/ProviderTransportTest.cpp
+++ b/tests/ProviderTransportTest.cpp
@@ -2,11 +2,14 @@
 
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QPointer>
 #include <QSignalSpy>
 #include <QTimer>
 #include <cstring>
+#include <functional>
+#include <utility>
 
 #include "network/HttpTransport.h"
 #include "providers/IProviderAuthenticator.h"
@@ -101,6 +104,9 @@ private slots:
     void transportDoesNotRetryClientErrors();
     void transportSuppressesCancellationCallbacks();
     void transportEmitsUnauthorizedPolicy();
+    void transportCoalescesUnauthorizedRecovery();
+    void transportCapsUnauthorizedRetryAtOne();
+    void transportTreatsRefreshFailureAsTerminal();
     void cancellationIsNotClassifiedAsTransient();
 };
 
@@ -298,6 +304,168 @@ void ProviderTransportTest::transportEmitsUnauthorizedPolicy()
     QCOMPARE(unauthorizedSpy.count(), 1);
     QCOMPARE(unauthorizedSpy.first().first().toBool(), true);
 }
+
+void ProviderTransportTest::transportCoalescesUnauthorizedRecovery()
+{
+    HttpTransport transport;
+    int refreshes = 0;
+    int firstAttempts = 0;
+    int secondAttempts = 0;
+    int successes = 0;
+    int failures = 0;
+    QList<QNetworkRequest> requests;
+    QList<QByteArray> bodies;
+    std::function<void(bool)> finishRefresh;
+
+    transport.setUnauthorizedRecovery([&](std::function<void(bool)> completion) {
+        ++refreshes;
+        finishRefresh = std::move(completion);
+    });
+
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    const auto factory = [&](int &attempts, const QString &path) -> QNetworkReply * {
+        ++attempts;
+        QNetworkRequest request = requestFor(path);
+        request.setRawHeader("Authorization", QByteArrayLiteral("Bearer access-token"));
+        request.setRawHeader("X-Test-Method", QByteArrayLiteral("POST"));
+        request.setRawHeader("X-Profile-Id", QByteArrayLiteral("profile-1"));
+        request.setRawHeader("X-Profile-Token", QByteArrayLiteral("profile-token"));
+        const QByteArray body = QByteArrayLiteral(R"({"operation":"replay"})");
+        requests.append(request);
+        bodies.append(body);
+        const bool unauthorized = attempts == 1;
+        return new FakeReply(request,
+                             unauthorized ? QNetworkReply::AuthenticationRequiredError
+                                          : QNetworkReply::NoError,
+                             unauthorized ? 401 : 200,
+                             QByteArray(),
+                             &transport);
+    };
+    const auto success = [&](QNetworkReply *) { ++successes; };
+    const auto failure = [&](const NetworkError &) { ++failures; };
+
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/api/v1/first"),
+        [&]() { return factory(firstAttempts, QStringLiteral("/api/v1/first")); },
+        success,
+        failure,
+        options);
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/api/v1/second"),
+        [&]() { return factory(secondAttempts, QStringLiteral("/api/v1/second")); },
+        success,
+        failure,
+        options);
+
+    QTRY_COMPARE_WITH_TIMEOUT(refreshes, 1, 1000);
+    QVERIFY(finishRefresh);
+    finishRefresh(true);
+    QTRY_COMPARE_WITH_TIMEOUT(successes, 2, 1000);
+    QCOMPARE(failures, 0);
+    QCOMPARE(firstAttempts, 2);
+    QCOMPARE(requests.size(), 4);
+    QCOMPARE(bodies.at(0), bodies.at(2));
+    QCOMPARE(bodies.at(1), bodies.at(3));
+    QCOMPARE(secondAttempts, 2);
+    QCOMPARE(requests.at(0).rawHeader("Authorization"),
+             requests.at(2).rawHeader("Authorization"));
+    QCOMPARE(requests.at(0).rawHeader("X-Test-Method"),
+             requests.at(2).rawHeader("X-Test-Method"));
+    QCOMPARE(requests.at(1).rawHeader("X-Profile-Id"),
+             requests.at(3).rawHeader("X-Profile-Id"));
+    QCOMPARE(requests.at(1).rawHeader("X-Profile-Token"),
+             requests.at(3).rawHeader("X-Profile-Token"));
+}
+
+void ProviderTransportTest::transportCapsUnauthorizedRetryAtOne()
+{
+    HttpTransport transport;
+    int refreshes = 0;
+    int attempts = 0;
+    int failures = 0;
+    std::function<void(bool)> finishRefresh;
+    transport.setUnauthorizedRecovery([&](std::function<void(bool)> completion) {
+        ++refreshes;
+        finishRefresh = std::move(completion);
+    });
+
+    HttpRequestOptions options;
+    options.retryEnabled = true;
+    options.retryPolicy = RetryPolicy{5, 0, true};
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/api/v1/protected"),
+        [&]() -> QNetworkReply * {
+            ++attempts;
+            return new FakeReply(
+                requestFor(QStringLiteral("/api/v1/protected")),
+                QNetworkReply::AuthenticationRequiredError,
+                401,
+                QByteArray(),
+                &transport);
+        },
+        [](QNetworkReply *) {},
+        [&](const NetworkError &error) {
+            QCOMPARE(error.code, 401);
+            ++failures;
+        },
+        options);
+
+    QTRY_COMPARE_WITH_TIMEOUT(refreshes, 1, 1000);
+    QVERIFY(finishRefresh);
+    finishRefresh(true);
+    QTRY_COMPARE_WITH_TIMEOUT(failures, 1, 1000);
+    QCOMPARE(attempts, 2);
+    QCOMPARE(refreshes, 1);
+}
+
+void ProviderTransportTest::transportTreatsRefreshFailureAsTerminal()
+{
+    HttpTransport transport;
+    int refreshes = 0;
+    int attempts = 0;
+    int failures = 0;
+    std::function<void(bool)> finishRefresh;
+    transport.setUnauthorizedRecovery([&](std::function<void(bool)> completion) {
+        ++refreshes;
+        finishRefresh = std::move(completion);
+    });
+
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/api/v1/protected"),
+        [&]() -> QNetworkReply * {
+            ++attempts;
+            return new FakeReply(
+                requestFor(QStringLiteral("/api/v1/protected")),
+                QNetworkReply::NoError,
+                401,
+                QByteArray(),
+                &transport);
+        },
+        [](QNetworkReply *) {},
+        [&](const NetworkError &error) {
+            QCOMPARE(error.code, 401);
+            ++failures;
+        },
+        options);
+
+    QTRY_COMPARE_WITH_TIMEOUT(refreshes, 1, 1000);
+    QVERIFY(finishRefresh);
+    finishRefresh(false);
+    QTRY_COMPARE_WITH_TIMEOUT(failures, 1, 1000);
+    QCOMPARE(attempts, 1);
+    QCOMPARE(refreshes, 1);
+}
+
 
 void ProviderTransportTest::cancellationIsNotClassifiedAsTransient()
 {

--- a/tests/SiloAuthenticationTest.cpp
+++ b/tests/SiloAuthenticationTest.cpp
@@ -171,6 +171,7 @@ private slots:
     void failedSharedRefreshExpiresSessionOnce();
     void profileTokenIsBoundToSelectionAndClearedOnSwitch();
     void serviceLoadsRevokedSessionsAndCallsRevokeEndpoint();
+    void profileVerificationNeverReceivesStaleProfileHeaders();
 };
 
 void SiloAuthenticationTest::adapterExposesNativeAuthenticationBoundaries()
@@ -267,7 +268,28 @@ void SiloAuthenticationTest::authenticationEndpointsNeverReceiveBearerAuthentica
     QVERIFY(!login.hasRawHeader("Authorization"));
     QVERIFY(!refresh.hasRawHeader("Authorization"));
     QVERIFY(!login.hasRawHeader("X-Profile-Id"));
+    const QNetworkRequest health = factory.createRequest(
+        context, QStringLiteral("/api/v1/health"));
+    QVERIFY(!health.hasRawHeader("Authorization"));
+    QVERIFY(!health.hasRawHeader("X-Profile-Id"));
+    QVERIFY(!health.hasRawHeader("X-Profile-Token"));
     QVERIFY(!refresh.hasRawHeader("X-Profile-Token"));
+}
+
+void SiloAuthenticationTest::profileVerificationNeverReceivesStaleProfileHeaders()
+{
+    SiloRequestFactory factory;
+    ProviderRequestContext context;
+    context.baseUrl = QStringLiteral("https://silo.example.test");
+    context.accessToken = QStringLiteral("access-secret");
+    context.profileId = QStringLiteral("new-profile");
+    context.profileToken = QStringLiteral("stale-profile-token");
+
+    const QNetworkRequest request = factory.createRequest(
+        context, QStringLiteral("/api/v1/profiles/new-profile/verify-pin"));
+    QCOMPARE(request.rawHeader("Authorization"), QByteArrayLiteral("Bearer access-secret"));
+    QVERIFY(!request.hasRawHeader("X-Profile-Id"));
+    QVERIFY(!request.hasRawHeader("X-Profile-Token"));
 }
 
 void SiloAuthenticationTest::authenticatorBuildsAndParsesLoginAndRefreshContracts()
@@ -312,6 +334,9 @@ void SiloAuthenticationTest::authenticatorRejectsMalformedAndIncompleteResponses
                  .isValid());
     QVERIFY(!authenticator.parseLoginResponse(
                  QByteArrayLiteral(R"({"access_token":"access-1","expires_in":900,"user":{"id":42,"username":"Alice"}})"))
+                 .isValid());
+    QVERIFY(!authenticator.parseProfileLoginResponse(
+                 QByteArrayLiteral(R"({"valid":true,"profile_token":"profile-token-1"})"))
                  .isValid());
 
     const ProviderAuthenticationResult incompleteRefresh = authenticator.parseRefreshResponse(

--- a/tests/SiloAuthenticationTest.cpp
+++ b/tests/SiloAuthenticationTest.cpp
@@ -172,6 +172,10 @@ private slots:
     void profileTokenIsBoundToSelectionAndClearedOnSwitch();
     void serviceLoadsRevokedSessionsAndCallsRevokeEndpoint();
     void profileVerificationNeverReceivesStaleProfileHeaders();
+    void nullTransportFailsAuthenticationWithoutCrashing();
+    void emptyProfilesAfterSwitchLeaveVisibleErrorAndAuthenticatedStep();
+    void restoreRejectsValidationForAnotherAccount();
+    void refreshWithoutRotationRetainsPreviousToken();
 };
 
 void SiloAuthenticationTest::adapterExposesNativeAuthenticationBoundaries()
@@ -339,10 +343,11 @@ void SiloAuthenticationTest::authenticatorRejectsMalformedAndIncompleteResponses
                  QByteArrayLiteral(R"({"valid":true,"profile_token":"profile-token-1"})"))
                  .isValid());
 
-    const ProviderAuthenticationResult incompleteRefresh = authenticator.parseRefreshResponse(
+    const ProviderAuthenticationResult retainedRefresh = authenticator.parseRefreshResponse(
         QByteArrayLiteral(R"({"access_token":"access-2","expires_in":1800})"));
-    QVERIFY(incompleteRefresh.accessToken.isEmpty());
-    QVERIFY(incompleteRefresh.refreshToken.isEmpty());
+    QCOMPARE(retainedRefresh.accessToken, QStringLiteral("access-2"));
+    QVERIFY(retainedRefresh.refreshToken.isEmpty());
+    QVERIFY(retainedRefresh.isValidRefresh());
     QVERIFY(!authenticator.createRefreshRequest(QString()).has_value());
 
     const SiloAuthenticationError invalidCredentials =
@@ -424,16 +429,22 @@ void SiloAuthenticationTest::adapterExposesProfileAndSessionRoutes()
     const auto pin = adapter.endpointFor(ProviderRoute::VerifyProfilePin, context);
     const auto sessions = adapter.endpointFor(ProviderRoute::AuthSessions);
     const auto revoke = adapter.endpointFor(ProviderRoute::RevokeAuthSession, context);
+    const auto health = adapter.endpointFor(ProviderRoute::Health);
+    const auto logout = adapter.endpointFor(ProviderRoute::CallerLogout);
     QVERIFY(profiles.has_value());
     QVERIFY(pin.has_value());
     QVERIFY(sessions.has_value());
     QVERIFY(revoke.has_value());
+    QVERIFY(health.has_value());
+    QVERIFY(logout.has_value());
     QCOMPARE(*profiles, QStringLiteral("/api/v1/profiles"));
     QCOMPARE(*pin,
              QStringLiteral("/api/v1/profiles/profile%2Fwith%20space/verify-pin"));
     QCOMPARE(*sessions, QStringLiteral("/api/v1/auth/sessions"));
     QCOMPARE(*revoke,
              QStringLiteral("/api/v1/auth/sessions/session%2Fwith%20space"));
+    QCOMPARE(*health, QStringLiteral("/api/v1/health"));
+    QCOMPARE(*logout, QStringLiteral("/api/v1/auth/logout"));
 }
 
 void SiloAuthenticationTest::authenticatorDistinguishesIncorrectAndValidProfilePins()
@@ -768,6 +779,131 @@ void SiloAuthenticationTest::serviceLoadsRevokedSessionsAndCallsRevokeEndpoint()
                  .request.rawHeader("Authorization"),
              QByteArrayLiteral("Bearer access-1"));
 }
+void SiloAuthenticationTest::refreshWithoutRotationRetainsPreviousToken()
+{
+    FakeNetworkAccessManager manager;
+    manager.responses = {
+        response(200, successfulLogin()),
+        response(200, singleUnlockedProfile())
+    };
+    HttpTransport transport(&manager);
+    SiloProviderAdapter adapter;
+    AuthenticationService service(nullptr, &transport, &adapter);
+    service.setProviderSelection(QStringLiteral("silo"));
+    service.authenticate(QStringLiteral("https://silo.example.test"),
+                         QStringLiteral("Alice"),
+                         QStringLiteral("password"));
+    QTRY_VERIFY_WITH_TIMEOUT(service.isAuthenticated(), 1000);
+
+    manager.responses.append(response(
+        401, QByteArrayLiteral(R"({"error":"invalid_token","message":"Expired"})")));
+    manager.responses.append(response(
+        200, QByteArrayLiteral(R"({"access_token":"access-2","expires_in":1800})")));
+    manager.responses.append(response(200, QByteArrayLiteral(R"({"ok":true})")));
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    int successes = 0;
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/api/v1/protected"),
+        [&]() { return manager.get(service.createRequest(QStringLiteral("/api/v1/protected"))); },
+        [&](QNetworkReply *) { ++successes; },
+        [](const NetworkError &) {},
+        options);
+    QTRY_COMPARE_WITH_TIMEOUT(successes, 1, 1000);
+
+    manager.responses.append(response(
+        401, QByteArrayLiteral(R"({"error":"invalid_token","message":"Expired"})")));
+    manager.responses.append(response(
+        200, QByteArrayLiteral(R"({"access_token":"access-3","expires_in":1800})")));
+    manager.responses.append(response(200, QByteArrayLiteral(R"({"ok":true})")));
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/api/v1/protected-again"),
+        [&]() {
+            return manager.get(service.createRequest(
+                QStringLiteral("/api/v1/protected-again")));
+        },
+        [&](QNetworkReply *) { ++successes; },
+        [](const NetworkError &) {},
+        options);
+    QTRY_COMPARE_WITH_TIMEOUT(successes, 2, 1000);
+
+    int refreshRequests = 0;
+    for (const RecordedRequest &request : manager.requests) {
+        if (request.request.url().path() == QStringLiteral("/api/v1/auth/refresh")) {
+            ++refreshRequests;
+            if (refreshRequests == 2) {
+                QCOMPARE(QJsonDocument::fromJson(request.body).object()
+                             .value(QStringLiteral("refresh_token")).toString(),
+                         QStringLiteral("refresh-1"));
+            }
+        }
+    }
+    QCOMPARE(refreshRequests, 2);
+}
+
+void SiloAuthenticationTest::nullTransportFailsAuthenticationWithoutCrashing()
+{
+    SiloProviderAdapter adapter;
+    AuthenticationService service(nullptr, nullptr, &adapter);
+    QSignalSpy errorSpy(&service, &AuthenticationService::loginError);
+
+    service.setProviderSelection(QStringLiteral("silo"));
+    service.authenticate(QStringLiteral("https://silo.example.test"),
+                         QStringLiteral("Alice"),
+                         QStringLiteral("password"));
+
+    QCOMPARE(errorSpy.count(), 1);
+    QVERIFY(!service.isAuthenticated());
+}
+
+void SiloAuthenticationTest::emptyProfilesAfterSwitchLeaveVisibleErrorAndAuthenticatedStep()
+{
+    FakeNetworkAccessManager manager;
+    manager.responses = {
+        response(200, successfulLogin()),
+        response(200, singleUnlockedProfile())
+    };
+    HttpTransport transport(&manager);
+    SiloProviderAdapter adapter;
+    AuthenticationService service(nullptr, &transport, &adapter);
+    QSignalSpy errorSpy(&service, &AuthenticationService::loginError);
+
+    service.setProviderSelection(QStringLiteral("silo"));
+    service.authenticate(QStringLiteral("https://silo.example.test"),
+                         QStringLiteral("Alice"),
+                         QStringLiteral("password"));
+    QTRY_VERIFY_WITH_TIMEOUT(service.isAuthenticated(), 1000);
+
+    manager.responses.append(response(200, QByteArrayLiteral(R"({"profiles": []})")));
+    service.switchProfile();
+    QTRY_COMPARE_WITH_TIMEOUT(errorSpy.count(), 1, 1000);
+    QCOMPARE(service.authenticationStep(), QStringLiteral("authenticated"));
+}
+
+void SiloAuthenticationTest::restoreRejectsValidationForAnotherAccount()
+{
+    FakeNetworkAccessManager manager;
+    manager.responses = {
+        response(200, QByteArrayLiteral(
+            R"({"id":43,"username":"Bob","role":"user"})"))
+    };
+    HttpTransport transport(&manager);
+    SiloProviderAdapter adapter;
+    AuthenticationService service(nullptr, &transport, &adapter);
+
+    service.restoreSession(QStringLiteral("https://silo.example.test"),
+                           QStringLiteral("42"),
+                           QStringLiteral("stale-access"),
+                           QStringLiteral("Alice"));
+    QTRY_COMPARE_WITH_TIMEOUT(service.getUserId(), QString(), 1000);
+    QCOMPARE(manager.requests.size(), 1);
+    QCOMPARE(manager.requests.constFirst().request.url().path(),
+             QStringLiteral("/api/v1/auth/me"));
+}
+
 
 QTEST_MAIN(SiloAuthenticationTest)
 #include "SiloAuthenticationTest.moc"

--- a/tests/SiloAuthenticationTest.cpp
+++ b/tests/SiloAuthenticationTest.cpp
@@ -1,0 +1,748 @@
+#include <QtTest/QtTest>
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QSignalSpy>
+#include <QTimer>
+#include <cstring>
+
+#include "network/AuthenticationService.h"
+#include "network/HttpTransport.h"
+#include "providers/IProviderAuthenticator.h"
+#include "providers/IProviderAdapter.h"
+#include "providers/IProviderRequestFactory.h"
+#include "providers/silo/SiloAuthenticator.h"
+#include "providers/silo/SiloProviderAdapter.h"
+#include "providers/silo/SiloRequestFactory.h"
+
+namespace {
+
+class FakeReply final : public QNetworkReply
+{
+public:
+    FakeReply(const QNetworkRequest &request,
+              NetworkError error,
+              int statusCode,
+              QByteArray payload,
+              QObject *parent)
+        : QNetworkReply(parent)
+        , m_payload(std::move(payload))
+    {
+        setRequest(request);
+        setUrl(request.url());
+        setAttribute(QNetworkRequest::HttpStatusCodeAttribute, statusCode);
+        if (error != NoError) {
+            setError(error, QStringLiteral("test network error"));
+        }
+        open(QIODevice::ReadOnly);
+        QTimer::singleShot(0, this, [this]() { finish(); });
+    }
+
+    void abort() override
+    {
+        if (!isFinished()) {
+            setError(OperationCanceledError, QStringLiteral("canceled"));
+        }
+    }
+
+    qint64 bytesAvailable() const override
+    {
+        return (m_payload.size() - m_offset) + QNetworkReply::bytesAvailable();
+    }
+
+protected:
+    qint64 readData(char *data, qint64 maxSize) override
+    {
+        const qint64 remaining = m_payload.size() - m_offset;
+        const qint64 count = qMin(maxSize, remaining);
+        if (count <= 0) {
+            return -1;
+        }
+        memcpy(data, m_payload.constData() + m_offset, static_cast<size_t>(count));
+        m_offset += count;
+        return count;
+    }
+
+private:
+    void finish()
+    {
+        if (isFinished()) {
+            return;
+        }
+        setFinished(true);
+        if (!m_payload.isEmpty()) {
+            emit readyRead();
+        }
+        emit finished();
+    }
+
+    QByteArray m_payload;
+    qint64 m_offset = 0;
+};
+
+struct QueuedResponse {
+    int statusCode;
+    QByteArray payload;
+    QNetworkReply::NetworkError error = QNetworkReply::NoError;
+};
+
+struct RecordedRequest {
+    QNetworkAccessManager::Operation operation;
+    QNetworkRequest request;
+    QByteArray body;
+};
+
+class FakeNetworkAccessManager final : public QNetworkAccessManager
+{
+public:
+    QList<QueuedResponse> responses;
+    QList<RecordedRequest> requests;
+
+protected:
+    QNetworkReply *createRequest(Operation operation,
+                                 const QNetworkRequest &request,
+                                 QIODevice *outgoingData) override
+    {
+        const QByteArray body = outgoingData ? outgoingData->readAll() : QByteArray{};
+        requests.append({operation, request, body});
+        QueuedResponse response{
+            500,
+            QByteArrayLiteral(R"({"error":"test_queue_empty","message":"No response queued"})"),
+            QNetworkReply::UnknownServerError
+        };
+        if (!responses.isEmpty()) {
+            response = responses.takeFirst();
+        }
+        return new FakeReply(request,
+                             response.error,
+                             response.statusCode,
+                             response.payload,
+                             this);
+    }
+};
+
+QueuedResponse response(int statusCode, const QByteArray &payload)
+{
+    QNetworkReply::NetworkError error = QNetworkReply::NoError;
+    if (statusCode == 401) {
+        error = QNetworkReply::AuthenticationRequiredError;
+    } else if (statusCode == 404) {
+        error = QNetworkReply::ContentNotFoundError;
+    } else if (statusCode >= 400) {
+        error = QNetworkReply::UnknownServerError;
+    }
+    return {statusCode, payload, error};
+}
+
+QByteArray successfulLogin()
+{
+    return QByteArrayLiteral(
+        R"({"access_token":"access-1","refresh_token":"refresh-1","expires_in":900,"user":{"id":42,"username":"Alice"}})");
+}
+
+QByteArray singleUnlockedProfile()
+{
+    return QByteArrayLiteral(
+        R"({"profiles":[{"id":"profile-1","name":"Alice","has_pin":false,"is_child":false,"is_primary":true}]})");
+}
+
+} // namespace
+
+class SiloAuthenticationTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void adapterExposesNativeAuthenticationBoundaries();
+    void healthDetectionAcceptsOmittedIdentityWithoutFabricatingOne();
+    void requestFactoryBuildsNativeHeadersAndRedactsSecrets();
+    void authenticationEndpointsNeverReceiveBearerAuthentication();
+    void authenticatorBuildsAndParsesLoginAndRefreshContracts();
+    void authenticatorRejectsMalformedAndIncompleteResponses();
+    void adapterMapsProfilesAndRevokedAuthenticationSessions();
+    void adapterExposesProfileAndSessionRoutes();
+    void authenticatorDistinguishesIncorrectAndValidProfilePins();
+    void unauthorizedRequestRefreshesAndRetriesExactlyOnce();
+    void concurrentUnauthorizedRequestsShareOneRefresh();
+    void failedSharedRefreshExpiresSessionOnce();
+    void profileTokenIsBoundToSelectionAndClearedOnSwitch();
+    void serviceLoadsRevokedSessionsAndCallsRevokeEndpoint();
+};
+
+void SiloAuthenticationTest::adapterExposesNativeAuthenticationBoundaries()
+{
+    SiloProviderAdapter adapter;
+    QCOMPARE(adapter.providerKind(), ProviderKind::Silo);
+    QCOMPARE(adapter.protocolMode(), ProtocolMode::Native);
+    QVERIFY(adapter.authenticator());
+    QVERIFY(adapter.requestFactory());
+    QVERIFY(adapter.supportsCapability(ProviderCapability::RefreshAuthentication));
+    QVERIFY(adapter.supportsCapability(ProviderCapability::Profiles));
+    QVERIFY(adapter.supportsCapability(ProviderCapability::ProfilePin));
+    QVERIFY(adapter.supportsCapability(ProviderCapability::AuthSessions));
+}
+
+void SiloAuthenticationTest::healthDetectionAcceptsOmittedIdentityWithoutFabricatingOne()
+{
+    SiloProviderAdapter adapter;
+
+    const auto omitted = adapter.mapDetectionResult(QJsonObject{
+        {QStringLiteral("status"), QStringLiteral("ok")}
+    });
+    QVERIFY(omitted.has_value());
+    QCOMPARE(omitted->providerKind, ProviderKind::Silo);
+    QCOMPARE(omitted->protocolMode, ProtocolMode::Native);
+    QVERIFY(omitted->serverId.isEmpty());
+    QVERIFY(omitted->serverName.isEmpty());
+
+    const auto configuredDefault = adapter.mapDetectionResult(QJsonObject{
+        {QStringLiteral("status"), QStringLiteral("ok")},
+        {QStringLiteral("server_id"),
+         QStringLiteral("b2d9e6c9-1237-5add-a687-5dae547ece33")},
+        {QStringLiteral("server_name"), QStringLiteral("Living Room")}
+    });
+    QVERIFY(configuredDefault.has_value());
+    QVERIFY(configuredDefault->serverId.isEmpty());
+    QCOMPARE(configuredDefault->serverName, QStringLiteral("Living Room"));
+
+    QVERIFY(!adapter.mapDetectionResult(QJsonObject{
+        {QStringLiteral("status"), QStringLiteral("starting")},
+        {QStringLiteral("server_id"), QStringLiteral("default-server-id")}
+    }).has_value());
+    QVERIFY(!adapter.mapDetectionResult(QJsonObject{
+        {QStringLiteral("status"), QStringLiteral("ok")},
+        {QStringLiteral("server_id"), 17}
+    }).has_value());
+}
+
+void SiloAuthenticationTest::requestFactoryBuildsNativeHeadersAndRedactsSecrets()
+{
+    SiloRequestFactory factory;
+    ProviderRequestContext context;
+    context.baseUrl = QStringLiteral("https://silo.example.test///");
+    context.accessToken = QStringLiteral("access-secret");
+    context.profileId = QStringLiteral("profile-1");
+    context.profileToken = QStringLiteral("profile-secret");
+    context.clientName = QStringLiteral("Bloom Test");
+    context.clientVersion = QStringLiteral("1.2.3");
+    context.deviceId = QStringLiteral("device-1");
+    context.deviceName = QStringLiteral("Living Room");
+    context.devicePlatform = QStringLiteral("linux");
+
+    const QNetworkRequest request = factory.createRequest(context, QStringLiteral("api/v1/profiles"));
+    QCOMPARE(request.url(), QUrl(QStringLiteral("https://silo.example.test/api/v1/profiles")));
+    QCOMPARE(request.rawHeader("Authorization"), QByteArrayLiteral("Bearer access-secret"));
+    QCOMPARE(request.rawHeader("X-Profile-Id"), QByteArrayLiteral("profile-1"));
+    QCOMPARE(request.rawHeader("X-Profile-Token"), QByteArrayLiteral("profile-secret"));
+    QCOMPARE(request.rawHeader("X-Silo-Client"), QByteArrayLiteral("Bloom Test"));
+    QCOMPARE(request.rawHeader("X-Silo-Client-Version"), QByteArrayLiteral("1.2.3"));
+    QCOMPARE(request.rawHeader("X-Silo-Device-Id"), QByteArrayLiteral("device-1"));
+    QCOMPARE(request.rawHeader("X-Silo-Device-Name"), QByteArrayLiteral("Living Room"));
+    QCOMPARE(request.rawHeader("X-Silo-Device-Platform"), QByteArrayLiteral("linux"));
+
+    const QString redacted = factory.redactedUrl(QUrl(QStringLiteral(
+        "https://user:password@silo.example.test/api/v1/items?access_token=access-secret&profile_token=profile-secret&q=title")));
+    QVERIFY(!redacted.contains(QStringLiteral("access-secret")));
+    QVERIFY(!redacted.contains(QStringLiteral("profile-secret")));
+    QVERIFY(!redacted.contains(QStringLiteral("user")));
+    QVERIFY(!redacted.contains(QStringLiteral("password")));
+    QVERIFY(redacted.contains(QStringLiteral("q=title")));
+}
+
+void SiloAuthenticationTest::authenticationEndpointsNeverReceiveBearerAuthentication()
+{
+    SiloRequestFactory factory;
+    ProviderRequestContext context;
+    context.baseUrl = QStringLiteral("https://silo.example.test");
+    context.accessToken = QStringLiteral("stale-access-token");
+    context.profileId = QStringLiteral("profile-1");
+    context.profileToken = QStringLiteral("stale-profile-token");
+
+    const QNetworkRequest login = factory.createRequest(context, QStringLiteral("/api/v1/auth/login"));
+    const QNetworkRequest refresh = factory.createRequest(context, QStringLiteral("/api/v1/auth/refresh"));
+    QVERIFY(!login.hasRawHeader("Authorization"));
+    QVERIFY(!refresh.hasRawHeader("Authorization"));
+    QVERIFY(!login.hasRawHeader("X-Profile-Id"));
+    QVERIFY(!refresh.hasRawHeader("X-Profile-Token"));
+}
+
+void SiloAuthenticationTest::authenticatorBuildsAndParsesLoginAndRefreshContracts()
+{
+    SiloAuthenticator authenticator;
+    const ProviderAuthenticationRequest login = authenticator.createLoginRequest(
+        QStringLiteral("Alice"), QStringLiteral("password"));
+    QCOMPARE(login.endpoint, QStringLiteral("/api/v1/auth/login"));
+    const QJsonObject loginBody = QJsonDocument::fromJson(login.body).object();
+    QCOMPARE(loginBody.value(QStringLiteral("username")).toString(), QStringLiteral("Alice"));
+    QCOMPARE(loginBody.value(QStringLiteral("password")).toString(), QStringLiteral("password"));
+
+    const ProviderAuthenticationResult loginResult = authenticator.parseLoginResponse(
+        QByteArrayLiteral(R"({"access_token":"access-1","refresh_token":"refresh-1","expires_in":900,"user":{"id":42,"username":"Alice"}})"));
+    QVERIFY(loginResult.isValid());
+    QCOMPARE(loginResult.accessToken, QStringLiteral("access-1"));
+    QCOMPARE(loginResult.refreshToken, QStringLiteral("refresh-1"));
+    QCOMPARE(loginResult.accountId, QStringLiteral("42"));
+    QCOMPARE(loginResult.username, QStringLiteral("Alice"));
+    QCOMPARE(loginResult.expiresInSeconds, 900);
+
+    const auto refresh = authenticator.createRefreshRequest(QStringLiteral("refresh-1"));
+    QVERIFY(refresh.has_value());
+    QCOMPARE(refresh->endpoint, QStringLiteral("/api/v1/auth/refresh"));
+    QCOMPARE(QJsonDocument::fromJson(refresh->body).object()
+                 .value(QStringLiteral("refresh_token")).toString(),
+             QStringLiteral("refresh-1"));
+
+    const ProviderAuthenticationResult refreshResult = authenticator.parseRefreshResponse(
+        QByteArrayLiteral(R"({"access_token":"access-2","refresh_token":"refresh-2","expires_in":1800})"));
+    QCOMPARE(refreshResult.accessToken, QStringLiteral("access-2"));
+    QCOMPARE(refreshResult.refreshToken, QStringLiteral("refresh-2"));
+    QCOMPARE(refreshResult.expiresInSeconds, 1800);
+}
+
+void SiloAuthenticationTest::authenticatorRejectsMalformedAndIncompleteResponses()
+{
+    SiloAuthenticator authenticator;
+    QVERIFY(!authenticator.parseLoginResponse(QByteArrayLiteral("not-json")).isValid());
+    QVERIFY(!authenticator.parseLoginResponse(
+                 QByteArrayLiteral(R"({"access_token":"access-1","refresh_token":"refresh-1","expires_in":0,"user":{"id":42,"username":"Alice"}})"))
+                 .isValid());
+    QVERIFY(!authenticator.parseLoginResponse(
+                 QByteArrayLiteral(R"({"access_token":"access-1","expires_in":900,"user":{"id":42,"username":"Alice"}})"))
+                 .isValid());
+
+    const ProviderAuthenticationResult incompleteRefresh = authenticator.parseRefreshResponse(
+        QByteArrayLiteral(R"({"access_token":"access-2","expires_in":1800})"));
+    QVERIFY(incompleteRefresh.accessToken.isEmpty());
+    QVERIFY(incompleteRefresh.refreshToken.isEmpty());
+    QVERIFY(!authenticator.createRefreshRequest(QString()).has_value());
+
+    const SiloAuthenticationError invalidCredentials =
+        authenticator.parseErrorResponse(QByteArrayLiteral(
+            R"({"error":"invalid_credentials","message":"Invalid username or password"})"));
+    QVERIFY(invalidCredentials.isValid());
+    QCOMPARE(invalidCredentials.failure,
+             SiloAuthenticationFailure::InvalidCredentials);
+    const SiloAuthenticationError revoked =
+        authenticator.parseErrorResponse(QByteArrayLiteral(
+            R"({"error":"session_revoked","message":"Session was revoked"})"));
+    QVERIFY(revoked.isValid());
+    QVERIFY(revoked.isSessionRevoked());
+}
+
+void SiloAuthenticationTest::adapterMapsProfilesAndRevokedAuthenticationSessions()
+{
+    SiloProviderAdapter adapter;
+    const auto profiles = adapter.mapProfiles(QJsonArray{
+        QJsonObject{
+            {QStringLiteral("id"), QStringLiteral("profile-1")},
+            {QStringLiteral("name"), QStringLiteral("Alice")},
+            {QStringLiteral("avatar_url"), QStringLiteral("https://images.example.test/alice")},
+            {QStringLiteral("has_pin"), true},
+            {QStringLiteral("is_child"), false},
+            {QStringLiteral("is_primary"), true}
+        },
+        QJsonObject{
+            {QStringLiteral("id"), QStringLiteral("profile-2")},
+            {QStringLiteral("name"), QStringLiteral("Child")},
+            {QStringLiteral("has_pin"), false},
+            {QStringLiteral("is_child"), true},
+            {QStringLiteral("is_primary"), false}
+        }
+    });
+    QVERIFY(profiles.has_value());
+    QCOMPARE(profiles->size(), 2);
+    QCOMPARE(profiles->at(0).id, QStringLiteral("profile-1"));
+    QCOMPARE(profiles->at(0).avatarUrl, QStringLiteral("https://images.example.test/alice"));
+    QVERIFY(profiles->at(0).hasPin);
+    QVERIFY(profiles->at(0).isPrimary);
+    QVERIFY(profiles->at(1).isChild);
+
+    const auto sessions = adapter.mapAuthSessions(QJsonArray{
+        QJsonObject{
+            {QStringLiteral("id"), QStringLiteral("session-current")},
+            {QStringLiteral("device_name"), QStringLiteral("Living Room")},
+            {QStringLiteral("ip_address"), QStringLiteral("192.0.2.1")},
+            {QStringLiteral("created_at"), QStringLiteral("2026-08-01T10:00:00Z")},
+            {QStringLiteral("expires_at"), QStringLiteral("2026-08-08T10:00:00Z")}
+        },
+        QJsonObject{
+            {QStringLiteral("id"), QStringLiteral("session-revoked")},
+            {QStringLiteral("device_name"), QStringLiteral("Bedroom")},
+            {QStringLiteral("ip_address"), QStringLiteral("192.0.2.2")},
+            {QStringLiteral("created_at"), QStringLiteral("2026-07-01T10:00:00Z")},
+            {QStringLiteral("expires_at"), QStringLiteral("2026-07-08T10:00:00Z")},
+            {QStringLiteral("revoked_at"), QStringLiteral("2026-07-02T10:00:00Z")}
+        }
+    });
+    QVERIFY(sessions.has_value());
+    QCOMPARE(sessions->size(), 2);
+    QCOMPARE(sessions->at(0).id, QStringLiteral("session-current"));
+    QCOMPARE(sessions->at(0).deviceName, QStringLiteral("Living Room"));
+    QVERIFY(sessions->at(0).createdAt > 0);
+    QCOMPARE(sessions->at(0).revokedAt, -1);
+    QCOMPARE(sessions->at(1).id, QStringLiteral("session-revoked"));
+    QVERIFY(sessions->at(1).revokedAt > sessions->at(1).createdAt);
+}
+
+void SiloAuthenticationTest::adapterExposesProfileAndSessionRoutes()
+{
+    SiloProviderAdapter adapter;
+    ProviderRouteContext context;
+    context.profileId = QStringLiteral("profile/with space");
+    context.sessionId = QStringLiteral("session/with space");
+
+    const auto profiles = adapter.endpointFor(ProviderRoute::Profiles);
+    const auto pin = adapter.endpointFor(ProviderRoute::VerifyProfilePin, context);
+    const auto sessions = adapter.endpointFor(ProviderRoute::AuthSessions);
+    const auto revoke = adapter.endpointFor(ProviderRoute::RevokeAuthSession, context);
+    QVERIFY(profiles.has_value());
+    QVERIFY(pin.has_value());
+    QVERIFY(sessions.has_value());
+    QVERIFY(revoke.has_value());
+    QCOMPARE(*profiles, QStringLiteral("/api/v1/profiles"));
+    QCOMPARE(*pin,
+             QStringLiteral("/api/v1/profiles/profile%2Fwith%20space/verify-pin"));
+    QCOMPARE(*sessions, QStringLiteral("/api/v1/auth/sessions"));
+    QCOMPARE(*revoke,
+             QStringLiteral("/api/v1/auth/sessions/session%2Fwith%20space"));
+}
+
+void SiloAuthenticationTest::authenticatorDistinguishesIncorrectAndValidProfilePins()
+{
+    SiloAuthenticator authenticator;
+    const auto request = authenticator.createProfileLoginRequest(
+        QStringLiteral("profile/one"), QStringLiteral("1234"));
+    QVERIFY(request.has_value());
+    QCOMPARE(request->endpoint,
+             QStringLiteral("/api/v1/profiles/profile%2Fone/verify-pin"));
+    QCOMPARE(QJsonDocument::fromJson(request->body).object()
+                 .value(QStringLiteral("pin")).toString(),
+             QStringLiteral("1234"));
+
+    const ProviderProfileAuthenticationResult incorrect =
+        authenticator.parseProfileLoginResponse(QByteArrayLiteral(R"({"valid":false})"));
+    QVERIFY(incorrect.responseParsed);
+    QVERIFY(incorrect.isIncorrectPin());
+    QVERIFY(!incorrect.isValid());
+    QVERIFY(incorrect.profileToken.isEmpty());
+
+    const ProviderProfileAuthenticationResult valid =
+        authenticator.parseProfileLoginResponse(QByteArrayLiteral(
+            R"({"valid":true,"profile_token":"profile-token-1","expires_at":"2026-08-08T10:00:00Z"})"));
+    QVERIFY(valid.responseParsed);
+    QVERIFY(valid.valid);
+    QVERIFY(valid.isValid());
+    QCOMPARE(valid.profileToken, QStringLiteral("profile-token-1"));
+}
+
+void SiloAuthenticationTest::unauthorizedRequestRefreshesAndRetriesExactlyOnce()
+{
+    FakeNetworkAccessManager manager;
+    manager.responses = {
+        response(200, successfulLogin()),
+        response(200, singleUnlockedProfile())
+    };
+    HttpTransport transport(&manager);
+    SiloProviderAdapter adapter;
+    AuthenticationService service(nullptr, &transport, &adapter);
+    service.setProviderSelection(QStringLiteral("silo"));
+    service.authenticate(QStringLiteral("https://silo.example.test"),
+                         QStringLiteral("Alice"),
+                         QStringLiteral("password"));
+    QTRY_VERIFY_WITH_TIMEOUT(service.isAuthenticated(), 1000);
+
+    const qsizetype initialRequestCount = manager.requests.size();
+    manager.responses.append(response(
+        401,
+        QByteArrayLiteral(R"({"error":"invalid_token","message":"Expired"})")));
+    manager.responses.append(response(
+        200,
+        QByteArrayLiteral(
+            R"({"access_token":"access-2","refresh_token":"refresh-2","expires_in":1800})")));
+    manager.responses.append(response(
+        401,
+        QByteArrayLiteral(R"({"error":"invalid_token","message":"Still unauthorized"})")));
+
+    int attempts = 0;
+    int successes = 0;
+    int failures = 0;
+    QSignalSpy expiredSpy(&service, &AuthenticationService::sessionExpired);
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/api/v1/protected"),
+        [&]() -> QNetworkReply * {
+            ++attempts;
+            return manager.get(service.createRequest(QStringLiteral("/api/v1/protected")));
+        },
+        [&](QNetworkReply *) { ++successes; },
+        [&](const NetworkError &) { ++failures; },
+        options);
+
+    QTRY_COMPARE_WITH_TIMEOUT(failures, 1, 1000);
+    QCOMPARE(successes, 0);
+    QCOMPARE(attempts, 2);
+    QCOMPARE(expiredSpy.count(), 1);
+    QCOMPARE(manager.requests.size(), initialRequestCount + 3);
+    QCOMPARE(manager.requests.at(initialRequestCount).request.rawHeader("Authorization"),
+             QByteArrayLiteral("Bearer access-1"));
+    QCOMPARE(manager.requests.at(initialRequestCount + 1).request.url().path(),
+             QStringLiteral("/api/v1/auth/refresh"));
+    QVERIFY(!manager.requests.at(initialRequestCount + 1)
+                 .request.hasRawHeader("Authorization"));
+    QCOMPARE(QJsonDocument::fromJson(manager.requests.at(initialRequestCount + 1).body)
+                 .object().value(QStringLiteral("refresh_token")).toString(),
+             QStringLiteral("refresh-1"));
+    QCOMPARE(manager.requests.at(initialRequestCount + 2).request.rawHeader("Authorization"),
+             QByteArrayLiteral("Bearer access-2"));
+}
+
+void SiloAuthenticationTest::concurrentUnauthorizedRequestsShareOneRefresh()
+{
+    FakeNetworkAccessManager manager;
+    manager.responses = {
+        response(200, successfulLogin()),
+        response(200, singleUnlockedProfile())
+    };
+    HttpTransport transport(&manager);
+    SiloProviderAdapter adapter;
+    AuthenticationService service(nullptr, &transport, &adapter);
+    service.setProviderSelection(QStringLiteral("silo"));
+    service.authenticate(QStringLiteral("https://silo.example.test"),
+                         QStringLiteral("Alice"),
+                         QStringLiteral("password"));
+    QTRY_VERIFY_WITH_TIMEOUT(service.isAuthenticated(), 1000);
+
+    const qsizetype initialRequestCount = manager.requests.size();
+    manager.responses.append(response(
+        401,
+        QByteArrayLiteral(R"({"error":"invalid_token","message":"Expired"})")));
+    manager.responses.append(response(
+        401,
+        QByteArrayLiteral(R"({"error":"invalid_token","message":"Expired"})")));
+    manager.responses.append(response(
+        200,
+        QByteArrayLiteral(
+            R"({"access_token":"access-2","refresh_token":"refresh-2","expires_in":1800})")));
+    manager.responses.append(response(200, QByteArrayLiteral(R"({"ok":true})")));
+    manager.responses.append(response(200, QByteArrayLiteral(R"({"ok":true})")));
+
+    int firstAttempts = 0;
+    int secondAttempts = 0;
+    int successes = 0;
+    int failures = 0;
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    const auto success = [&](QNetworkReply *) { ++successes; };
+    const auto failure = [&](const NetworkError &) { ++failures; };
+
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/api/v1/first"),
+        [&]() -> QNetworkReply * {
+            ++firstAttempts;
+            return manager.get(service.createRequest(QStringLiteral("/api/v1/first")));
+        },
+        success,
+        failure,
+        options);
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/api/v1/second"),
+        [&]() -> QNetworkReply * {
+            ++secondAttempts;
+            return manager.get(service.createRequest(QStringLiteral("/api/v1/second")));
+        },
+        success,
+        failure,
+        options);
+
+    QTRY_COMPARE_WITH_TIMEOUT(successes, 2, 1000);
+    QCOMPARE(failures, 0);
+    QCOMPARE(firstAttempts, 2);
+    QCOMPARE(secondAttempts, 2);
+    int refreshRequests = 0;
+    for (qsizetype i = initialRequestCount; i < manager.requests.size(); ++i) {
+        if (manager.requests.at(i).request.url().path()
+            == QStringLiteral("/api/v1/auth/refresh")) {
+            ++refreshRequests;
+        }
+    }
+    QCOMPARE(refreshRequests, 1);
+    QCOMPARE(manager.requests.constLast().request.rawHeader("Authorization"),
+             QByteArrayLiteral("Bearer access-2"));
+}
+
+void SiloAuthenticationTest::failedSharedRefreshExpiresSessionOnce()
+{
+    FakeNetworkAccessManager manager;
+    manager.responses = {
+        response(200, successfulLogin()),
+        response(200, singleUnlockedProfile())
+    };
+    HttpTransport transport(&manager);
+    SiloProviderAdapter adapter;
+    AuthenticationService service(nullptr, &transport, &adapter);
+    service.setProviderSelection(QStringLiteral("silo"));
+    service.authenticate(QStringLiteral("https://silo.example.test"),
+                         QStringLiteral("Alice"),
+                         QStringLiteral("password"));
+    QTRY_VERIFY_WITH_TIMEOUT(service.isAuthenticated(), 1000);
+
+    const qsizetype initialRequestCount = manager.requests.size();
+    manager.responses.append(response(
+        401,
+        QByteArrayLiteral(R"({"error":"invalid_token","message":"Expired"})")));
+    manager.responses.append(response(
+        401,
+        QByteArrayLiteral(R"({"error":"invalid_token","message":"Expired"})")));
+    manager.responses.append(response(
+        401,
+        QByteArrayLiteral(R"({"error":"invalid_token","message":"Refresh expired"})")));
+
+    int firstAttempts = 0;
+    int secondAttempts = 0;
+    int failures = 0;
+    QSignalSpy expiredSpy(&service, &AuthenticationService::sessionExpired);
+    HttpRequestOptions options;
+    options.retryEnabled = false;
+    options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
+    const auto failure = [&](const NetworkError &) { ++failures; };
+
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/api/v1/first"),
+        [&]() -> QNetworkReply * {
+            ++firstAttempts;
+            return manager.get(service.createRequest(QStringLiteral("/api/v1/first")));
+        },
+        [](QNetworkReply *) {},
+        failure,
+        options);
+    transport.sendWithRetry(
+        this,
+        QStringLiteral("/api/v1/second"),
+        [&]() -> QNetworkReply * {
+            ++secondAttempts;
+            return manager.get(service.createRequest(QStringLiteral("/api/v1/second")));
+        },
+        [](QNetworkReply *) {},
+        failure,
+        options);
+
+    QTRY_COMPARE_WITH_TIMEOUT(failures, 2, 1000);
+    QCOMPARE(firstAttempts, 1);
+    QCOMPARE(secondAttempts, 1);
+    QCOMPARE(expiredSpy.count(), 1);
+    int refreshRequests = 0;
+    for (qsizetype i = initialRequestCount; i < manager.requests.size(); ++i) {
+        if (manager.requests.at(i).request.url().path()
+            == QStringLiteral("/api/v1/auth/refresh")) {
+            ++refreshRequests;
+        }
+    }
+    QCOMPARE(refreshRequests, 1);
+}
+
+void SiloAuthenticationTest::profileTokenIsBoundToSelectionAndClearedOnSwitch()
+{
+    FakeNetworkAccessManager manager;
+    manager.responses = {
+        response(200, successfulLogin()),
+        response(200, QByteArrayLiteral(
+            R"({"profiles":[{"id":"profile-1","name":"Alice","has_pin":true,"is_child":false,"is_primary":true}]})"))
+    };
+    HttpTransport transport(&manager);
+    SiloProviderAdapter adapter;
+    AuthenticationService service(nullptr, &transport, &adapter);
+    service.setProviderSelection(QStringLiteral("silo"));
+    service.authenticate(QStringLiteral("https://silo.example.test"),
+                         QStringLiteral("Alice"),
+                         QStringLiteral("password"));
+    QTRY_COMPARE_WITH_TIMEOUT(service.authenticationStep(), QStringLiteral("pin"), 1000);
+
+    manager.responses.append(response(
+        200,
+        QByteArrayLiteral(
+            R"({"valid":true,"profile_token":"profile-token-1","expires_at":"2026-08-08T10:00:00Z"})")));
+    service.verifyProfilePin(QStringLiteral("profile-1"), QStringLiteral("1234"));
+    QTRY_VERIFY_WITH_TIMEOUT(service.isAuthenticated(), 1000);
+
+    const QNetworkRequest selected =
+        service.createRequest(QStringLiteral("/api/v1/catalog"));
+    QCOMPARE(selected.rawHeader("Authorization"),
+             QByteArrayLiteral("Bearer access-1"));
+    QCOMPARE(selected.rawHeader("X-Profile-Id"),
+             QByteArrayLiteral("profile-1"));
+    QCOMPARE(selected.rawHeader("X-Profile-Token"),
+             QByteArrayLiteral("profile-token-1"));
+
+    service.clearProfileState();
+    const QNetworkRequest cleared =
+        service.createRequest(QStringLiteral("/api/v1/catalog"));
+    QCOMPARE(cleared.rawHeader("Authorization"),
+             QByteArrayLiteral("Bearer access-1"));
+    QVERIFY(!cleared.hasRawHeader("X-Profile-Id"));
+    QVERIFY(!cleared.hasRawHeader("X-Profile-Token"));
+}
+
+void SiloAuthenticationTest::serviceLoadsRevokedSessionsAndCallsRevokeEndpoint()
+{
+    FakeNetworkAccessManager manager;
+    manager.responses = {
+        response(200, successfulLogin()),
+        response(200, singleUnlockedProfile())
+    };
+    HttpTransport transport(&manager);
+    SiloProviderAdapter adapter;
+    AuthenticationService service(nullptr, &transport, &adapter);
+    service.setProviderSelection(QStringLiteral("silo"));
+    service.authenticate(QStringLiteral("https://silo.example.test"),
+                         QStringLiteral("Alice"),
+                         QStringLiteral("password"));
+    QTRY_VERIFY_WITH_TIMEOUT(service.isAuthenticated(), 1000);
+
+    const qsizetype initialRequestCount = manager.requests.size();
+    manager.responses.append(response(
+        200,
+        QByteArrayLiteral(
+            R"({"sessions":[{"id":"session-current","device_name":"Living Room","ip_address":"192.0.2.1","created_at":"2026-08-01T10:00:00Z","expires_at":"2026-08-08T10:00:00Z","is_current":true},{"id":"session-revoked","device_name":"Bedroom","ip_address":"192.0.2.2","created_at":"2026-07-01T10:00:00Z","expires_at":"2026-07-08T10:00:00Z","revoked_at":"2026-07-02T10:00:00Z","is_current":false}]})")));
+    service.loadAuthSessions();
+    QTRY_COMPARE_WITH_TIMEOUT(service.authSessions().size(), 2, 1000);
+    QCOMPARE(service.authSessions().at(1).toMap()
+                 .value(QStringLiteral("id")).toString(),
+             QStringLiteral("session-revoked"));
+    QVERIFY(service.authSessions().at(1).toMap()
+                .value(QStringLiteral("revokedAt")).toLongLong() > 0);
+    QCOMPARE(manager.requests.at(initialRequestCount).operation,
+             QNetworkAccessManager::GetOperation);
+    QCOMPARE(manager.requests.at(initialRequestCount).request.url().path(),
+             QStringLiteral("/api/v1/auth/sessions"));
+    QCOMPARE(manager.requests.at(initialRequestCount).request.rawHeader("Authorization"),
+             QByteArrayLiteral("Bearer access-1"));
+
+    manager.responses.append(response(204, QByteArray{}));
+    manager.responses.append(response(
+        200,
+        QByteArrayLiteral(
+            R"({"sessions":[{"id":"session-current","device_name":"Living Room","ip_address":"192.0.2.1","created_at":"2026-08-01T10:00:00Z","expires_at":"2026-08-08T10:00:00Z","is_current":true}]})")));
+    service.revokeAuthSession(QStringLiteral("session-revoked"));
+    QTRY_COMPARE_WITH_TIMEOUT(service.authSessions().size(), 1, 1000);
+    QCOMPARE(manager.requests.at(initialRequestCount + 1).operation,
+             QNetworkAccessManager::DeleteOperation);
+    QCOMPARE(manager.requests.at(initialRequestCount + 1).request.url().path(),
+             QStringLiteral("/api/v1/auth/sessions/session-revoked"));
+    QCOMPARE(manager.requests.at(initialRequestCount + 1)
+                 .request.rawHeader("Authorization"),
+             QByteArrayLiteral("Bearer access-1"));
+}
+
+QTEST_MAIN(SiloAuthenticationTest)
+#include "SiloAuthenticationTest.moc"

--- a/tests/SiloCatalogServiceTest.cpp
+++ b/tests/SiloCatalogServiceTest.cpp
@@ -1,6 +1,7 @@
+#include <QCoreApplication>
+#include <QEventLoop>
 #include <QtTest/QtTest>
 
-#include <QDir>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -9,7 +10,6 @@
 #include <QNetworkRequest>
 #include <QPointer>
 #include <QSignalSpy>
-#include <QStandardPaths>
 #include <QTemporaryDir>
 #include <QTimer>
 #include <QUrl>
@@ -23,6 +23,8 @@
 #include "providers/silo/SiloCatalogProvider.h"
 #include "providers/silo/SiloProviderAdapter.h"
 #include "utils/ConfigManager.h"
+
+#include "TestConfigIsolation.h"
 
 namespace {
 
@@ -137,50 +139,6 @@ protected:
     }
 };
 
-class ScopedConfigIsolation
-{
-public:
-    explicit ScopedConfigIsolation(const QString &path)
-        : m_previousConfigHome(qgetenv("XDG_CONFIG_HOME"))
-        , m_previousAppData(qgetenv("APPDATA"))
-        , m_previousHome(qgetenv("HOME"))
-        , m_hadPreviousConfigHome(!m_previousConfigHome.isNull())
-        , m_hadPreviousAppData(!m_previousAppData.isNull())
-        , m_hadPreviousHome(!m_previousHome.isNull())
-    {
-        QStandardPaths::setTestModeEnabled(true);
-        qputenv("XDG_CONFIG_HOME", path.toUtf8());
-        qputenv("APPDATA", path.toUtf8());
-        qputenv("HOME", path.toUtf8());
-        QDir().mkpath(path + QStringLiteral("/Library/Preferences"));
-    }
-
-    ~ScopedConfigIsolation()
-    {
-        restore("XDG_CONFIG_HOME", m_previousConfigHome, m_hadPreviousConfigHome);
-        restore("APPDATA", m_previousAppData, m_hadPreviousAppData);
-        restore("HOME", m_previousHome, m_hadPreviousHome);
-        QStandardPaths::setTestModeEnabled(false);
-    }
-
-private:
-    static void restore(const char *name, const QByteArray &value, bool hadPrevious)
-    {
-        if (hadPrevious) {
-            qputenv(name, value);
-        } else {
-            qunsetenv(name);
-        }
-    }
-
-    QByteArray m_previousConfigHome;
-    QByteArray m_previousAppData;
-    QByteArray m_previousHome;
-    bool m_hadPreviousConfigHome;
-    bool m_hadPreviousAppData;
-    bool m_hadPreviousHome;
-};
-
 class ExposedAuthenticationService final : public AuthenticationService
 {
 public:
@@ -211,6 +169,7 @@ private slots:
     void unsupportedFiltersAreExplicit();
     void responsePreservesSnapshotAndPaginationTruth();
     void nativeResponseShapesPreserveHomeLibrarySearchAndDetailData();
+    void sparseNativeMappingsPreserveFallbacksAndState();
     void requestHeadersAndGenerationSuppressStaleReplies();
 };
 
@@ -231,6 +190,14 @@ void SiloCatalogServiceTest::nativeRoutesUseContentIdentityAndCorrectMethods()
     QCOMPARE(request.method, ProviderHttpMethod::Get);
     QCOMPARE(request.relativeEndpoint,
              QStringLiteral("/api/v1/catalog?source=query&include_technical=true"));
+
+    ProviderCatalogQuery paged;
+    paged.snapshot = QStringLiteral("opaque/snapshot + token");
+    request = provider.createRequest(ProviderCatalogOperation::Items, paged);
+    QVERIFY(request.supported);
+    const QUrlQuery pagedParameters(QUrl(request.relativeEndpoint));
+    QCOMPARE(pagedParameters.queryItemValue(QStringLiteral("snapshot")),
+             QStringLiteral("opaque/snapshot + token"));
 
     query.itemId = QStringLiteral("content/with space");
     request = provider.createRequest(ProviderCatalogOperation::Item, query);
@@ -260,6 +227,13 @@ void SiloCatalogServiceTest::nativeRoutesUseContentIdentityAndCorrectMethods()
     ProviderCatalogQuery state;
     state.itemId = QStringLiteral("content-42");
     state.stateValue = true;
+    ProviderCatalogQuery season;
+    season.parentId = QStringLiteral("series/one");
+    season.includeItemTypes = {QStringLiteral("Season")};
+    request = provider.createRequest(ProviderCatalogOperation::Items, season);
+    QVERIFY(request.supported);
+    QCOMPARE(request.relativeEndpoint,
+             QStringLiteral("/api/v1/catalog/series/series%2Fone/seasons"));
     request = provider.createRequest(ProviderCatalogOperation::SetWatched, state);
     QVERIFY(request.supported);
     QCOMPARE(request.method, ProviderHttpMethod::Post);
@@ -276,6 +250,8 @@ void SiloCatalogServiceTest::nativeRoutesUseContentIdentityAndCorrectMethods()
     request = provider.createRequest(ProviderCatalogOperation::SetFavorite, state);
     QCOMPARE(request.method, ProviderHttpMethod::Delete);
     QCOMPARE(request.relativeEndpoint, QStringLiteral("/api/v1/favorites/content-42"));
+    QVERIFY(provider.parseResponse(ProviderCatalogOperation::SetWatched, {}).valid);
+    QVERIFY(provider.parseResponse(ProviderCatalogOperation::SetFavorite, {}).valid);
 }
 
 void SiloCatalogServiceTest::structuredFiltersUseNativeQueryBody()
@@ -336,6 +312,12 @@ void SiloCatalogServiceTest::structuredFiltersUseNativeQueryBody()
     QCOMPARE(groups.at(2).toObject().value(QStringLiteral("match")).toString(),
              QStringLiteral("any"));
     QCOMPARE(groups.at(2).toObject().value(QStringLiteral("rules")).toArray().size(), 2);
+    query.parentId.clear();
+    const ProviderCatalogRequest unscopedRequest = provider.createRequest(
+        ProviderCatalogOperation::Items, query);
+    QVERIFY(unscopedRequest.supported);
+    const QJsonObject unscopedBody = QJsonDocument::fromJson(unscopedRequest.body).object();
+    QVERIFY(!unscopedBody.contains(QStringLiteral("library_id")));
 
     ProviderCatalogQuery search;
     search.parentId = QStringLiteral("17");
@@ -397,6 +379,47 @@ void SiloCatalogServiceTest::unsupportedFiltersAreExplicit()
              QStringLiteral("/api/v1/home/sections/system-next-up/items"));
     verifyUnsupported(ProviderCatalogOperation::RandomItems, query);
     verifyUnsupported(ProviderCatalogOperation::ResolveLibrary, query);
+}
+
+void SiloCatalogServiceTest::sparseNativeMappingsPreserveFallbacksAndState()
+{
+    const QJsonObject item{
+        {QStringLiteral("content_id"), QStringLiteral("content-1")},
+        {QStringLiteral("title"), QStringLiteral("Sparse")},
+        {QStringLiteral("poster_url"), QString()},
+        {QStringLiteral("still_url"), QStringLiteral("still-url")},
+        {QStringLiteral("poster_thumbhash"), QString()},
+        {QStringLiteral("still_thumbhash"), QStringLiteral("still-hash")},
+        {QStringLiteral("user_state"), QJsonObject{
+             {QStringLiteral("position_seconds"), 12.5},
+             {QStringLiteral("is_in_progress"), false}}},
+        {QStringLiteral("versions"), QJsonArray{
+             QJsonObject{{QStringLiteral("file_id"), QStringLiteral("file-1")},
+                         {QStringLiteral("chapters"), QJsonArray{
+                              QJsonObject{{QStringLiteral("start_seconds"), 0.0}}}}}}}};
+    const QVariantMap mapped = SiloModelMapper::mediaItem(item, QStringLiteral("silo"));
+    QCOMPARE(mapped.value(QStringLiteral("primaryArtworkUrl")).toString(),
+             QStringLiteral("still-url"));
+    QCOMPARE(mapped.value(QStringLiteral("artworkThumbhashes")).toMap()
+                 .value(QStringLiteral("poster")).toString(),
+             QStringLiteral("still-hash"));
+    QVERIFY(mapped.value(QStringLiteral("isInProgress")).toBool());
+    const QVariantList versions = mapped.value(QStringLiteral("versions")).toList();
+    QCOMPARE(versions.size(), 1);
+    const QVariantList chapters = versions.constFirst().toMap()
+                                      .value(QStringLiteral("chapters")).toList();
+    QCOMPARE(chapters.size(), 1);
+    QCOMPARE(chapters.constFirst().toMap().value(QStringLiteral("endMs")).toLongLong(), -1);
+
+    const QVariantMap native = SiloModelMapper::nativeState(
+        QJsonObject{
+            {QStringLiteral("content_id"), QStringLiteral("content-1")},
+            {QStringLiteral("state"), QJsonObject{
+                 {QStringLiteral("position_seconds"), 4.0},
+                 {QStringLiteral("played"), false}}}},
+        QStringLiteral("silo"));
+    QCOMPARE(native.value(QStringLiteral("itemId")).toString(), QStringLiteral("content-1"));
+    QVERIFY(native.value(QStringLiteral("isInProgress")).toBool());
 }
 
 void SiloCatalogServiceTest::responsePreservesSnapshotAndPaginationTruth()
@@ -573,7 +596,8 @@ void SiloCatalogServiceTest::requestHeadersAndGenerationSuppressStaleReplies()
     auth.replaceAccount(QStringLiteral("account-2"), QStringLiteral("access-2"));
     QTRY_VERIFY_WITH_TIMEOUT(staleAccountReply->wasAborted(), 1000);
     staleAccountReply->complete();
-    QTest::qWait(20);
+    QCoreApplication::sendPostedEvents();
+    QCoreApplication::processEvents(QEventLoop::AllEvents);
     QCOMPARE(viewsSpy.count(), 0);
 
     manager.responses.append(
@@ -611,7 +635,8 @@ void SiloCatalogServiceTest::requestHeadersAndGenerationSuppressStaleReplies()
              QStringLiteral("profile-2"));
     QTRY_VERIFY_WITH_TIMEOUT(staleProfileReply->wasAborted(), 1000);
     staleProfileReply->complete();
-    QTest::qWait(20);
+    QCoreApplication::sendPostedEvents();
+    QCoreApplication::processEvents(QEventLoop::AllEvents);
     QCOMPARE(viewsSpy.count(), 1);
 
     manager.responses.append(

--- a/tests/SiloCatalogServiceTest.cpp
+++ b/tests/SiloCatalogServiceTest.cpp
@@ -1,0 +1,568 @@
+#include <QtTest/QtTest>
+
+#include <QDir>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QPointer>
+#include <QSignalSpy>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QTimer>
+#include <QUrl>
+#include <QUrlQuery>
+#include <cstring>
+
+#include "network/AuthenticationService.h"
+#include "network/HttpTransport.h"
+#include "network/LibraryService.h"
+#include "providers/ICatalogProvider.h"
+#include "providers/silo/SiloCatalogProvider.h"
+#include "providers/silo/SiloProviderAdapter.h"
+#include "utils/ConfigManager.h"
+
+namespace {
+
+class ControlledReply final : public QNetworkReply
+{
+public:
+    ControlledReply(const QNetworkRequest &request,
+                    int statusCode,
+                    QByteArray payload,
+                    bool delayed,
+                    QObject *parent)
+        : QNetworkReply(parent)
+        , m_statusCode(statusCode)
+        , m_payload(std::move(payload))
+    {
+        setRequest(request);
+        setUrl(request.url());
+        setAttribute(QNetworkRequest::HttpStatusCodeAttribute, statusCode);
+        if (statusCode >= 400) {
+            setError(statusCode == 401
+                         ? QNetworkReply::AuthenticationRequiredError
+                         : QNetworkReply::UnknownServerError,
+                     QStringLiteral("test network error"));
+        }
+        open(QIODevice::ReadOnly);
+        if (!delayed) {
+            QTimer::singleShot(0, this, [this]() { complete(); });
+        }
+    }
+
+    void abort() override
+    {
+        m_aborted = true;
+    }
+
+    qint64 bytesAvailable() const override
+    {
+        return (m_payload.size() - m_offset) + QNetworkReply::bytesAvailable();
+    }
+
+    void complete()
+    {
+        if (isFinished()) {
+            return;
+        }
+        setAttribute(QNetworkRequest::HttpStatusCodeAttribute, m_statusCode);
+        setFinished(true);
+        if (!m_payload.isEmpty()) {
+            emit readyRead();
+        }
+        emit finished();
+    }
+
+    bool wasAborted() const { return m_aborted; }
+
+protected:
+    qint64 readData(char *data, qint64 maxSize) override
+    {
+        const qint64 remaining = m_payload.size() - m_offset;
+        const qint64 count = qMin(maxSize, remaining);
+        if (count <= 0) {
+            return -1;
+        }
+        memcpy(data, m_payload.constData() + m_offset,
+               static_cast<size_t>(count));
+        m_offset += count;
+        return count;
+    }
+
+private:
+    int m_statusCode;
+    QByteArray m_payload;
+    qint64 m_offset = 0;
+    bool m_aborted = false;
+};
+
+struct ResponsePlan
+{
+    int statusCode;
+    QByteArray payload;
+    bool delayed = false;
+};
+
+struct RecordedRequest
+{
+    QNetworkAccessManager::Operation operation;
+    QNetworkRequest request;
+    QByteArray body;
+};
+
+class ControlledNetworkAccessManager final : public QNetworkAccessManager
+{
+public:
+    QList<ResponsePlan> responses;
+    QList<RecordedRequest> requests;
+    QList<QPointer<ControlledReply>> replies;
+
+protected:
+    QNetworkReply *createRequest(Operation operation,
+                                 const QNetworkRequest &request,
+                                 QIODevice *outgoingData) override
+    {
+        requests.append(
+            {operation, request, outgoingData ? outgoingData->readAll() : QByteArray()});
+        const ResponsePlan plan = responses.isEmpty()
+            ? ResponsePlan{500, QByteArrayLiteral(R"({"error":"queue_empty"})"), false}
+            : responses.takeFirst();
+        auto *reply = new ControlledReply(
+            request, plan.statusCode, plan.payload, plan.delayed, this);
+        replies.append(reply);
+        return reply;
+    }
+};
+
+class ScopedConfigIsolation
+{
+public:
+    explicit ScopedConfigIsolation(const QString &path)
+        : m_previousConfigHome(qgetenv("XDG_CONFIG_HOME"))
+        , m_previousAppData(qgetenv("APPDATA"))
+        , m_previousHome(qgetenv("HOME"))
+        , m_hadPreviousConfigHome(!m_previousConfigHome.isNull())
+        , m_hadPreviousAppData(!m_previousAppData.isNull())
+        , m_hadPreviousHome(!m_previousHome.isNull())
+    {
+        QStandardPaths::setTestModeEnabled(true);
+        qputenv("XDG_CONFIG_HOME", path.toUtf8());
+        qputenv("APPDATA", path.toUtf8());
+        qputenv("HOME", path.toUtf8());
+        QDir().mkpath(path + QStringLiteral("/Library/Preferences"));
+    }
+
+    ~ScopedConfigIsolation()
+    {
+        restore("XDG_CONFIG_HOME", m_previousConfigHome, m_hadPreviousConfigHome);
+        restore("APPDATA", m_previousAppData, m_hadPreviousAppData);
+        restore("HOME", m_previousHome, m_hadPreviousHome);
+        QStandardPaths::setTestModeEnabled(false);
+    }
+
+private:
+    static void restore(const char *name, const QByteArray &value, bool hadPrevious)
+    {
+        if (hadPrevious) {
+            qputenv(name, value);
+        } else {
+            qunsetenv(name);
+        }
+    }
+
+    QByteArray m_previousConfigHome;
+    QByteArray m_previousAppData;
+    QByteArray m_previousHome;
+    bool m_hadPreviousConfigHome;
+    bool m_hadPreviousAppData;
+    bool m_hadPreviousHome;
+};
+
+class ExposedAuthenticationService final : public AuthenticationService
+{
+public:
+    ExposedAuthenticationService(HttpTransport *transport,
+                                 IProviderAdapter *adapter)
+        : AuthenticationService(nullptr, transport, adapter)
+    {
+    }
+
+    void replaceAccount(const QString &accountId, const QString &accessToken)
+    {
+        seedSession(QStringLiteral("https://silo.example.test"),
+                    accountId,
+                    accessToken,
+                    accountId);
+    }
+};
+
+} // namespace
+
+class SiloCatalogServiceTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void nativeRoutesUseContentIdentityAndCorrectMethods();
+    void structuredFiltersUseNativeQueryBody();
+    void unsupportedFiltersAreExplicit();
+    void responsePreservesSnapshotAndPaginationTruth();
+    void requestHeadersAndGenerationSuppressStaleReplies();
+};
+
+void SiloCatalogServiceTest::nativeRoutesUseContentIdentityAndCorrectMethods()
+{
+    SiloCatalogProvider provider;
+    ProviderCatalogQuery query;
+
+    ProviderCatalogRequest request = provider.createRequest(
+        ProviderCatalogOperation::Views, query);
+    QVERIFY(request.supported);
+    QCOMPARE(request.method, ProviderHttpMethod::Get);
+    QCOMPARE(request.relativeEndpoint, QStringLiteral("/api/v1/user/libraries"));
+    QVERIFY(request.body.isEmpty());
+
+    request = provider.createRequest(ProviderCatalogOperation::Items, query);
+    QVERIFY(request.supported);
+    QCOMPARE(request.method, ProviderHttpMethod::Get);
+    QCOMPARE(request.relativeEndpoint,
+             QStringLiteral("/api/v1/catalog?source=query&include_technical=true"));
+
+    query.itemId = QStringLiteral("content/with space");
+    request = provider.createRequest(ProviderCatalogOperation::Item, query);
+    QVERIFY(request.supported);
+    QCOMPARE(request.method, ProviderHttpMethod::Get);
+    QCOMPARE(request.relativeEndpoint,
+             QStringLiteral("/api/v1/catalog/items/content%2Fwith%20space"));
+
+    request = provider.createRequest(ProviderCatalogOperation::Versions, query);
+    QVERIFY(request.supported);
+    QCOMPARE(request.method, ProviderHttpMethod::Get);
+    QCOMPARE(request.relativeEndpoint,
+             QStringLiteral("/api/v1/catalog/items/content%2Fwith%20space/versions"));
+
+    ProviderCatalogQuery hierarchy;
+    hierarchy.seriesId = QStringLiteral("series/one");
+    request = provider.createRequest(ProviderCatalogOperation::Items, hierarchy);
+    QVERIFY(request.supported);
+    QCOMPARE(request.relativeEndpoint,
+             QStringLiteral("/api/v1/catalog/series/series%2Fone/seasons"));
+    hierarchy.parentId = QStringLiteral("season/one");
+    request = provider.createRequest(ProviderCatalogOperation::Items, hierarchy);
+    QVERIFY(request.supported);
+    QCOMPARE(request.relativeEndpoint,
+             QStringLiteral("/api/v1/catalog/items/season%2Fone/episodes"));
+
+    ProviderCatalogQuery state;
+    state.itemId = QStringLiteral("content-42");
+    state.stateValue = true;
+    request = provider.createRequest(ProviderCatalogOperation::SetWatched, state);
+    QVERIFY(request.supported);
+    QCOMPARE(request.method, ProviderHttpMethod::Post);
+    QCOMPARE(request.relativeEndpoint, QStringLiteral("/api/v1/watched/content-42"));
+    request = provider.createRequest(ProviderCatalogOperation::SetFavorite, state);
+    QVERIFY(request.supported);
+    QCOMPARE(request.method, ProviderHttpMethod::Put);
+    QCOMPARE(request.relativeEndpoint, QStringLiteral("/api/v1/favorites/content-42"));
+
+    state.stateValue = false;
+    request = provider.createRequest(ProviderCatalogOperation::SetWatched, state);
+    QCOMPARE(request.method, ProviderHttpMethod::Delete);
+    QCOMPARE(request.relativeEndpoint, QStringLiteral("/api/v1/watched/content-42"));
+    request = provider.createRequest(ProviderCatalogOperation::SetFavorite, state);
+    QCOMPARE(request.method, ProviderHttpMethod::Delete);
+    QCOMPARE(request.relativeEndpoint, QStringLiteral("/api/v1/favorites/content-42"));
+}
+
+void SiloCatalogServiceTest::structuredFiltersUseNativeQueryBody()
+{
+    SiloCatalogProvider provider;
+    ProviderCatalogQuery query;
+    query.parentId = QStringLiteral("17");
+    query.startIndex = 40;
+    query.limit = 250;
+    query.genres = {QStringLiteral("Science Fiction")};
+    query.studios = {QStringLiteral("Example Studio")};
+    query.years = {1982, 2026};
+    query.includeItemTypes = {QStringLiteral("Movie"), QStringLiteral("Series")};
+    query.watched = ProviderCatalogTriState::No;
+    query.favorite = ProviderCatalogTriState::Yes;
+    query.sortBy = QStringLiteral("PremiereDate");
+    query.sortOrder = QStringLiteral("Descending");
+
+    const ProviderCatalogRequest request = provider.createRequest(
+        ProviderCatalogOperation::Items, query);
+    QVERIFY(request.supported);
+    QCOMPARE(request.method, ProviderHttpMethod::Post);
+    QCOMPARE(request.relativeEndpoint, QStringLiteral("/api/v1/catalog/query"));
+    QCOMPARE(request.extraHeaders.value(QByteArrayLiteral("Content-Type")),
+             QByteArrayLiteral("application/json"));
+
+    const QJsonObject body = QJsonDocument::fromJson(request.body).object();
+    QCOMPARE(body.value(QStringLiteral("library_id")).toInt(), 17);
+    QCOMPARE(body.value(QStringLiteral("offset")).toInt(), 40);
+    QCOMPARE(body.value(QStringLiteral("limit")).toInt(), 100);
+    QCOMPARE(body.value(QStringLiteral("sort")).toString(),
+             QStringLiteral("release_date"));
+    QCOMPARE(body.value(QStringLiteral("order")).toString(), QStringLiteral("desc"));
+    QCOMPARE(body.value(QStringLiteral("match")).toString(), QStringLiteral("all"));
+
+    const QJsonArray groups = body.value(QStringLiteral("groups")).toArray();
+    QCOMPARE(groups.size(), 3);
+    const QJsonObject allGroup = groups.at(0).toObject();
+    QCOMPARE(allGroup.value(QStringLiteral("match")).toString(), QStringLiteral("all"));
+    const QJsonArray allRules = allGroup.value(QStringLiteral("rules")).toArray();
+    QCOMPARE(allRules.size(), 4);
+    QCOMPARE(allRules.at(0).toObject().value(QStringLiteral("field")).toString(),
+             QStringLiteral("genre"));
+    QCOMPARE(allRules.at(0).toObject().value(QStringLiteral("op")).toString(),
+             QStringLiteral("contains"));
+    QCOMPARE(allRules.at(1).toObject().value(QStringLiteral("field")).toString(),
+             QStringLiteral("studio"));
+    QCOMPARE(allRules.at(2).toObject().value(QStringLiteral("field")).toString(),
+             QStringLiteral("watched"));
+    QCOMPARE(allRules.at(2).toObject().value(QStringLiteral("value")).toBool(), false);
+    QCOMPARE(allRules.at(3).toObject().value(QStringLiteral("field")).toString(),
+             QStringLiteral("favorited"));
+    QCOMPARE(allRules.at(3).toObject().value(QStringLiteral("value")).toBool(), true);
+
+    QCOMPARE(groups.at(1).toObject().value(QStringLiteral("match")).toString(),
+             QStringLiteral("any"));
+    QCOMPARE(groups.at(1).toObject().value(QStringLiteral("rules")).toArray().size(), 2);
+    QCOMPARE(groups.at(2).toObject().value(QStringLiteral("match")).toString(),
+             QStringLiteral("any"));
+    QCOMPARE(groups.at(2).toObject().value(QStringLiteral("rules")).toArray().size(), 2);
+
+    ProviderCatalogQuery search;
+    search.parentId = QStringLiteral("17");
+    search.searchTerm = QStringLiteral("Alien & Aliens");
+    search.limit = 30;
+    const ProviderCatalogRequest searchRequest = provider.createRequest(
+        ProviderCatalogOperation::Search, search);
+    QVERIFY(searchRequest.supported);
+    QCOMPARE(searchRequest.method, ProviderHttpMethod::Get);
+    QVERIFY(searchRequest.body.isEmpty());
+    const QUrl searchUrl(searchRequest.relativeEndpoint);
+    const QUrlQuery parameters(searchUrl);
+    QCOMPARE(searchUrl.path(), QStringLiteral("/api/v1/catalog"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("source")), QStringLiteral("query"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("library_id")), QStringLiteral("17"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("q")), QStringLiteral("Alien & Aliens"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("limit")), QStringLiteral("30"));
+}
+
+void SiloCatalogServiceTest::unsupportedFiltersAreExplicit()
+{
+    SiloCatalogProvider provider;
+    const auto verifyUnsupported = [&provider](ProviderCatalogOperation operation,
+                                               const ProviderCatalogQuery &query) {
+        const ProviderCatalogRequest request = provider.createRequest(operation, query);
+        QVERIFY(!request.supported);
+        QVERIFY2(!request.unsupportedReason.trimmed().isEmpty(),
+                 "Unsupported provider semantics must include a reason");
+        QVERIFY(request.relativeEndpoint.isEmpty());
+        QVERIFY(request.body.isEmpty());
+    };
+
+    ProviderCatalogQuery query;
+    query.tags = {QStringLiteral("award-winner")};
+    verifyUnsupported(ProviderCatalogOperation::Items, query);
+
+    query = {};
+    query.includeItemTypes = {QStringLiteral("Audio")};
+    verifyUnsupported(ProviderCatalogOperation::Items, query);
+
+    query = {};
+    query.minPremiereDate = QDate(2020, 1, 1);
+    verifyUnsupported(ProviderCatalogOperation::Items, query);
+
+    query = {};
+    query.sortBy = QStringLiteral("unsupported-sort");
+    verifyUnsupported(ProviderCatalogOperation::Items, query);
+
+    query = {};
+    query.itemIds = {QStringLiteral("content-1")};
+    verifyUnsupported(ProviderCatalogOperation::Items, query);
+
+    query = {};
+    const ProviderCatalogRequest nextUp = provider.createRequest(
+        ProviderCatalogOperation::NextUp, query);
+    QVERIFY(nextUp.supported);
+    QCOMPARE(nextUp.method, ProviderHttpMethod::Get);
+    QCOMPARE(nextUp.relativeEndpoint,
+             QStringLiteral("/api/v1/home/sections/system-next-up/items"));
+    verifyUnsupported(ProviderCatalogOperation::RandomItems, query);
+    verifyUnsupported(ProviderCatalogOperation::ResolveLibrary, query);
+}
+
+void SiloCatalogServiceTest::responsePreservesSnapshotAndPaginationTruth()
+{
+    SiloCatalogProvider provider;
+    const ProviderCatalogResponse page = provider.parseResponse(
+        ProviderCatalogOperation::Items,
+        QByteArrayLiteral(
+            R"({"items":[{"content_id":"content-1"},{"content_id":"content-2"}],"total":912,"total_exact":false,"has_more":true,"snapshot":"2026-08-07T11:22:33.123456789Z"})"),
+        {{QByteArrayLiteral("ETAG"), QByteArrayLiteral("\"silo-page-v1\"")},
+         {QByteArrayLiteral("last-modified"),
+          QByteArrayLiteral("Fri, 07 Aug 2026 11:22:33 GMT")}});
+    QVERIFY(page.valid);
+    QCOMPARE(page.rawItems.size(), 2);
+    QCOMPARE(page.total, 912);
+    QVERIFY(page.hasMore);
+    QCOMPARE(page.capabilityMetadata.value(QStringLiteral("totalPresent")).toBool(), true);
+    QCOMPARE(page.capabilityMetadata.value(QStringLiteral("totalExact")).toBool(), false);
+    QCOMPARE(page.capabilityMetadata.value(QStringLiteral("hasMorePresent")).toBool(), true);
+    QCOMPARE(page.snapshot.value(QStringLiteral("snapshot")).toString(),
+             QStringLiteral("2026-08-07T11:22:33.123456789Z"));
+    QCOMPARE(page.snapshot.value(QStringLiteral("etag")).toByteArray(),
+             QByteArrayLiteral("\"silo-page-v1\""));
+    QCOMPARE(page.snapshot.value(QStringLiteral("lastModified")).toByteArray(),
+             QByteArrayLiteral("Fri, 07 Aug 2026 11:22:33 GMT"));
+
+    const ProviderCatalogResponse queryWindow = provider.parseResponse(
+        ProviderCatalogOperation::Items,
+        QByteArrayLiteral(
+            R"({"items":[{"content_id":"content-3"}],"total":1,"total_exact":false,"has_more":false})"));
+    QVERIFY(queryWindow.valid);
+    QCOMPARE(queryWindow.total, 1);
+    QVERIFY(!queryWindow.hasMore);
+    QCOMPARE(queryWindow.capabilityMetadata.value(QStringLiteral("totalExact")).toBool(),
+             false);
+    QVERIFY(!queryWindow.snapshot.contains(QStringLiteral("snapshot")));
+
+    const ProviderCatalogResponse detail = provider.parseResponse(
+        ProviderCatalogOperation::Item,
+        QByteArrayLiteral(
+            R"({"content_id":"content-42","versions":[{"file_id":"file-99"}]})"));
+    QVERIFY(detail.valid);
+    QCOMPARE(detail.rawItem.value(QStringLiteral("content_id")).toString(),
+             QStringLiteral("content-42"));
+    QCOMPARE(detail.rawItem.value(QStringLiteral("versions")).toArray()
+                 .at(0).toObject().value(QStringLiteral("file_id")).toString(),
+             QStringLiteral("file-99"));
+}
+
+void SiloCatalogServiceTest::requestHeadersAndGenerationSuppressStaleReplies()
+{
+    QTemporaryDir temporaryDirectory;
+    QVERIFY(temporaryDirectory.isValid());
+    ScopedConfigIsolation isolation(temporaryDirectory.path());
+    ConfigManager config;
+
+    ControlledNetworkAccessManager manager;
+    manager.responses = {
+        {200,
+         QByteArrayLiteral(
+             R"({"access_token":"access-1","refresh_token":"refresh-1","expires_in":900,"user":{"id":42,"username":"Alice"}})"),
+         false},
+        {200,
+         QByteArrayLiteral(
+             R"({"profiles":[{"id":"profile-1","name":"Alice","has_pin":false,"is_child":false,"is_primary":true},{"id":"profile-2","name":"Cinema","has_pin":false,"is_child":false,"is_primary":false}]})"),
+         false}
+    };
+    HttpTransport transport(&manager);
+    SiloProviderAdapter adapter;
+    ExposedAuthenticationService auth(&transport, &adapter);
+    auth.initialize(&config);
+    // Wait out async restore so later auth state is deterministic.
+    QTRY_VERIFY_WITH_TIMEOUT(!auth.isRestoringSession(), 1000);
+    auth.setProviderSelection(QStringLiteral("silo"));
+    auth.authenticate(QStringLiteral("https://silo.example.test"),
+                      QStringLiteral("Alice"),
+                      QStringLiteral("password"));
+    QTRY_COMPARE_WITH_TIMEOUT(auth.authenticationStep(), QStringLiteral("profiles"), 1000);
+    auth.selectProfile(QStringLiteral("profile-1"));
+    QTRY_VERIFY_WITH_TIMEOUT(auth.isAuthenticated(), 1000);
+    QCOMPARE(config.getActiveConnection().value_or(ServerConnection{}).profileId,
+             QStringLiteral("profile-1"));
+
+    LibraryService service(&auth);
+    QSignalSpy viewsSpy(&service, &LibraryService::canonicalViewsLoadedForConnection);
+    QVERIFY(viewsSpy.isValid());
+
+    manager.responses.append(
+        {200, QByteArrayLiteral(R"([{"id":1,"name":"Old account"}])"), true});
+    const qsizetype oldRequestIndex = manager.requests.size();
+    service.getViews();
+    QTRY_COMPARE_WITH_TIMEOUT(manager.requests.size(), oldRequestIndex + 1, 1000);
+    const RecordedRequest oldRequest = manager.requests.at(oldRequestIndex);
+    QCOMPARE(oldRequest.operation, QNetworkAccessManager::GetOperation);
+    QCOMPARE(oldRequest.request.url().path(),
+             QStringLiteral("/api/v1/user/libraries"));
+    QCOMPARE(oldRequest.request.rawHeader("Authorization"),
+             QByteArrayLiteral("Bearer access-1"));
+    QCOMPARE(oldRequest.request.rawHeader("X-Profile-Id"),
+             QByteArrayLiteral("profile-1"));
+    QVERIFY(oldRequest.body.isEmpty());
+    QPointer<ControlledReply> staleAccountReply = manager.replies.constLast();
+    QVERIFY(staleAccountReply);
+
+    auth.replaceAccount(QStringLiteral("account-2"), QStringLiteral("access-2"));
+    QTRY_VERIFY_WITH_TIMEOUT(staleAccountReply->wasAborted(), 1000);
+    staleAccountReply->complete();
+    QTest::qWait(20);
+    QCOMPARE(viewsSpy.count(), 0);
+
+    manager.responses.append(
+        {200, QByteArrayLiteral(R"([{"id":2,"name":"New account"}])"), true});
+    const qsizetype newRequestIndex = manager.requests.size();
+    service.getViews();
+    QTRY_COMPARE_WITH_TIMEOUT(manager.requests.size(), newRequestIndex + 1, 1000);
+    const RecordedRequest newRequest = manager.requests.at(newRequestIndex);
+    QCOMPARE(newRequest.operation, QNetworkAccessManager::GetOperation);
+    QCOMPARE(newRequest.request.url().path(),
+             QStringLiteral("/api/v1/user/libraries"));
+    QCOMPARE(newRequest.request.rawHeader("Authorization"),
+             QByteArrayLiteral("Bearer access-2"));
+    QCOMPARE(newRequest.request.rawHeader("X-Profile-Id"),
+             QByteArrayLiteral("profile-1"));
+    QPointer<ControlledReply> currentReply = manager.replies.constLast();
+    QVERIFY(currentReply);
+    currentReply->complete();
+    QTRY_COMPARE_WITH_TIMEOUT(viewsSpy.count(), 1, 1000);
+    const QVariantList currentViews = viewsSpy.first().at(1).toList();
+    QCOMPARE(currentViews.size(), 1);
+    QCOMPARE(currentViews.constFirst().toMap()
+                 .value(QStringLiteral("itemId")).toString(),
+             QStringLiteral("2"));
+
+    manager.responses.append(
+        {200, QByteArrayLiteral(R"([{"id":3,"name":"Stale profile"}])"), true});
+    service.getViews();
+    QTRY_COMPARE_WITH_TIMEOUT(manager.requests.size(), newRequestIndex + 2, 1000);
+    QPointer<ControlledReply> staleProfileReply = manager.replies.constLast();
+    QVERIFY(staleProfileReply);
+    auth.selectProfile(QStringLiteral("profile-2"));
+    QTRY_VERIFY_WITH_TIMEOUT(auth.isAuthenticated(), 1000);
+    QCOMPARE(config.getActiveConnection().value_or(ServerConnection{}).profileId,
+             QStringLiteral("profile-2"));
+    QTRY_VERIFY_WITH_TIMEOUT(staleProfileReply->wasAborted(), 1000);
+    staleProfileReply->complete();
+    QTest::qWait(20);
+    QCOMPARE(viewsSpy.count(), 1);
+
+    manager.responses.append(
+        {200, QByteArrayLiteral(R"([{"id":4,"name":"Current profile"}])"), true});
+    const qsizetype profileRequestIndex = manager.requests.size();
+    service.getViews();
+    QTRY_COMPARE_WITH_TIMEOUT(manager.requests.size(), profileRequestIndex + 1, 1000);
+    const RecordedRequest profileRequest = manager.requests.at(profileRequestIndex);
+    QCOMPARE(profileRequest.operation, QNetworkAccessManager::GetOperation);
+    QCOMPARE(profileRequest.request.url().path(),
+             QStringLiteral("/api/v1/user/libraries"));
+    QCOMPARE(profileRequest.request.rawHeader("Authorization"),
+             QByteArrayLiteral("Bearer access-2"));
+    QCOMPARE(profileRequest.request.rawHeader("X-Profile-Id"),
+             QByteArrayLiteral("profile-2"));
+    QVERIFY(profileRequest.body.isEmpty());
+    QPointer<ControlledReply> profileReply = manager.replies.constLast();
+    QVERIFY(profileReply);
+    profileReply->complete();
+    QTRY_COMPARE_WITH_TIMEOUT(viewsSpy.count(), 2, 1000);
+}
+
+QTEST_MAIN(SiloCatalogServiceTest)
+#include "SiloCatalogServiceTest.moc"

--- a/tests/SiloCatalogServiceTest.cpp
+++ b/tests/SiloCatalogServiceTest.cpp
@@ -166,6 +166,7 @@ class SiloCatalogServiceTest : public QObject
 private slots:
     void nativeRoutesUseContentIdentityAndCorrectMethods();
     void structuredFiltersUseNativeQueryBody();
+    void bookQueriesUseEbookType();
     void unsupportedFiltersAreExplicit();
     void responsePreservesSnapshotAndPaginationTruth();
     void nativeResponseShapesPreserveHomeLibrarySearchAndDetailData();
@@ -335,6 +336,27 @@ void SiloCatalogServiceTest::structuredFiltersUseNativeQueryBody()
     QCOMPARE(parameters.queryItemValue(QStringLiteral("library_id")), QStringLiteral("17"));
     QCOMPARE(parameters.queryItemValue(QStringLiteral("q")), QStringLiteral("Alien & Aliens"));
     QCOMPARE(parameters.queryItemValue(QStringLiteral("limit")), QStringLiteral("30"));
+}
+
+void SiloCatalogServiceTest::bookQueriesUseEbookType()
+{
+    SiloCatalogProvider provider;
+    ProviderCatalogQuery query;
+    query.includeItemTypes = {QStringLiteral("Book")};
+
+    const ProviderCatalogRequest request = provider.createRequest(
+        ProviderCatalogOperation::Items, query);
+    QVERIFY(request.supported);
+    QCOMPARE(request.method, ProviderHttpMethod::Post);
+    const QJsonObject body = QJsonDocument::fromJson(request.body).object();
+    const QJsonArray groups = body.value(QStringLiteral("groups")).toArray();
+    QVERIFY(!groups.isEmpty());
+    const QJsonArray rules = groups.first().toObject().value(QStringLiteral("rules")).toArray();
+    QVERIFY(!rules.isEmpty());
+    QCOMPARE(rules.first().toObject().value(QStringLiteral("field")).toString(),
+             QStringLiteral("type"));
+    QCOMPARE(rules.first().toObject().value(QStringLiteral("value")).toString(),
+             QStringLiteral("ebook"));
 }
 
 void SiloCatalogServiceTest::unsupportedFiltersAreExplicit()

--- a/tests/SiloCatalogServiceTest.cpp
+++ b/tests/SiloCatalogServiceTest.cpp
@@ -210,6 +210,7 @@ private slots:
     void structuredFiltersUseNativeQueryBody();
     void unsupportedFiltersAreExplicit();
     void responsePreservesSnapshotAndPaginationTruth();
+    void nativeResponseShapesPreserveHomeLibrarySearchAndDetailData();
     void requestHeadersAndGenerationSuppressStaleReplies();
 };
 
@@ -410,6 +411,13 @@ void SiloCatalogServiceTest::responsePreservesSnapshotAndPaginationTruth()
           QByteArrayLiteral("Fri, 07 Aug 2026 11:22:33 GMT")}});
     QVERIFY(page.valid);
     QCOMPARE(page.rawItems.size(), 2);
+    const QString firstId = page.rawItems.at(0).toObject()
+                                .value(QStringLiteral("content_id")).toString();
+    const QString secondId = page.rawItems.at(1).toObject()
+                                 .value(QStringLiteral("content_id")).toString();
+    QVERIFY(!firstId.isEmpty());
+    QVERIFY(!secondId.isEmpty());
+    QVERIFY(firstId != secondId);
     QCOMPARE(page.total, 912);
     QVERIFY(page.hasMore);
     QCOMPARE(page.capabilityMetadata.value(QStringLiteral("totalPresent")).toBool(), true);
@@ -427,6 +435,12 @@ void SiloCatalogServiceTest::responsePreservesSnapshotAndPaginationTruth()
         QByteArrayLiteral(
             R"({"items":[{"content_id":"content-3"}],"total":1,"total_exact":false,"has_more":false})"));
     QVERIFY(queryWindow.valid);
+    QCOMPARE(queryWindow.rawItems.size(), 1);
+    const QString nextId = queryWindow.rawItems.first().toObject()
+                               .value(QStringLiteral("content_id")).toString();
+    QVERIFY(!nextId.isEmpty());
+    QVERIFY(nextId != firstId);
+    QVERIFY(nextId != secondId);
     QCOMPARE(queryWindow.total, 1);
     QVERIFY(!queryWindow.hasMore);
     QCOMPARE(queryWindow.capabilityMetadata.value(QStringLiteral("totalExact")).toBool(),
@@ -443,6 +457,62 @@ void SiloCatalogServiceTest::responsePreservesSnapshotAndPaginationTruth()
     QCOMPARE(detail.rawItem.value(QStringLiteral("versions")).toArray()
                  .at(0).toObject().value(QStringLiteral("file_id")).toString(),
              QStringLiteral("file-99"));
+}
+
+void SiloCatalogServiceTest::nativeResponseShapesPreserveHomeLibrarySearchAndDetailData()
+{
+    SiloCatalogProvider provider;
+
+    const ProviderCatalogResponse home = provider.parseResponse(
+        ProviderCatalogOperation::Views,
+        QByteArrayLiteral(
+            R"({"sections":[{"id":"system-next-up","title":"Next Up","type":"next_up"},{"id":"library-17","title":"Movies","type":"library"}]})"));
+    QVERIFY(home.valid);
+    QCOMPARE(home.rawItems.size(), 2);
+    QCOMPARE(home.rawItems.at(0).toObject().value(QStringLiteral("id")).toString(),
+             QStringLiteral("system-next-up"));
+    QCOMPARE(home.rawItems.at(1).toObject().value(QStringLiteral("type")).toString(),
+             QStringLiteral("library"));
+
+    const ProviderCatalogResponse library = provider.parseResponse(
+        ProviderCatalogOperation::Items,
+        QByteArrayLiteral(
+            R"({"items":[{"content_id":"content-1","type":"movie","title":"One"},{"content_id":"content-2","type":"movie","title":"Two"}],"total":2,"total_exact":true,"has_more":false})"));
+    QVERIFY(library.valid);
+    QCOMPARE(library.rawItems.size(), 2);
+    QCOMPARE(library.rawItems.at(1).toObject().value(QStringLiteral("content_id")).toString(),
+             QStringLiteral("content-2"));
+    QCOMPARE(library.total, 2);
+    QCOMPARE(library.capabilityMetadata.value(QStringLiteral("totalExact")).toBool(), true);
+    QVERIFY(!library.hasMore);
+
+    const ProviderCatalogResponse search = provider.parseResponse(
+        ProviderCatalogOperation::Search,
+        QByteArrayLiteral("{\"items\":[{\"content_id\":\"content-9\",\"type\":\"series\",\"title\":\"Alien\"}],\"total\":1,\"total_exact\":true,\"has_more\":false,\"search_diagnostics\":{\"term\":\"Alien\"}}"));
+    QVERIFY(search.valid);
+    QCOMPARE(search.rawItems.size(), 1);
+    QCOMPARE(search.rawItems.first().toObject()
+                 .value(QStringLiteral("content_id")).toString(),
+             QStringLiteral("content-9"));
+    QCOMPARE(search.capabilityMetadata.value(QStringLiteral("searchDiagnostics")).toMap()
+                 .value(QStringLiteral("term")).toString(),
+             QStringLiteral("Alien"));
+
+    const ProviderCatalogResponse detailResponse = provider.parseResponse(
+        ProviderCatalogOperation::Item,
+        QByteArrayLiteral(
+            R"JSON({"content_id":"content-42","type":"movie","title":"Example","provider_ids":{"imdb_id":"tt123"},"user_state":{"played":true,"is_favorite":true},"versions":[{"file_id":"file-99","duration":123.456}],"playback_variants":[{"variant_id":"variant-1","part_count":2}],"subtitles":[{"language":"en"}]})JSON"));
+    QVERIFY(detailResponse.valid);
+    QCOMPARE(detailResponse.rawItem.value(QStringLiteral("content_id")).toString(),
+             QStringLiteral("content-42"));
+    QCOMPARE(detailResponse.rawItem.value(QStringLiteral("provider_ids")).toObject()
+                 .value(QStringLiteral("imdb_id")).toString(),
+             QStringLiteral("tt123"));
+    QCOMPARE(detailResponse.rawItem.value(QStringLiteral("versions")).toArray().size(), 1);
+    QCOMPARE(detailResponse.rawItem.value(QStringLiteral("playback_variants")).toArray()
+                 .first().toObject().value(QStringLiteral("part_count")).toInt(),
+             2);
+    QCOMPARE(detailResponse.rawItem.value(QStringLiteral("subtitles")).toArray().size(), 1);
 }
 
 void SiloCatalogServiceTest::requestHeadersAndGenerationSuppressStaleReplies()

--- a/tests/TestConfigIsolation.h
+++ b/tests/TestConfigIsolation.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <QByteArray>
+#include <QDir>
+#include <QStandardPaths>
+#include <QString>
+
+namespace {
+
+// Redirects config-related paths into a temporary directory and restores the
+// previous environment on destruction. Shared by tests that exercise
+// ConfigManager, CredentialStore, and SessionManager so each test runs against
+// an isolated, throwaway configuration tree.
+class ScopedConfigIsolation
+{
+public:
+    explicit ScopedConfigIsolation(const QString &path)
+        : m_previousConfigHome(qgetenv("XDG_CONFIG_HOME"))
+        , m_previousAppData(qgetenv("APPDATA"))
+        , m_previousHome(qgetenv("HOME"))
+        , m_hadPreviousConfigHome(!m_previousConfigHome.isNull())
+        , m_hadPreviousAppData(!m_previousAppData.isNull())
+        , m_hadPreviousHome(!m_previousHome.isNull())
+    {
+        QStandardPaths::setTestModeEnabled(true);
+        qputenv("XDG_CONFIG_HOME", path.toUtf8());
+        qputenv("APPDATA", path.toUtf8());
+        qputenv("HOME", path.toUtf8());
+        QDir().mkpath(path + QStringLiteral("/Library/Preferences"));
+    }
+
+    ~ScopedConfigIsolation()
+    {
+        restore("XDG_CONFIG_HOME", m_previousConfigHome, m_hadPreviousConfigHome);
+        restore("APPDATA", m_previousAppData, m_hadPreviousAppData);
+        restore("HOME", m_previousHome, m_hadPreviousHome);
+        QStandardPaths::setTestModeEnabled(false);
+    }
+
+private:
+    static void restore(const char *name, const QByteArray &value, bool hadPrevious)
+    {
+        if (hadPrevious) {
+            qputenv(name, value);
+        } else {
+            qunsetenv(name);
+        }
+    }
+
+    QByteArray m_previousConfigHome;
+    QByteArray m_previousAppData;
+    QByteArray m_previousHome;
+    bool m_hadPreviousConfigHome;
+    bool m_hadPreviousAppData;
+    bool m_hadPreviousHome;
+};
+
+} // namespace

--- a/tests/contracts/provider-contracts.json
+++ b/tests/contracts/provider-contracts.json
@@ -463,19 +463,396 @@
     }
   ],
   "nativeSiloContract": {
+    "sourceRevision": "8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6",
     "detection": {
       "method": "GET",
       "path": "/api/v1/health",
-      "requiredFields": ["status", "server_id"],
-      "notes": ["server_id identifies one installation reached through multiple URLs", "Do not infer Silo from compatibility /System/Info"]
+      "requiredFields": ["status"],
+      "optionalFields": ["server_name", "server_id"],
+      "requiredValues": {"status": "ok"},
+      "serverIdPolicy": "server_id is optional and its default is deterministic across installations, so it is not sufficient as a unique connection identity",
+      "notes": ["Do not infer Silo from compatibility /System/Info", "Persist server_id only when present and do not assume it is globally unique"]
     },
-    "authenticationRoutes": ["GET /api/v1/auth/providers", "POST /api/v1/auth/login", "POST /api/v1/auth/refresh", "GET /api/v1/auth/me", "POST /api/v1/auth/logout", "GET /api/v1/auth/sessions", "DELETE /api/v1/auth/sessions/{id}"],
-    "profileRoutes": ["GET /api/v1/profiles", "POST /api/v1/profiles/{id}/verify-pin"],
-    "catalogRoutes": ["GET /api/v1/user/libraries", "GET /api/v1/catalog", "POST /api/v1/catalog/query", "GET /api/v1/catalog/items/{id}", "GET /api/v1/catalog/items/{id}/versions", "GET /api/v1/catalog/series/{id}/seasons", "GET /api/v1/catalog/series/{id}/seasons/{number}/episodes"],
-    "playbackRoutes": ["GET /api/v1/playback/capability", "POST /api/v1/playback/start", "POST /api/v1/playback/{session_id}/progress", "DELETE /api/v1/playback/{session_id}"],
     "requiredHeaders": ["Authorization: Bearer <access token>", "X-Profile-Id after profile selection", "X-Profile-Token after successful PIN verification", "X-Silo-Client", "X-Silo-Client-Version", "X-Silo-Device-Id", "X-Silo-Device-Name", "X-Silo-Device-Platform"],
-    "identityRules": ["Use content_id for catalog and user-state identity", "Use file_id for playback", "Use milliseconds inside Bloom", "Treat native artwork URLs as expiring fetch locations, not cache identities"],
-    "playbackDecision": "Use the legacy native playback envelope until Silo documents an mpv-compatible protocol-v3 contract; v3 currently advertises media3_only."
+    "identityRules": ["Use content_id for catalog and user-state identity", "Use file_id for playback and version selection", "Use seconds in Silo playback and marker envelopes and convert to milliseconds at Bloom's adapter boundary", "Treat native artwork URLs as expiring fetch locations, not cache identities"],
+    "coverageRequirements": [
+      "native.health",
+      "native.auth.providers",
+      "native.auth.login",
+      "native.auth.errors",
+      "native.auth.refresh",
+      "native.auth.me",
+      "native.auth.logout",
+      "native.auth.sessions",
+      "native.profiles.list",
+      "native.profiles.pin",
+      "native.catalog.libraries",
+      "native.catalog.page",
+      "native.catalog.query",
+      "native.catalog.detail",
+      "native.catalog.hierarchy",
+      "native.state.watched",
+      "native.state.favorite",
+      "native.artwork.refetch",
+      "native.playback.capability",
+      "native.playback.start-legacy",
+      "native.playback.progress",
+      "native.playback.stop",
+      "native.playback.transcode",
+      "native.playback.track",
+      "native.markers",
+      "native.chapters",
+      "native.trickplay",
+      "native.theme-songs"
+    ],
+    "requirements": [
+      {
+        "id": "native.health",
+        "issue": 77,
+        "method": "GET",
+        "path": "/api/v1/health",
+        "outcome": "partial",
+        "capability": {"state": "available", "discovery": "public route"},
+        "requestSemantics": ["No authentication or profile header is required"],
+        "requiredSemantics": ["HTTP 200 JSON has status equal to ok", "server_id and server_name may be omitted", "The configured default server_id is deterministic and therefore cannot prove installation uniqueness"],
+        "evidenceSources": [
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/health.go",
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/config/config.go"
+        ],
+        "liveProbe": true
+      },
+      {
+        "id": "native.auth.providers",
+        "issue": 77,
+        "method": "GET",
+        "path": "/api/v1/auth/providers",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "route response"},
+        "requestSemantics": ["The route is public and precedes login"],
+        "requiredSemantics": ["Response is an array of provider objects with id, display_name, mode, and default", "OAuth providers are omitted unless their completion routes are available"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/auth.go"]
+      },
+      {
+        "id": "native.auth.login",
+        "issue": 77,
+        "method": "POST",
+        "path": "/api/v1/auth/login",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "auth providers"},
+        "requestSemantics": ["JSON contains username and password plus optional provider", "User-Agent supplies the stored device name"],
+        "requiredSemantics": ["Success returns access_token, refresh_token, positive expires_in, and a user with numeric id and username", "Login creates one auth session for the account and device"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/auth.go"]
+      },
+      {
+        "id": "native.auth.errors",
+        "issue": 77,
+        "method": "GET/POST/DELETE",
+        "path": "/api/v1/auth/*",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "route status and JSON envelope"},
+        "requestSemantics": ["Malformed, invalid, expired, revoked, forbidden, and missing resources are handled separately"],
+        "requiredSemantics": ["Errors use JSON fields error and message", "Invalid credentials return 401 invalid_credentials", "Invalid or expired refresh tokens return 401 invalid_token and revoked sessions return 401 session_revoked", "Missing bearer authentication returns 401 without a protected payload"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/auth.go"]
+      },
+      {
+        "id": "native.auth.refresh",
+        "issue": 77,
+        "method": "POST",
+        "path": "/api/v1/auth/refresh",
+        "outcome": "partial",
+        "capability": {"state": "available", "discovery": "route response"},
+        "requestSemantics": ["JSON contains refresh_token and no bearer access token is required"],
+        "requiredSemantics": ["Success returns replacement access_token, refresh_token, and expires_in and extends the session window", "The pinned implementation does not revoke the previously issued refresh JWT, so clients must update stored tokens but cannot treat reuse of the old token as a rotation failure"],
+        "evidenceSources": [
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/auth.go",
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/auth/service.go"
+        ]
+      },
+      {
+        "id": "native.auth.me",
+        "issue": 77,
+        "method": "GET",
+        "path": "/api/v1/auth/me",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "protected route"},
+        "requestSemantics": ["Authorization carries a bearer access token"],
+        "requiredSemantics": ["Response identifies the authenticated account with id, username, role, permissions, and download_allowed", "The account response does not select a household profile"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/auth.go"]
+      },
+      {
+        "id": "native.auth.logout",
+        "issue": 77,
+        "method": "POST",
+        "path": "/api/v1/auth/logout",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "protected route"},
+        "requestSemantics": ["Authorization identifies the caller session"],
+        "requiredSemantics": ["Success revokes the caller session and returns 204", "Subsequent bearer or refresh use for that session is rejected"],
+        "evidenceSources": [
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/auth.go",
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/auth/service.go"
+        ]
+      },
+      {
+        "id": "native.auth.sessions",
+        "issue": 77,
+        "method": "GET/DELETE",
+        "path": "/api/v1/auth/sessions and /api/v1/auth/sessions/{id}",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "protected routes"},
+        "requestSemantics": ["Authorization scopes list and revoke operations to the authenticated account"],
+        "requiredSemantics": ["List response has sessions with id, device_name, ip_address, created_at, expires_at, and optional revoked_at", "DELETE revokes only a session owned by the caller and returns 204", "An unknown or other-account session is reported as not_found"],
+        "evidenceSources": [
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/auth.go",
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/auth/service.go"
+        ]
+      },
+      {
+        "id": "native.profiles.list",
+        "issue": 77,
+        "method": "GET",
+        "path": "/api/v1/profiles",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "protected route"},
+        "requestSemantics": ["Bearer authentication identifies the account; no profile selection is required to list its profiles"],
+        "requiredSemantics": ["Response has profiles and avatar_upload_enabled", "Each profile has stable id, name, has_pin, is_child, is_primary, access settings, and playback preferences"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/profiles.go"]
+      },
+      {
+        "id": "native.profiles.pin",
+        "issue": 77,
+        "method": "POST",
+        "path": "/api/v1/profiles/{id}/verify-pin",
+        "outcome": "supported",
+        "capability": {"state": "conditional", "discovery": "profiles[].has_pin"},
+        "requestSemantics": ["JSON contains pin and bearer authentication binds verification to the account session"],
+        "requiredSemantics": ["A correct PIN returns valid true plus profile_token and expires_at", "An incorrect PIN returns HTTP 200 with valid false and no token", "A missing profile or profile without a PIN returns 404", "X-Profile-Token is bound to user, auth session, profile, and access-policy revision"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/profiles.go"]
+      },
+      {
+        "id": "native.catalog.libraries",
+        "issue": 78,
+        "method": "GET",
+        "path": "/api/v1/user/libraries",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "protected route"},
+        "requestSemantics": ["Bearer and selected profile scope library visibility"],
+        "requiredSemantics": ["Only profile-accessible libraries are returned", "Library IDs are presentation scopes and do not replace content_id item identity"],
+        "evidenceSources": [
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/libraries.go",
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/router.go"
+        ]
+      },
+      {
+        "id": "native.catalog.page",
+        "issue": 78,
+        "method": "GET",
+        "path": "/api/v1/catalog",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "total_exact, has_more, and snapshot response fields"},
+        "requestSemantics": ["limit is capped at 100", "Clients replay the RFC3339Nano snapshot on later offset pages", "include_total=false permits an inexact or omitted-cost count"],
+        "requiredSemantics": ["Response has items, total, total_exact, and has_more", "A generated snapshot freezes results to items created at or before its timestamp and is reusable on later pages", "total_exact is false for grouped work views and whenever the source did not compute an exact total"],
+        "evidenceSources": [
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/catalog.go",
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/catalog/catalog_parser.go"
+        ]
+      },
+      {
+        "id": "native.catalog.query",
+        "issue": 78,
+        "method": "POST",
+        "path": "/api/v1/catalog/query",
+        "outcome": "partial",
+        "capability": {"state": "conditional", "discovery": "/api/v1/catalog/filters plus request validation"},
+        "requestSemantics": ["JSON filter_config, library_id, limit, offset, sort, and order drive a bounded query"],
+        "requiredSemantics": ["Invalid or unsupported filter rules return 400 rather than silently disappearing", "Response carries items, total, and has_more", "The pinned POST response uses total_exact false even though its window count is exact and has no snapshot field, so snapshot-aware pagination must use GET /catalog"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/catalog.go"]
+      },
+      {
+        "id": "native.catalog.detail",
+        "issue": 78,
+        "method": "GET",
+        "path": "/api/v1/catalog/items/{id} and /api/v1/catalog/items/{id}/versions",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "canonical resource routes"},
+        "requestSemantics": ["id is content_id; selected file identity remains file_id inside versions"],
+        "requiredSemantics": ["Detail includes content_id, type, title, provider IDs where known, user state, versions, subtitles, markers, artwork, and multipart playback_variants", "Version entries preserve file_id, technical tracks, duration, edition, ordered multipart indices, chapters, and markers", "Unauthorized file paths are removed without removing playable file identity"],
+        "evidenceSources": [
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/catalog_resources.go",
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/catalog/detail.go"
+        ]
+      },
+      {
+        "id": "native.catalog.hierarchy",
+        "issue": 78,
+        "method": "GET",
+        "path": "/api/v1/catalog/items/{id}/episodes and /api/v1/catalog/series/{id}/seasons*",
+        "outcome": "supported",
+        "capability": {"state": "conditional", "discovery": "item type"},
+        "requestSemantics": ["Series and season routes use content_id plus a numeric season number where applicable"],
+        "requiredSemantics": ["Series routes return ordered seasons and episodes with stable content_id values", "Synthetic and persisted seasons preserve access checks and profile user-data rollups"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/catalog_resources.go"]
+      },
+      {
+        "id": "native.state.watched",
+        "issue": 78,
+        "method": "POST/DELETE",
+        "path": "/api/v1/watched/{id}",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "profile-scoped route"},
+        "requestSemantics": ["id is content_id and X-Profile-Id is required"],
+        "requiredSemantics": ["POST marks the resolved playable target or hierarchy watched and DELETE reverses it", "Response reports content_id, type, affected_count, and played", "A subsequent detail/user-state read reflects the mutation"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/items.go"]
+      },
+      {
+        "id": "native.state.favorite",
+        "issue": 78,
+        "method": "GET/PUT/DELETE",
+        "path": "/api/v1/favorites/{item_id}",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "profile-scoped route"},
+        "requestSemantics": ["item_id is content_id and X-Profile-Id is required"],
+        "requiredSemantics": ["GET returns 204 when favorited and 404 when not", "PUT and DELETE are idempotent profile-scoped mutations returning 204", "List/detail user state reflects changes"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/favorites.go"]
+      },
+      {
+        "id": "native.artwork.refetch",
+        "issue": 78,
+        "method": "GET",
+        "path": "opaque URLs from catalog, detail, person, and chapter resources",
+        "outcome": "supported",
+        "capability": {"state": "conditional", "discovery": "*_url fields"},
+        "requestSemantics": ["Clients preserve absolute or relative opaque URLs and every signed query parameter"],
+        "requiredSemantics": ["Artwork URLs are fetch locations rather than durable cache keys", "Missing or expired artwork triggers refetch of the owning catalog/detail resource to obtain a fresh URL", "Poster, backdrop, logo, person, and chapter URLs may be omitted when no image exists"],
+        "evidenceSources": [
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/catalog/detail.go",
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/items.go"
+        ]
+      },
+      {
+        "id": "native.playback.capability",
+        "issue": 79,
+        "method": "GET",
+        "path": "/api/v1/playback/capability",
+        "outcome": "partial",
+        "capability": {"state": "conditional", "discovery": "enabled, protocol_versions, features, deliveries, and transformations"},
+        "requestSemantics": ["Bearer authentication is required"],
+        "requiredSemantics": ["Disabled protocol v3 returns enabled false, reason disabled, and empty feature, delivery, and transformation arrays", "Enabled protocol v3 advertises only runtime-probed transformations and includes media3_only", "media3_only is not an mpv capability and the response does not advertise the legacy envelope, so Bloom must use the pinned legacy contract rather than infer v3 suitability"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/playback_v3.go"]
+      },
+      {
+        "id": "native.playback.start-legacy",
+        "issue": 79,
+        "method": "POST",
+        "path": "/api/v1/playback/start",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "absence of protocol_version selects the legacy decoder"},
+        "requestSemantics": ["JSON includes file_id, optional matching profile_id, play_method or client codec/container/HDR capabilities, start_position seconds, and optional audio_track_index", "X-Profile-Id is mandatory and file_id must be accessible to that profile"],
+        "requiredSemantics": ["Without protocol_version 3 the legacy decoder selects direct, remux, or transcode and returns HTTP 201", "Response includes session_id, media_file_id, play_method, position, stream_url, audio_track_index, duration_seconds, subtitle_urls, and playback_info", "Relative or absolute stream/subtitle URLs and signed query parameters remain opaque", "Alternate-version selection is reflected by media_file_id and multipart ordering remains in catalog playback_variants"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/playback.go"]
+      },
+      {
+        "id": "native.playback.progress",
+        "issue": 79,
+        "method": "POST",
+        "path": "/api/v1/playback/{session_id}/progress",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "legacy playback session"},
+        "requestSemantics": ["JSON contains position seconds and is_paused"],
+        "requiredSemantics": ["Only the session owner may update progress", "Update returns 204 and best-effort persists resume/completion state to the selected profile", "Pause and resume transitions update scrobble state without ending the session"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/playback.go"]
+      },
+      {
+        "id": "native.playback.stop",
+        "issue": 79,
+        "method": "DELETE",
+        "path": "/api/v1/playback/{session_id}",
+        "outcome": "supported",
+        "capability": {"state": "available", "discovery": "legacy playback session"},
+        "requestSemantics": ["Bearer account must own session_id"],
+        "requiredSemantics": ["Stop persists final session progress, tears down stream/transcode resources, and returns 204", "Missing sessions use the playback_session_not_found error rather than succeeding silently"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/playback.go"]
+      },
+      {
+        "id": "native.playback.transcode",
+        "issue": 79,
+        "method": "POST",
+        "path": "/api/v1/playback/transcode/start",
+        "outcome": "supported",
+        "capability": {"state": "conditional", "discovery": "legacy start play_method plus user/server transcode policy"},
+        "requestSemantics": ["JSON names session_id, seek_seconds, target codecs/resolution/bitrate, segment_duration, and subtitle burn-in selection"],
+        "requiredSemantics": ["Response has manifest_url, duration_seconds, player_start_seconds, stream_origin_seconds, timeline_offset_seconds, and can_seek_anywhere", "Signed manifest URLs are replaced after recipe, seek, quality, file, or subtitle changes", "Server policy may return transcoding_disabled, audio_transcoding_disabled, no_alternate_version, or subtitle_source_unavailable instead of claiming support"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/playback.go"]
+      },
+      {
+        "id": "native.playback.track",
+        "issue": 79,
+        "method": "PATCH",
+        "path": "/api/v1/playback/{session_id}/audio",
+        "outcome": "supported",
+        "capability": {"state": "conditional", "discovery": "audio track inventory in catalog versions"},
+        "requestSemantics": ["JSON contains audio_track_index and position seconds"],
+        "requiredSemantics": ["Out-of-range indices return 400 and other-account sessions return 403", "Success returns audio_track_index, effective play_method, replacement stream_url, switch_mode reload, and playback_info", "A track change may promote direct play to remux or audio transcode and must replace the signed stream recipe"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/playback.go"]
+      },
+      {
+        "id": "native.markers",
+        "issue": 80,
+        "method": "GET",
+        "path": "/api/v1/markers/items/{id} and /api/v1/markers/files/{fileId}",
+        "outcome": "supported",
+        "capability": {"state": "conditional", "discovery": "route availability and marker fields"},
+        "requestSemantics": ["Item lookup uses content_id; exact-version lookup uses file_id; profile access is enforced"],
+        "requiredSemantics": ["Response includes file_id and intro, credits, recap, and preview objects", "Each marker exposes optional start/end seconds plus provenance fields source, provider, confidence, algorithm, and detected_at", "Absent segment values remain null rather than fabricated zero-length markers"],
+        "evidenceSources": [
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/markers.go",
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/router.go"
+        ]
+      },
+      {
+        "id": "native.chapters",
+        "issue": 80,
+        "method": "GET",
+        "path": "/api/v1/catalog/items/{id} and /api/v1/catalog/items/{id}/versions",
+        "outcome": "supported",
+        "capability": {"state": "conditional", "discovery": "versions[].chapters"},
+        "requestSemantics": ["Chapter identity is scoped to a file_id version"],
+        "requiredSemantics": ["Each chapter contains index, title, start_seconds, end_seconds, source, optional thumbnail_url, and optional thumbnail_thumbhash", "Chapter thumbnails are opaque expiring artwork URLs and follow the owning-detail refetch rule", "An item with no chapters returns an empty chapter array rather than a fake chapter"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/catalog/detail.go"]
+      },
+      {
+        "id": "native.trickplay",
+        "issue": 80,
+        "method": "GET",
+        "path": "no native route at the pinned revision",
+        "outcome": "missing",
+        "capability": {"state": "unavailable", "discovery": "no route or advertised capability"},
+        "requestSemantics": ["Bloom must not probe Jellyfin trickplay routes on a native connection"],
+        "requiredSemantics": ["Hide seek-preview UI or degrade quietly because neither native trickplay metadata nor tile delivery is registered"],
+        "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/router.go"]
+      },
+      {
+        "id": "native.theme-songs",
+        "issue": 80,
+        "method": "GET",
+        "path": "no native media theme-song route at the pinned revision",
+        "outcome": "missing",
+        "capability": {"state": "unavailable", "discovery": "no route or advertised capability"},
+        "requestSemantics": ["Bloom must not confuse the /api/v1/theme UI-branding routes with playable media theme songs"],
+        "requiredSemantics": ["Hide series theme-song playback because no native media-item theme-song contract is exposed"],
+        "evidenceSources": [
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/router.go",
+          "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/theme.go"
+        ]
+      }
+    ],
+    "playbackDecision": "Use the legacy native playback envelope until Silo documents an mpv-compatible protocol-v3 contract; v3 currently advertises media3_only.",
+    "headResearch": {
+      "revision": "39efe308afe903c0fab4cc06fa1795449e6fc2e1",
+      "status": "research-only-not-release-validated",
+      "finding": "The legacy start decoder and start/progress/stop/transcode/audio request fields remain compatible with the pinned baseline; the audio-switch response has additive timeline fields.",
+      "source": "https://github.com/Silo-Server/silo-server/blob/39efe308afe903c0fab4cc06fa1795449e6fc2e1/internal/api/handlers/playback.go"
+    }
   },
   "upstreamIssues": [
     "https://github.com/Silo-Server/silo-server/issues/431",

--- a/tests/contracts/provider-contracts.json
+++ b/tests/contracts/provider-contracts.json
@@ -24,7 +24,7 @@
     },
     {
       "id": "silo-native-v1",
-      "description": "Silo's native /api/v1 surface; documented for later adapters and not consumed in this issue.",
+      "description": "Silo's native /api/v1 surface consumed by the native provider adapter for profile-scoped catalog and state requests.",
       "timeUnit": "milliseconds",
       "authorizationProfile": "Bearer access token plus profile and device headers"
     }
@@ -650,8 +650,8 @@
         "path": "/api/v1/catalog",
         "outcome": "supported",
         "capability": {"state": "available", "discovery": "total_exact, has_more, and snapshot response fields"},
-        "requestSemantics": ["limit is capped at 100", "Clients replay the RFC3339Nano snapshot on later offset pages", "include_total=false permits an inexact or omitted-cost count"],
-        "requiredSemantics": ["Response has items, total, total_exact, and has_more", "A generated snapshot freezes results to items created at or before its timestamp and is reusable on later pages", "total_exact is false for grouped work views and whenever the source did not compute an exact total"],
+        "requestSemantics": ["limit is capped at 100", "Clients replay the RFC3339Nano snapshot on later offset pages", "include_total=false permits an inexact or omitted-cost count", "Home and library section envelopes retain their item arrays and section identity"],
+        "requiredSemantics": ["Response has items, total, total_exact, and has_more", "A generated snapshot freezes results to items created at or before its timestamp and is reusable on later pages", "total_exact is false for grouped work views and whenever the source did not compute an exact total", "Pagination preserves item identity and ordering without duplicate or omitted entries when the same snapshot is replayed"],
         "evidenceSources": [
           "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/catalog.go",
           "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/catalog/catalog_parser.go"
@@ -664,8 +664,8 @@
         "path": "/api/v1/catalog/query",
         "outcome": "partial",
         "capability": {"state": "conditional", "discovery": "/api/v1/catalog/filters plus request validation"},
-        "requestSemantics": ["JSON filter_config, library_id, limit, offset, sort, and order drive a bounded query"],
-        "requiredSemantics": ["Invalid or unsupported filter rules return 400 rather than silently disappearing", "Response carries items, total, and has_more", "The pinned POST response uses total_exact false even though its window count is exact and has no snapshot field, so snapshot-aware pagination must use GET /catalog"],
+        "requestSemantics": ["JSON filter_config, library_id, limit, offset, sort, and order drive a bounded query", "Filter groups preserve explicit any/all semantics for genres, studios, years, item types, watched, and favorited values"],
+        "requiredSemantics": ["Invalid or unsupported filter rules return 400 rather than silently disappearing", "Response carries items, total, and has_more", "The pinned POST response uses total_exact false even though its window count is exact and has no snapshot field, so snapshot-aware pagination must use GET /catalog", "The adapter marks unsupported Bloom filters as unsupported instead of claiming they were applied"],
         "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/catalog.go"]
       },
       {
@@ -675,8 +675,8 @@
         "path": "/api/v1/catalog/items/{id} and /api/v1/catalog/items/{id}/versions",
         "outcome": "supported",
         "capability": {"state": "available", "discovery": "canonical resource routes"},
-        "requestSemantics": ["id is content_id; selected file identity remains file_id inside versions"],
-        "requiredSemantics": ["Detail includes content_id, type, title, provider IDs where known, user state, versions, subtitles, markers, artwork, and multipart playback_variants", "Version entries preserve file_id, technical tracks, duration, edition, ordered multipart indices, chapters, and markers", "Unauthorized file paths are removed without removing playable file identity"],
+        "requestSemantics": ["id is content_id; selected file identity remains file_id inside versions", "Detail responses may omit unauthorized file paths while retaining file_id and playable metadata"],
+        "requiredSemantics": ["Detail includes content_id, type, title, provider IDs where known, profile-scoped user state, versions, subtitles, markers, artwork, and multipart playback_variants", "Version entries preserve file_id, technical tracks, duration, edition, ordered multipart indices, chapters with optional end times and artwork provenance, and markers", "The adapter exposes provider-neutral camelCase identity and milliseconds without replacing content_id with file_id"],
         "evidenceSources": [
           "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/catalog_resources.go",
           "https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/catalog/detail.go"

--- a/tests/contracts/provider-contracts.json
+++ b/tests/contracts/provider-contracts.json
@@ -664,7 +664,7 @@
         "path": "/api/v1/catalog/query",
         "outcome": "partial",
         "capability": {"state": "conditional", "discovery": "/api/v1/catalog/filters plus request validation"},
-        "requestSemantics": ["JSON filter_config, library_id, limit, offset, sort, and order drive a bounded query", "Filter groups preserve explicit any/all semantics for genres, studios, years, item types, watched, and favorited values"],
+        "requestSemantics": ["JSON match/groups, library_id, limit, offset, sort, and order drive a bounded query", "Filter groups preserve explicit any/all semantics for genres, studios, years, item types, watched, and favorited values"],
         "requiredSemantics": ["Invalid or unsupported filter rules return 400 rather than silently disappearing", "Response carries items, total, and has_more", "The pinned POST response uses total_exact false even though its window count is exact and has no snapshot field, so snapshot-aware pagination must use GET /catalog", "The adapter marks unsupported Bloom filters as unsupported instead of claiming they were applied"],
         "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/catalog.go"]
       },

--- a/tests/contracts/provider_contracts_test.py
+++ b/tests/contracts/provider_contracts_test.py
@@ -22,6 +22,7 @@ class ProviderContractValidationTest(unittest.TestCase):
     def test_checked_in_contract_is_valid(self):
         validated = load_and_validate(self.contract_path)
         self.assertGreater(len(validated["contracts"]), 20)
+        self.assertGreater(len(validated["nativeSiloContract"]["requirements"]), 20)
 
     def test_rejects_status_only_semantics(self):
         for rule in ("HTTP status is 200", "Returns HTTP 404"):
@@ -60,8 +61,49 @@ class ProviderContractValidationTest(unittest.TestCase):
         with self.assertRaisesRegex(ContractValidationError, "detection must be an object"):
             validate_contract_data(data)
 
+    def test_native_health_allows_omitted_server_id(self):
+        data = copy.deepcopy(self.valid_data)
+        detection = data["nativeSiloContract"]["detection"]
+        self.assertNotIn("server_id", detection["requiredFields"])
+        self.assertIn("server_id", detection["optionalFields"])
+        validate_contract_data(data)
+
+    def test_rejects_missing_native_requirement(self):
+        data = copy.deepcopy(self.valid_data)
+        data["nativeSiloContract"]["requirements"] = [
+            requirement
+            for requirement in data["nativeSiloContract"]["requirements"]
+            if requirement["id"] != "native.playback.track"
+        ]
+
+        with self.assertRaisesRegex(ContractValidationError, "coverageRequirements and requirements must match"):
+            validate_contract_data(data)
+
+    def test_rejects_native_evidence_from_another_revision(self):
+        data = copy.deepcopy(self.valid_data)
+        data["nativeSiloContract"]["requirements"][0]["evidenceSources"] = [
+            "https://github.com/Silo-Server/silo-server/blob/main/internal/api/handlers/health.go"
+        ]
+
+        with self.assertRaisesRegex(ContractValidationError, "pinned to native sourceRevision"):
+            validate_contract_data(data)
+
+    def test_rejects_unavailable_capability_labeled_supported(self):
+        data = copy.deepcopy(self.valid_data)
+        trickplay = next(
+            requirement
+            for requirement in data["nativeSiloContract"]["requirements"]
+            if requirement["id"] == "native.trickplay"
+        )
+        trickplay["outcome"] = "supported"
+
+        with self.assertRaisesRegex(ContractValidationError, "unavailable capability cannot be labeled supported"):
+            validate_contract_data(data)
+
     def test_live_drivers_are_registered_by_protocol_surface(self):
         self.assertIn("mediabrowser-v1", DRIVERS)
+        self.assertIn("silo-native-v1", DRIVERS)
+        self.assertFalse(DRIVERS["silo-native-v1"].requires_credentials)
         self.assertNotIn("jellyfin-supported", DRIVERS)
         self.assertNotIn("silo-8044eb8-compat", DRIVERS)
 
@@ -70,6 +112,35 @@ class ProviderContractValidationTest(unittest.TestCase):
         self.assertEqual(response.json(), {"Items": []})
         malformed = Response(200, {"Content-Type": "text/html"}, b"not-json")
         self.assertIsNone(malformed.json())
+
+    def test_native_live_probe_is_read_only_and_accepts_omitted_server_id(self):
+        class RecordingTransport:
+            def __init__(self):
+                self.calls = []
+
+            def request(self, method, path, **kwargs):
+                self.calls.append((method, path, kwargs))
+                return Response(200, {"Content-Type": "application/json"}, b'{"status": "ok"}')
+
+        transport = RecordingTransport()
+        probe = DRIVERS["silo-native-v1"](transport, "", "", "0.0-contract")
+        results = probe.run({"native.health": "partial"}, allow_mutations=False)
+
+        self.assertEqual([(call[0], call[1]) for call in transport.calls], [("GET", "/api/v1/health")])
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].passed)
+        self.assertIn("server_id=omitted", results[0].evidence)
+
+    def test_native_live_probe_rejects_success_shaped_bad_health(self):
+        class BadHealthTransport:
+            def request(self, method, path, **kwargs):
+                return Response(200, {"Content-Type": "application/json"}, b'{"status": "degraded"}')
+
+        probe = DRIVERS["silo-native-v1"](BadHealthTransport(), "", "", "0.0-contract")
+        result = probe.run({"native.health": "partial"}, allow_mutations=False)[0]
+
+        self.assertEqual(result.observed, "missing")
+        self.assertFalse(result.passed)
 
     def test_transport_converts_network_failure_to_response(self):
         class FailingOpener:

--- a/tests/contracts/provider_contracts_test.py
+++ b/tests/contracts/provider_contracts_test.py
@@ -67,6 +67,46 @@ class ProviderContractValidationTest(unittest.TestCase):
         self.assertNotIn("server_id", detection["requiredFields"])
         self.assertIn("server_id", detection["optionalFields"])
         validate_contract_data(data)
+    def test_rejects_native_route_shape_drift(self):
+        data = copy.deepcopy(self.valid_data)
+        page = next(
+            requirement
+            for requirement in data["nativeSiloContract"]["requirements"]
+            if requirement["id"] == "native.catalog.page"
+        )
+        page["path"] = "/api/v1/catalog/search"
+
+        with self.assertRaisesRegex(ContractValidationError, "route shape drifted"):
+            validate_contract_data(data)
+
+    def test_rejects_native_auth_and_catalog_shape_drift(self):
+        data = copy.deepcopy(self.valid_data)
+        login = next(
+            requirement
+            for requirement in data["nativeSiloContract"]["requirements"]
+            if requirement["id"] == "native.auth.login"
+        )
+        login["requiredSemantics"] = ["HTTP 200"]
+
+        with self.assertRaisesRegex(ContractValidationError, "not only an HTTP status"):
+            validate_contract_data(data)
+
+    def test_native_deployment_is_distinct_from_compatibility_mode(self):
+        native = next(
+            deployment
+            for deployment in self.valid_data["deployments"]
+            if deployment["surface"] == "silo-native-v1"
+        )
+        compatibility = next(
+            deployment
+            for deployment in self.valid_data["deployments"]
+            if deployment["id"] == "silo-8044eb8-compat"
+        )
+        self.assertEqual(native["protocolMode"], "native")
+        self.assertNotEqual(native["id"], compatibility["id"])
+        self.assertNotEqual(native["supportLabel"], compatibility["supportLabel"])
+        validate_contract_data(self.valid_data)
+
 
     def test_rejects_missing_native_requirement(self):
         data = copy.deepcopy(self.valid_data)

--- a/tests/contracts/provider_contracts_test.py
+++ b/tests/contracts/provider_contracts_test.py
@@ -4,11 +4,14 @@ import sys
 import unittest
 import urllib.error
 from pathlib import Path
+from unittest import mock
+
 
 CONTRACT_DIR = Path(__file__).resolve().parent
 if str(CONTRACT_DIR) not in sys.path:
     sys.path.insert(0, str(CONTRACT_DIR))
 
+import run_live_contracts
 from run_live_contracts import DRIVERS, HttpTransport, Response
 from validate_contracts import ContractValidationError, load_and_validate, validate_contract_data
 
@@ -106,6 +109,33 @@ class ProviderContractValidationTest(unittest.TestCase):
         self.assertNotEqual(native["id"], compatibility["id"])
         self.assertNotEqual(native["supportLabel"], compatibility["supportLabel"])
         validate_contract_data(self.valid_data)
+
+    def test_rejects_native_contract_without_live_probe(self):
+        data = copy.deepcopy(self.valid_data)
+        for requirement in data["nativeSiloContract"]["requirements"]:
+            requirement.pop("liveProbe", None)
+
+        with self.assertRaisesRegex(ContractValidationError, "at least one liveProbe"):
+            validate_contract_data(data)
+
+    def test_live_runner_rejects_empty_selected_surface(self):
+        data = copy.deepcopy(self.valid_data)
+        for requirement in data["nativeSiloContract"]["requirements"]:
+            requirement["liveProbe"] = False
+
+        with mock.patch.object(run_live_contracts, "load_and_validate", return_value=data):
+            with self.assertRaises(SystemExit) as raised:
+                run_live_contracts.main(
+                    [
+                        "--deployment",
+                        "silo-8044eb8-native",
+                        "--base-url",
+                        "https://silo.example",
+                    ]
+                )
+
+        self.assertEqual(raised.exception.code, 2)
+
 
 
     def test_rejects_missing_native_requirement(self):

--- a/tests/contracts/run_live_contracts.py
+++ b/tests/contracts/run_live_contracts.py
@@ -643,7 +643,9 @@ class SiloNativeV1Probe:
         status = payload.get("status") if isinstance(payload, dict) else None
         server_id_present = isinstance(payload, dict) and "server_id" in payload
         server_id = payload.get("server_id") if isinstance(payload, dict) else None
-        server_id_valid = not server_id_present or self._non_empty_string(server_id)
+        server_id_valid = not server_id_present or (
+            isinstance(server_id, str) and bool(server_id.strip())
+        )
         valid = response.status == 200 and status == "ok" and server_id_valid
         self._record(
             results,
@@ -988,6 +990,7 @@ def main(argv: list[str] | None = None):
     parser.add_argument("--username", default=os.environ.get("BLOOM_CONTRACT_USERNAME", ""))
     parser.add_argument("--profile-id", default=os.environ.get("BLOOM_CONTRACT_PROFILE_ID", ""))
     parser.add_argument("--profile-pin-env", default="BLOOM_CONTRACT_PROFILE_PIN", help="environment variable containing an optional native profile PIN")
+    parser.add_argument("--password-env", default="BLOOM_CONTRACT_PASSWORD", help="environment variable containing the password")
     parser.add_argument("--version", default="0.0-contract")
     parser.add_argument("--timeout", type=float, default=20.0)
     parser.add_argument("--allow-mutations", action="store_true")
@@ -1008,12 +1011,16 @@ def main(argv: list[str] | None = None):
     if not deployment:
         parser.error(f"unknown deployment {args.deployment!r}")
     surface = deployment["surface"]
+    driver_type = DRIVERS.get(surface)
+    if driver_type is None:
+        parser.error(f"unsupported protocol surface {surface!r}")
     if surface == "silo-native-v1":
         if deployment.get("protocolMode") != "native":
             parser.error(f"deployment {args.deployment!r} is not configured for native Silo mode")
         expected = {
             requirement["id"]: requirement["outcome"]
             for requirement in data["nativeSiloContract"]["requirements"]
+            if requirement.get("liveProbe", False)
         }
     else:
         expected = {
@@ -1021,6 +1028,8 @@ def main(argv: list[str] | None = None):
             for contract in data["contracts"]
             if args.deployment in contract["expectations"]
         }
+    if not expected:
+        parser.error(f"deployment {args.deployment!r} has no live probes for selected surface")
     transport = HttpTransport(args.base_url, args.timeout)
     if surface == "silo-native-v1":
         driver = driver_type(

--- a/tests/contracts/run_live_contracts.py
+++ b/tests/contracts/run_live_contracts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run Bloom's MediaBrowser contract probes against an operator-owned server."""
+"""Run Bloom's opt-in provider contract probes against an operator-owned server."""
 
 from __future__ import annotations
 
@@ -93,6 +93,7 @@ class HttpTransport:
 
 class MediaBrowserV1Probe:
     """The current Bloom wire surface. Other protocol drivers can be added beside it."""
+    requires_credentials = True
 
     def __init__(self, transport: HttpTransport, username: str, password: str, version: str):
         self.transport = transport
@@ -554,8 +555,39 @@ class MediaBrowserV1Probe:
         return results
 
 
-DRIVERS = {"mediabrowser-v1": MediaBrowserV1Probe}
+class SiloNativeV1Probe:
+    """Read-only native checks that are deterministic without fixture media or credentials."""
 
+    requires_credentials = False
+
+    def __init__(self, transport: HttpTransport, username: str, password: str, version: str):
+        self.transport = transport
+
+    def run(self, expected: dict[str, str], allow_mutations: bool):
+        if "native.health" not in expected:
+            return []
+
+        response = self.transport.request("GET", "/api/v1/health", headers={"Accept": "application/json"})
+        payload = response.json() if response.status == 200 else None
+        status = payload.get("status") if isinstance(payload, dict) else None
+        server_id_present = isinstance(payload, dict) and "server_id" in payload
+        server_id = payload.get("server_id") if isinstance(payload, dict) else None
+        server_id_valid = not server_id_present or isinstance(server_id, str) and bool(server_id.strip())
+        valid = response.status == 200 and status == "ok" and server_id_valid
+        wanted = expected["native.health"]
+        observed = wanted if valid else "missing"
+        evidence = (
+            f"health returned HTTP {response.status}, status={status!r}, "
+            f"server_id={'present' if server_id_present else 'omitted'}; "
+            "installation uniqueness is intentionally not inferred"
+        )
+        return [ProbeResult("native.health", wanted, observed, observed == wanted, evidence)]
+
+
+DRIVERS = {
+    "mediabrowser-v1": MediaBrowserV1Probe,
+    "silo-native-v1": SiloNativeV1Probe,
+}
 
 def main(argv: list[str] | None = None):
     parser = argparse.ArgumentParser(description=__doc__)
@@ -571,8 +603,6 @@ def main(argv: list[str] | None = None):
     args = parser.parse_args(argv)
 
     password = os.environ.get(args.password_env, "")
-    if not args.username or not password:
-        parser.error(f"--username/BLOOM_CONTRACT_USERNAME and {args.password_env} are required")
 
     data = load_and_validate(args.matrix)
     deployment = next((item for item in data["deployments"] if item["id"] == args.deployment), None)
@@ -582,12 +612,21 @@ def main(argv: list[str] | None = None):
     driver_type = DRIVERS.get(surface)
     if not driver_type:
         parser.error(f"no live probe driver is registered for surface {surface!r}")
+    if getattr(driver_type, "requires_credentials", True) and (not args.username or not password):
+        parser.error(f"--username/BLOOM_CONTRACT_USERNAME and {args.password_env} are required for {surface}")
 
-    expected = {
-        contract["id"]: contract["expectations"][args.deployment]["outcome"]
-        for contract in data["contracts"]
-        if args.deployment in contract["expectations"]
-    }
+    if surface == "silo-native-v1":
+        expected = {
+            requirement["id"]: requirement["outcome"]
+            for requirement in data["nativeSiloContract"]["requirements"]
+            if requirement.get("liveProbe", False)
+        }
+    else:
+        expected = {
+            contract["id"]: contract["expectations"][args.deployment]["outcome"]
+            for contract in data["contracts"]
+            if args.deployment in contract["expectations"]
+        }
     driver = driver_type(HttpTransport(args.base_url, args.timeout), args.username, password, args.version)
     results = driver.run(expected, args.allow_mutations)
 

--- a/tests/contracts/run_live_contracts.py
+++ b/tests/contracts/run_live_contracts.py
@@ -556,32 +556,424 @@ class MediaBrowserV1Probe:
 
 
 class SiloNativeV1Probe:
-    """Read-only native checks that are deterministic without fixture media or credentials."""
+    """Probe native Silo health, auth, profiles, catalog, and artwork when credentials are supplied."""
 
     requires_credentials = False
 
-    def __init__(self, transport: HttpTransport, username: str, password: str, version: str):
+    def __init__(
+        self,
+        transport: HttpTransport,
+        username: str,
+        password: str,
+        version: str,
+        profile_id: str = "",
+        profile_pin: str = "",
+    ):
         self.transport = transport
+        self.username = username
+        self.password = password
+        self.version = version
+        self.profile_id = profile_id
+        self.profile_pin = profile_pin
+        self.access_token = ""
+        self.refresh_token = ""
+        self.profile_token = ""
 
-    def run(self, expected: dict[str, str], allow_mutations: bool):
-        if "native.health" not in expected:
-            return []
+    def headers(self, token: str = "", profile_id: str = "", profile_token: str = ""):
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-Silo-Client": "Bloom Contract",
+            "X-Silo-Client-Version": self.version,
+            "X-Silo-Device-Id": "bloom-contract-native",
+            "X-Silo-Device-Name": "Bloom Contract Probe",
+            "X-Silo-Device-Platform": sys.platform,
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        if profile_id:
+            headers["X-Profile-Id"] = profile_id
+        if profile_token:
+            headers["X-Profile-Token"] = profile_token
+        return headers
 
-        response = self.transport.request("GET", "/api/v1/health", headers={"Accept": "application/json"})
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        token: str = "",
+        profile_id: str = "",
+        profile_token: str = "",
+        json_body: Any = None,
+    ):
+        headers = self.headers(token=token, profile_id=profile_id, profile_token=profile_token)
+        if path.startswith(("http://", "https://")) and not self.transport.is_same_origin(path):
+            headers = {"Accept": "application/json"}
+        return self.transport.request(method, path, headers=headers, json_body=json_body)
+
+    @staticmethod
+    def _object(payload: Any):
+        return payload if isinstance(payload, dict) else {}
+
+    @staticmethod
+    def _array(payload: Any, *keys: str):
+        if isinstance(payload, list):
+            return payload
+        if isinstance(payload, dict):
+            for key in keys:
+                if isinstance(payload.get(key), list):
+                    return payload[key]
+        return []
+
+    @staticmethod
+    def _non_empty_string(value: Any):
+        return isinstance(value, str) and bool(value.strip())
+
+    def _record(self, results: list[ProbeResult], expected: dict[str, str], contract: str, observed: str, evidence: str):
+        wanted = expected.get(contract)
+        if wanted is None:
+            return
+        passed = observed == "inconclusive" or observed == wanted or (wanted == "partial" and observed == "supported")
+        results.append(ProbeResult(contract, wanted, observed, passed, evidence))
+
+    def _health(self, expected: dict[str, str], results: list[ProbeResult]):
+        response = self.request("GET", "/api/v1/health")
         payload = response.json() if response.status == 200 else None
         status = payload.get("status") if isinstance(payload, dict) else None
         server_id_present = isinstance(payload, dict) and "server_id" in payload
         server_id = payload.get("server_id") if isinstance(payload, dict) else None
-        server_id_valid = not server_id_present or isinstance(server_id, str) and bool(server_id.strip())
+        server_id_valid = not server_id_present or self._non_empty_string(server_id)
         valid = response.status == 200 and status == "ok" and server_id_valid
-        wanted = expected["native.health"]
-        observed = wanted if valid else "missing"
-        evidence = (
+        self._record(
+            results,
+            expected,
+            "native.health",
+            expected.get("native.health", "missing") if valid else "missing",
             f"health returned HTTP {response.status}, status={status!r}, "
             f"server_id={'present' if server_id_present else 'omitted'}; "
-            "installation uniqueness is intentionally not inferred"
+            "installation uniqueness is intentionally not inferred",
         )
-        return [ProbeResult("native.health", wanted, observed, observed == wanted, evidence)]
+    def _cleanup(self):
+        if self.access_token:
+            self.request("POST", "/api/v1/auth/logout", token=self.access_token)
+
+
+    def run(self, expected: dict[str, str], allow_mutations: bool):
+        results: list[ProbeResult] = []
+        self._health(expected, results)
+        if not self.username or not self.password:
+            return results
+
+        providers_response = self.request("GET", "/api/v1/auth/providers")
+        providers = self._array(providers_response.json() if providers_response.status == 200 else None, "providers")
+        providers_ok = providers_response.status == 200 and bool(providers) and all(
+            isinstance(provider, dict)
+            and self._non_empty_string(provider.get("id"))
+            and self._non_empty_string(provider.get("display_name"))
+            and self._non_empty_string(provider.get("mode"))
+            and isinstance(provider.get("default"), bool)
+            for provider in providers
+        )
+        self._record(
+            results,
+            expected,
+            "native.auth.providers",
+            "supported" if providers_ok else "partial" if providers_response.status == 200 else "missing",
+            f"provider discovery returned HTTP {providers_response.status} with {len(providers)} shape-valid providers={providers_ok}",
+        )
+
+        unauthenticated = self.request("GET", "/api/v1/auth/me")
+        unauthenticated_payload = self._object(unauthenticated.json())
+        errors_ok = (
+            unauthenticated.status == 401
+            and self._non_empty_string(unauthenticated_payload.get("error"))
+            and self._non_empty_string(unauthenticated_payload.get("message"))
+        )
+        self._record(
+            results,
+            expected,
+            "native.auth.errors",
+            "supported" if errors_ok else "partial",
+            f"missing-bearer auth/me returned HTTP {unauthenticated.status} with error/message envelope={errors_ok}",
+        )
+
+        login = self.request(
+            "POST",
+            "/api/v1/auth/login",
+            json_body={"username": self.username, "password": self.password},
+        )
+        login_payload = self._object(login.json())
+        user = self._object(login_payload.get("user"))
+        self.access_token = login_payload.get("access_token", "")
+        self.refresh_token = login_payload.get("refresh_token", "")
+        login_ok = (
+            login.status == 200
+            and self._non_empty_string(self.access_token)
+            and self._non_empty_string(self.refresh_token)
+            and isinstance(login_payload.get("expires_in"), int)
+            and login_payload["expires_in"] > 0
+            and isinstance(user.get("id"), int)
+            and not isinstance(user.get("id"), bool)
+            and self._non_empty_string(user.get("username"))
+        )
+        self._record(
+            results,
+            expected,
+            "native.auth.login",
+            "supported" if login_ok else "missing" if login.status in {404, 405, 501} else "partial",
+            f"login returned HTTP {login.status} with access/refresh/user identity shape={login_ok}",
+        )
+        if not login_ok:
+            self._cleanup()
+            return results
+
+        refresh = self.request(
+            "POST",
+            "/api/v1/auth/refresh",
+            json_body={"refresh_token": self.refresh_token},
+        )
+        refresh_payload = self._object(refresh.json())
+        refreshed_access = refresh_payload.get("access_token", "")
+        refreshed_refresh = refresh_payload.get("refresh_token", "")
+        refresh_ok = (
+            refresh.status == 200
+            and self._non_empty_string(refreshed_access)
+            and self._non_empty_string(refreshed_refresh)
+            and isinstance(refresh_payload.get("expires_in"), int)
+            and refresh_payload["expires_in"] > 0
+        )
+        if refresh_ok:
+            self.access_token, self.refresh_token = refreshed_access, refreshed_refresh
+        self._record(
+            results,
+            expected,
+            "native.auth.refresh",
+            "supported" if refresh_ok else "partial" if refresh.status == 200 else "missing",
+            f"refresh returned HTTP {refresh.status} with replacement token pair shape={refresh_ok}",
+        )
+
+        me = self.request("GET", "/api/v1/auth/me", token=self.access_token)
+        me_payload = self._object(me.json())
+        me_ok = (
+            me.status == 200
+            and self._non_empty_string(me_payload.get("username"))
+            and me_payload.get("id") is not None
+            and self._non_empty_string(me_payload.get("role"))
+            and isinstance(me_payload.get("permissions"), list)
+            and isinstance(me_payload.get("download_allowed"), bool)
+        )
+        self._record(
+            results,
+            expected,
+            "native.auth.me",
+            "supported" if me_ok else "partial" if me.status == 200 else "missing",
+            f"auth/me returned HTTP {me.status} with account shape={me_ok}",
+        )
+
+        profiles_response = self.request("GET", "/api/v1/profiles", token=self.access_token)
+        profiles_payload = self._object(profiles_response.json())
+        profiles = self._array(profiles_payload, "profiles")
+        profiles_ok = profiles_response.status == 200 and bool(profiles) and all(
+            isinstance(profile, dict)
+            and self._non_empty_string(profile.get("id"))
+            and self._non_empty_string(profile.get("name"))
+            and all(isinstance(profile.get(field), bool) for field in ("has_pin", "is_child", "is_primary"))
+            for profile in profiles
+        )
+        self._record(
+            results,
+            expected,
+            "native.profiles.list",
+            "supported" if profiles_ok else "partial" if profiles_response.status == 200 else "missing",
+            f"profiles returned HTTP {profiles_response.status} with {len(profiles)} shape-valid profiles={profiles_ok}",
+        )
+        if not profiles_ok:
+            self._cleanup()
+            return results
+
+        selected = next((profile for profile in profiles if str(profile.get("id")) == self.profile_id), None)
+        selected = selected or next((profile for profile in profiles if profile.get("is_primary")), profiles[0])
+        profile_id = str(selected["id"])
+        self.profile_id = profile_id
+        if selected.get("has_pin"):
+            if not self.profile_pin:
+                self._cleanup()
+                return results
+            pin_response = self.request(
+                "POST",
+                f"/api/v1/profiles/{urllib.parse.quote(profile_id, safe='')}/verify-pin",
+                token=self.access_token,
+                json_body={"pin": self.profile_pin},
+            )
+            pin_payload = self._object(pin_response.json())
+            self.profile_token = pin_payload.get("profile_token", "")
+            pin_ok = (
+                pin_response.status == 200
+                and pin_payload.get("valid") is True
+                and self._non_empty_string(self.profile_token)
+                and self._non_empty_string(pin_payload.get("expires_at"))
+            )
+            self._record(
+                results,
+                expected,
+                "native.profiles.pin",
+                "supported" if pin_ok else "partial" if pin_response.status == 200 else "missing",
+                f"profile PIN verification returned HTTP {pin_response.status} with token/expiry shape={pin_ok}",
+            )
+            if not pin_ok:
+                self._cleanup()
+                return results
+        else:
+            self._record(results, expected, "native.profiles.pin", "inconclusive", "selected profile has no PIN; verification route is conditional")
+
+        scoped = {"token": self.access_token, "profile_id": self.profile_id, "profile_token": self.profile_token}
+        libraries_response = self.request("GET", "/api/v1/user/libraries", **scoped)
+        libraries = self._array(libraries_response.json() if libraries_response.status == 200 else None, "libraries")
+        libraries_ok = libraries_response.status == 200 and all(
+            isinstance(library, dict)
+            and self._non_empty_string(library.get("id"))
+            and self._non_empty_string(library.get("name"))
+            for library in libraries
+        )
+        self._record(
+            results,
+            expected,
+            "native.catalog.libraries",
+            "supported" if libraries_ok else "partial" if libraries_response.status == 200 else "missing",
+            f"libraries returned HTTP {libraries_response.status} with {len(libraries)} stable id/name entries={libraries_ok}",
+        )
+
+        catalog_query = urllib.parse.urlencode({"source": "query", "include_technical": "true", "limit": "5", "offset": "0"})
+        page_response = self.request("GET", f"/api/v1/catalog?{catalog_query}", **scoped)
+        page_payload = self._object(page_response.json() if page_response.status == 200 else None)
+        items = page_payload.get("items")
+        content_ids = [
+            item.get("content_id")
+            for item in items
+            if isinstance(item, dict) and self._non_empty_string(item.get("content_id"))
+        ] if isinstance(items, list) else []
+        page_ok = (
+            page_response.status == 200
+            and isinstance(items, list)
+            and isinstance(page_payload.get("total"), int)
+            and isinstance(page_payload.get("total_exact"), bool)
+            and isinstance(page_payload.get("has_more"), bool)
+            and len(content_ids) == len(items) == len(set(content_ids))
+            and all(
+                isinstance(item, dict)
+                and self._non_empty_string(item.get("content_id"))
+                and self._non_empty_string(item.get("title"))
+                and self._non_empty_string(item.get("type"))
+                for item in items
+            )
+        )
+        if page_ok and page_payload.get("has_more"):
+            page_ok = self._non_empty_string(page_payload.get("snapshot"))
+        self._record(
+            results,
+            expected,
+            "native.catalog.page",
+            "supported" if page_ok else "partial" if page_response.status == 200 else "missing",
+            f"catalog page returned HTTP {page_response.status} with {len(items) if isinstance(items, list) else 0} stable canonical items={page_ok}",
+        )
+        query_response = self.request(
+            "POST",
+            "/api/v1/catalog/query",
+            **scoped,
+            json_body={"limit": 5, "offset": 0},
+        )
+        query_payload = self._object(query_response.json() if query_response.status == 200 else None)
+        query_items = query_payload.get("items")
+        query_ok = (
+            query_response.status == 200
+            and isinstance(query_items, list)
+            and isinstance(query_payload.get("total"), int)
+            and isinstance(query_payload.get("total_exact"), bool)
+            and query_payload.get("total_exact") is False
+            and isinstance(query_payload.get("has_more"), bool)
+            and all(isinstance(item, dict) and self._non_empty_string(item.get("content_id")) for item in query_items)
+        )
+        self._record(
+            results,
+            expected,
+            "native.catalog.query",
+            "supported" if query_ok else "partial" if query_response.status == 200 else "missing",
+            f"catalog query returned HTTP {query_response.status} with response capability truthfulness={query_ok}",
+        )
+        if not page_ok or not content_ids:
+            self._cleanup()
+            return results
+
+        detail_id = str(content_ids[0])
+        detail_path = f"/api/v1/catalog/items/{urllib.parse.quote(detail_id, safe='')}"
+        detail_response = self.request("GET", detail_path, **scoped)
+        detail = self._object(detail_response.json() if detail_response.status == 200 else None)
+        versions = detail.get("versions")
+        detail_ok = (
+            detail_response.status == 200
+            and detail.get("content_id") == detail_id
+            and self._non_empty_string(detail.get("title"))
+            and self._non_empty_string(detail.get("type"))
+            and isinstance(detail.get("user_state"), dict)
+            and isinstance(versions, list)
+            and all(isinstance(version, dict) and self._non_empty_string(version.get("file_id")) for version in versions)
+            and isinstance(detail.get("playback_variants", []), list)
+        )
+        self._record(
+            results,
+            expected,
+            "native.catalog.detail",
+            "supported" if detail_ok else "partial" if detail_response.status == 200 else "missing",
+            f"catalog detail returned HTTP {detail_response.status} with canonical content/version shape={detail_ok}",
+        )
+
+        artwork_urls = [
+            detail.get(field)
+            for field in ("poster_url", "still_url", "backdrop_url", "logo_url")
+            if self._non_empty_string(detail.get(field))
+        ]
+        if not artwork_urls:
+            self._record(results, expected, "native.artwork.refetch", "inconclusive", "selected catalog item has no artwork URL to refetch")
+        else:
+            artwork_url = str(artwork_urls[0])
+            artwork_response = self.request("GET", urllib.parse.urljoin(self.transport.base_url + "/", artwork_url), **scoped)
+            content_type = artwork_response.headers.get("Content-Type", "")
+            artwork_ok = artwork_response.status == 200 and content_type.startswith("image/") and bool(artwork_response.body)
+            self._record(
+                results,
+                expected,
+                "native.artwork.refetch",
+                "supported" if artwork_ok else "partial",
+                f"opaque artwork URL returned HTTP {artwork_response.status}, {content_type!r}, {len(artwork_response.body)} bytes",
+            )
+
+        sessions = self.request("GET", "/api/v1/auth/sessions", token=self.access_token)
+        session_items = self._array(sessions.json() if sessions.status == 200 else None, "sessions")
+        sessions_ok = sessions.status == 200 and all(
+            isinstance(session, dict)
+            and self._non_empty_string(session.get("id"))
+            and self._non_empty_string(session.get("device_name"))
+            and self._non_empty_string(session.get("created_at"))
+            and self._non_empty_string(session.get("expires_at"))
+            for session in session_items
+        )
+        self._record(
+            results,
+            expected,
+            "native.auth.sessions",
+            "supported" if sessions_ok else "partial" if sessions.status == 200 else "missing",
+            f"auth session list returned HTTP {sessions.status} with shape-valid sessions={sessions_ok}",
+        )
+        logout = self.request("POST", "/api/v1/auth/logout", token=self.access_token)
+        self._record(
+            results,
+            expected,
+            "native.auth.logout",
+            "supported" if logout.status == 204 else "partial",
+            f"caller logout returned HTTP {logout.status}; credentials are not written to the report",
+        )
+        return results
 
 
 DRIVERS = {
@@ -594,32 +986,34 @@ def main(argv: list[str] | None = None):
     parser.add_argument("--deployment", required=True, help="deployment id from provider-contracts.json")
     parser.add_argument("--base-url", required=True)
     parser.add_argument("--username", default=os.environ.get("BLOOM_CONTRACT_USERNAME", ""))
-    parser.add_argument("--password-env", default="BLOOM_CONTRACT_PASSWORD", help="environment variable containing the password")
+    parser.add_argument("--profile-id", default=os.environ.get("BLOOM_CONTRACT_PROFILE_ID", ""))
+    parser.add_argument("--profile-pin-env", default="BLOOM_CONTRACT_PROFILE_PIN", help="environment variable containing an optional native profile PIN")
     parser.add_argument("--version", default="0.0-contract")
     parser.add_argument("--timeout", type=float, default=20.0)
     parser.add_argument("--allow-mutations", action="store_true")
     parser.add_argument("--output", type=Path)
     parser.add_argument("--matrix", type=Path, default=Path(__file__).with_name("provider-contracts.json"))
     args = parser.parse_args(argv)
+    parsed_base_url = urllib.parse.urlsplit(args.base_url)
+    if parsed_base_url.scheme not in {"http", "https"} or not parsed_base_url.netloc:
+        parser.error("--base-url must be an HTTP(S) URL")
+    if parsed_base_url.username or parsed_base_url.password:
+        parser.error("--base-url must not contain embedded credentials")
 
     password = os.environ.get(args.password_env, "")
+    profile_pin = os.environ.get(args.profile_pin_env, "")
 
     data = load_and_validate(args.matrix)
     deployment = next((item for item in data["deployments"] if item["id"] == args.deployment), None)
     if not deployment:
         parser.error(f"unknown deployment {args.deployment!r}")
     surface = deployment["surface"]
-    driver_type = DRIVERS.get(surface)
-    if not driver_type:
-        parser.error(f"no live probe driver is registered for surface {surface!r}")
-    if getattr(driver_type, "requires_credentials", True) and (not args.username or not password):
-        parser.error(f"--username/BLOOM_CONTRACT_USERNAME and {args.password_env} are required for {surface}")
-
     if surface == "silo-native-v1":
+        if deployment.get("protocolMode") != "native":
+            parser.error(f"deployment {args.deployment!r} is not configured for native Silo mode")
         expected = {
             requirement["id"]: requirement["outcome"]
             for requirement in data["nativeSiloContract"]["requirements"]
-            if requirement.get("liveProbe", False)
         }
     else:
         expected = {
@@ -627,7 +1021,18 @@ def main(argv: list[str] | None = None):
             for contract in data["contracts"]
             if args.deployment in contract["expectations"]
         }
-    driver = driver_type(HttpTransport(args.base_url, args.timeout), args.username, password, args.version)
+    transport = HttpTransport(args.base_url, args.timeout)
+    if surface == "silo-native-v1":
+        driver = driver_type(
+            transport,
+            args.username,
+            password,
+            args.version,
+            args.profile_id,
+            profile_pin,
+        )
+    else:
+        driver = driver_type(transport, args.username, password, args.version)
     results = driver.run(expected, args.allow_mutations)
 
     for result in results:

--- a/tests/contracts/validate_contracts.py
+++ b/tests/contracts/validate_contracts.py
@@ -92,11 +92,35 @@ def validate_contract_data(data: dict[str, Any]):
         _require(deployment.get("surface") in surface_ids, f"deployment {deployment['id']} references an unknown surface")
         _require(deployment.get("protocolMode") in {"native", "compatibility"}, f"deployment {deployment['id']} has an invalid protocolMode")
         _require(bool(deployment.get("supportLabel")), f"deployment {deployment['id']} needs a supportLabel")
+        if deployment.get("product") == "Silo Server" and deployment.get("surface") == "silo-native-v1":
+            _require(
+                deployment.get("protocolMode") == "native",
+                f"deployment {deployment['id']} must model native Silo as a native protocol mode",
+            )
+            _require(
+                deployment.get("id") != "silo-8044eb8-compat",
+                "native Silo deployment must remain distinct from its compatibility deployment",
+            )
+            _require(
+                deployment.get("supportLabel") != "silo-compatibility-support",
+                f"deployment {deployment['id']} cannot use the compatibility support label",
+            )
 
     media_browser_deployments = {
         deployment["id"] for deployment in deployments if deployment.get("surface") == "mediabrowser-v1"
     }
     _require(media_browser_deployments, "at least one mediabrowser-v1 deployment is required")
+
+    native_deployments = [
+        deployment
+        for deployment in deployments
+        if deployment.get("product") == "Silo Server" and deployment.get("surface") == "silo-native-v1"
+    ]
+    _require(native_deployments, "a native Silo deployment is required")
+    _require(
+        len(native_deployments) == len({deployment["id"] for deployment in native_deployments}),
+        "native Silo deployments must have unique ids",
+    )
 
     for contract in contracts:
         contract_id = contract["id"]
@@ -152,6 +176,21 @@ def validate_contract_data(data: dict[str, Any]):
     _require(any("Bearer" in header for header in native["requiredHeaders"]), "native requiredHeaders must include bearer authentication")
     _require(any("X-Profile-Id" in header for header in native["requiredHeaders"]), "native requiredHeaders must include profile selection")
     _require(any("X-Profile-Token" in header for header in native["requiredHeaders"]), "native requiredHeaders must include PIN verification")
+    required_header_terms = (
+        "X-Silo-Client",
+        "X-Silo-Client-Version",
+        "X-Silo-Device-Id",
+        "X-Silo-Device-Name",
+        "X-Silo-Device-Platform",
+    )
+    _require(
+        all(any(term in header for header in native["requiredHeaders"]) for term in required_header_terms),
+        "native requiredHeaders must include the complete Silo client/device identity",
+    )
+    identity_text = " ".join(native["identityRules"]).lower().replace("_", " ")
+    _require("content id" in identity_text, "native identityRules must preserve content_id identity")
+    _require("file id" in identity_text, "native identityRules must preserve file_id identity")
+    _require("millisecond" in identity_text, "native identityRules must state canonical millisecond conversion")
 
     detection = native.get("detection")
     _require(isinstance(detection, dict), "nativeSiloContract detection must be an object")
@@ -161,6 +200,42 @@ def validate_contract_data(data: dict[str, Any]):
     _require("server_id" in detection.get("optionalFields", []), "native health detection must describe optional server_id")
     _require(detection.get("requiredValues", {}).get("status") == "ok", "native health detection must require status=ok")
     server_id_policy = detection.get("serverIdPolicy", "").lower()
+    native_route_shapes = {
+        "native.health": ("GET", "/api/v1/health"),
+        "native.auth.providers": ("GET", "/api/v1/auth/providers"),
+        "native.auth.login": ("POST", "/api/v1/auth/login"),
+        "native.auth.errors": ("GET/POST/DELETE", "/api/v1/auth/*"),
+        "native.auth.refresh": ("POST", "/api/v1/auth/refresh"),
+        "native.auth.me": ("GET", "/api/v1/auth/me"),
+        "native.auth.logout": ("POST", "/api/v1/auth/logout"),
+        "native.auth.sessions": ("GET/DELETE", "/api/v1/auth/sessions and /api/v1/auth/sessions/{id}"),
+        "native.profiles.list": ("GET", "/api/v1/profiles"),
+        "native.profiles.pin": ("POST", "/api/v1/profiles/{id}/verify-pin"),
+        "native.catalog.libraries": ("GET", "/api/v1/user/libraries"),
+        "native.catalog.page": ("GET", "/api/v1/catalog"),
+        "native.catalog.query": ("POST", "/api/v1/catalog/query"),
+        "native.catalog.detail": ("GET", "/api/v1/catalog/items/{id} and /api/v1/catalog/items/{id}/versions"),
+        "native.catalog.hierarchy": ("GET", "/api/v1/catalog/items/{id}/episodes and /api/v1/catalog/series/{id}/seasons*"),
+        "native.state.watched": ("POST/DELETE", "/api/v1/watched/{id}"),
+        "native.state.favorite": ("GET/PUT/DELETE", "/api/v1/favorites/{item_id}"),
+        "native.artwork.refetch": ("GET", "opaque URLs from catalog, detail, person, and chapter resources"),
+    }
+    native_shape_terms = {
+        "native.auth.providers": ("id", "display name", "mode", "default"),
+        "native.auth.login": ("access token", "refresh token", "expires in", "user", "username"),
+        "native.auth.errors": ("error", "message", "invalid credentials", "invalid token", "session revoked"),
+        "native.auth.me": ("id", "username", "role", "permissions", "download allowed"),
+        "native.profiles.list": ("profiles", "avatar upload enabled", "has pin", "is child", "is primary"),
+        "native.profiles.pin": ("valid", "profile token", "expires at"),
+        "native.catalog.libraries": ("profile accessible", "library id"),
+        "native.catalog.page": ("items", "total", "total exact", "has more", "snapshot"),
+        "native.catalog.query": ("items", "total", "total exact", "has more", "snapshot"),
+        "native.catalog.detail": ("content id", "provider ids", "user state", "versions", "playback variants"),
+        "native.catalog.hierarchy": ("content id", "ordered seasons", "episodes"),
+        "native.state.watched": ("content id", "affected count", "played"),
+        "native.state.favorite": ("204", "idempotent", "user state"),
+        "native.artwork.refetch": ("artwork urls", "fetch locations", "refetch", "signed query"),
+    }
     _require(
         all(term in server_id_policy for term in ("optional", "deterministic", "unique")),
         "native health detection must document the optional deterministic server_id caveat",
@@ -181,6 +256,12 @@ def validate_contract_data(data: dict[str, Any]):
         _require(requirement.get("issue") in {77, 78, 79, 80}, f"{requirement_id} must reference issue 77, 78, 79, or 80")
         for field in ("method", "path"):
             _require(isinstance(requirement.get(field), str) and requirement[field].strip(), f"{requirement_id} needs {field}")
+        if requirement_id in native_route_shapes:
+            expected_method, expected_path = native_route_shapes[requirement_id]
+            _require(
+                (requirement.get("method"), requirement.get("path")) == (expected_method, expected_path),
+                f"{requirement_id} route shape drifted from the pinned native contract",
+            )
         _require(requirement.get("outcome") in ALLOWED_OUTCOMES, f"{requirement_id} has an invalid outcome")
 
         capability = requirement.get("capability")
@@ -203,6 +284,14 @@ def validate_contract_data(data: dict[str, Any]):
             any(_has_behavior_semantics(rule) for rule in required_semantics),
             f"{requirement_id} must assert payload or behavior semantics, not only an HTTP status",
         )
+        if requirement_id in native_shape_terms:
+            semantic_text = " ".join(request_semantics + required_semantics).lower()
+            semantic_text = re.sub(r"[_-]+", " ", semantic_text)
+            missing_terms = [term for term in native_shape_terms[requirement_id] if term not in semantic_text]
+            _require(
+                not missing_terms,
+                f"{requirement_id} is missing deterministic shape semantics: {', '.join(missing_terms)}",
+            )
 
         evidence_sources = requirement.get("evidenceSources")
         _require(isinstance(evidence_sources, list) and evidence_sources, f"{requirement_id} needs pinned evidenceSources")

--- a/tests/contracts/validate_contracts.py
+++ b/tests/contracts/validate_contracts.py
@@ -306,6 +306,10 @@ def validate_contract_data(data: dict[str, Any]):
                 f"{requirement_id} liveProbe must be deterministic and read-only",
             )
 
+    _require(
+        any(requirement.get("liveProbe", False) for requirement in native_requirements),
+        "native requirements must include at least one liveProbe",
+    )
     _require(native_ids.issuperset({"native.trickplay", "native.theme-songs"}), "native baseline must name unsupported optional capabilities")
     by_native_id = {requirement["id"]: requirement for requirement in native_requirements}
     for unsupported_id in ("native.trickplay", "native.theme-songs"):

--- a/tests/contracts/validate_contracts.py
+++ b/tests/contracts/validate_contracts.py
@@ -11,6 +11,37 @@ from pathlib import Path
 from typing import Any
 
 ALLOWED_OUTCOMES = {"supported", "partial", "stubbed", "missing", "not-applicable"}
+NATIVE_CAPABILITY_STATES = {"available", "conditional", "unavailable"}
+REQUIRED_NATIVE_COVERAGE = {
+    "native.health",
+    "native.auth.providers",
+    "native.auth.login",
+    "native.auth.errors",
+    "native.auth.refresh",
+    "native.auth.me",
+    "native.auth.logout",
+    "native.auth.sessions",
+    "native.profiles.list",
+    "native.profiles.pin",
+    "native.catalog.libraries",
+    "native.catalog.page",
+    "native.catalog.query",
+    "native.catalog.detail",
+    "native.catalog.hierarchy",
+    "native.state.watched",
+    "native.state.favorite",
+    "native.artwork.refetch",
+    "native.playback.capability",
+    "native.playback.start-legacy",
+    "native.playback.progress",
+    "native.playback.stop",
+    "native.playback.transcode",
+    "native.playback.track",
+    "native.markers",
+    "native.chapters",
+    "native.trickplay",
+    "native.theme-songs",
+}
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_IMAGE_RE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
 HTTP_STATUS_RE = re.compile(r"\bHTTP\s+\d{3}\b", re.IGNORECASE)
@@ -110,12 +141,96 @@ def validate_contract_data(data: dict[str, Any]):
 
     native = data.get("nativeSiloContract")
     _require(isinstance(native, dict), "nativeSiloContract must be an object")
-    for field in ("detection", "authenticationRoutes", "profileRoutes", "catalogRoutes", "playbackRoutes", "requiredHeaders", "identityRules", "playbackDecision"):
+    for field in ("sourceRevision", "detection", "requiredHeaders", "identityRules", "coverageRequirements", "requirements", "playbackDecision", "headResearch"):
         _require(bool(native.get(field)), f"nativeSiloContract needs {field}")
-    _require(isinstance(native.get("detection"), dict), "nativeSiloContract detection must be an object")
-    _require(native["detection"].get("path") == "/api/v1/health", "native detection must use /api/v1/health")
-    _require("server_id" in native["detection"].get("requiredFields", []), "native health detection must require server_id")
+    _require(native["sourceRevision"] == snapshot["siloRevision"], "native sourceRevision must match the pinned Silo revision")
+    _require(SHA_RE.fullmatch(native["sourceRevision"]) is not None, "native sourceRevision must be a full Git SHA")
+    for field in ("requiredHeaders", "identityRules"):
+        values = native.get(field)
+        _require(isinstance(values, list) and values, f"nativeSiloContract {field} must be a non-empty array")
+        _require(all(isinstance(value, str) and value.strip() for value in values), f"nativeSiloContract {field} entries must be non-empty")
+    _require(any("Bearer" in header for header in native["requiredHeaders"]), "native requiredHeaders must include bearer authentication")
+    _require(any("X-Profile-Id" in header for header in native["requiredHeaders"]), "native requiredHeaders must include profile selection")
+    _require(any("X-Profile-Token" in header for header in native["requiredHeaders"]), "native requiredHeaders must include PIN verification")
 
+    detection = native.get("detection")
+    _require(isinstance(detection, dict), "nativeSiloContract detection must be an object")
+    _require(detection.get("method") == "GET" and detection.get("path") == "/api/v1/health", "native detection must use GET /api/v1/health")
+    _require("status" in detection.get("requiredFields", []), "native health detection must require status")
+    _require("server_id" not in detection.get("requiredFields", []), "native health detection must not require optional server_id")
+    _require("server_id" in detection.get("optionalFields", []), "native health detection must describe optional server_id")
+    _require(detection.get("requiredValues", {}).get("status") == "ok", "native health detection must require status=ok")
+    server_id_policy = detection.get("serverIdPolicy", "").lower()
+    _require(
+        all(term in server_id_policy for term in ("optional", "deterministic", "unique")),
+        "native health detection must document the optional deterministic server_id caveat",
+    )
+
+    native_coverage = native.get("coverageRequirements")
+    native_requirements = native.get("requirements")
+    _require(isinstance(native_coverage, list) and native_coverage, "native coverageRequirements must be a non-empty array")
+    _require(len(native_coverage) == len(set(native_coverage)), "native coverageRequirements must be unique")
+    _require(set(native_coverage) == REQUIRED_NATIVE_COVERAGE, "native coverageRequirements must cover the #77-#80 baseline")
+    _require(isinstance(native_requirements, list) and native_requirements, "native requirements must be a non-empty array")
+    native_ids = _unique_ids(native_requirements, "native requirement")
+    _require(native_ids == set(native_coverage), "native coverageRequirements and requirements must match")
+
+    evidence_prefix = f"https://github.com/Silo-Server/silo-server/blob/{native['sourceRevision']}/"
+    for requirement in native_requirements:
+        requirement_id = requirement["id"]
+        _require(requirement.get("issue") in {77, 78, 79, 80}, f"{requirement_id} must reference issue 77, 78, 79, or 80")
+        for field in ("method", "path"):
+            _require(isinstance(requirement.get(field), str) and requirement[field].strip(), f"{requirement_id} needs {field}")
+        _require(requirement.get("outcome") in ALLOWED_OUTCOMES, f"{requirement_id} has an invalid outcome")
+
+        capability = requirement.get("capability")
+        _require(isinstance(capability, dict), f"{requirement_id} capability must be an object")
+        capability_state = capability.get("state")
+        _require(capability_state in NATIVE_CAPABILITY_STATES, f"{requirement_id} has an invalid capability state")
+        _require(isinstance(capability.get("discovery"), str) and capability["discovery"].strip(), f"{requirement_id} needs capability discovery evidence")
+        if capability_state == "unavailable":
+            _require(requirement["outcome"] in {"missing", "not-applicable"}, f"{requirement_id} unavailable capability cannot be labeled supported")
+
+        request_semantics = requirement.get("requestSemantics")
+        required_semantics = requirement.get("requiredSemantics")
+        _require(isinstance(request_semantics, list) and request_semantics, f"{requirement_id} needs requestSemantics")
+        _require(isinstance(required_semantics, list) and required_semantics, f"{requirement_id} needs requiredSemantics")
+        _require(
+            all(isinstance(rule, str) and rule.strip() for rule in request_semantics + required_semantics),
+            f"{requirement_id} semantics must be non-empty strings",
+        )
+        _require(
+            any(_has_behavior_semantics(rule) for rule in required_semantics),
+            f"{requirement_id} must assert payload or behavior semantics, not only an HTTP status",
+        )
+
+        evidence_sources = requirement.get("evidenceSources")
+        _require(isinstance(evidence_sources, list) and evidence_sources, f"{requirement_id} needs pinned evidenceSources")
+        _require(
+            all(isinstance(url, str) and url.startswith(evidence_prefix) for url in evidence_sources),
+            f"{requirement_id} evidenceSources must be pinned to native sourceRevision",
+        )
+        _require(isinstance(requirement.get("liveProbe", False), bool), f"{requirement_id} liveProbe must be boolean")
+        if requirement.get("liveProbe", False):
+            _require(
+                requirement["method"] == "GET" and requirement["path"] == "/api/v1/health",
+                f"{requirement_id} liveProbe must be deterministic and read-only",
+            )
+
+    _require(native_ids.issuperset({"native.trickplay", "native.theme-songs"}), "native baseline must name unsupported optional capabilities")
+    by_native_id = {requirement["id"]: requirement for requirement in native_requirements}
+    for unsupported_id in ("native.trickplay", "native.theme-songs"):
+        _require(by_native_id[unsupported_id]["capability"]["state"] == "unavailable", f"{unsupported_id} must remain explicitly unavailable")
+
+    head_research = native.get("headResearch")
+    _require(isinstance(head_research, dict), "native headResearch must be an object")
+    _require(SHA_RE.fullmatch(head_research.get("revision", "")) is not None, "native headResearch revision must be a full Git SHA")
+    _require(head_research.get("status") == "research-only-not-release-validated", "native headResearch must not claim release validation")
+    _require(isinstance(head_research.get("finding"), str) and head_research["finding"].strip(), "native headResearch needs a finding")
+    _require(
+        isinstance(head_research.get("source"), str) and f"/blob/{head_research['revision']}/" in head_research["source"],
+        "native headResearch source must be pinned to its revision",
+    )
     upstream_issues = data.get("upstreamIssues")
     _require(isinstance(upstream_issues, list) and upstream_issues, "upstreamIssues must be a non-empty array")
     _require(all(isinstance(url, str) and url.startswith("https://github.com/") for url in upstream_issues), "upstreamIssues entries must be GitHub URLs")


### PR DESCRIPTION
## Summary
- Lands first-class Silo authentication, household profiles, session restore/refresh, and navigable login selection for epic #73 / issue #77.
- Introduces provider-owned catalog routing (`ICatalogProvider`) with Jellyfin compatibility preserved and native Silo libraries/browse/search/details/user-state support for issue #78.
- Adds signed Silo artwork resolution/refresh plus ActiveArtworkProvider cache wiring, with deterministic Qt coverage for auth, catalog, and artwork contracts.

## Status
Draft / incremental. Native Silo playback (#79), full capability parity, and end-to-end UI validation are still outstanding. App UI smoke was deferred pending dummy HDMI / graphics backend availability on the dev box.

## Test plan
- [x] `./scripts/dev-build.sh --tests`
- [x] `ctest --test-dir build-dev --output-on-failure -R '^(ProviderCatalogTest|SiloCatalogServiceTest|ArtworkRefreshTest|SiloAuthenticationTest|ProviderTransportTest|ConnectionPersistenceTest)$'`
- [ ] `nix flake check`
- [ ] Manual Jellyfin login regression
- [ ] Manual native Silo login + library/home browse once a Silo instance is available
- [ ] Windows/Linux UI validation once display/HDMI path is available

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native Silo provider with authentication, catalog, and profile support
> - Introduces a full Silo provider stack: `SiloProviderAdapter`, `SiloAuthenticator`, `SiloCatalogProvider`, `SiloRequestFactory`, `SiloModelMapper`, and `SiloArtworkProvider` implementing the existing provider interfaces for native Silo API endpoints.
> - `AuthenticationService` gains multi-provider support: auto-detection probes for Silo at the Health endpoint and falls back to Jellyfin; supports profile selection and PIN verification as intermediate authentication steps; reads and persists refresh and profile tokens.
> - `LibraryService` is fully migrated from direct REST endpoint construction to the `ICatalogProvider` abstraction, routing all catalog operations through the active provider; adds identity-gated request cancellation on auth changes.
> - `HttpTransport` now coalesces concurrent 401 responses into a single token-refresh attempt and replays requests once on success, tracked by an authentication epoch.
> - `LoginScreen` becomes a multi-step flow covering provider selection (Auto/Jellyfin/Silo), credentials, profile selection, and PIN entry.
> - `ActiveArtworkProvider` dispatches artwork resolution and refresh to the provider matching the current active session; `ImageCacheProvider` retries artwork fetches once via the provider on HTTP 401/403.
> - Both Jellyfin and Silo adapters are registered at startup in `ApplicationInitializer`.
> - Risk: `isAuthenticated()` now returns `true` only when `authenticationStep == "authenticated"`, which may affect any code that checked `isAuthenticated()` during intermediate auth steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5a2f69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Silo server support alongside Jellyfin.
  * Added automatic provider detection, profile selection, PIN verification, session management, token refresh, and remote logout.
  * Added Silo catalog browsing, search, filtering, pagination, playback state, favorites, and watch-status updates.
  * Added provider-aware artwork loading and refresh support.
* **Bug Fixes**
  * Improved handling of expired authentication and unauthorized artwork requests.
  * Improved login navigation, cancellation, error feedback, and session restoration.
* **Tests**
  * Added comprehensive coverage for authentication, catalogs, artwork refresh, persistence, and provider contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->