### PR TITLE
feat(playback): add native Silo lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Key files: `src/core/ServiceLocator.h`, `utils/ConfigManager.*`, `src/providers/
 
 Conventions: C++ PascalCase classes, camelCase methods, `m_` prefix; QML PascalCase components, camelCase props; use `FocusScope` for navigable views; keep `Theme.qml` as the single source for tokens.
 
-Playback & API: Key endpoints `/Users/{userId}/Items`, `/Shows/NextUp`, `/PlaybackInfo`, `/Sessions/Playing`. Report start/progress/pause/stop and mark watched via `ConfigManager` thresholds.
+Playback & API: Provider-owned playback lifecycle/report routing serializes each provider's wire contract; key Jellyfin endpoints include `/Users/{userId}/Items`, `/Shows/NextUp`, `/PlaybackInfo`, `/Sessions/Playing`.
 
 Windows embedded playback guardrail (regression prevention):
 - When using `win-libmpv` embedded playback (`--wid` child window), playback controls MUST render in a dedicated transparent top-level overlay `Window` synced to the app window geometry.

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -103,8 +103,8 @@ Key components
 - MpvVideoItem / VideoSurface: minimal viewport plumbing for embedded backend integration.
 - PlayerProcessManager: manages external mpv process lifetime, sockets/pipes, scripts and config dir. Observes `time-pos`, `duration`, `pause`, `aid`, and `sid` properties.
 - PlayerController: provider-neutral state machine that handles play/pause/resume, listens for backend updates, manages track selection, and sends canonical playback state through `PlaybackService`.
-- `IPlaybackProvider` / `JellyfinPlaybackProvider`: finalize provider PlaybackInfo into Bloom `PlaybackDescriptor` values and serialize canonical playback reports into provider endpoints and wire payloads.
-- PlaybackService: stable application façade for playback preparation and reporting transport; its public timing contract uses milliseconds.
+- `IPlaybackProvider` / `JellyfinPlaybackProvider` / `SiloPlaybackProvider`: finalize provider PlaybackInfo into Bloom `PlaybackDescriptor` values and serialize canonical playback reports into provider endpoints and wire payloads. Silo uses its pinned legacy native envelope; Jellyfin retains its synchronous descriptor path.
+- `PlaybackService`: stable application façade for playback preparation and reporting transport; its public timing contract uses milliseconds.
 - TrackPreferencesManager: persists explicit audio/subtitle user choices to a separate JSON file using a versioned schema.
 
 HDR and Dolby Vision policy
@@ -264,6 +264,20 @@ Playback overlay metadata
   - Movies: title + production year.
   - Episodes: series title + `Sxx Exx - Episode Name`.
 - Fallback behavior still exists (`currentItemId`) when explicit metadata is not provided.
+
+Native Silo playback (pinned legacy envelope)
+- Native playback uses the legacy Silo envelope at revision `8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6` (the same immutable revision documented in [provider compatibility](provider-compatibility.md)). Bloom deliberately omits `protocol_version: 3`: the pinned capability route advertises `media3_only`, which is a Media3/Android contract and is not an mpv wire contract. Bloom must not infer mpv support from a v3 capability response.
+- Start is `POST /api/v1/playback/start`. The body contains numeric `file_id`, the selected `profile_id`, `start_position` in seconds, optional `audio_track_index`, and mpv capabilities for codecs, containers, resolution, HDR, passthrough, and bitmap subtitles. There is no invented native “variant” field: alternate versions are selected by their catalog `file_id`; multipart parts are separate sequential native sessions.
+- The `201` response is mapped into the provider-neutral `PlaybackDescriptor`: `session_id`/`media_file_id`, effective `play_method`, `position`, `stream_url`, `subtitle_urls`, selected audio index, duration, and `playback_info`. Direct play, remux, and HLS/transcode responses are accepted when Silo's policy/runtime permits them. Range-capable direct URLs are passed to mpv unchanged so seeking remains a server capability, not a client URL rewrite.
+- Stream and subtitle URLs are opaque signed locations. Bloom resolves relative URLs against the configured server origin with `QUrl` while preserving absolute URLs and every existing query byte-for-byte; it never appends auth query parameters or reconstructs a URL from IDs.
+- Progress and pause/resume use `POST /api/v1/playback/{session_id}/progress` with `{ "seconds": <seconds>, "is_paused": <bool> }`. Stop uses `DELETE /api/v1/playback/{session_id}`. Playback network calls go through `AuthenticationService`/`HttpTransport`, including the normal refresh-once behavior and current profile headers.
+- Runtime audio switching uses `PATCH /api/v1/playback/{session_id}/audio` with the selected track index. A successful response supplies a replacement signed reload URL and effective play method; Bloom swaps the mpv stream without inventing a provider variant.
+- PlaybackInfo for native Silo is derived from catalog item/version track data, not Jellyfin `/Items/{id}/PlaybackInfo` or `/Videos/*` endpoints. Direct/remux/HLS capability, subtitle inventory, and version identity therefore remain provider-native.
+- Native multipart playback resolves each catalog part/version by `file_id`, starts one native session per physical file, and reports each session's progress/stop independently while preserving the logical item's aggregate timeline and autoplay context. Native Silo does not use Jellyfin `/AdditionalParts`.
+- Recovery retries the provider request through the shared transport once after authentication refresh; transient stream interruption remains mpv's reconnect/cache path. A failed native start or expired opaque URL is surfaced as playback failure/refetched from its owning catalog resource rather than silently falling back to a Jellyfin stream.
+- Pinned limits are intentional: protocol-v3 is unavailable for mpv, native trickplay and playable theme-song routes are absent, capability discovery does not establish an mpv contract, and transcode/HLS/audio-switch behavior remains conditional on Silo policy and runtime support. The Silo HEAD comparison in the contract matrix is research-only and does not change the pinned release claim.
+
+Jellyfin and native Silo playback share the provider-neutral descriptor/reporting boundary; only the provider owns endpoint construction and wire serialization.
 
 Alternate versions and multipart playback
 - Jellyfin alternate media sources are surfaced from `PlaybackInfoResponse.mediaSources`. When there is more than one source and playback is user-initiated, Bloom now prompts before playback starts instead of silently taking the first source.

--- a/docs/provider-compatibility.md
+++ b/docs/provider-compatibility.md
@@ -7,8 +7,8 @@ The machine-readable source is [`tests/contracts/provider-contracts.json`](../te
 ## Support terminology
 
 - **Silo compatibility support**: Bloom connects to Silo's optional Jellyfin compatibility listener. The native API is not used, and household-profile login has compatibility-specific limitations.
-- **Experimental native Silo support**: Bloom connects to `/api/v1` with Silo's compatibility listener disabled and implements the native authentication, household-profile, catalog, and signed-artwork boundaries from PR #111; native playback remains outside this release gate.
-- **First-class Silo support**: Bloom connects to `/api/v1` without the compatibility listener and passes the authentication, profile, catalog, playback, recovery, and platform gates in issue #73.
+- **Experimental native Silo support**: Bloom connects to `/api/v1` with Silo's compatibility listener disabled and implements native authentication, household-profile, catalog, signed-artwork, and legacy mpv playback boundaries from the pinned revision; optional v3/media3-only features remain unavailable.
+- **First-class Silo support**: Bloom connects to `/api/v1` without the compatibility listener and passes authentication, profile, catalog, playback, recovery, and platform gates in issue #73.
 
 These labels describe a connection's protocol mode, not an application-wide provider choice. A future provider can add another protocol surface and deployment to the contract matrix without changing existing Jellyfin or Silo rows.
 
@@ -90,7 +90,7 @@ podman run --rm --name bloom-jellyfin-contract \
 
 The live deployments are intentionally not started inside `nix flake check`. They require operator-owned media, credentials, mutable databases, and platform playback checks. The checked-in validator keeps the matrix complete and immutable between live runs.
 
-The native deployment runs without the compatibility listener. Without credentials, the live runner performs only the deterministic public health check and never creates server state. Set `BLOOM_CONTRACT_USERNAME` and `BLOOM_CONTRACT_PASSWORD` (and, for a PIN profile, `BLOOM_CONTRACT_PROFILE_PIN`) to extend the run with provider discovery, login/refresh/error envelopes, account/profile shapes, catalog pagination/query/detail shapes, and one opaque artwork fetch; it logs no token, password, or PIN:
+The native deployment runs without the compatibility listener. Without credentials, the live runner performs only the deterministic public health check and never creates server state. Set `BLOOM_CONTRACT_USERNAME` and `BLOOM_CONTRACT_PASSWORD` (and, for a PIN profile, `BLOOM_CONTRACT_PROFILE_PIN`) to extend the run with provider discovery, login/refresh/error envelopes, account/profile shapes, catalog pagination/query/detail shapes, and one opaque artwork fetch; it logs no token, password, or PIN. Native playback start/progress/audio-switch/stop probes are destructive session lifecycle checks and are skipped unless `--allow-mutations` is explicitly supplied with the fixture credentials.
 
 ```fish
 python3 tests/contracts/run_live_contracts.py \
@@ -99,6 +99,15 @@ python3 tests/contracts/run_live_contracts.py \
   --output .contract-data/silo-native-health-report.json
 ```
 
+To opt into the native playback lifecycle, use a disposable fixture account/library:
+
+```fish
+python3 tests/contracts/run_live_contracts.py \
+  --deployment silo-8044eb8-native \
+  --base-url http://127.0.0.1:8090 \
+  --allow-mutations \
+  --output .contract-data/silo-native-playback-report.json
+```
 MediaBrowser deployments use the same provider-neutral authenticated probe. The password is read from the environment and is never written to the report:
 ```fish
 set -x BLOOM_CONTRACT_USERNAME bloom-contract
@@ -118,7 +127,7 @@ python3 tests/contracts/run_live_contracts.py \
   --output .contract-data/jellyfin-report.json
 ```
 
-The live driver is selected by protocol surface, while expectations are selected by deployment. Native health is always safe without credentials; credentialed native runs use a dedicated fixture account, perform only the auth/profile/catalog/artwork reads needed for shape checks plus login/refresh/logout lifecycle cleanup, and never enable `--allow-mutations`. MediaBrowser mutating probes remain opt-in. Played/favorite probes restore their exact original booleans; playback reporting can change resume state, so run it only with a dedicated fixture account/library. The harness rejects embedded base-URL credentials, never writes password/PIN/token values to reports, never forwards provider authorization to a different origin, and refuses automatic redirects.
+The live driver is selected by protocol surface, while expectations are selected by deployment. Native health is always safe without credentials; credentialed native runs use a dedicated fixture account and perform auth/profile/catalog/artwork reads plus login/refresh/logout cleanup. Native playback start/progress/audio-switch/stop probes remain skipped unless `--allow-mutations` is explicitly supplied with fixture credentials. MediaBrowser mutating probes also remain opt-in. Played/favorite probes restore their exact original booleans; playback reporting can change resume state, so run it only with a dedicated fixture account/library. The harness rejects embedded base-URL credentials, never writes password/PIN/token values to reports, never forwards provider authorization to a different origin, and refuses automatic redirects.
 
 ## Bloom's current MediaBrowser contract
 
@@ -197,7 +206,7 @@ The native baseline is source-grounded in Silo revision `8044eb84dd0cfa512ce8f24
 | Artwork refetch | Supported when artwork exists | URLs are opaque, may expire, and are not cache identity. Refetch the owning catalog/detail/person/chapter resource after expiry; never reconstruct or strip signed query parameters. |
 | Playback capability | Partial | Protocol v3 truthfully reports disabled state and runtime-probed transformations, but advertises `media3_only`; that is not an mpv capability and does not describe the legacy envelope. |
 | Legacy start/progress/stop | Supported | Omit `protocol_version: 3`; preserve session/file identity, seconds, opaque URLs, pause state, and teardown. |
-| Legacy transcode and audio switch | Supported when policy/runtime permits | Replacement manifest/stream URLs carry the new signed recipe. Policy errors are capability outcomes, not silent fallbacks. |
+| Legacy transcode and audio switch | Partial/conditional | Start can return HLS/transcode and audio switch returns replacement URLs when policy/runtime permits; Bloom does not claim a standalone transcode route beyond the implemented native start/audio-switch paths. |
 | Markers and chapters | Supported when media/routes expose them | Markers cover intro, credits, recap, and preview with provenance; chapters are file-version scoped and use seconds plus optional opaque thumbnail URLs. |
 | Native trickplay | Missing | No native metadata/tile route or capability is registered. Hide/degrade seek previews. |
 | Native media theme songs | Missing | `/api/v1/theme/*` is UI branding, not playable item theme media. Hide/degrade theme-song playback. |
@@ -244,25 +253,28 @@ GET `/catalog` supports snapshot-aware offset pagination and reports `total_exac
 
 Profile state uses `POST`/`DELETE /api/v1/watched/{content_id}` and `GET`/`PUT`/`DELETE /api/v1/favorites/{content_id}`. Artwork fields are fetch locations, not durable identity. On an expired or missing signed URL, refetch the owning resource and replace the whole URL.
 
-### Native playback, markers, and chapters (future #79/#80 baseline)
+### Native playback, markers, and chapters
 
-Native playback is outside PR #111. The matrix records the pinned Silo envelope for later work; Bloom/mpv must not infer support from this documentation. At this pin, `GET /api/v1/playback/capability` describes protocol v3 only; enabled v3 includes `media3_only`, while disabled v3 returns empty features, deliveries, and transformations with `reason: "disabled"`.
+Native playback uses the pinned legacy envelope at Silo revision `8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6`. The Bloom native provider intentionally omits `protocol_version: 3`: the pinned capability route advertises `media3_only`, which is not an mpv contract. Protocol v3 remains unavailable for mpv until Silo documents an mpv-capable engine contract.
 
-The legacy lifecycle is:
+The implemented legacy lifecycle is:
 
 ```text
 POST   /api/v1/playback/start
 POST   /api/v1/playback/{session_id}/progress
 DELETE /api/v1/playback/{session_id}
-POST   /api/v1/playback/transcode/start
 PATCH  /api/v1/playback/{session_id}/audio
-GET    /api/v1/markers/items/{content_id}
-GET    /api/v1/markers/files/{file_id}
 ```
 
-For future implementation, legacy start is selected when `protocol_version: 3` is absent. The request carries `file_id`, optional matching `profile_id`, play method or codec/container/HDR capabilities, start position seconds, and optional audio track. The `201` response carries session/file IDs, effective play method, position, stream URL, selected audio index, duration, subtitle URLs, and playback info. Transcode responses add a replacement manifest and explicit player/origin/timeline offsets. Audio switching returns a replacement stream URL with `switch_mode: "reload"` and may promote direct play to remux or transcode.
+Start sends numeric `file_id`, selected `profile_id`, `start_position` in seconds, optional `audio_track_index`, and mpv codec/container/resolution/HDR/passthrough/bitmap-subtitle capabilities. It does not send an invented native variant field. The `201` response contains `session_id`, `media_file_id`, effective `play_method`, `position`, `stream_url`, subtitle URLs, selected audio index, duration, and `playback_info`, which the provider maps to `PlaybackDescriptor`. Direct play, remux, and HLS/transcode are accepted only when Silo policy/runtime returns them; range support is retained on direct URLs.
 
-For future implementation, progress accepts `{position, is_paused}` in seconds and persists profile state best-effort. Stop persists final progress and tears down the session and transcode resources. Marker reads expose nullable intro/credits/recap/preview ranges plus provenance. Version chapters expose index, title, start/end seconds, source, optional thumbnail URL, and optional thumbhash. Native trickplay and playable media theme songs are explicitly unavailable at the pinned revision.
+Progress sends `{ "seconds": <seconds>, "is_paused": <bool> }`; stop persists final progress and tears down the session. Audio switching sends the selected audio index and maps the replacement signed reload URL and effective method without changing the provider-neutral descriptor contract. All native playback requests use `AuthenticationService`/`HttpTransport` refresh-once semantics and current profile headers.
+
+Native URLs are opaque signed fetch locations. Relative URLs resolve against the configured server origin with `QUrl`; absolute URLs and existing query bytes are preserved exactly, and Bloom never appends auth query parameters. Native `PlaybackInfo` comes from catalog item/version data rather than Jellyfin `/Items/{id}/PlaybackInfo` or `/Videos/*`.
+
+Native multipart playback starts sequential native sessions by physical `file_id`, one session per file/part, while preserving logical-item aggregate progress and autoplay context. Version selection is catalog-driven and keeps `content_id` (logical identity) separate from `file_id` (playback identity).
+
+Markers and version chapters remain supported when the native resources expose them. Native trickplay metadata/tiles and playable media theme songs are unavailable at the pin. HLS/transcode, audio switching, and subtitle delivery are conditional on server policy/runtime; capability v3 does not make those features available. Silo HEAD comparisons remain research-only and do not change the pinned revision or release evidence.
 
 ### Current upstream HEAD research
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,8 @@ qt_add_executable(Bloom
     providers/silo/SiloCatalogProvider.h
     providers/silo/SiloRequestFactory.h
     providers/silo/SiloModelMapper.h
+    providers/silo/SiloPlaybackProvider.h
+    providers/silo/SiloPlaybackProvider.cpp
     providers/silo/SiloModelMapper.cpp
     providers/silo/SiloProviderAdapter.h
     resources/fonts.qrc

--- a/src/models/MediaModels.cpp
+++ b/src/models/MediaModels.cpp
@@ -283,7 +283,8 @@ QVariantMap PlaybackTrack::toVariantMap() const
         {QStringLiteral("isDefault"), isDefault},
         {QStringLiteral("isForced"), isForced},
         {QStringLiteral("isExternal"), isExternal},
-        {QStringLiteral("isHearingImpaired"), isHearingImpaired}
+        {QStringLiteral("isHearingImpaired"), isHearingImpaired},
+        {QStringLiteral("externalUrl"), externalUrl}
     };
 }
 

--- a/src/models/MediaModels.h
+++ b/src/models/MediaModels.h
@@ -133,6 +133,9 @@ struct PlaybackTrack {
     bool isForced = false;
     bool isExternal = false;
     bool isHearingImpaired = false;
+    // Transient executable location for external subtitle tracks. This is
+    // retained in-process only and is not part of persistent model identity.
+    QUrl externalUrl;
 
     QVariantMap toVariantMap() const;
 };

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -14,7 +14,7 @@
 #include <QLoggingCategory>
 #include <QCoreApplication>
 #include <QSysInfo>
-#include <optional>
+#include <QStringList>
 
 namespace {
 
@@ -26,6 +26,22 @@ QString activeConnectionId(AuthenticationService *authService, ConfigManager *co
     const auto connection = config ? config->getActiveConnection() : std::nullopt;
     return connection.has_value() ? connection->connectionId : QString();
 }
+QString playbackRequestIdentity(AuthenticationService *authService,
+                                ConfigManager *configManager,
+                                const PlaybackProviderContext &context)
+{
+    const QStringList fields{
+        context.serverUrl.toString(QUrl::FullyEncoded),
+        context.accessToken,
+        context.profileId,
+        context.profileToken,
+        context.deviceId,
+        activeConnectionId(authService, configManager),
+        authService ? authService->getUserId() : QString()
+    };
+    return fields.join(QChar(0x1f));
+}
+
 
 PlaybackReport makePlaybackReport(PlaybackReportEvent event,
                                   const QString &itemId,
@@ -171,6 +187,17 @@ quint64 PlaybackService::beginRequest(const QString &operation,
     return generation;
 }
 
+void PlaybackService::endRequest(const QString &operation,
+                                 const QString &itemId,
+                                 const QString &requestContext,
+                                 quint64 generation)
+{
+    const QString key = operation + QChar(0x1f) + requestContext + QChar(0x1f) + itemId;
+    if (m_requestGenerations.value(key, 0) == generation) {
+        m_requestGenerations.remove(key);
+    }
+}
+
 bool PlaybackService::isCurrentRequest(const QString &operation,
                                        const QString &itemId,
                                        const QString &requestContext,
@@ -217,9 +244,7 @@ void PlaybackService::emitDescriptorFailure(const QString &itemId,
                                              const QString &requestContext,
                                              const QString &error)
 {
-    if (!requestContext.isEmpty()) {
-        emit playbackDescriptorFailedForRequest(itemId, error, requestContext);
-    }
+    emit playbackDescriptorFailedForRequest(itemId, error, requestContext);
 }
 
 void PlaybackService::requestPlaybackDescriptor(const QString &itemId,
@@ -235,6 +260,7 @@ void PlaybackService::requestPlaybackDescriptor(const QString &itemId,
     const IPlaybackProvider *provider =
         m_authService ? m_authService->playbackProvider() : nullptr;
     if (!m_authService || !provider || !m_authService->isAuthenticated()) {
+        endRequest(QStringLiteral("descriptor"), itemId, requestContext, generation);
         emitDescriptorFailure(itemId, requestContext, tr("Not authenticated"));
         return;
     }
@@ -262,6 +288,7 @@ void PlaybackService::requestPlaybackDescriptor(const QString &itemId,
             const Bloom::PlaybackDescriptor descriptor = provider->createDescriptor(
                 context, media, providerSource, selectedAudioTrack,
                 selectedSubtitleTrack, startPositionMs, playbackSessionId);
+            endRequest(QStringLiteral("descriptor"), itemId, requestContext, generation);
             if (!descriptor.isValid()) {
                 emitDescriptorFailure(itemId, requestContext,
                                       tr("The playback provider returned an invalid stream request."));
@@ -286,6 +313,8 @@ void PlaybackService::requestPlaybackDescriptor(const QString &itemId,
             if (!parsed.valid || !parsed.descriptor.isValid()) {
                 if (isCurrentRequest(QStringLiteral("descriptor"), itemId,
                                      requestContext, generation)) {
+                    endRequest(QStringLiteral("descriptor"), itemId,
+                               requestContext, generation);
                     emitDescriptorFailure(
                         itemId, requestContext,
                         parsed.error.isEmpty()
@@ -299,12 +328,16 @@ void PlaybackService::requestPlaybackDescriptor(const QString &itemId,
                                                         descriptor.stream.url);
             if (isCurrentRequest(QStringLiteral("descriptor"), itemId,
                                  requestContext, generation)) {
+                endRequest(QStringLiteral("descriptor"), itemId,
+                           requestContext, generation);
                 emit playbackDescriptorLoadedForRequest(itemId, descriptor, requestContext);
             }
         },
         [this, itemId, requestContext, generation](const NetworkError &error) {
             if (isCurrentRequest(QStringLiteral("descriptor"), itemId,
                                 requestContext, generation)) {
+                endRequest(QStringLiteral("descriptor"), itemId,
+                           requestContext, generation);
                 emitDescriptorFailure(itemId, requestContext, error.userMessage);
             }
         },
@@ -321,6 +354,7 @@ bool PlaybackService::switchPlaybackAudio(const QString &playbackSessionId,
     const IPlaybackProvider *provider =
         m_authService ? m_authService->playbackProvider() : nullptr;
     if (!m_authService || !provider || !m_authService->isAuthenticated() || !m_transport) {
+        endRequest(QStringLiteral("audio"), playbackSessionId, requestContext, generation);
         if (!requestContext.isEmpty()) {
             emit playbackAudioSwitchFailedForRequest(playbackSessionId,
                                                       tr("Not authenticated"),
@@ -333,6 +367,7 @@ bool PlaybackService::switchPlaybackAudio(const QString &playbackSessionId,
         provider->createAudioSwitchRequest(context, playbackSessionId,
                                            audioTrackIndex, positionMs);
     if (!switchRequest.isValid()) {
+        endRequest(QStringLiteral("audio"), playbackSessionId, requestContext, generation);
         if (!requestContext.isEmpty()) {
             emit playbackAudioSwitchFailedForRequest(playbackSessionId,
                                                       tr("Audio switching is unavailable."),
@@ -353,29 +388,37 @@ bool PlaybackService::switchPlaybackAudio(const QString &playbackSessionId,
                     context, QJsonDocument::fromJson(reply->readAll()).object());
             if (!parsed.valid || !parsed.reloadUrl.isValid()) {
                 if (isCurrentRequest(QStringLiteral("audio"), playbackSessionId,
-                                     requestContext, generation)
-                    && !requestContext.isEmpty()) {
-                    emit playbackAudioSwitchFailedForRequest(
-                        playbackSessionId,
-                        parsed.error.isEmpty() ? tr("Audio switching failed.") : parsed.error,
-                        requestContext);
+                                     requestContext, generation)) {
+                    endRequest(QStringLiteral("audio"), playbackSessionId,
+                               requestContext, generation);
+                    if (!requestContext.isEmpty()) {
+                        emit playbackAudioSwitchFailedForRequest(
+                            playbackSessionId,
+                            parsed.error.isEmpty() ? tr("Audio switching failed.") : parsed.error,
+                            requestContext);
+                    }
                 }
                 return;
             }
             const QUrl reloadUrl = resolvePlaybackUrl(context.serverUrl, parsed.reloadUrl);
             if (isCurrentRequest(QStringLiteral("audio"), playbackSessionId,
                                  requestContext, generation)) {
+                endRequest(QStringLiteral("audio"), playbackSessionId,
+                           requestContext, generation);
                 emit playbackAudioSwitchedForRequest(playbackSessionId,
                                                      reloadUrl, requestContext);
             }
         },
         [this, playbackSessionId, requestContext, generation](const NetworkError &error) {
             if (isCurrentRequest(QStringLiteral("audio"), playbackSessionId,
-                                 requestContext, generation)
-                && !requestContext.isEmpty()) {
-                emit playbackAudioSwitchFailedForRequest(playbackSessionId,
-                                                         error.userMessage,
-                                                         requestContext);
+                                 requestContext, generation)) {
+                endRequest(QStringLiteral("audio"), playbackSessionId,
+                           requestContext, generation);
+                if (!requestContext.isEmpty()) {
+                    emit playbackAudioSwitchFailedForRequest(playbackSessionId,
+                                                             error.userMessage,
+                                                             requestContext);
+                }
             }
         });
     return true;
@@ -391,6 +434,7 @@ void PlaybackService::requestPlaybackRecovery(const QString &itemId,
     const IPlaybackProvider *provider =
         m_authService ? m_authService->playbackProvider() : nullptr;
     if (!m_authService || !provider || !m_authService->isAuthenticated()) {
+        endRequest(QStringLiteral("recovery"), itemId, requestContext, generation);
         if (!requestContext.isEmpty()) {
             emit playbackRecoveryFailedForRequest(itemId, tr("Not authenticated"),
                                                    requestContext);
@@ -404,6 +448,7 @@ void PlaybackService::requestPlaybackRecovery(const QString &itemId,
         provider->createPlaybackRecoveryRequest(
             context, media, providerSource, startPositionMs);
     if (!recoveryRequest.isValid()) {
+        endRequest(QStringLiteral("recovery"), itemId, requestContext, generation);
         if (!requestContext.isEmpty()) {
             emit playbackRecoveryFailedForRequest(itemId,
                                                    tr("Playback recovery is unavailable."),
@@ -427,13 +472,16 @@ void PlaybackService::requestPlaybackRecovery(const QString &itemId,
                     providerSource);
             if (!parsed.valid || !parsed.descriptor.isValid()) {
                 if (isCurrentRequest(QStringLiteral("recovery"), itemId,
-                                     requestContext, generation)
-                    && !requestContext.isEmpty()) {
-                    emit playbackRecoveryFailedForRequest(
-                        itemId,
-                        parsed.error.isEmpty() ? tr("Playback recovery failed.")
-                                               : parsed.error,
-                        requestContext);
+                                     requestContext, generation)) {
+                    endRequest(QStringLiteral("recovery"), itemId,
+                               requestContext, generation);
+                    if (!requestContext.isEmpty()) {
+                        emit playbackRecoveryFailedForRequest(
+                            itemId,
+                            parsed.error.isEmpty() ? tr("Playback recovery failed.")
+                                                   : parsed.error,
+                            requestContext);
+                    }
                 }
                 return;
             }
@@ -442,16 +490,21 @@ void PlaybackService::requestPlaybackRecovery(const QString &itemId,
                                                         descriptor.stream.url);
             if (isCurrentRequest(QStringLiteral("recovery"), itemId,
                                  requestContext, generation)) {
+                endRequest(QStringLiteral("recovery"), itemId,
+                           requestContext, generation);
                 emit playbackRecoveryLoadedForRequest(itemId, descriptor,
                                                       requestContext);
             }
         },
         [this, itemId, requestContext, generation](const NetworkError &error) {
             if (isCurrentRequest(QStringLiteral("recovery"), itemId,
-                                 requestContext, generation)
-                && !requestContext.isEmpty()) {
-                emit playbackRecoveryFailedForRequest(itemId, error.userMessage,
-                                                      requestContext);
+                                 requestContext, generation)) {
+                endRequest(QStringLiteral("recovery"), itemId,
+                           requestContext, generation);
+                if (!requestContext.isEmpty()) {
+                    emit playbackRecoveryFailedForRequest(itemId, error.userMessage,
+                                                          requestContext);
+                }
             }
         });
 }
@@ -533,6 +586,7 @@ void PlaybackService::getPlaybackInfo(const QString &itemId, const QString &requ
         error.endpoint = QStringLiteral("getPlaybackInfo");
         error.code = -1;
         error.userMessage = tr("Not authenticated");
+        endRequest(QStringLiteral("info"), itemId, requestContext, generation);
         emitError(error);
         if (!requestContext.isEmpty()) {
             emit playbackInfoFailedForRequest(itemId, error.userMessage, requestContext);
@@ -569,6 +623,7 @@ void PlaybackService::getPlaybackInfo(const QString &itemId, const QString &requ
                                       requestContext, generation)) {
                     return;
                 }
+                endRequest(QStringLiteral("info"), itemId, requestContext, generation);
                 emit playbackInfoLoaded(itemId, info);
                 if (!requestContext.isEmpty()) {
                     emit playbackInfoLoadedForRequest(itemId, info, requestContext);
@@ -576,9 +631,13 @@ void PlaybackService::getPlaybackInfo(const QString &itemId, const QString &requ
             },
             [this, itemId, requestContext, generation](const NetworkError &error) {
                 if (isCurrentRequest(QStringLiteral("info"), itemId,
-                                     requestContext, generation)
-                    && !requestContext.isEmpty()) {
-                    emit playbackInfoFailedForRequest(itemId, error.userMessage, requestContext);
+                                     requestContext, generation)) {
+                    endRequest(QStringLiteral("info"), itemId,
+                               requestContext, generation);
+                    if (!requestContext.isEmpty()) {
+                        emit playbackInfoFailedForRequest(itemId, error.userMessage,
+                                                          requestContext);
+                    }
                 }
             });
         return;
@@ -597,13 +656,16 @@ void PlaybackService::getPlaybackInfo(const QString &itemId, const QString &requ
                 QJsonDocument::fromJson(reply->readAll()).object());
             if (!parsed.valid) {
                 if (isCurrentRequest(QStringLiteral("info"), itemId,
-                                     requestContext, generation)
-                    && !requestContext.isEmpty()) {
-                    emit playbackInfoFailedForRequest(
-                        itemId,
-                        parsed.error.isEmpty() ? tr("Playback information is unavailable.")
-                                               : parsed.error,
-                        requestContext);
+                                     requestContext, generation)) {
+                    endRequest(QStringLiteral("info"), itemId,
+                               requestContext, generation);
+                    if (!requestContext.isEmpty()) {
+                        emit playbackInfoFailedForRequest(
+                            itemId,
+                            parsed.error.isEmpty() ? tr("Playback information is unavailable.")
+                                                   : parsed.error,
+                            requestContext);
+                    }
                 }
                 return;
             }
@@ -611,6 +673,7 @@ void PlaybackService::getPlaybackInfo(const QString &itemId, const QString &requ
                                   requestContext, generation)) {
                 return;
             }
+            endRequest(QStringLiteral("info"), itemId, requestContext, generation);
             emit playbackInfoLoaded(itemId, parsed.response);
             if (!requestContext.isEmpty()) {
                 emit playbackInfoLoadedForRequest(itemId, parsed.response, requestContext);
@@ -618,9 +681,13 @@ void PlaybackService::getPlaybackInfo(const QString &itemId, const QString &requ
         },
         [this, itemId, requestContext, generation](const NetworkError &error) {
             if (isCurrentRequest(QStringLiteral("info"), itemId,
-                                 requestContext, generation)
-                && !requestContext.isEmpty()) {
-                emit playbackInfoFailedForRequest(itemId, error.userMessage, requestContext);
+                                 requestContext, generation)) {
+                endRequest(QStringLiteral("info"), itemId,
+                           requestContext, generation);
+                if (!requestContext.isEmpty()) {
+                    emit playbackInfoFailedForRequest(itemId, error.userMessage,
+                                                      requestContext);
+                }
             }
         });
 }
@@ -640,6 +707,7 @@ void PlaybackService::getAdditionalParts(const QString &itemId,
         error.endpoint = QStringLiteral("getAdditionalParts");
         error.code = -1;
         error.userMessage = tr("Not authenticated");
+        endRequest(QStringLiteral("parts"), itemId, requestContext, generation);
         emitError(error);
         if (!requestContext.isEmpty()) {
             emit additionalPartsFailedForRequest(itemId, error.userMessage, requestContext);
@@ -647,6 +715,7 @@ void PlaybackService::getAdditionalParts(const QString &itemId,
         return;
     }
     if (m_authService->activeProviderKind() == ProviderKind::Silo) {
+        endRequest(QStringLiteral("parts"), itemId, requestContext, generation);
         emit additionalPartsLoaded(itemId, {});
         if (!requestContext.isEmpty()) {
             emit additionalPartsLoadedForRequest(itemId, {}, requestContext);
@@ -673,6 +742,7 @@ void PlaybackService::getAdditionalParts(const QString &itemId,
             const QVariantList parts = response.success
                 ? m_authService->mapMediaItems(response.items, connectionId)
                 : QVariantList{};
+            endRequest(QStringLiteral("parts"), itemId, requestContext, generation);
             emit additionalPartsLoaded(itemId, parts);
             if (!requestContext.isEmpty()) {
                 emit additionalPartsLoadedForRequest(itemId, parts, requestContext);
@@ -680,9 +750,13 @@ void PlaybackService::getAdditionalParts(const QString &itemId,
         },
         [this, itemId, requestContext, generation](const NetworkError &error) {
             if (isCurrentRequest(QStringLiteral("parts"), itemId,
-                                 requestContext, generation)
-                && !requestContext.isEmpty()) {
-                emit additionalPartsFailedForRequest(itemId, error.userMessage, requestContext);
+                                 requestContext, generation)) {
+                endRequest(QStringLiteral("parts"), itemId,
+                           requestContext, generation);
+                if (!requestContext.isEmpty()) {
+                    emit additionalPartsFailedForRequest(itemId, error.userMessage,
+                                                         requestContext);
+                }
             }
         });
 }
@@ -1013,6 +1087,9 @@ void PlaybackService::sendPlaybackReport(const PlaybackReport &report,
         && m_pendingProgressReports.value(sessionId, 0) > 0) {
         m_pendingStopReports.insert(sessionId, report);
         m_pendingStopProviders.insert(sessionId, provider);
+        m_pendingStopRequestIdentities.insert(
+            sessionId,
+            playbackRequestIdentity(m_authService, m_configManager, providerContext()));
         return;
     }
 
@@ -1033,7 +1110,16 @@ void PlaybackService::sendPlaybackReport(const PlaybackReport &report,
             const auto stop = m_pendingStopReports.take(sessionId);
             const IPlaybackProvider *stopProvider =
                 m_pendingStopProviders.take(sessionId);
-            if (!stop.playbackSessionId.isEmpty()) {
+            const QString stopIdentity =
+                m_pendingStopRequestIdentities.take(sessionId);
+            // A progress completion may outlive a server/account switch. Never
+            // send the old session's stop report through the new credentials.
+            if (!stop.playbackSessionId.isEmpty()
+                && stopProvider
+                && stopProvider == (m_authService ? m_authService->playbackProvider() : nullptr)
+                && stopIdentity
+                    == playbackRequestIdentity(m_authService, m_configManager,
+                                                providerContext())) {
                 sendPlaybackReport(stop, {}, stopProvider);
             }
         };

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -4,6 +4,7 @@
 #include "MediaSegmentProviderService.h"
 #include "providers/IPlaybackProvider.h"
 #include "../utils/ConfigManager.h"
+#include "../utils/BloomLogging.h"
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -11,8 +12,9 @@
 #include <QTimer>
 #include <QUrl>
 #include <QLoggingCategory>
+#include <QCoreApplication>
+#include <QSysInfo>
 #include <optional>
-#include "../utils/BloomLogging.h"
 
 namespace {
 
@@ -58,6 +60,16 @@ PlaybackReport makePlaybackReport(PlaybackReportEvent event,
     return report;
 }
 
+QUrl resolvePlaybackUrl(const QUrl &serverUrl, const QUrl &url)
+{
+    if (!url.isRelative() || !serverUrl.isValid()) {
+        return url;
+    }
+    QUrl origin = serverUrl;
+    origin.setPath(QStringLiteral("/"));
+    return origin.resolved(url);
+}
+
 } // namespace
 
 PlaybackService::PlaybackService(AuthenticationService *authService,
@@ -69,7 +81,6 @@ PlaybackService::PlaybackService(AuthenticationService *authService,
     , m_transport(authService ? authService->transport() : nullptr)
     , m_configManager(configManager)
     , m_mediaSegmentProviderService(mediaSegmentProviderService)
-    , m_provider(authService ? authService->playbackProvider() : nullptr)
     , m_retryPolicy{3, 1000, true}
 {
 }
@@ -85,7 +96,9 @@ Bloom::PlaybackDescriptor PlaybackService::createPlaybackDescriptor(
     const QString &playbackSessionId,
     bool emitFailure)
 {
-    if (!m_authService || !m_provider) {
+    const IPlaybackProvider *provider =
+        m_authService ? m_authService->playbackProvider() : nullptr;
+    if (!m_authService || !provider) {
         if (emitFailure) {
             NetworkError error;
             error.code = -1;
@@ -105,11 +118,8 @@ Bloom::PlaybackDescriptor PlaybackService::createPlaybackDescriptor(
     if (connection.has_value()) {
         media.connectionId = connection->connectionId;
     }
-    const PlaybackProviderContext context{
-        QUrl(m_authService->getServerUrl()),
-        m_authService->getAccessToken()
-    };
-    const Bloom::PlaybackDescriptor descriptor = m_provider->createDescriptor(
+    const PlaybackProviderContext context = providerContext();
+    const Bloom::PlaybackDescriptor descriptor = provider->createDescriptor(
         context,
         media,
         providerSource,
@@ -127,6 +137,325 @@ Bloom::PlaybackDescriptor PlaybackService::createPlaybackDescriptor(
     return descriptor;
 }
 
+PlaybackProviderContext PlaybackService::providerContext() const
+{
+    PlaybackProviderContext context;
+    if (!m_authService) {
+        return context;
+    }
+    context.serverUrl = QUrl(m_authService->getServerUrl());
+    context.accessToken = m_authService->getAccessToken();
+    context.clientName = QStringLiteral("Bloom");
+    context.clientVersion = QCoreApplication::applicationVersion();
+    ConfigManager *config = m_configManager
+        ? m_configManager : m_authService->configManager();
+    if (config) {
+        context.deviceId = config->getDeviceId();
+        const auto connection = config->getActiveConnection();
+        if (connection.has_value()) {
+            context.profileId = connection->profileId;
+        }
+    }
+    context.deviceName = QSysInfo::machineHostName();
+    context.devicePlatform = QSysInfo::prettyProductName();
+    return context;
+}
+
+quint64 PlaybackService::beginRequest(const QString &operation,
+                                      const QString &itemId,
+                                      const QString &requestContext)
+{
+    const QString key = operation + QChar(0x1f) + requestContext + QChar(0x1f) + itemId;
+    const quint64 generation = m_requestGenerations.value(key, 0) + 1;
+    m_requestGenerations.insert(key, generation);
+    return generation;
+}
+
+bool PlaybackService::isCurrentRequest(const QString &operation,
+                                       const QString &itemId,
+                                       const QString &requestContext,
+                                       quint64 generation) const
+{
+    const QString key = operation + QChar(0x1f) + requestContext + QChar(0x1f) + itemId;
+    return m_requestGenerations.value(key, 0) == generation;
+}
+
+QNetworkReply *PlaybackService::sendProviderRequest(const QString &endpoint,
+                                                    const QString &method,
+                                                    const QJsonObject &body) const
+{
+    if (!m_authService) {
+        return nullptr;
+    }
+    QNetworkRequest request = m_authService->createRequest(endpoint);
+    if (!body.isEmpty()) {
+        request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));
+    }
+    const QByteArray payload = QJsonDocument(body).toJson(QJsonDocument::Compact);
+    const QString normalizedMethod = method.trimmed().toUpper();
+    if (normalizedMethod == QStringLiteral("GET")) {
+        return m_authService->networkManager()->get(request);
+    }
+    if (normalizedMethod == QStringLiteral("POST")) {
+        return m_authService->networkManager()->post(request, payload);
+    }
+    if (normalizedMethod == QStringLiteral("PUT")) {
+        return m_authService->networkManager()->put(request, payload);
+    }
+    if (normalizedMethod == QStringLiteral("DELETE")) {
+        if (body.isEmpty()) {
+            return m_authService->networkManager()->deleteResource(request);
+        }
+        return m_authService->networkManager()->sendCustomRequest(
+            request, QByteArrayLiteral("DELETE"), payload);
+    }
+    return m_authService->networkManager()->sendCustomRequest(
+        request, normalizedMethod.toLatin1(), payload);
+}
+
+void PlaybackService::emitDescriptorFailure(const QString &itemId,
+                                             const QString &requestContext,
+                                             const QString &error)
+{
+    if (!requestContext.isEmpty()) {
+        emit playbackDescriptorFailedForRequest(itemId, error, requestContext);
+    }
+}
+
+void PlaybackService::requestPlaybackDescriptor(const QString &itemId,
+                                                const QVariantMap &providerSource,
+                                                int selectedAudioTrack,
+                                                int selectedSubtitleTrack,
+                                                qint64 startPositionMs,
+                                                const QString &playbackSessionId,
+                                                const QString &requestContext)
+{
+    const quint64 generation =
+        beginRequest(QStringLiteral("descriptor"), itemId, requestContext);
+    const IPlaybackProvider *provider =
+        m_authService ? m_authService->playbackProvider() : nullptr;
+    if (!m_authService || !provider || !m_authService->isAuthenticated()) {
+        emitDescriptorFailure(itemId, requestContext, tr("Not authenticated"));
+        return;
+    }
+
+    Bloom::MediaRef media;
+    media.itemId = itemId;
+    ConfigManager *config = m_configManager ? m_configManager : m_authService->configManager();
+    if (const auto connection = config ? config->getActiveConnection() : std::nullopt;
+        connection.has_value()) {
+        media.connectionId = connection->connectionId;
+    }
+    const PlaybackProviderContext context = providerContext();
+    const PlaybackStartRequest startRequest = provider->createPlaybackStartRequest(
+        context, media, providerSource, selectedAudioTrack, selectedSubtitleTrack,
+        startPositionMs);
+    if (!startRequest.isValid()) {
+        QTimer::singleShot(0, this, [this, provider, itemId, providerSource,
+                                     selectedAudioTrack, selectedSubtitleTrack,
+                                     startPositionMs, playbackSessionId,
+                                     requestContext, generation, context, media]() {
+            if (!isCurrentRequest(QStringLiteral("descriptor"), itemId,
+                                  requestContext, generation)) {
+                return;
+            }
+            const Bloom::PlaybackDescriptor descriptor = provider->createDescriptor(
+                context, media, providerSource, selectedAudioTrack,
+                selectedSubtitleTrack, startPositionMs, playbackSessionId);
+            if (!descriptor.isValid()) {
+                emitDescriptorFailure(itemId, requestContext,
+                                      tr("The playback provider returned an invalid stream request."));
+                return;
+            }
+            emit playbackDescriptorLoadedForRequest(itemId, descriptor, requestContext);
+        });
+        return;
+    }
+
+    sendRequestWithRetry(
+        startRequest.endpoint,
+        [this, startRequest]() {
+            return sendProviderRequest(startRequest.endpoint, startRequest.method,
+                                       startRequest.body);
+        },
+        [this, provider, itemId, providerSource, requestContext, generation, context, media]
+        (QNetworkReply *reply) {
+            const PlaybackStartParseResult parsed = provider->parsePlaybackStartResponse(
+                context, media,
+                QJsonDocument::fromJson(reply->readAll()).object(), providerSource);
+            if (!parsed.valid || !parsed.descriptor.isValid()) {
+                if (isCurrentRequest(QStringLiteral("descriptor"), itemId,
+                                     requestContext, generation)) {
+                    emitDescriptorFailure(
+                        itemId, requestContext,
+                        parsed.error.isEmpty()
+                            ? tr("The playback provider returned an invalid stream request.")
+                            : parsed.error);
+                }
+                return;
+            }
+            Bloom::PlaybackDescriptor descriptor = parsed.descriptor;
+            descriptor.stream.url = resolvePlaybackUrl(context.serverUrl,
+                                                        descriptor.stream.url);
+            if (isCurrentRequest(QStringLiteral("descriptor"), itemId,
+                                 requestContext, generation)) {
+                emit playbackDescriptorLoadedForRequest(itemId, descriptor, requestContext);
+            }
+        },
+        [this, itemId, requestContext, generation](const NetworkError &error) {
+            if (isCurrentRequest(QStringLiteral("descriptor"), itemId,
+                                requestContext, generation)) {
+                emitDescriptorFailure(itemId, requestContext, error.userMessage);
+            }
+        },
+        0, true, false);
+}
+
+bool PlaybackService::switchPlaybackAudio(const QString &playbackSessionId,
+                                           int audioTrackIndex,
+                                           qint64 positionMs,
+                                           const QString &requestContext)
+{
+    const quint64 generation =
+        beginRequest(QStringLiteral("audio"), playbackSessionId, requestContext);
+    const IPlaybackProvider *provider =
+        m_authService ? m_authService->playbackProvider() : nullptr;
+    if (!m_authService || !provider || !m_authService->isAuthenticated() || !m_transport) {
+        if (!requestContext.isEmpty()) {
+            emit playbackAudioSwitchFailedForRequest(playbackSessionId,
+                                                      tr("Not authenticated"),
+                                                      requestContext);
+        }
+        return false;
+    }
+    const PlaybackProviderContext context = providerContext();
+    const PlaybackAudioSwitchRequest switchRequest =
+        provider->createAudioSwitchRequest(context, playbackSessionId,
+                                           audioTrackIndex, positionMs);
+    if (!switchRequest.isValid()) {
+        if (!requestContext.isEmpty()) {
+            emit playbackAudioSwitchFailedForRequest(playbackSessionId,
+                                                      tr("Audio switching is unavailable."),
+                                                      requestContext);
+        }
+        return false;
+    }
+    sendRequestWithRetry(
+        switchRequest.endpoint,
+        [this, switchRequest]() {
+            return sendProviderRequest(switchRequest.endpoint, switchRequest.method,
+                                       switchRequest.body);
+        },
+        [this, provider, playbackSessionId, requestContext, generation, context]
+        (QNetworkReply *reply) {
+            const PlaybackAudioSwitchParseResult parsed =
+                provider->parseAudioSwitchResponse(
+                    context, QJsonDocument::fromJson(reply->readAll()).object());
+            if (!parsed.valid || !parsed.reloadUrl.isValid()) {
+                if (isCurrentRequest(QStringLiteral("audio"), playbackSessionId,
+                                     requestContext, generation)
+                    && !requestContext.isEmpty()) {
+                    emit playbackAudioSwitchFailedForRequest(
+                        playbackSessionId,
+                        parsed.error.isEmpty() ? tr("Audio switching failed.") : parsed.error,
+                        requestContext);
+                }
+                return;
+            }
+            const QUrl reloadUrl = resolvePlaybackUrl(context.serverUrl, parsed.reloadUrl);
+            if (isCurrentRequest(QStringLiteral("audio"), playbackSessionId,
+                                 requestContext, generation)) {
+                emit playbackAudioSwitchedForRequest(playbackSessionId,
+                                                     reloadUrl, requestContext);
+            }
+        },
+        [this, playbackSessionId, requestContext, generation](const NetworkError &error) {
+            if (isCurrentRequest(QStringLiteral("audio"), playbackSessionId,
+                                 requestContext, generation)
+                && !requestContext.isEmpty()) {
+                emit playbackAudioSwitchFailedForRequest(playbackSessionId,
+                                                         error.userMessage,
+                                                         requestContext);
+            }
+        });
+    return true;
+}
+
+void PlaybackService::requestPlaybackRecovery(const QString &itemId,
+                                              const QVariantMap &providerSource,
+                                              qint64 startPositionMs,
+                                              const QString &requestContext)
+{
+    const quint64 generation =
+        beginRequest(QStringLiteral("recovery"), itemId, requestContext);
+    const IPlaybackProvider *provider =
+        m_authService ? m_authService->playbackProvider() : nullptr;
+    if (!m_authService || !provider || !m_authService->isAuthenticated()) {
+        if (!requestContext.isEmpty()) {
+            emit playbackRecoveryFailedForRequest(itemId, tr("Not authenticated"),
+                                                   requestContext);
+        }
+        return;
+    }
+    Bloom::MediaRef media;
+    media.itemId = itemId;
+    const PlaybackProviderContext context = providerContext();
+    const PlaybackRecoveryRequest recoveryRequest =
+        provider->createPlaybackRecoveryRequest(
+            context, media, providerSource, startPositionMs);
+    if (!recoveryRequest.isValid()) {
+        if (!requestContext.isEmpty()) {
+            emit playbackRecoveryFailedForRequest(itemId,
+                                                   tr("Playback recovery is unavailable."),
+                                                   requestContext);
+        }
+        return;
+    }
+    sendRequestWithRetry(
+        recoveryRequest.endpoint,
+        [this, recoveryRequest]() {
+            return sendProviderRequest(recoveryRequest.endpoint,
+                                       recoveryRequest.method,
+                                       recoveryRequest.body);
+        },
+        [this, provider, itemId, providerSource, requestContext, generation, context, media]
+        (QNetworkReply *reply) {
+            const PlaybackStartParseResult parsed =
+                provider->parsePlaybackRecoveryResponse(
+                    context, media,
+                    QJsonDocument::fromJson(reply->readAll()).object(),
+                    providerSource);
+            if (!parsed.valid || !parsed.descriptor.isValid()) {
+                if (isCurrentRequest(QStringLiteral("recovery"), itemId,
+                                     requestContext, generation)
+                    && !requestContext.isEmpty()) {
+                    emit playbackRecoveryFailedForRequest(
+                        itemId,
+                        parsed.error.isEmpty() ? tr("Playback recovery failed.")
+                                               : parsed.error,
+                        requestContext);
+                }
+                return;
+            }
+            Bloom::PlaybackDescriptor descriptor = parsed.descriptor;
+            descriptor.stream.url = resolvePlaybackUrl(context.serverUrl,
+                                                        descriptor.stream.url);
+            if (isCurrentRequest(QStringLiteral("recovery"), itemId,
+                                 requestContext, generation)) {
+                emit playbackRecoveryLoadedForRequest(itemId, descriptor,
+                                                      requestContext);
+            }
+        },
+        [this, itemId, requestContext, generation](const NetworkError &error) {
+            if (isCurrentRequest(QStringLiteral("recovery"), itemId,
+                                 requestContext, generation)
+                && !requestContext.isEmpty()) {
+                emit playbackRecoveryFailedForRequest(itemId, error.userMessage,
+                                                      requestContext);
+            }
+        });
+}
+
 // ============================================================================
 // Request Helpers
 // ============================================================================
@@ -135,7 +464,9 @@ void PlaybackService::sendRequestWithRetry(const QString &endpoint,
                                             RequestFactory requestFactory,
                                             ResponseHandler responseHandler,
                                             FailureHandler failureHandler,
-                                            int attemptNumber)
+                                            int attemptNumber,
+                                            bool deferSessionExpiry,
+                                            bool enableTransientRetry)
 {
     Q_UNUSED(attemptNumber)
     if (!m_transport) {
@@ -152,7 +483,10 @@ void PlaybackService::sendRequestWithRetry(const QString &endpoint,
 
     HttpRequestOptions options;
     options.retryPolicy = m_retryPolicy;
-    options.unauthorizedPolicy = UnauthorizedPolicy::DeferSessionExpiry;
+    options.retryEnabled = enableTransientRetry;
+    options.unauthorizedPolicy = deferSessionExpiry
+        ? UnauthorizedPolicy::DeferSessionExpiry
+        : UnauthorizedPolicy::ExpireSession;
     m_transport->sendWithRetry(
         this,
         endpoint,
@@ -190,9 +524,13 @@ void PlaybackService::getPlaybackInfo(const QString &itemId)
 
 void PlaybackService::getPlaybackInfo(const QString &itemId, const QString &requestContext)
 {
-    if (!m_authService->isAuthenticated()) {
+    const quint64 generation =
+        beginRequest(QStringLiteral("info"), itemId, requestContext);
+    const IPlaybackProvider *provider =
+        m_authService ? m_authService->playbackProvider() : nullptr;
+    if (!m_authService || !provider || !m_authService->isAuthenticated()) {
         NetworkError error;
-        error.endpoint = "getPlaybackInfo";
+        error.endpoint = QStringLiteral("getPlaybackInfo");
         error.code = -1;
         error.userMessage = tr("Not authenticated");
         emitError(error);
@@ -201,26 +539,87 @@ void PlaybackService::getPlaybackInfo(const QString &itemId, const QString &requ
         }
         return;
     }
-    
-    QString endpoint = QString("/Items/%1/PlaybackInfo?UserId=%2")
-        .arg(itemId, m_authService->getUserId());
-    
-    sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
-            QNetworkRequest request = m_authService->createRequest(endpoint);
-            request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-            return m_authService->networkManager()->post(request, QByteArray("{}"));
+
+    Bloom::MediaRef media;
+    media.itemId = itemId;
+    ConfigManager *config = m_configManager ? m_configManager : m_authService->configManager();
+    if (const auto connection = config ? config->getActiveConnection() : std::nullopt;
+        connection.has_value()) {
+        media.connectionId = connection->connectionId;
+    }
+    const PlaybackProviderContext context = providerContext();
+    const PlaybackInfoRequest providerRequest =
+        provider->createPlaybackInfoRequest(context, media, {});
+    if (!providerRequest.isValid()) {
+        const QString endpoint = QStringLiteral("/Items/%1/PlaybackInfo?UserId=%2")
+            .arg(itemId, m_authService->getUserId());
+        sendRequestWithRetry(
+            endpoint,
+            [this, endpoint]() {
+                QNetworkRequest request = m_authService->createRequest(endpoint);
+                request.setHeader(QNetworkRequest::ContentTypeHeader,
+                                  QStringLiteral("application/json"));
+                return m_authService->networkManager()->post(request, QByteArray("{}"));
+            },
+            [this, itemId, requestContext, generation](QNetworkReply *reply) {
+                const PlaybackInfoResponse info =
+                    m_authService->mapPlaybackInfo(
+                        QJsonDocument::fromJson(reply->readAll()).object());
+                if (!isCurrentRequest(QStringLiteral("info"), itemId,
+                                      requestContext, generation)) {
+                    return;
+                }
+                emit playbackInfoLoaded(itemId, info);
+                if (!requestContext.isEmpty()) {
+                    emit playbackInfoLoadedForRequest(itemId, info, requestContext);
+                }
+            },
+            [this, itemId, requestContext, generation](const NetworkError &error) {
+                if (isCurrentRequest(QStringLiteral("info"), itemId,
+                                     requestContext, generation)
+                    && !requestContext.isEmpty()) {
+                    emit playbackInfoFailedForRequest(itemId, error.userMessage, requestContext);
+                }
+            });
+        return;
+    }
+
+    sendRequestWithRetry(
+        providerRequest.endpoint,
+        [this, providerRequest]() {
+            return sendProviderRequest(providerRequest.endpoint, providerRequest.method,
+                                       providerRequest.body);
         },
-        [this, itemId, requestContext](QNetworkReply *reply) {
-            const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-            const PlaybackInfoResponse info = m_authService->mapPlaybackInfo(doc.object());
-            emit playbackInfoLoaded(itemId, info);
+        [this, provider, itemId, requestContext, generation, context, media]
+        (QNetworkReply *reply) {
+            const PlaybackInfoParseResult parsed = provider->parsePlaybackInfoResponse(
+                context, media,
+                QJsonDocument::fromJson(reply->readAll()).object());
+            if (!parsed.valid) {
+                if (isCurrentRequest(QStringLiteral("info"), itemId,
+                                     requestContext, generation)
+                    && !requestContext.isEmpty()) {
+                    emit playbackInfoFailedForRequest(
+                        itemId,
+                        parsed.error.isEmpty() ? tr("Playback information is unavailable.")
+                                               : parsed.error,
+                        requestContext);
+                }
+                return;
+            }
+            if (!isCurrentRequest(QStringLiteral("info"), itemId,
+                                  requestContext, generation)) {
+                return;
+            }
+            emit playbackInfoLoaded(itemId, parsed.response);
             if (!requestContext.isEmpty()) {
-                emit playbackInfoLoadedForRequest(itemId, info, requestContext);
+                emit playbackInfoLoadedForRequest(itemId, parsed.response, requestContext);
             }
         },
-        [this, itemId, requestContext](const NetworkError &error) {
-            if (!requestContext.isEmpty()) {
+        [this, itemId, requestContext, generation](const NetworkError &error) {
+            if (isCurrentRequest(QStringLiteral("info"), itemId,
+                                 requestContext, generation)
+                && !requestContext.isEmpty()) {
                 emit playbackInfoFailedForRequest(itemId, error.userMessage, requestContext);
             }
         });
@@ -231,11 +630,14 @@ void PlaybackService::getAdditionalParts(const QString &itemId)
     getAdditionalParts(itemId, QString());
 }
 
-void PlaybackService::getAdditionalParts(const QString &itemId, const QString &requestContext)
+void PlaybackService::getAdditionalParts(const QString &itemId,
+                                         const QString &requestContext)
 {
-    if (!m_authService->isAuthenticated()) {
+    const quint64 generation =
+        beginRequest(QStringLiteral("parts"), itemId, requestContext);
+    if (!m_authService || !m_authService->isAuthenticated()) {
         NetworkError error;
-        error.endpoint = "getAdditionalParts";
+        error.endpoint = QStringLiteral("getAdditionalParts");
         error.code = -1;
         error.userMessage = tr("Not authenticated");
         emitError(error);
@@ -244,9 +646,16 @@ void PlaybackService::getAdditionalParts(const QString &itemId, const QString &r
         }
         return;
     }
+    if (m_authService->activeProviderKind() == ProviderKind::Silo) {
+        emit additionalPartsLoaded(itemId, {});
+        if (!requestContext.isEmpty()) {
+            emit additionalPartsLoadedForRequest(itemId, {}, requestContext);
+        }
+        return;
+    }
 
     const QString connectionId = activeConnectionId(m_authService, m_configManager);
-    QString endpoint = QString("/Videos/%1/AdditionalParts?UserId=%2")
+    const QString endpoint = QStringLiteral("/Videos/%1/AdditionalParts?UserId=%2")
         .arg(itemId, m_authService->getUserId());
 
     sendRequestWithRetry(endpoint,
@@ -254,7 +663,11 @@ void PlaybackService::getAdditionalParts(const QString &itemId, const QString &r
             QNetworkRequest request = m_authService->createRequest(endpoint);
             return m_authService->networkManager()->get(request);
         },
-        [this, itemId, requestContext, connectionId](QNetworkReply *reply) {
+        [this, itemId, requestContext, connectionId, generation](QNetworkReply *reply) {
+            if (!isCurrentRequest(QStringLiteral("parts"), itemId,
+                                  requestContext, generation)) {
+                return;
+            }
             const ParsedItemsResult response =
                 m_authService->parseItemsResponse(reply->readAll(), QString());
             const QVariantList parts = response.success
@@ -265,8 +678,10 @@ void PlaybackService::getAdditionalParts(const QString &itemId, const QString &r
                 emit additionalPartsLoadedForRequest(itemId, parts, requestContext);
             }
         },
-        [this, itemId, requestContext](const NetworkError &error) {
-            if (!requestContext.isEmpty()) {
+        [this, itemId, requestContext, generation](const NetworkError &error) {
+            if (isCurrentRequest(QStringLiteral("parts"), itemId,
+                                 requestContext, generation)
+                && !requestContext.isEmpty()) {
                 emit additionalPartsFailedForRequest(itemId, error.userMessage, requestContext);
             }
         });
@@ -486,20 +901,17 @@ void PlaybackService::getTrickplayInfo(const QString &itemId)
 
 QString PlaybackService::getTrickplayTileUrl(const QString &itemId, int width, int tileIndex)
 {
-    if (!m_authService || !m_provider) {
+    const IPlaybackProvider *provider =
+        m_authService ? m_authService->playbackProvider() : nullptr;
+    if (!m_authService || !provider) {
         return {};
     }
-    return m_provider->createTrickplayTileUrl(
-        PlaybackProviderContext{
-            QUrl(m_authService->getServerUrl()),
-            m_authService->getAccessToken()
-        },
+    return provider->createTrickplayTileUrl(
+        providerContext(),
         itemId,
         width,
         tileIndex).toString();
 }
-
-// ============================================================================
 // Playback Reporting
 // ============================================================================
 
@@ -517,7 +929,6 @@ void PlaybackService::reportPlaybackStart(const QString &itemId, const QString &
                                           canSeek, isPaused, isMuted, playMethod,
                                           repeatMode, playbackOrder));
 }
-
 void PlaybackService::reportPlaybackProgress(const QString &itemId, qint64 positionMs,
                                               const QString &mediaSourceId,
                                               int audioStreamIndex, int subtitleStreamIndex,
@@ -582,10 +993,50 @@ void PlaybackService::reportPlaybackStopped(const QString &itemId, qint64 positi
                                           repeatMode, playbackOrder));
 }
 
-void PlaybackService::sendPlaybackReport(const PlaybackReport &report)
+void PlaybackService::sendPlaybackReport(const PlaybackReport &report,
+                                         std::function<void()> completion,
+                                         const IPlaybackProvider *providerOverride)
 {
-    if (!m_authService || !m_authService->isAuthenticated() || !m_provider) {
+    const IPlaybackProvider *provider = providerOverride
+        ? providerOverride
+        : (m_authService ? m_authService->playbackProvider() : nullptr);
+    if (!m_authService || !m_authService->isAuthenticated() || !provider) {
+        if (completion) {
+            completion();
+        }
         return;
+    }
+
+    const QString sessionId = report.playbackSessionId;
+    if (report.event == PlaybackReportEvent::Stop
+        && !sessionId.isEmpty()
+        && m_pendingProgressReports.value(sessionId, 0) > 0) {
+        m_pendingStopReports.insert(sessionId, report);
+        m_pendingStopProviders.insert(sessionId, provider);
+        return;
+    }
+
+    if (report.event == PlaybackReportEvent::Progress && !sessionId.isEmpty()) {
+        m_pendingProgressReports[sessionId] =
+            m_pendingProgressReports.value(sessionId, 0) + 1;
+        const auto originalCompletion = std::move(completion);
+        completion = [this, sessionId, originalCompletion]() mutable {
+            if (originalCompletion) {
+                originalCompletion();
+            }
+            const int remaining = m_pendingProgressReports.value(sessionId, 0) - 1;
+            if (remaining > 0) {
+                m_pendingProgressReports.insert(sessionId, remaining);
+                return;
+            }
+            m_pendingProgressReports.remove(sessionId);
+            const auto stop = m_pendingStopReports.take(sessionId);
+            const IPlaybackProvider *stopProvider =
+                m_pendingStopProviders.take(sessionId);
+            if (!stop.playbackSessionId.isEmpty()) {
+                sendPlaybackReport(stop, {}, stopProvider);
+            }
+        };
     }
 
     PlaybackReport providerReport = report;
@@ -598,10 +1049,13 @@ void PlaybackService::sendPlaybackReport(const PlaybackReport &report)
     }
 
     const PlaybackReportRequest providerRequest =
-        m_provider->createReportRequest(providerReport);
+        provider->createReportRequest(providerReport);
     if (!providerRequest.isValid()) {
         qCWarning(lcPlayback) << "Playback provider returned an invalid report request"
                               << "itemId=" << report.media.itemId;
+        if (completion) {
+            completion();
+        }
         return;
     }
 
@@ -610,44 +1064,52 @@ void PlaybackService::sendPlaybackReport(const PlaybackReport &report)
                         << "positionMs=" << report.positionMs
                         << "endpoint=" << providerRequest.endpoint;
 
-    QNetworkRequest request = m_authService->createRequest(providerRequest.endpoint);
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    QNetworkReply *reply = m_authService->networkManager()->post(
-        request, QJsonDocument(providerRequest.body).toJson());
-    connect(reply, &QNetworkReply::finished, this,
-            [this, reply, itemId = report.media.itemId,
-             deferSessionExpiry = providerRequest.deferSessionExpiry]() {
-        reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply, deferSessionExpiry)) {
-            return;
-        }
-        if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(lcPlayback) << "Failed to report playback event for" << itemId
-                                  << ":" << reply->errorString();
-        }
-    });
+    sendRequestWithRetry(
+        providerRequest.endpoint,
+        [this, providerRequest]() {
+            return sendProviderRequest(providerRequest.endpoint,
+                                       providerRequest.method,
+                                       providerRequest.body);
+        },
+        [this, itemId = report.media.itemId, completion](QNetworkReply *reply) mutable {
+            if (reply->error() != QNetworkReply::NoError) {
+                qCWarning(lcPlayback) << "Failed to report playback event for" << itemId
+                                      << ":" << reply->errorString();
+            }
+            if (completion) {
+                completion();
+            }
+        },
+        [completion](const NetworkError &) mutable {
+            if (completion) {
+                completion();
+            }
+        },
+        0,
+        providerRequest.deferSessionExpiry);
 }
 
 void PlaybackService::markItemPlayed(const QString &itemId)
 {
     if (!m_authService->isAuthenticated()) return;
 
-    qCDebug(lcPlayback) << "Marking item as played:" << itemId;
-
-    QString endpoint = QString("/Users/%1/PlayedItems/%2").arg(m_authService->getUserId(), itemId);
-    QNetworkRequest request = m_authService->createRequest(endpoint);
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    
-    QNetworkReply *reply = m_authService->networkManager()->post(request, QByteArray());
-    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
-        reply->deleteLater();
-        if (m_authService->checkForSessionExpiry(reply, false)) return;
-        if (reply->error() != QNetworkReply::NoError) {
-            qCWarning(lcPlayback) << "Failed to mark item as played:" << itemId 
-                                       << ":" << reply->errorString();
-        } else {
-            qCDebug(lcPlayback) << "Successfully marked item as played:" << itemId;
-            emit itemMarkedPlayed(itemId);
-        }
-    });
+    const QString endpoint = QString("/Users/%1/PlayedItems/%2")
+        .arg(m_authService->getUserId(), itemId);
+    sendRequestWithRetry(
+        endpoint,
+        [this, endpoint]() {
+            return sendProviderRequest(endpoint, QStringLiteral("POST"), {});
+        },
+        [this, itemId](QNetworkReply *reply) {
+            if (reply->error() != QNetworkReply::NoError) {
+                qCWarning(lcPlayback) << "Failed to mark item as played:" << itemId
+                                      << ":" << reply->errorString();
+            } else {
+                qCDebug(lcPlayback) << "Successfully marked item as played:" << itemId;
+                emit itemMarkedPlayed(itemId);
+            }
+        },
+        FailureHandler(),
+        0,
+        false);
 }

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -2,7 +2,7 @@
 #include "AuthenticationService.h"
 #include "HttpTransport.h"
 #include "MediaSegmentProviderService.h"
-#include "providers/IPlaybackProvider.h"
+#include "providers/ICatalogProvider.h"
 #include "../utils/ConfigManager.h"
 #include "../utils/BloomLogging.h"
 #include <QJsonDocument>
@@ -28,7 +28,8 @@ QString activeConnectionId(AuthenticationService *authService, ConfigManager *co
 }
 QString playbackRequestIdentity(AuthenticationService *authService,
                                 ConfigManager *configManager,
-                                const PlaybackProviderContext &context)
+                                const PlaybackProviderContext &context,
+                                const IPlaybackProvider *provider)
 {
     const QStringList fields{
         context.serverUrl.toString(QUrl::FullyEncoded),
@@ -37,7 +38,10 @@ QString playbackRequestIdentity(AuthenticationService *authService,
         context.profileToken,
         context.deviceId,
         activeConnectionId(authService, configManager),
-        authService ? authService->getUserId() : QString()
+        authService ? authService->getUserId() : QString(),
+        QString::number(static_cast<int>(
+            authService ? authService->activeProviderKind() : ProviderKind::Jellyfin)),
+        QString::number(reinterpret_cast<quintptr>(provider), 16)
     };
     return fields.join(QChar(0x1f));
 }
@@ -182,8 +186,14 @@ quint64 PlaybackService::beginRequest(const QString &operation,
                                       const QString &requestContext)
 {
     const QString key = operation + QChar(0x1f) + requestContext + QChar(0x1f) + itemId;
-    const quint64 generation = m_requestGenerations.value(key, 0) + 1;
+    const quint64 generation = ++m_nextRequestGeneration;
     m_requestGenerations.insert(key, generation);
+    const IPlaybackProvider *provider =
+        m_authService ? m_authService->playbackProvider() : nullptr;
+    m_requestIdentities.insert(
+        key,
+        playbackRequestIdentity(m_authService, m_configManager,
+                                 providerContext(), provider));
     return generation;
 }
 
@@ -195,6 +205,7 @@ void PlaybackService::endRequest(const QString &operation,
     const QString key = operation + QChar(0x1f) + requestContext + QChar(0x1f) + itemId;
     if (m_requestGenerations.value(key, 0) == generation) {
         m_requestGenerations.remove(key);
+        m_requestIdentities.remove(key);
     }
 }
 
@@ -204,7 +215,14 @@ bool PlaybackService::isCurrentRequest(const QString &operation,
                                        quint64 generation) const
 {
     const QString key = operation + QChar(0x1f) + requestContext + QChar(0x1f) + itemId;
-    return m_requestGenerations.value(key, 0) == generation;
+    if (m_requestGenerations.value(key, 0) != generation) {
+        return false;
+    }
+    const IPlaybackProvider *provider =
+        m_authService ? m_authService->playbackProvider() : nullptr;
+    return m_requestIdentities.value(key)
+        == playbackRequestIdentity(m_authService, m_configManager,
+                                    providerContext(), provider);
 }
 
 QNetworkReply *PlaybackService::sendProviderRequest(const QString &endpoint,
@@ -283,6 +301,7 @@ void PlaybackService::requestPlaybackDescriptor(const QString &itemId,
                                      requestContext, generation, context, media]() {
             if (!isCurrentRequest(QStringLiteral("descriptor"), itemId,
                                   requestContext, generation)) {
+                endRequest(QStringLiteral("descriptor"), itemId, requestContext, generation);
                 return;
             }
             const Bloom::PlaybackDescriptor descriptor = provider->createDescriptor(
@@ -301,12 +320,21 @@ void PlaybackService::requestPlaybackDescriptor(const QString &itemId,
 
     sendRequestWithRetry(
         startRequest.endpoint,
-        [this, startRequest]() {
+        [this, startRequest, itemId, requestContext, generation]() -> QNetworkReply * {
+            if (!isCurrentRequest(QStringLiteral("descriptor"), itemId,
+                                  requestContext, generation)) {
+                return nullptr;
+            }
             return sendProviderRequest(startRequest.endpoint, startRequest.method,
                                        startRequest.body);
         },
         [this, provider, itemId, providerSource, requestContext, generation, context, media]
         (QNetworkReply *reply) {
+            if (!isCurrentRequest(QStringLiteral("descriptor"), itemId,
+                                  requestContext, generation)) {
+                endRequest(QStringLiteral("descriptor"), itemId, requestContext, generation);
+                return;
+            }
             const PlaybackStartParseResult parsed = provider->parsePlaybackStartResponse(
                 context, media,
                 QJsonDocument::fromJson(reply->readAll()).object(), providerSource);
@@ -320,6 +348,9 @@ void PlaybackService::requestPlaybackDescriptor(const QString &itemId,
                         parsed.error.isEmpty()
                             ? tr("The playback provider returned an invalid stream request.")
                             : parsed.error);
+                } else {
+                    endRequest(QStringLiteral("descriptor"), itemId,
+                               requestContext, generation);
                 }
                 return;
             }
@@ -331,6 +362,8 @@ void PlaybackService::requestPlaybackDescriptor(const QString &itemId,
                 endRequest(QStringLiteral("descriptor"), itemId,
                            requestContext, generation);
                 emit playbackDescriptorLoadedForRequest(itemId, descriptor, requestContext);
+            } else {
+                endRequest(QStringLiteral("descriptor"), itemId, requestContext, generation);
             }
         },
         [this, itemId, requestContext, generation](const NetworkError &error) {
@@ -339,6 +372,8 @@ void PlaybackService::requestPlaybackDescriptor(const QString &itemId,
                 endRequest(QStringLiteral("descriptor"), itemId,
                            requestContext, generation);
                 emitDescriptorFailure(itemId, requestContext, error.userMessage);
+            } else {
+                endRequest(QStringLiteral("descriptor"), itemId, requestContext, generation);
             }
         },
         0, true, false);
@@ -377,12 +412,21 @@ bool PlaybackService::switchPlaybackAudio(const QString &playbackSessionId,
     }
     sendRequestWithRetry(
         switchRequest.endpoint,
-        [this, switchRequest]() {
+        [this, switchRequest, playbackSessionId, requestContext, generation]() -> QNetworkReply * {
+            if (!isCurrentRequest(QStringLiteral("audio"), playbackSessionId,
+                                  requestContext, generation)) {
+                return nullptr;
+            }
             return sendProviderRequest(switchRequest.endpoint, switchRequest.method,
                                        switchRequest.body);
         },
         [this, provider, playbackSessionId, requestContext, generation, context]
         (QNetworkReply *reply) {
+            if (!isCurrentRequest(QStringLiteral("audio"), playbackSessionId,
+                                  requestContext, generation)) {
+                endRequest(QStringLiteral("audio"), playbackSessionId, requestContext, generation);
+                return;
+            }
             const PlaybackAudioSwitchParseResult parsed =
                 provider->parseAudioSwitchResponse(
                     context, QJsonDocument::fromJson(reply->readAll()).object());
@@ -397,6 +441,9 @@ bool PlaybackService::switchPlaybackAudio(const QString &playbackSessionId,
                             parsed.error.isEmpty() ? tr("Audio switching failed.") : parsed.error,
                             requestContext);
                     }
+                } else {
+                    endRequest(QStringLiteral("audio"), playbackSessionId,
+                               requestContext, generation);
                 }
                 return;
             }
@@ -407,6 +454,9 @@ bool PlaybackService::switchPlaybackAudio(const QString &playbackSessionId,
                            requestContext, generation);
                 emit playbackAudioSwitchedForRequest(playbackSessionId,
                                                      reloadUrl, requestContext);
+            } else {
+                endRequest(QStringLiteral("audio"), playbackSessionId,
+                           requestContext, generation);
             }
         },
         [this, playbackSessionId, requestContext, generation](const NetworkError &error) {
@@ -419,6 +469,9 @@ bool PlaybackService::switchPlaybackAudio(const QString &playbackSessionId,
                                                              error.userMessage,
                                                              requestContext);
                 }
+            } else {
+                endRequest(QStringLiteral("audio"), playbackSessionId,
+                           requestContext, generation);
             }
         });
     return true;
@@ -426,6 +479,7 @@ bool PlaybackService::switchPlaybackAudio(const QString &playbackSessionId,
 
 void PlaybackService::requestPlaybackRecovery(const QString &itemId,
                                               const QVariantMap &providerSource,
+                                              int selectedAudioTrack,
                                               qint64 startPositionMs,
                                               const QString &requestContext)
 {
@@ -443,10 +497,15 @@ void PlaybackService::requestPlaybackRecovery(const QString &itemId,
     }
     Bloom::MediaRef media;
     media.itemId = itemId;
+    ConfigManager *config = m_configManager ? m_configManager : m_authService->configManager();
+    if (const auto connection = config ? config->getActiveConnection() : std::nullopt;
+        connection.has_value()) {
+        media.connectionId = connection->connectionId;
+    }
     const PlaybackProviderContext context = providerContext();
     const PlaybackRecoveryRequest recoveryRequest =
         provider->createPlaybackRecoveryRequest(
-            context, media, providerSource, startPositionMs);
+            context, media, providerSource, selectedAudioTrack, startPositionMs);
     if (!recoveryRequest.isValid()) {
         endRequest(QStringLiteral("recovery"), itemId, requestContext, generation);
         if (!requestContext.isEmpty()) {
@@ -458,13 +517,22 @@ void PlaybackService::requestPlaybackRecovery(const QString &itemId,
     }
     sendRequestWithRetry(
         recoveryRequest.endpoint,
-        [this, recoveryRequest]() {
+        [this, recoveryRequest, itemId, requestContext, generation]() -> QNetworkReply * {
+            if (!isCurrentRequest(QStringLiteral("recovery"), itemId,
+                                  requestContext, generation)) {
+                return nullptr;
+            }
             return sendProviderRequest(recoveryRequest.endpoint,
                                        recoveryRequest.method,
                                        recoveryRequest.body);
         },
         [this, provider, itemId, providerSource, requestContext, generation, context, media]
         (QNetworkReply *reply) {
+            if (!isCurrentRequest(QStringLiteral("recovery"), itemId,
+                                  requestContext, generation)) {
+                endRequest(QStringLiteral("recovery"), itemId, requestContext, generation);
+                return;
+            }
             const PlaybackStartParseResult parsed =
                 provider->parsePlaybackRecoveryResponse(
                     context, media,
@@ -482,6 +550,9 @@ void PlaybackService::requestPlaybackRecovery(const QString &itemId,
                                                    : parsed.error,
                             requestContext);
                     }
+                } else {
+                    endRequest(QStringLiteral("recovery"), itemId,
+                               requestContext, generation);
                 }
                 return;
             }
@@ -494,6 +565,8 @@ void PlaybackService::requestPlaybackRecovery(const QString &itemId,
                            requestContext, generation);
                 emit playbackRecoveryLoadedForRequest(itemId, descriptor,
                                                       requestContext);
+            } else {
+                endRequest(QStringLiteral("recovery"), itemId, requestContext, generation);
             }
         },
         [this, itemId, requestContext, generation](const NetworkError &error) {
@@ -505,6 +578,8 @@ void PlaybackService::requestPlaybackRecovery(const QString &itemId,
                     emit playbackRecoveryFailedForRequest(itemId, error.userMessage,
                                                           requestContext);
                 }
+            } else {
+                endRequest(QStringLiteral("recovery"), itemId, requestContext, generation);
             }
         });
 }
@@ -609,18 +684,28 @@ void PlaybackService::getPlaybackInfo(const QString &itemId, const QString &requ
             .arg(itemId, m_authService->getUserId());
         sendRequestWithRetry(
             endpoint,
-            [this, endpoint]() {
+            [this, endpoint, itemId, requestContext, generation]() -> QNetworkReply * {
+                if (!isCurrentRequest(QStringLiteral("info"), itemId,
+                                      requestContext, generation)) {
+                    return nullptr;
+                }
                 QNetworkRequest request = m_authService->createRequest(endpoint);
                 request.setHeader(QNetworkRequest::ContentTypeHeader,
                                   QStringLiteral("application/json"));
                 return m_authService->networkManager()->post(request, QByteArray("{}"));
             },
             [this, itemId, requestContext, generation](QNetworkReply *reply) {
+                if (!isCurrentRequest(QStringLiteral("info"), itemId,
+                                      requestContext, generation)) {
+                    endRequest(QStringLiteral("info"), itemId, requestContext, generation);
+                    return;
+                }
                 const PlaybackInfoResponse info =
                     m_authService->mapPlaybackInfo(
                         QJsonDocument::fromJson(reply->readAll()).object());
                 if (!isCurrentRequest(QStringLiteral("info"), itemId,
                                       requestContext, generation)) {
+                    endRequest(QStringLiteral("info"), itemId, requestContext, generation);
                     return;
                 }
                 endRequest(QStringLiteral("info"), itemId, requestContext, generation);
@@ -645,12 +730,21 @@ void PlaybackService::getPlaybackInfo(const QString &itemId, const QString &requ
 
     sendRequestWithRetry(
         providerRequest.endpoint,
-        [this, providerRequest]() {
+        [this, providerRequest, itemId, requestContext, generation]() -> QNetworkReply * {
+            if (!isCurrentRequest(QStringLiteral("info"), itemId,
+                                  requestContext, generation)) {
+                return nullptr;
+            }
             return sendProviderRequest(providerRequest.endpoint, providerRequest.method,
                                        providerRequest.body);
         },
         [this, provider, itemId, requestContext, generation, context, media]
         (QNetworkReply *reply) {
+            if (!isCurrentRequest(QStringLiteral("info"), itemId,
+                                  requestContext, generation)) {
+                endRequest(QStringLiteral("info"), itemId, requestContext, generation);
+                return;
+            }
             const PlaybackInfoParseResult parsed = provider->parsePlaybackInfoResponse(
                 context, media,
                 QJsonDocument::fromJson(reply->readAll()).object());
@@ -671,6 +765,7 @@ void PlaybackService::getPlaybackInfo(const QString &itemId, const QString &requ
             }
             if (!isCurrentRequest(QStringLiteral("info"), itemId,
                                   requestContext, generation)) {
+                endRequest(QStringLiteral("info"), itemId, requestContext, generation);
                 return;
             }
             endRequest(QStringLiteral("info"), itemId, requestContext, generation);
@@ -728,13 +823,18 @@ void PlaybackService::getAdditionalParts(const QString &itemId,
         .arg(itemId, m_authService->getUserId());
 
     sendRequestWithRetry(endpoint,
-        [this, endpoint]() {
+        [this, endpoint, itemId, requestContext, generation]() -> QNetworkReply * {
+            if (!isCurrentRequest(QStringLiteral("parts"), itemId,
+                                  requestContext, generation)) {
+                return nullptr;
+            }
             QNetworkRequest request = m_authService->createRequest(endpoint);
             return m_authService->networkManager()->get(request);
         },
         [this, itemId, requestContext, connectionId, generation](QNetworkReply *reply) {
             if (!isCurrentRequest(QStringLiteral("parts"), itemId,
                                   requestContext, generation)) {
+                endRequest(QStringLiteral("parts"), itemId, requestContext, generation);
                 return;
             }
             const ParsedItemsResult response =
@@ -1089,7 +1189,7 @@ void PlaybackService::sendPlaybackReport(const PlaybackReport &report,
         m_pendingStopProviders.insert(sessionId, provider);
         m_pendingStopRequestIdentities.insert(
             sessionId,
-            playbackRequestIdentity(m_authService, m_configManager, providerContext()));
+            playbackRequestIdentity(m_authService, m_configManager, providerContext(), provider));
         return;
     }
 
@@ -1119,7 +1219,7 @@ void PlaybackService::sendPlaybackReport(const PlaybackReport &report,
                 && stopProvider == (m_authService ? m_authService->playbackProvider() : nullptr)
                 && stopIdentity
                     == playbackRequestIdentity(m_authService, m_configManager,
-                                                providerContext())) {
+                                                providerContext(), stopProvider)) {
                 sendPlaybackReport(stop, {}, stopProvider);
             }
         };
@@ -1177,7 +1277,51 @@ void PlaybackService::sendPlaybackReport(const PlaybackReport &report,
 
 void PlaybackService::markItemPlayed(const QString &itemId)
 {
-    if (!m_authService->isAuthenticated()) return;
+    if (!m_authService || !m_authService->isAuthenticated()) {
+        return;
+    }
+
+    if (m_authService->activeProviderKind() == ProviderKind::Silo) {
+        const ICatalogProvider *catalogProvider = m_authService->catalogProvider();
+        ProviderCatalogQuery query;
+        query.userId = m_authService->getUserId();
+        query.itemId = itemId;
+        query.stateValue = true;
+        const ProviderCatalogRequest providerRequest =
+            catalogProvider
+                ? catalogProvider->createRequest(ProviderCatalogOperation::SetWatched, query)
+                : ProviderCatalogRequest{};
+        if (!providerRequest.supported || providerRequest.relativeEndpoint.isEmpty()) {
+            qCWarning(lcPlayback) << "Silo watched-state request unavailable for" << itemId;
+            return;
+        }
+        QString method;
+        switch (providerRequest.method) {
+        case ProviderHttpMethod::Get: method = QStringLiteral("GET"); break;
+        case ProviderHttpMethod::Post: method = QStringLiteral("POST"); break;
+        case ProviderHttpMethod::Put: method = QStringLiteral("PUT"); break;
+        case ProviderHttpMethod::Delete: method = QStringLiteral("DELETE"); break;
+        }
+        const QString endpoint = providerRequest.relativeEndpoint;
+        sendRequestWithRetry(
+            endpoint,
+            [this, endpoint, method, body = providerRequest.body]() {
+                return sendProviderRequest(endpoint, method,
+                                           QJsonDocument::fromJson(body).object());
+            },
+            [this, itemId](QNetworkReply *reply) {
+                if (reply->error() != QNetworkReply::NoError) {
+                    qCWarning(lcPlayback) << "Failed to mark Silo item as played:" << itemId
+                                          << ":" << reply->errorString();
+                } else {
+                    emit itemMarkedPlayed(itemId);
+                }
+            },
+            FailureHandler(),
+            0,
+            false);
+        return;
+    }
 
     const QString endpoint = QString("/Users/%1/PlayedItems/%2")
         .arg(m_authService->getUserId(), itemId);

--- a/src/network/PlaybackService.h
+++ b/src/network/PlaybackService.h
@@ -182,6 +182,7 @@ private:
     RetryPolicy m_retryPolicy;
     QHash<QString, int> m_pendingProgressReports;
     QHash<QString, const IPlaybackProvider *> m_pendingStopProviders;
+    QHash<QString, QString> m_pendingStopRequestIdentities;
     QHash<QString, PlaybackReport> m_pendingStopReports;
     
     // Retry mechanism types  
@@ -199,6 +200,10 @@ private:
     quint64 beginRequest(const QString &operation,
                          const QString &itemId,
                          const QString &requestContext);
+    void endRequest(const QString &operation,
+                    const QString &itemId,
+                    const QString &requestContext,
+                    quint64 generation);
     bool isCurrentRequest(const QString &operation,
                           const QString &itemId,
                           const QString &requestContext,

--- a/src/network/PlaybackService.h
+++ b/src/network/PlaybackService.h
@@ -1,12 +1,18 @@
 #pragma once
 
+#include <QHash>
 #include <QJsonArray>
+#include <QJsonObject>
 #include <QObject>
 #include <QNetworkReply>
+#include <QUrl>
+#include <QVariantMap>
 #include <functional>
 #include "Types.h"
 #include "models/MediaModels.h"  // For data structs (PlaybackInfoResponse, MediaSegmentInfo, TrickplayTileInfo, etc.)
-
+struct PlaybackProviderContext;
+struct PlaybackReportRequest;
+class IPlaybackProvider;
 class AuthenticationService;
 class ConfigManager;
 class HttpTransport;
@@ -44,7 +50,27 @@ public:
         qint64 startPositionMs = 0,
         const QString &playbackSessionId = QString(),
         bool emitFailure = true);
-    
+
+    // Provider-neutral asynchronous playback plan API. Jellyfin completes this
+    // through its existing descriptor path; native providers execute their plan.
+    Q_INVOKABLE virtual void requestPlaybackDescriptor(
+        const QString &itemId,
+        const QVariantMap &providerSource,
+        int selectedAudioTrack,
+        int selectedSubtitleTrack,
+        qint64 startPositionMs = 0,
+        const QString &playbackSessionId = QString(),
+        const QString &requestContext = QString());
+    Q_INVOKABLE virtual bool switchPlaybackAudio(const QString &playbackSessionId,
+                                                  int audioTrackIndex,
+                                                  qint64 positionMs = 0,
+                                                  const QString &requestContext = QString());
+    Q_INVOKABLE virtual void requestPlaybackRecovery(
+        const QString &itemId,
+        const QVariantMap &providerSource,
+        qint64 startPositionMs = 0,
+        const QString &requestContext = QString());
+
     // Playback Info - Get media streams and track information
     Q_INVOKABLE virtual void getPlaybackInfo(const QString &itemId);
     Q_INVOKABLE virtual void getAdditionalParts(const QString &itemId);
@@ -103,6 +129,24 @@ public:
 signals:
     // Playback info with media streams for track selection
     void playbackInfoLoaded(const QString &itemId, const PlaybackInfoResponse &playbackInfo);
+    void playbackDescriptorLoadedForRequest(const QString &itemId,
+                                            const Bloom::PlaybackDescriptor &descriptor,
+                                            const QString &requestContext);
+    void playbackDescriptorFailedForRequest(const QString &itemId,
+                                            const QString &error,
+                                            const QString &requestContext);
+    void playbackAudioSwitchedForRequest(const QString &playbackSessionId,
+                                         const QUrl &reloadUrl,
+                                         const QString &requestContext);
+    void playbackAudioSwitchFailedForRequest(const QString &playbackSessionId,
+                                             const QString &error,
+                                             const QString &requestContext);
+    void playbackRecoveryLoadedForRequest(const QString &itemId,
+                                          const Bloom::PlaybackDescriptor &descriptor,
+                                          const QString &requestContext);
+    void playbackRecoveryFailedForRequest(const QString &itemId,
+                                          const QString &error,
+                                          const QString &requestContext);
     void playbackInfoLoadedForRequest(const QString &itemId,
                                       const PlaybackInfoResponse &playbackInfo,
                                       const QString &requestContext);
@@ -135,19 +179,37 @@ private:
     HttpTransport *m_transport = nullptr;
     ConfigManager *m_configManager = nullptr;
     MediaSegmentProviderService *m_mediaSegmentProviderService = nullptr;
-    const class IPlaybackProvider *m_provider = nullptr;
     RetryPolicy m_retryPolicy;
+    QHash<QString, int> m_pendingProgressReports;
+    QHash<QString, const IPlaybackProvider *> m_pendingStopProviders;
+    QHash<QString, PlaybackReport> m_pendingStopReports;
     
     // Retry mechanism types  
     using ResponseHandler = std::function<void(QNetworkReply*)>;
     using RequestFactory = std::function<QNetworkReply*()>;
     using FailureHandler = std::function<void(const NetworkError&)>;
-    
     void sendRequestWithRetry(const QString &endpoint,
                                RequestFactory requestFactory,
                                ResponseHandler responseHandler,
                                FailureHandler failureHandler = FailureHandler(),
-                               int attemptNumber = 0);
+                               int attemptNumber = 0,
+                               bool deferSessionExpiry = true,
+                               bool enableTransientRetry = true);
+    PlaybackProviderContext providerContext() const;
+    quint64 beginRequest(const QString &operation,
+                         const QString &itemId,
+                         const QString &requestContext);
+    bool isCurrentRequest(const QString &operation,
+                          const QString &itemId,
+                          const QString &requestContext,
+                          quint64 generation) const;
+    QNetworkReply *sendProviderRequest(const QString &endpoint,
+                                       const QString &method,
+                                       const QJsonObject &body) const;
+    void emitDescriptorFailure(const QString &itemId,
+                               const QString &requestContext,
+                               const QString &error);
+    QHash<QString, quint64> m_requestGenerations;
     
     void emitError(const NetworkError &error);
     void maybeLoadExternalMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &serverSegments);
@@ -155,6 +217,9 @@ private:
     void finishExternalMediaSegments(const QString &itemId,
                                      const QList<MediaSegmentInfo> &serverSegments,
                                      const QList<MediaSegmentInfo> &mergedSegments);
-    void finishMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &segments);
-    void sendPlaybackReport(const PlaybackReport &report);
+    void finishMediaSegments(const QString &itemId,
+                             const QList<MediaSegmentInfo> &segments);
+    void sendPlaybackReport(const PlaybackReport &report,
+                            std::function<void()> completion = {},
+                            const IPlaybackProvider *providerOverride = nullptr);
 };

--- a/src/network/PlaybackService.h
+++ b/src/network/PlaybackService.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include "Types.h"
 #include "models/MediaModels.h"  // For data structs (PlaybackInfoResponse, MediaSegmentInfo, TrickplayTileInfo, etc.)
+#include "providers/IPlaybackProvider.h"
 struct PlaybackProviderContext;
 struct PlaybackReportRequest;
 class IPlaybackProvider;
@@ -68,6 +69,7 @@ public:
     Q_INVOKABLE virtual void requestPlaybackRecovery(
         const QString &itemId,
         const QVariantMap &providerSource,
+        int selectedAudioTrack = -1,
         qint64 startPositionMs = 0,
         const QString &requestContext = QString());
 
@@ -214,6 +216,8 @@ private:
     void emitDescriptorFailure(const QString &itemId,
                                const QString &requestContext,
                                const QString &error);
+    QHash<QString, QString> m_requestIdentities;
+    quint64 m_nextRequestGeneration = 0;
     QHash<QString, quint64> m_requestGenerations;
     
     void emitError(const NetworkError &error);

--- a/src/network/Types.cpp
+++ b/src/network/Types.cpp
@@ -154,6 +154,9 @@ QVariantList PlaybackInfoResponse::getMediaSourcesVariant() const
         sourceMap["durationMs"] = source.durationMs;
         sourceMap["defaultAudioStreamIndex"] = source.defaultAudioStreamIndex;
         sourceMap["defaultSubtitleStreamIndex"] = source.defaultSubtitleStreamIndex;
+        sourceMap["playbackVariantId"] = source.playbackVariantId;
+        sourceMap["presentationPartIndex"] = source.presentationPartIndex;
+        sourceMap["presentationPartTotal"] = source.presentationPartTotal;
         sourceMap["mediaStreams"] = source.getMediaStreamsVariant();
         result.append(sourceMap);
     }

--- a/src/network/Types.h
+++ b/src/network/Types.h
@@ -93,6 +93,9 @@ struct MediaSourceInfo
     Q_PROPERTY(qint64 durationMs MEMBER durationMs)
     Q_PROPERTY(int defaultAudioStreamIndex MEMBER defaultAudioStreamIndex)
     Q_PROPERTY(int defaultSubtitleStreamIndex MEMBER defaultSubtitleStreamIndex)
+    Q_PROPERTY(QString playbackVariantId MEMBER playbackVariantId)
+    Q_PROPERTY(int presentationPartIndex MEMBER presentationPartIndex)
+    Q_PROPERTY(int presentationPartTotal MEMBER presentationPartTotal)
     Q_PROPERTY(QVariantList mediaStreams READ getMediaStreamsVariant)
 
 public:
@@ -108,6 +111,9 @@ public:
     qint64 durationMs = 0;
     int defaultAudioStreamIndex = -1;
     int defaultSubtitleStreamIndex = -1;
+    QString playbackVariantId;
+    int presentationPartIndex = 0;
+    int presentationPartTotal = 0;
     QList<MediaStreamInfo> mediaStreams;
 
     [[nodiscard]] QList<MediaStreamInfo> getVideoStreams() const;

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -102,6 +102,13 @@ QVariantList mediaStreams(const QVariantMap &mediaSource)
     return mediaSource.value(QStringLiteral("mediaStreams")).toList();
 }
 
+int parsePinnedTrackId(const QString &rawTrackId)
+{
+    bool ok = false;
+    const int trackId = rawTrackId.trimmed().toInt(&ok);
+    return ok ? trackId : -1;
+}
+
 QVariantList mediaStreamsForType(const QVariantMap &mediaSource, const QString &streamType)
 {
     QVariantList result;
@@ -2246,6 +2253,13 @@ void PlayerController::onPlaybackAudioSwitchedForRequest(const QString &sessionI
         m_playbackSegments[m_activePlaybackSegmentIndex][QStringLiteral("audioIndex")] =
             m_selectedAudioTrack;
     }
+    // Native audio switching reloads the media URL. Rebuild the source-to-mpv
+    // maps from the active source while retaining them when no source metadata
+    // is available, so the post-reload aid notification still resolves.
+    if (!m_activeMediaSource.isEmpty()) {
+        updateTrackMappings(m_activeMediaSource);
+        m_mpvAudioTrack = mpvAudioTrackForSourceIndex(m_selectedAudioTrack);
+    }
     // mpv's replacement URL starts at the current physical-file timeline. The
     // aggregate position includes preceding multipart files and would seek past
     // the end of the active file.
@@ -2672,8 +2686,10 @@ void PlayerController::applyPlaybackDescriptorToSegment(
     segment[QStringLiteral("playMethod")] = Bloom::playbackMethodName(descriptor.stream.method);
     segment[QStringLiteral("pinsAudioTrack")] = descriptor.stream.pinsAudioTrack;
     segment[QStringLiteral("pinsSubtitleTrack")] = descriptor.stream.pinsSubtitleTrack;
-    segment[QStringLiteral("pinnedAudioTrack")] = descriptor.stream.pinnedAudioTrackId.toInt();
-    segment[QStringLiteral("pinnedSubtitleTrack")] = descriptor.stream.pinnedSubtitleTrackId.toInt();
+    segment[QStringLiteral("pinnedAudioTrack")] =
+        parsePinnedTrackId(descriptor.stream.pinnedAudioTrackId);
+    segment[QStringLiteral("pinnedSubtitleTrack")] =
+        parsePinnedTrackId(descriptor.stream.pinnedSubtitleTrackId);
     segment[QStringLiteral("durationMs")] = descriptor.durationMs;
     if (!descriptor.playbackSessionId.isEmpty()) {
         segment[QStringLiteral("playSessionId")] = descriptor.playbackSessionId;
@@ -2779,8 +2795,8 @@ void PlayerController::onPlaybackDescriptorLoadedForRequest(
         m_nextPlaybackMethod = Bloom::playbackMethodName(descriptor.stream.method);
         m_nextStreamPinsAudioTrack = descriptor.stream.pinsAudioTrack;
         m_nextStreamPinsSubtitleTrack = descriptor.stream.pinsSubtitleTrack;
-        m_nextPinnedAudioTrack = descriptor.stream.pinnedAudioTrackId.toInt();
-        m_nextPinnedSubtitleTrack = descriptor.stream.pinnedSubtitleTrackId.toInt();
+        m_nextPinnedAudioTrack = parsePinnedTrackId(descriptor.stream.pinnedAudioTrackId);
+        m_nextPinnedSubtitleTrack = parsePinnedTrackId(descriptor.stream.pinnedSubtitleTrackId);
         playUrlWithTracks(url,
                           itemId,
                           m_pendingAutoplayDescriptorStartPositionMs,
@@ -4180,15 +4196,38 @@ void PlayerController::setSelectedSubtitleTrack(int index)
 
     if (m_playbackState == Playing || m_playbackState == Paused) {
         if (index >= 0 || m_externalSubtitleTrackMap.contains(index)) {
-            const int mpvTrackId = m_externalSubtitleTrackMap.value(index, mpvSubtitleTrackForSourceIndex(index));
-            if (mpvTrackId > 0) {
+            const bool isExternal = m_externalSubtitleTrackMap.contains(index);
+            const int mpvTrackId =
+                m_externalSubtitleTrackMap.value(index, mpvSubtitleTrackForSourceIndex(index));
+            if (isExternal && mpvTrackId <= 0) {
+                QVariantMap externalTrack;
+                for (const QVariant &trackVariant : m_availableSubtitleTracks) {
+                    const QVariantMap candidate = trackVariant.toMap();
+                    if (candidate.value(QStringLiteral("index"), -1).toInt() == index) {
+                        externalTrack = candidate;
+                        break;
+                    }
+                }
+                const QString externalUrl =
+                    externalTrack.value(QStringLiteral("externalUrl")).toString().trimmed();
+                if (!externalUrl.isEmpty()) {
+                    // Non-selected multipart subtitles may not receive an mpv sid
+                    // until explicitly added with select semantics.
+                    m_pendingExternalSubtitleIndex = index;
+                    addExternalSubtitleTrackInternal(
+                        externalUrl,
+                        externalTrack.value(QStringLiteral("displayTitle")).toString(),
+                        externalTrack.value(QStringLiteral("language")).toString(),
+                        index,
+                        true);
+                } else {
+                    qCWarning(lcPlayback) << "External subtitle has no usable URL:" << index;
+                }
+            } else if (mpvTrackId > 0) {
                 m_mpvSubtitleTrack = mpvTrackId;
                 qCDebug(lcPlayback) << "Applying subtitle track switch via sid:" << mpvTrackId;
                 m_playerBackend->sendVariantCommand({"set_property", "sid", mpvTrackId});
                 m_pendingExternalSubtitleIndex = -1;
-            } else if (m_externalSubtitleTrackMap.contains(index) && mpvTrackId < 0) {
-                m_pendingExternalSubtitleIndex = index;
-                qCDebug(lcPlayback) << "Deferring sid application for pending external subtitle:" << index;
             } else {
                 qCWarning(lcPlayback) << "No mapped mpv subtitle track for provider source index" << index
                                       << "- skipping runtime sid command";
@@ -5048,6 +5087,13 @@ void PlayerController::applyAudioOutputDevice()
     // Point mpv at the desired device (a no-op if it already matches), then force
     // the audio output to reinitialize. For "auto" this re-selects the current
     // system default; for an explicit device it (re)opens that endpoint.
+    // ao-reload can cause mpv to publish a fresh aid value. Rebuild the
+    // canonical maps before that notification arrives so reverse lookup stays
+    // aligned with the active source.
+    if (!m_activeMediaSource.isEmpty()) {
+        updateTrackMappings(m_activeMediaSource);
+        m_mpvAudioTrack = mpvAudioTrackForSourceIndex(m_selectedAudioTrack);
+    }
     m_playerBackend->sendVariantCommand({"set_property", "audio-device", desired});
     m_playerBackend->sendVariantCommand({"ao-reload"});
 }

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -1099,15 +1099,17 @@ void PlayerController::onEnterBufferingState()
     m_playerBackend->sendVariantCommand({"set_property", "mute", m_muted});
 }
 
-void PlayerController::onEnterPlayingState()
+void PlayerController::applyPendingExternalSubtitleTracks()
 {
-    qCInfo(lcPlayback) << "Entering Playing state for item:" << m_currentItemId;
+    if (!(m_playbackState == Playing || m_playbackState == Paused)) {
+        return;
+    }
 
-    // Clear the initial tracks flag - from now on, track changes are user-initiated
-    // and should be saved to preferences
-    m_applyingInitialTracks = false;
-
-    for (const QVariant &pendingVariant : m_pendingExternalSubtitleTracks) {
+    // Add non-selected tracks first so the selected external track is applied after
+    // mpv has seen every active-segment subtitle URL. The pending list is also used
+    // when the segment is activated before playback reaches Playing.
+    const QVariantList pendingTracks = m_pendingExternalSubtitleTracks;
+    for (const QVariant &pendingVariant : pendingTracks) {
         const QVariantMap pending = pendingVariant.toMap();
         if (pending.value(QStringLiteral("select"), false).toBool()) {
             continue;
@@ -1119,7 +1121,7 @@ void PlayerController::onEnterPlayingState()
             pending.value(QStringLiteral("index"), -1).toInt(),
             false);
     }
-    for (const QVariant &pendingVariant : m_pendingExternalSubtitleTracks) {
+    for (const QVariant &pendingVariant : pendingTracks) {
         const QVariantMap pending = pendingVariant.toMap();
         if (!pending.value(QStringLiteral("select"), false).toBool()) {
             continue;
@@ -1132,6 +1134,47 @@ void PlayerController::onEnterPlayingState()
             true);
     }
     m_pendingExternalSubtitleTracks.clear();
+}
+
+void PlayerController::queueActiveSegmentExternalSubtitleTracks()
+{
+    m_pendingExternalSubtitleTracks.clear();
+    const QVariantMap segment = activePlaybackSegment();
+    if (segment.isEmpty()) {
+        return;
+    }
+
+    const int selectedSubtitleIndex =
+        segment.value(QStringLiteral("subtitleIndex"), -1).toInt();
+    for (const QVariant &trackVariant :
+         segment.value(QStringLiteral("availableSubtitleTracks")).toList()) {
+        const QVariantMap track = trackVariant.toMap();
+        const QString externalUrl = track.value(QStringLiteral("externalUrl")).toString().trimmed();
+        if (!track.value(QStringLiteral("isExternal")).toBool() || externalUrl.isEmpty()) {
+            continue;
+        }
+
+        QVariantMap pending = track;
+        pending[QStringLiteral("externalUrl")] = externalUrl;
+        pending[QStringLiteral("select")] =
+            track.value(QStringLiteral("index"), -1).toInt() == selectedSubtitleIndex;
+        m_pendingExternalSubtitleTracks.append(pending);
+    }
+
+    if (m_playbackState == Playing || m_playbackState == Paused) {
+        applyPendingExternalSubtitleTracks();
+    }
+}
+
+void PlayerController::onEnterPlayingState()
+{
+    qCInfo(lcPlayback) << "Entering Playing state for item:" << m_currentItemId;
+
+    // Clear the initial tracks flag - from now on, track changes are user-initiated
+    // and should be saved to preferences
+    m_applyingInitialTracks = false;
+
+    applyPendingExternalSubtitleTracks();
 
 
     // Report playback start if not already done
@@ -2084,6 +2127,11 @@ void PlayerController::onPlaybackInfoLoaded(const QString &itemId, const Playbac
         return;
     }
 
+    // A matching response can be delivered more than once. Once a descriptor
+    // request is in flight, do not replace its context or issue a duplicate.
+    if (!m_pendingAutoplayDescriptorContext.isEmpty()) {
+        return;
+    }
     stopAutoplayPlaybackInfoWait();
 
     const qint64 startPositionMs = resumePositionMs(m_pendingAutoplayEpisodeData);
@@ -2123,6 +2171,7 @@ void PlayerController::onPlaybackInfoLoaded(const QString &itemId, const Playbac
     m_pendingAutoplayDescriptorContext =
         QStringLiteral("autoplay|descriptor|") + itemId + QStringLiteral("|")
         + QString::number(m_playbackAttemptId);
+    armAutoplayPlaybackInfoWait();
     m_playbackService->requestPlaybackDescriptor(
         itemId,
         mediaSource,
@@ -3098,9 +3147,15 @@ void PlayerController::applyPlaybackSegment(int index, bool reportSegmentStart)
     m_availableSubtitleTracks = segment.value(QStringLiteral("availableSubtitleTracks")).toList();
     m_selectedAudioTrack = segment.value(QStringLiteral("audioIndex"), -1).toInt();
     m_selectedSubtitleTrack = segment.value(QStringLiteral("subtitleIndex"), -1).toInt();
+    // A playlist position switch changes the external subtitle namespace as well as
+    // the embedded stream maps. Drop stale mpv ids before queuing this segment's URLs.
+    m_externalSubtitleTrackMap.clear();
+    m_pendingExternalSubtitleIndex = -1;
+    m_mpvSubtitleTrack = -1;
     updateTrackMappings(m_activeMediaSource);
     m_mpvAudioTrack = mpvAudioTrackForSourceIndex(m_selectedAudioTrack);
     m_mpvSubtitleTrack = m_selectedSubtitleTrack >= 0 ? mpvSubtitleTrackForSourceIndex(m_selectedSubtitleTrack) : -1;
+    queueActiveSegmentExternalSubtitleTracks();
 
     emit mediaSourceIdChanged();
     emit playSessionIdChanged();
@@ -3999,6 +4054,7 @@ void PlayerController::setSelectedAudioTrack(int index)
                         << "sourceIndex=" << index
                         << "previousSourceIndex=" << previousAudioTrack;
 
+    bool selectionRolledBackSynchronously = false;
     if (m_playbackState == Playing || m_playbackState == Paused) {
         const auto applyMpvAudioTrack = [this, index]() {
             if (index >= 0) {
@@ -4032,21 +4088,42 @@ void PlayerController::setSelectedAudioTrack(int index)
                     m_pendingAudioSwitchContext);
             if (!nativeSwitchDispatched) {
                 // Providers without a native audio-switch request (notably
-                // Jellyfin) retain the existing mpv aid behavior.
+                // Jellyfin) retain the existing mpv aid behavior. A provider
+                // can emit a synchronous failure before returning false; in
+                // that case the rollback callback has already restored the
+                // selected track and must not be overwritten by mpv.
                 m_pendingAudioSwitchContext.clear();
                 m_pendingAudioSwitchPreviousTrack = -2;
-                applyMpvAudioTrack();
+                if (m_selectedAudioTrack == index) {
+                    applyMpvAudioTrack();
+                }
+            } else {
+                selectionRolledBackSynchronously = m_selectedAudioTrack != index;
             }
         } else {
+            // A non-native selection supersedes any in-flight native switch.
+            // Its eventual response is stale and must not roll back this
+            // newer selection.
+            m_pendingAudioSwitchContext.clear();
+            m_pendingAudioSwitchPreviousTrack = -2;
             applyMpvAudioTrack();
         }
+    } else {
+        // A selection outside active playback is also a new selection path;
+        // never let an old native response roll it back later.
+        m_pendingAudioSwitchContext.clear();
+        m_pendingAudioSwitchPreviousTrack = -2;
     }
 
-    persistAudioPreferenceForCurrentScope(index);
+    const int effectiveAudioTrack = m_selectedAudioTrack;
+    persistAudioPreferenceForCurrentScope(effectiveAudioTrack);
     if (m_activePlaybackSegmentIndex >= 0 && m_activePlaybackSegmentIndex < m_playbackSegments.size()) {
-        m_playbackSegments[m_activePlaybackSegmentIndex][QStringLiteral("audioIndex")] = index;
+        m_playbackSegments[m_activePlaybackSegmentIndex][QStringLiteral("audioIndex")] =
+            effectiveAudioTrack;
     }
-    emit selectedAudioTrackChanged();
+    if (!selectionRolledBackSynchronously) {
+        emit selectedAudioTrackChanged();
+    }
 }
 
 void PlayerController::setAudioDelay(int ms)
@@ -4168,7 +4245,8 @@ void PlayerController::addExternalSubtitleTrackInternal(const QString &subtitleU
                                                           return trackVariant.toMap().value(QStringLiteral("index")).toInt() == syntheticIndex;
                                                       });
     if (trackIndexAlreadyPresent
-        && m_externalSubtitleTrackMap.value(syntheticIndex, -2) != -1) {
+        && m_externalSubtitleTrackMap.contains(syntheticIndex)
+        && m_externalSubtitleTrackMap.value(syntheticIndex) != -1) {
         qCDebug(lcPlayback) << "Skipping external subtitle; index already present and resolved:" << syntheticIndex;
         return;
     }
@@ -5614,6 +5692,16 @@ qint64 PlayerController::resumePositionMs(const QVariantMap &item)
 
 void PlayerController::fallbackToPendingAutoplayPlayback()
 {
+    // A fallback descriptor is itself asynchronous. If it has already timed
+    // out, stop here rather than issuing the same request repeatedly.
+    if (m_pendingAutoplayDescriptorContext.endsWith(QStringLiteral("|fallback"))) {
+        stopAutoplayPlaybackInfoWait();
+        clearPendingAutoplayContext();
+        clearNextEpisodePrefetchState();
+        return;
+    }
+    stopAutoplayPlaybackInfoWait();
+
     const QString itemId = m_pendingAutoplayEpisodeData.value(QStringLiteral("itemId")).toString();
     if (itemId.isEmpty()) {
         qCWarning(lcPlayback) << "Cannot fall back to pending autoplay playback without an episode id";
@@ -5647,13 +5735,15 @@ void PlayerController::fallbackToPendingAutoplayPlayback()
     m_pendingAutoplayDescriptorSubtitleTracks.clear();
     m_pendingAutoplayDescriptorContext =
         QStringLiteral("autoplay|descriptor|") + itemId + QStringLiteral("|fallback");
-    m_playbackService->requestPlaybackDescriptor(itemId,
-                                                  {},
-                                                  -1,
-                                                  -1,
-                                                  startPositionMs,
-                                                  QString(),
-                                                  m_pendingAutoplayDescriptorContext);
+    armAutoplayPlaybackInfoWait();
+    m_playbackService->requestPlaybackDescriptor(
+        itemId,
+        {},
+        -1,
+        -1,
+        startPositionMs,
+        QString(),
+        m_pendingAutoplayDescriptorContext);
 }
 
 void PlayerController::stopAutoplayPlaybackInfoWait()
@@ -5661,6 +5751,13 @@ void PlayerController::stopAutoplayPlaybackInfoWait()
     m_waitingForAutoplayPlaybackInfo = false;
     if (m_autoplayPlaybackInfoTimeoutTimer) {
         m_autoplayPlaybackInfoTimeoutTimer->stop();
+    }
+}
+void PlayerController::armAutoplayPlaybackInfoWait()
+{
+    m_waitingForAutoplayPlaybackInfo = true;
+    if (m_autoplayPlaybackInfoTimeoutTimer) {
+        m_autoplayPlaybackInfoTimeoutTimer->start(kAutoplayPlaybackInfoTimeoutMs);
     }
 }
 

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -29,6 +29,7 @@
 #include <QThread>
 #include <atomic>
 #include <algorithm>
+#include <limits>
 #include "../utils/BloomLogging.h"
 #include "../utils/MpvArgFilter.h"
 
@@ -426,6 +427,27 @@ QString mediaSourceVideoDescriptor(const QVariantMap &mediaSource)
              normalizedStringKey(mediaSource.value(QStringLiteral("container")).toString()),
              QString::number(mediaSource.value(QStringLiteral("bitRate")).toInt()));
 }
+QVariantList primaryPresentationSources(const QVariantList &mediaSources)
+{
+    int firstPart = std::numeric_limits<int>::max();
+    for (const QVariant &value : mediaSources) {
+        const int part = value.toMap().value(QStringLiteral("presentationPartIndex")).toInt();
+        if (part > 0) {
+            firstPart = qMin(firstPart, part);
+        }
+    }
+    if (firstPart == std::numeric_limits<int>::max()) {
+        return mediaSources;
+    }
+
+    QVariantList result;
+    for (const QVariant &value : mediaSources) {
+        if (value.toMap().value(QStringLiteral("presentationPartIndex")).toInt() == firstPart) {
+            result.append(value);
+        }
+    }
+    return result;
+}
 }
 
 PlayerController::PlayerController(IPlayerBackend *playerBackend, ConfigManager *config, TrackPreferencesManager *trackPrefs, DisplayManager *displayManager, PlaybackService *playbackService, LibraryService *libraryService, AuthenticationService *authService, QObject *parent)
@@ -474,13 +496,21 @@ PlayerController::PlayerController(IPlayerBackend *playerBackend, ConfigManager 
     connect(m_libraryService, &LibraryService::chaptersFailed,
             this, &PlayerController::onChaptersFailed);
     
-    // Connect to PlaybackService for media segments and trickplay info signals
+    // Connect to PlaybackService for metadata and asynchronous provider plans.
     connect(m_playbackService, &PlaybackService::playbackInfoLoaded,
             this, &PlayerController::onPlaybackInfoLoaded);
     connect(m_playbackService, &PlaybackService::playbackInfoLoadedForRequest,
             this, &PlayerController::onPlaybackInfoLoadedForRequest);
     connect(m_playbackService, &PlaybackService::playbackInfoFailedForRequest,
             this, &PlayerController::onPlaybackInfoFailedForRequest);
+    connect(m_playbackService, &PlaybackService::playbackDescriptorLoadedForRequest,
+            this, &PlayerController::onPlaybackDescriptorLoadedForRequest);
+    connect(m_playbackService, &PlaybackService::playbackDescriptorFailedForRequest,
+            this, &PlayerController::onPlaybackDescriptorFailedForRequest);
+    connect(m_playbackService, &PlaybackService::playbackAudioSwitchedForRequest,
+            this, &PlayerController::onPlaybackAudioSwitchedForRequest);
+    connect(m_playbackService, &PlaybackService::playbackAudioSwitchFailedForRequest,
+            this, &PlayerController::onPlaybackAudioSwitchFailedForRequest);
     connect(m_playbackService, &PlaybackService::additionalPartsLoaded,
             this, &PlayerController::onAdditionalPartsLoaded);
     connect(m_playbackService, &PlaybackService::additionalPartsLoadedForRequest,
@@ -932,6 +962,7 @@ void PlayerController::enterIdleStateImmediate()
     m_playSessionId.clear();
     m_availableAudioTracks.clear();
     m_availableSubtitleTracks.clear();
+    m_pendingExternalSubtitleTracks.clear();
     m_activeMediaSource.clear();
     m_applyingInitialTracks = false;
     m_pendingAudioTrackPersistenceFromBackend = false;
@@ -1071,20 +1102,47 @@ void PlayerController::onEnterBufferingState()
 void PlayerController::onEnterPlayingState()
 {
     qCInfo(lcPlayback) << "Entering Playing state for item:" << m_currentItemId;
-    
+
     // Clear the initial tracks flag - from now on, track changes are user-initiated
     // and should be saved to preferences
     m_applyingInitialTracks = false;
-    
+
+    for (const QVariant &pendingVariant : m_pendingExternalSubtitleTracks) {
+        const QVariantMap pending = pendingVariant.toMap();
+        if (pending.value(QStringLiteral("select"), false).toBool()) {
+            continue;
+        }
+        addExternalSubtitleTrackInternal(
+            pending.value(QStringLiteral("externalUrl")).toString(),
+            pending.value(QStringLiteral("displayTitle")).toString(),
+            pending.value(QStringLiteral("language")).toString(),
+            pending.value(QStringLiteral("index"), -1).toInt(),
+            false);
+    }
+    for (const QVariant &pendingVariant : m_pendingExternalSubtitleTracks) {
+        const QVariantMap pending = pendingVariant.toMap();
+        if (!pending.value(QStringLiteral("select"), false).toBool()) {
+            continue;
+        }
+        addExternalSubtitleTrackInternal(
+            pending.value(QStringLiteral("externalUrl")).toString(),
+            pending.value(QStringLiteral("displayTitle")).toString(),
+            pending.value(QStringLiteral("language")).toString(),
+            pending.value(QStringLiteral("index"), -1).toInt(),
+            true);
+    }
+    m_pendingExternalSubtitleTracks.clear();
+
+
     // Report playback start if not already done
     if (!m_hasReportedStart && !m_currentItemId.isEmpty()) {
         reportPlaybackStart();
         m_hasReportedStart = true;
     }
-    
+
     // Start progress reporting
     m_progressReportTimer->start();
-    
+
     setBufferingProgress(100);
 }
 
@@ -1126,6 +1184,7 @@ void PlayerController::onEnterErrorState()
 
     clearPendingAutoplayContext();
     clearNextEpisodePrefetchState();
+    m_pendingExternalSubtitleTracks.clear();
 
     if (m_recoveryContext.valid) {
         beginRecovery();
@@ -2051,55 +2110,27 @@ void PlayerController::onPlaybackInfoLoaded(const QString &itemId, const Playbac
                                                                   m_pendingAutoplayAudioTrack,
                                                                   preferredSubtitleIndex);
 
-    const QString mediaSourceId = mediaSource.value(QStringLiteral("id")).toString();
-    const QVariantList availableAudioTracks = buildAvailableTrackOptions(mediaSource, QStringLiteral("Audio"));
-    const QVariantList availableSubtitleTracks = buildAvailableTrackOptions(mediaSource, QStringLiteral("Subtitle"));
-    Bloom::PlaybackDescriptor descriptor = m_playbackService->createPlaybackDescriptor(
+    m_pendingAutoplayDescriptorItemId = itemId;
+    m_pendingAutoplayDescriptorSource = mediaSource;
+    m_pendingAutoplayDescriptorAudioIndex = resolved.audioIndex;
+    m_pendingAutoplayDescriptorSubtitleIndex = resolved.subtitleIndex;
+    m_pendingAutoplayDescriptorStartPositionMs = startPositionMs;
+    m_pendingAutoplayDescriptorSessionId = playbackInfo.playSessionId;
+    m_pendingAutoplayDescriptorAudioTracks =
+        buildAvailableTrackOptions(mediaSource, QStringLiteral("Audio"));
+    m_pendingAutoplayDescriptorSubtitleTracks =
+        buildAvailableTrackOptions(mediaSource, QStringLiteral("Subtitle"));
+    m_pendingAutoplayDescriptorContext =
+        QStringLiteral("autoplay|descriptor|") + itemId + QStringLiteral("|")
+        + QString::number(m_playbackAttemptId);
+    m_playbackService->requestPlaybackDescriptor(
         itemId,
         mediaSource,
         resolved.audioIndex,
         resolved.subtitleIndex,
         startPositionMs,
         playbackInfo.playSessionId,
-        false);
-    if (!descriptor.stream.isValid()) {
-        descriptor = m_playbackService->createPlaybackDescriptor(
-            itemId, {}, -1, -1, startPositionMs, playbackInfo.playSessionId);
-    }
-    if (!descriptor.stream.isValid()) {
-        qCWarning(lcPlayback) << "Autoplay provider returned no valid stream request"
-                              << "itemId=" << itemId;
-        clearPendingAutoplayContext();
-        clearNextEpisodePrefetchState();
-        return;
-    }
-    const QString streamUrl = descriptor.stream.url.toString();
-    m_nextPlaybackMethod = Bloom::playbackMethodName(descriptor.stream.method);
-    m_nextStreamPinsAudioTrack = descriptor.stream.pinsAudioTrack;
-    m_nextStreamPinsSubtitleTrack = descriptor.stream.pinsSubtitleTrack;
-    m_nextPinnedAudioTrack = descriptor.stream.pinnedAudioTrackId.toInt();
-    m_nextPinnedSubtitleTrack = descriptor.stream.pinnedSubtitleTrackId.toInt();
-    const QString seriesId = m_pendingAutoplaySeriesId;
-    const QString libraryId = m_pendingAutoplayLibraryId;
-
-    playUrlWithTracks(streamUrl,
-                      itemId,
-                      startPositionMs,
-                      seriesId,
-                      targetSeasonId,
-                      libraryId,
-                      mediaSourceId,
-                      playbackInfo.playSessionId,
-                      mediaSource,
-                      resolved.audioIndex,
-                      resolved.subtitleIndex,
-                      availableAudioTracks,
-                      availableSubtitleTracks,
-                      descriptor.durationMs,
-                      videoFramerateForMediaSource(mediaSource),
-                      mediaSourceIsHdr(mediaSource),
-                      kindShouldToneMapToSdr(classifyMediaSourceHdr(mediaSource),
-                                             m_config->getDolbyVisionFallbackMode()));
+        m_pendingAutoplayDescriptorContext);
 }
 
 void PlayerController::onPlaybackInfoLoadedForRequest(const QString &itemId,
@@ -2141,6 +2172,60 @@ void PlayerController::onPlaybackInfoFailedForRequest(const QString &itemId,
     }
 
     maybeFinalizePendingPlaybackRequest(requestContext);
+}
+
+void PlayerController::onPlaybackAudioSwitchedForRequest(const QString &sessionId,
+                                                         const QUrl &reloadUrl,
+                                                         const QString &requestContext)
+{
+    if (requestContext != m_pendingAudioSwitchContext
+        || sessionId != m_playSessionId
+        || !reloadUrl.isValid()
+        || reloadUrl.isEmpty()
+        || m_playbackState == Idle
+        || m_playbackState == Error) {
+        return;
+    }
+    m_pendingAudioSwitchContext.clear();
+    m_pendingAudioSwitchPreviousTrack = -2;
+    m_pendingUrl = QString::fromUtf8(reloadUrl.toEncoded(QUrl::FullyEncoded));
+    m_pinnedAudioTrack = m_selectedAudioTrack;
+    m_streamPinsAudioTrack = true;
+    if (m_activePlaybackSegmentIndex >= 0
+        && m_activePlaybackSegmentIndex < m_playbackSegments.size()) {
+        m_playbackSegments[m_activePlaybackSegmentIndex][QStringLiteral("url")] = m_pendingUrl;
+        m_playbackSegments[m_activePlaybackSegmentIndex][QStringLiteral("audioIndex")] =
+            m_selectedAudioTrack;
+    }
+    // mpv's replacement URL starts at the current physical-file timeline. The
+    // aggregate position includes preceding multipart files and would seek past
+    // the end of the active file.
+    m_seekTargetWhileBuffering = m_segmentRelativePosition;
+    // Keep the logical timeline and state intact while replacing only mpv's URL.
+    m_playerBackend->sendVariantCommand({"loadfile", m_pendingUrl, "replace"});
+}
+
+void PlayerController::onPlaybackAudioSwitchFailedForRequest(const QString &sessionId,
+                                                             const QString &error,
+                                                             const QString &requestContext)
+{
+    if (requestContext != m_pendingAudioSwitchContext || sessionId != m_playSessionId) {
+        return;
+    }
+    m_pendingAudioSwitchContext.clear();
+    const int previousAudioTrack = m_pendingAudioSwitchPreviousTrack;
+    m_pendingAudioSwitchPreviousTrack = -2;
+    if (previousAudioTrack != -2 && previousAudioTrack != m_selectedAudioTrack) {
+        m_selectedAudioTrack = previousAudioTrack;
+        persistAudioPreferenceForCurrentScope(previousAudioTrack);
+        if (m_activePlaybackSegmentIndex >= 0
+            && m_activePlaybackSegmentIndex < m_playbackSegments.size()) {
+            m_playbackSegments[m_activePlaybackSegmentIndex][QStringLiteral("audioIndex")] =
+                previousAudioTrack;
+        }
+        emit selectedAudioTrackChanged();
+    }
+    qCWarning(lcPlayback) << "Pinned-audio switch failed:" << error;
 }
 
 void PlayerController::onPlaybackServiceErrorOccurred(const QString &endpoint, const QString &error)
@@ -2369,7 +2454,9 @@ void PlayerController::maybeFinalizePendingPlaybackRequest(const QString &reques
     }
 
     const PlaybackInfoResponse primaryPlaybackInfo = it->playbackInfos.value(it->itemId);
-    if (primaryPlaybackInfo.mediaSources.size() > 1
+    const QVariantList primarySources =
+        primaryPresentationSources(primaryPlaybackInfo.getMediaSourcesVariant());
+    if (primarySources.size() > 1
         && it->allowVersionPrompt
         && it->chosenMediaSourceId.isEmpty()) {
         if (!it->versionSelectionRequested) {
@@ -2392,8 +2479,10 @@ void PlayerController::launchResolvedPlaybackRequest(const QString &requestId)
     }
 
     const PendingPlaybackRequest request = *it;
-    const PlaybackInfoResponse primaryPlaybackInfo = request.playbackInfos.value(request.itemId);
-    const QVariantList primaryMediaSources = primaryPlaybackInfo.getMediaSourcesVariant();
+    const PlaybackInfoResponse primaryPlaybackInfo =
+        request.playbackInfos.value(request.itemId);
+    const QVariantList primaryMediaSources =
+        primaryPresentationSources(primaryPlaybackInfo.getMediaSourcesVariant());
 
     if (primaryMediaSources.isEmpty()) {
         failPendingPlaybackRequest(requestId, tr("No playable media sources found."));
@@ -2419,29 +2508,171 @@ void PlayerController::launchResolvedPlaybackRequest(const QString &requestId)
         failPendingPlaybackRequest(requestId, tr("No playable media sources found."));
         return;
     }
-
     setOverlayMetadata(request.overlayTitle,
                        request.overlaySubtitle,
                        request.overlayBackdropUrl,
                        request.overlayLogoUrl);
+    it->descriptorSegments = segments;
+    it->descriptors.clear();
+    it->pendingDescriptorCount = segments.size();
+    it->descriptorsRequested = true;
+    requestPlaybackDescriptors(requestId);
+}
 
+void PlayerController::requestPlaybackDescriptors(const QString &requestId)
+{
+    auto it = m_pendingPlaybackRequests.constFind(requestId);
+    if (it == m_pendingPlaybackRequests.constEnd()) {
+        return;
+    }
+
+    // Provider test doubles may complete descriptor requests synchronously. Do
+    // not retain an iterator into the hash across those callbacks: the final
+    // callback removes this request from m_pendingPlaybackRequests.
+    const QVariantList descriptorSegments = it->descriptorSegments;
+    for (int index = 0;
+         index < descriptorSegments.size() && m_pendingPlaybackRequests.contains(requestId);
+         ++index) {
+        const QVariantMap segment = descriptorSegments.at(index).toMap();
+        const QString itemId = segment.value(QStringLiteral("itemId")).toString();
+        const QVariantMap source = segment.value(QStringLiteral("mediaSource")).toMap();
+        if (itemId.isEmpty() || source.isEmpty()) {
+            failPendingPlaybackRequest(requestId, tr("Unable to resolve playback stream."));
+            return;
+        }
+        const QString context = requestId + QStringLiteral("|descriptor|") + QString::number(index);
+        m_playbackService->requestPlaybackDescriptor(
+            itemId,
+            source,
+            segment.value(QStringLiteral("audioIndex"), -1).toInt(),
+            segment.value(QStringLiteral("subtitleIndex"), -1).toInt(),
+            segment.value(QStringLiteral("startPositionMs")).toLongLong(),
+            segment.value(QStringLiteral("playSessionId")).toString(),
+            context);
+    }
+}
+
+void PlayerController::appendDescriptorExternalSubtitleTracks(
+    QVariantList &availableSubtitleTracks,
+    const Bloom::PlaybackDescriptor &descriptor,
+    int *selectedSubtitleIndex) const
+{
+    if (selectedSubtitleIndex == nullptr) {
+        return;
+    }
+
+    QSet<int> usedIndexes;
+    for (const QVariant &trackVariant : availableSubtitleTracks) {
+        usedIndexes.insert(trackVariant.toMap().value(QStringLiteral("index"), -1).toInt());
+    }
+
+    int nextSyntheticIndex = -1000;
+    for (const Bloom::PlaybackTrack &track : descriptor.subtitleTracks) {
+        const QVariantMap trackMap = track.toVariantMap();
+        if (!track.isExternal) {
+            continue;
+        }
+        const QVariant rawUrl = trackMap.value(QStringLiteral("externalUrl"));
+        QByteArray encodedUrl;
+        if (rawUrl.canConvert<QUrl>()) {
+            encodedUrl = rawUrl.toUrl().toEncoded(QUrl::FullyEncoded);
+        } else {
+            encodedUrl = rawUrl.toString().toUtf8();
+        }
+        if (encodedUrl.isEmpty()) {
+            continue;
+        }
+
+        while (usedIndexes.contains(nextSyntheticIndex)) {
+            --nextSyntheticIndex;
+        }
+        const int syntheticIndex = nextSyntheticIndex--;
+        usedIndexes.insert(syntheticIndex);
+
+        QVariantMap option;
+        option[QStringLiteral("index")] = syntheticIndex;
+        option[QStringLiteral("displayTitle")] = track.displayTitle.trimmed().isEmpty()
+            ? (track.language.trimmed().isEmpty()
+                   ? QStringLiteral("External subtitle")
+                   : track.language.trimmed())
+            : track.displayTitle;
+        option[QStringLiteral("language")] = track.language;
+        option[QStringLiteral("codec")] = track.codec;
+        option[QStringLiteral("channels")] = 0;
+        option[QStringLiteral("channelLayout")] = QString();
+        option[QStringLiteral("isDefault")] = track.isDefault;
+        option[QStringLiteral("isForced")] = track.isForced;
+        option[QStringLiteral("isHearingImpaired")] = track.isHearingImpaired;
+        option[QStringLiteral("isExternal")] = true;
+        option[QStringLiteral("externalUrl")] = QString::fromUtf8(encodedUrl);
+        option[QStringLiteral("trackId")] = track.trackId;
+        availableSubtitleTracks.append(option);
+
+        if (!descriptor.selectedSubtitleTrackId.isEmpty()
+            && track.trackId == descriptor.selectedSubtitleTrackId) {
+            *selectedSubtitleIndex = syntheticIndex;
+        }
+    }
+}
+
+void PlayerController::applyPlaybackDescriptorToSegment(
+    QVariantMap &segment, const Bloom::PlaybackDescriptor &descriptor) const
+{
+    segment[QStringLiteral("url")] =
+        QString::fromUtf8(descriptor.stream.url.toEncoded(QUrl::FullyEncoded));
+    segment[QStringLiteral("playMethod")] = Bloom::playbackMethodName(descriptor.stream.method);
+    segment[QStringLiteral("pinsAudioTrack")] = descriptor.stream.pinsAudioTrack;
+    segment[QStringLiteral("pinsSubtitleTrack")] = descriptor.stream.pinsSubtitleTrack;
+    segment[QStringLiteral("pinnedAudioTrack")] = descriptor.stream.pinnedAudioTrackId.toInt();
+    segment[QStringLiteral("pinnedSubtitleTrack")] = descriptor.stream.pinnedSubtitleTrackId.toInt();
+    segment[QStringLiteral("durationMs")] = descriptor.durationMs;
+    if (!descriptor.playbackSessionId.isEmpty()) {
+        segment[QStringLiteral("playSessionId")] = descriptor.playbackSessionId;
+    }
+    if (!descriptor.mediaVersionId.isEmpty()) {
+        segment[QStringLiteral("mediaSourceId")] = descriptor.mediaVersionId;
+    }
+    QVariantList subtitleTracks = segment.value(QStringLiteral("availableSubtitleTracks")).toList();
+    int selectedSubtitleIndex = segment.value(QStringLiteral("subtitleIndex"), -1).toInt();
+    appendDescriptorExternalSubtitleTracks(subtitleTracks, descriptor, &selectedSubtitleIndex);
+    segment[QStringLiteral("availableSubtitleTracks")] = subtitleTracks;
+    segment[QStringLiteral("subtitleIndex")] = selectedSubtitleIndex;
+    segment[QStringLiteral("descriptor")] = QVariant::fromValue(descriptor);
+}
+
+void PlayerController::maybeFinalizePlaybackDescriptors(const QString &requestId)
+{
+    auto it = m_pendingPlaybackRequests.find(requestId);
+    if (it == m_pendingPlaybackRequests.end() || it->pendingDescriptorCount > 0) {
+        return;
+    }
+
+    QVariantList segments = it->descriptorSegments;
+    for (int index = 0; index < segments.size(); ++index) {
+        const QString context = requestId + QStringLiteral("|descriptor|") + QString::number(index);
+        const auto descriptorIt = it->descriptors.constFind(context);
+        if (descriptorIt == it->descriptors.constEnd()) {
+            failPendingPlaybackRequest(requestId, tr("Unable to resolve playback stream."));
+            return;
+        }
+        QVariantMap segment = segments.at(index).toMap();
+        applyPlaybackDescriptorToSegment(segment, descriptorIt.value());
+        segments[index] = segment;
+    }
+
+    const PendingPlaybackRequest request = *it;
     const QVariantMap firstSegment = segments.first().toMap();
     m_nextPlaybackMethod = firstSegment.value(QStringLiteral("playMethod")).toString();
-    m_nextStreamPinsAudioTrack = firstSegment.value(
-        QStringLiteral("pinsAudioTrack")).toBool();
-    m_nextStreamPinsSubtitleTrack = firstSegment.value(
-        QStringLiteral("pinsSubtitleTrack")).toBool();
-    m_nextPinnedAudioTrack = firstSegment.value(
-        QStringLiteral("pinnedAudioTrack"), -1).toInt();
-    m_nextPinnedSubtitleTrack = firstSegment.value(
-        QStringLiteral("pinnedSubtitleTrack"), -1).toInt();
+    m_nextStreamPinsAudioTrack = firstSegment.value(QStringLiteral("pinsAudioTrack")).toBool();
+    m_nextStreamPinsSubtitleTrack = firstSegment.value(QStringLiteral("pinsSubtitleTrack")).toBool();
+    m_nextPinnedAudioTrack = firstSegment.value(QStringLiteral("pinnedAudioTrack"), -1).toInt();
+    m_nextPinnedSubtitleTrack = firstSegment.value(QStringLiteral("pinnedSubtitleTrack"), -1).toInt();
     m_nextPlaybackSegments = segments;
     m_nextPlaylistAppendUrls.clear();
     for (int index = 1; index < segments.size(); ++index) {
-        const QString segmentUrl = segments.at(index).toMap()
-                                       .value(QStringLiteral("url")).toString();
-        if (!segmentUrl.isEmpty()) {
-            m_nextPlaylistAppendUrls.append(segmentUrl);
+        const QString url = segments.at(index).toMap().value(QStringLiteral("url")).toString();
+        if (!url.isEmpty()) {
+            m_nextPlaylistAppendUrls.append(url);
         }
     }
     playUrlWithTracks(firstSegment.value(QStringLiteral("url")).toString(),
@@ -2461,8 +2692,115 @@ void PlayerController::launchResolvedPlaybackRequest(const QString &requestId)
                       firstSegment.value(QStringLiteral("framerate")).toDouble(),
                       firstSegment.value(QStringLiteral("isHDR")).toBool(),
                       firstSegment.value(QStringLiteral("toneMapToSdr")).toBool());
-
     m_pendingPlaybackRequests.remove(requestId);
+}
+
+void PlayerController::onPlaybackDescriptorLoadedForRequest(
+    const QString &itemId, const Bloom::PlaybackDescriptor &descriptor, const QString &requestContext)
+{
+    if (requestContext.startsWith(QStringLiteral("autoplay|descriptor|"))) {
+        if (requestContext != m_pendingAutoplayDescriptorContext
+            || itemId != m_pendingAutoplayDescriptorItemId
+            || !descriptor.stream.isValid()) {
+            return;
+        }
+        const QString url =
+            QString::fromUtf8(descriptor.stream.url.toEncoded(QUrl::FullyEncoded));
+        const QString autoplaySeriesId = m_pendingAutoplaySeriesId;
+        const QString autoplaySeasonId = m_pendingAutoplaySeasonId;
+        const QString autoplayLibraryId = m_pendingAutoplayLibraryId;
+        const QString episodeSeasonId = m_pendingAutoplayEpisodeData.value(
+            QStringLiteral("seasonId")).toString();
+        const QString targetSeasonId = episodeSeasonId.isEmpty()
+            ? m_pendingAutoplayEpisodeData.value(QStringLiteral("parentId")).toString()
+            : episodeSeasonId;
+        const QString resolvedSeasonId = targetSeasonId.isEmpty()
+            ? autoplaySeasonId : targetSeasonId;
+        const QString mediaSourceId = descriptor.mediaVersionId.isEmpty()
+            ? m_pendingAutoplayDescriptorSource.value(QStringLiteral("id")).toString()
+            : descriptor.mediaVersionId;
+        const QString sessionId = descriptor.playbackSessionId.isEmpty()
+            ? m_pendingAutoplayDescriptorSessionId : descriptor.playbackSessionId;
+        QVariantList autoplaySubtitleTracks = m_pendingAutoplayDescriptorSubtitleTracks;
+        int autoplaySubtitleIndex = m_pendingAutoplayDescriptorSubtitleIndex;
+        appendDescriptorExternalSubtitleTracks(autoplaySubtitleTracks,
+                                               descriptor,
+                                               &autoplaySubtitleIndex);
+        stopAutoplayPlaybackInfoWait();
+        m_nextPlaybackMethod = Bloom::playbackMethodName(descriptor.stream.method);
+        m_nextStreamPinsAudioTrack = descriptor.stream.pinsAudioTrack;
+        m_nextStreamPinsSubtitleTrack = descriptor.stream.pinsSubtitleTrack;
+        m_nextPinnedAudioTrack = descriptor.stream.pinnedAudioTrackId.toInt();
+        m_nextPinnedSubtitleTrack = descriptor.stream.pinnedSubtitleTrackId.toInt();
+        playUrlWithTracks(url,
+                          itemId,
+                          m_pendingAutoplayDescriptorStartPositionMs,
+                          autoplaySeriesId,
+                          resolvedSeasonId,
+                          autoplayLibraryId,
+                          mediaSourceId,
+                          sessionId,
+                          m_pendingAutoplayDescriptorSource,
+                          m_pendingAutoplayDescriptorAudioIndex,
+                          autoplaySubtitleIndex,
+                          m_pendingAutoplayDescriptorAudioTracks,
+                          autoplaySubtitleTracks,
+                          descriptor.durationMs,
+                          m_pendingAutoplayDescriptorSource.isEmpty()
+                              ? m_pendingAutoplayFramerate
+                              : videoFramerateForMediaSource(m_pendingAutoplayDescriptorSource),
+                          m_pendingAutoplayDescriptorSource.isEmpty()
+                              ? m_pendingAutoplayIsHDR
+                              : mediaSourceIsHdr(m_pendingAutoplayDescriptorSource),
+                          m_pendingAutoplayDescriptorSource.isEmpty()
+                              ? m_pendingAutoplayToneMapToSdr
+                              : kindShouldToneMapToSdr(
+                                  classifyMediaSourceHdr(m_pendingAutoplayDescriptorSource),
+                                  m_config->getDolbyVisionFallbackMode()));
+        m_pendingAutoplayDescriptorContext.clear();
+        return;
+    }
+
+    const int marker = requestContext.lastIndexOf(QStringLiteral("|descriptor|"));
+    if (marker <= 0) {
+        return;
+    }
+    const QString requestId = requestContext.left(marker);
+    auto it = m_pendingPlaybackRequests.find(requestId);
+    if (it == m_pendingPlaybackRequests.end()
+        || !descriptor.stream.isValid()
+        || !it->descriptorsRequested) {
+        return;
+    }
+    const int index = requestContext.mid(marker + QStringLiteral("|descriptor|").size()).toInt();
+    if (index < 0 || index >= it->descriptorSegments.size()
+        || it->descriptorSegments.at(index).toMap().value(QStringLiteral("itemId")).toString() != itemId) {
+        return;
+    }
+    if (!it->descriptors.contains(requestContext)) {
+        it->descriptors.insert(requestContext, descriptor);
+        it->pendingDescriptorCount = qMax(0, it->pendingDescriptorCount - 1);
+    }
+    maybeFinalizePlaybackDescriptors(requestId);
+}
+void PlayerController::onPlaybackDescriptorFailedForRequest(
+    const QString &itemId, const QString &error, const QString &requestContext)
+{
+    if (requestContext == m_pendingAutoplayDescriptorContext) {
+        qCWarning(lcPlayback) << "Autoplay descriptor failed" << itemId << error;
+        stopAutoplayPlaybackInfoWait();
+        clearPendingAutoplayContext();
+        clearNextEpisodePrefetchState();
+        return;
+    }
+    const int marker = requestContext.lastIndexOf(QStringLiteral("|descriptor|"));
+    if (marker <= 0) {
+        return;
+    }
+    const QString requestId = requestContext.left(marker);
+    if (m_pendingPlaybackRequests.contains(requestId)) {
+        failPendingPlaybackRequest(requestId, error);
+    }
 }
 
 void PlayerController::failPendingPlaybackRequest(const QString &requestId, const QString &message)
@@ -2491,7 +2829,8 @@ QVariantMap PlayerController::buildPlaybackVersionDialogModel(const QString &req
 
     QVariantList options;
     const PlaybackInfoResponse playbackInfo = it->playbackInfos.value(it->itemId);
-    const QVariantList mediaSources = playbackInfo.getMediaSourcesVariant();
+    const QVariantList mediaSources =
+        primaryPresentationSources(playbackInfo.getMediaSourcesVariant());
     for (const QVariant &mediaSourceVariant : mediaSources) {
         const QVariantMap mediaSource = mediaSourceVariant.toMap();
         options.append(QVariantMap{
@@ -2619,31 +2958,50 @@ QVariantList PlayerController::buildMultipartSegments(const QVariantMap &request
 
     QVariantMap primarySegment = primaryContext;
     primarySegment[QStringLiteral("itemId")] = itemId;
-    const Bloom::PlaybackDescriptor primaryDescriptor = m_playbackService->createPlaybackDescriptor(
-        itemId,
-        primaryContext.value(QStringLiteral("mediaSource")).toMap(),
-        primaryContext.value(QStringLiteral("audioIndex"), -1).toInt(),
-        primaryContext.value(QStringLiteral("subtitleIndex"), -1).toInt(),
-        request.value(QStringLiteral("startPositionMs")).toLongLong(),
-        primaryContext.value(QStringLiteral("playSessionId")).toString());
-    if (!primaryDescriptor.stream.isValid()) {
-        qCWarning(lcPlayback) << "Primary provider returned an invalid playback descriptor"
-                              << "itemId=" << itemId;
-        return {};
-    }
-    primarySegment[QStringLiteral("url")] = primaryDescriptor.stream.url.toString();
-    primarySegment[QStringLiteral("playMethod")] = Bloom::playbackMethodName(
-        primaryDescriptor.stream.method);
-    primarySegment[QStringLiteral("pinsAudioTrack")] =
-        primaryDescriptor.stream.pinsAudioTrack;
-    primarySegment[QStringLiteral("pinsSubtitleTrack")] =
-        primaryDescriptor.stream.pinsSubtitleTrack;
-    primarySegment[QStringLiteral("pinnedAudioTrack")] =
-        primaryDescriptor.stream.pinnedAudioTrackId.toInt();
-    primarySegment[QStringLiteral("pinnedSubtitleTrack")] =
-        primaryDescriptor.stream.pinnedSubtitleTrackId.toInt();
-    primarySegment[QStringLiteral("durationMs")] = primaryDescriptor.durationMs;
+    primarySegment[QStringLiteral("startPositionMs")] =
+        request.value(QStringLiteral("startPositionMs")).toLongLong();
     segments.append(primarySegment);
+    const int primaryPartIndex =
+        primarySource.value(QStringLiteral("presentationPartIndex")).toInt();
+    const int partTotal =
+        primarySource.value(QStringLiteral("presentationPartTotal")).toInt();
+    if (primaryPartIndex > 0 && partTotal > 1) {
+        const QString variantId =
+            primarySource.value(QStringLiteral("playbackVariantId")).toString();
+        const QVariantList allSources = primaryPlaybackInfo.getMediaSourcesVariant();
+        for (int partIndex = primaryPartIndex + 1; partIndex <= partTotal; ++partIndex) {
+            QVariantMap partSource;
+            for (const QVariant &sourceValue : allSources) {
+                const QVariantMap candidate = sourceValue.toMap();
+                if (candidate.value(QStringLiteral("presentationPartIndex")).toInt()
+                        != partIndex) {
+                    continue;
+                }
+                if (!variantId.isEmpty()
+                    && candidate.value(QStringLiteral("playbackVariantId")).toString()
+                        != variantId) {
+                    continue;
+                }
+                partSource = candidate;
+                break;
+            }
+            if (partSource.isEmpty()) {
+                return {};
+            }
+
+            const QVariantMap partContext = resolveSegmentPlaybackContext(
+                scopeId, isMovie, primaryPlaybackInfo, allSources, partSource,
+                preferredAudioIndex, preferredSubtitleIndex, false);
+            if (partContext.isEmpty()) {
+                return {};
+            }
+            QVariantMap segment = partContext;
+            segment[QStringLiteral("itemId")] = itemId;
+            segment[QStringLiteral("startPositionMs")] = 0;
+            segments.append(segment);
+        }
+        return segments;
+    }
 
     for (const PendingPlaybackRequest &pendingRequest : m_pendingPlaybackRequests) {
         if (pendingRequest.itemId != itemId) {
@@ -2675,30 +3033,7 @@ QVariantList PlayerController::buildMultipartSegments(const QVariantMap &request
 
             QVariantMap segment = partContext;
             segment[QStringLiteral("itemId")] = partId;
-            const Bloom::PlaybackDescriptor partDescriptor = m_playbackService->createPlaybackDescriptor(
-                partId,
-                partContext.value(QStringLiteral("mediaSource")).toMap(),
-                partContext.value(QStringLiteral("audioIndex"), -1).toInt(),
-                partContext.value(QStringLiteral("subtitleIndex"), -1).toInt(),
-                0,
-                partContext.value(QStringLiteral("playSessionId")).toString());
-            if (!partDescriptor.stream.isValid()) {
-                qCWarning(lcPlayback) << "Skipping multipart item with invalid playback descriptor"
-                                      << "itemId=" << partId;
-                continue;
-            }
-            segment[QStringLiteral("url")] = partDescriptor.stream.url.toString();
-            segment[QStringLiteral("playMethod")] = Bloom::playbackMethodName(
-                partDescriptor.stream.method);
-            segment[QStringLiteral("pinsAudioTrack")] =
-                partDescriptor.stream.pinsAudioTrack;
-            segment[QStringLiteral("pinsSubtitleTrack")] =
-                partDescriptor.stream.pinsSubtitleTrack;
-            segment[QStringLiteral("pinnedAudioTrack")] =
-                partDescriptor.stream.pinnedAudioTrackId.toInt();
-            segment[QStringLiteral("pinnedSubtitleTrack")] =
-                partDescriptor.stream.pinnedSubtitleTrackId.toInt();
-            segment[QStringLiteral("durationMs")] = partDescriptor.durationMs;
+            segment[QStringLiteral("startPositionMs")] = 0;
             segments.append(segment);
         }
         break;
@@ -3248,6 +3583,7 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
 
     clearPendingAutoplayContext();
     clearNextEpisodePrefetchState();
+    m_pendingExternalSubtitleTracks.clear();
 
     const QString requestedPlayMethod = m_nextPlaybackMethod.isEmpty()
         ? QStringLiteral("directPlay")
@@ -3312,6 +3648,24 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
             m_playbackSegments.append(segmentMap);
             m_aggregatePlaybackDuration += static_cast<double>(
                 segmentMap.value(QStringLiteral("durationMs")).toLongLong()) / 1000.0;
+        }
+        m_pendingExternalSubtitleTracks.clear();
+        if (!m_playbackSegments.isEmpty()) {
+            const QVariantMap firstSegment = m_playbackSegments.first();
+            const int selectedSubtitleIndex =
+                firstSegment.value(QStringLiteral("subtitleIndex"), -1).toInt();
+            for (const QVariant &trackVariant :
+                 firstSegment.value(QStringLiteral("availableSubtitleTracks")).toList()) {
+                const QVariantMap track = trackVariant.toMap();
+                const QString externalUrl = track.value(QStringLiteral("externalUrl")).toString();
+                if (!track.value(QStringLiteral("isExternal")).toBool() || externalUrl.isEmpty()) {
+                    continue;
+                }
+                QVariantMap pending = track;
+                pending[QStringLiteral("select")] =
+                    track.value(QStringLiteral("index"), -1).toInt() == selectedSubtitleIndex;
+                m_pendingExternalSubtitleTracks.append(pending);
+            }
         }
         if (!m_playbackSegments.isEmpty()) {
             if (m_aggregatePlaybackDuration > 0.0) {
@@ -3431,7 +3785,9 @@ void PlayerController::seekRelative(double seconds)
     
     // During buffering, convert relative to absolute and queue
     if (m_playbackState == Buffering) {
-        m_seekTargetWhileBuffering = m_currentPosition + seconds;
+        const double physicalPosition = m_activePlaybackSegmentIndex >= 0
+            ? m_segmentRelativePosition : m_currentPosition;
+        m_seekTargetWhileBuffering = physicalPosition + seconds;
         qCDebug(lcPlayback) << "PlayerController: Queued relative seek for after buffering";
         return;
     }
@@ -3571,7 +3927,7 @@ void PlayerController::onRecoveryTick()
             m_recoveryReply.clear();
         }
         reply->deleteLater();
-        int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        const int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         if (reply->error() == QNetworkReply::NoError) {
             qCDebug(lcPlayback) << "PlayerController: Recovery ping succeeded";
             if (m_isRecovering && m_playbackState == Error && !m_terminalTransitionActive) {
@@ -3644,19 +4000,45 @@ void PlayerController::setSelectedAudioTrack(int index)
                         << "previousSourceIndex=" << previousAudioTrack;
 
     if (m_playbackState == Playing || m_playbackState == Paused) {
-        if (index >= 0) {
-            const int mpvTrackId = mpvAudioTrackForSourceIndex(index);
-            if (mpvTrackId > 0) {
-                m_mpvAudioTrack = mpvTrackId;
-                qCDebug(lcPlayback) << "Applying audio track switch via aid:" << mpvTrackId;
-                m_playerBackend->sendVariantCommand({"set_property", "aid", mpvTrackId});
+        const auto applyMpvAudioTrack = [this, index]() {
+            if (index >= 0) {
+                const int mpvTrackId = mpvAudioTrackForSourceIndex(index);
+                if (mpvTrackId > 0) {
+                    m_mpvAudioTrack = mpvTrackId;
+                    qCDebug(lcPlayback) << "Applying audio track switch via aid:" << mpvTrackId;
+                    m_playerBackend->sendVariantCommand({"set_property", "aid", mpvTrackId});
+                } else {
+                    qCWarning(lcPlayback) << "No mapped mpv audio track for provider source index" << index
+                                          << "- skipping runtime aid command";
+                }
             } else {
-                qCWarning(lcPlayback) << "No mapped mpv audio track for provider source index" << index
-                                      << "- skipping runtime aid command";
+                m_mpvAudioTrack = -1;
+                m_playerBackend->sendVariantCommand({"set_property", "aid", "auto"});
+            }
+        };
+
+        bool nativeSwitchDispatched = false;
+        if (m_streamPinsAudioTrack && !m_playSessionId.isEmpty() && index >= 0
+            && index != m_pinnedAudioTrack) {
+            m_pendingAudioSwitchContext =
+                QStringLiteral("audio|") + QString::number(m_playbackAttemptId)
+                + QStringLiteral("|") + QString::number(index);
+            m_pendingAudioSwitchPreviousTrack = previousAudioTrack;
+            nativeSwitchDispatched = m_playbackService
+                && m_playbackService->switchPlaybackAudio(
+                    m_playSessionId,
+                    index,
+                    qRound64(m_segmentRelativePosition * 1000.0),
+                    m_pendingAudioSwitchContext);
+            if (!nativeSwitchDispatched) {
+                // Providers without a native audio-switch request (notably
+                // Jellyfin) retain the existing mpv aid behavior.
+                m_pendingAudioSwitchContext.clear();
+                m_pendingAudioSwitchPreviousTrack = -2;
+                applyMpvAudioTrack();
             }
         } else {
-            m_mpvAudioTrack = -1;
-            m_playerBackend->sendVariantCommand({"set_property", "aid", "auto"});
+            applyMpvAudioTrack();
         }
     }
 
@@ -3756,6 +4138,15 @@ void PlayerController::addExternalSubtitleTrack(const QString &subtitleUrl,
                                                 const QString &language,
                                                 int sourceStreamIndexHint)
 {
+    addExternalSubtitleTrackInternal(subtitleUrl, displayTitle, language, sourceStreamIndexHint, true);
+}
+
+void PlayerController::addExternalSubtitleTrackInternal(const QString &subtitleUrl,
+                                                        const QString &displayTitle,
+                                                        const QString &language,
+                                                        int sourceStreamIndexHint,
+                                                        bool select)
+{
     const QString normalizedSubtitleUrl = subtitleUrl.trimmed();
     if (normalizedSubtitleUrl.isEmpty()) {
         qCWarning(lcPlayback) << "Cannot add external subtitle: empty URL/path";
@@ -3768,7 +4159,7 @@ void PlayerController::addExternalSubtitleTrack(const QString &subtitleUrl,
     }
 
     int syntheticIndex = -1000 - m_externalSubtitleTrackMap.size();
-    if (sourceStreamIndexHint >= 0) {
+    if (sourceStreamIndexHint >= 0 || sourceStreamIndexHint <= -1000) {
         syntheticIndex = sourceStreamIndexHint;
     }
     const bool trackIndexAlreadyPresent = std::any_of(m_availableSubtitleTracks.cbegin(),
@@ -3776,39 +4167,50 @@ void PlayerController::addExternalSubtitleTrack(const QString &subtitleUrl,
                                                       [syntheticIndex](const QVariant &trackVariant) {
                                                           return trackVariant.toMap().value(QStringLiteral("index")).toInt() == syntheticIndex;
                                                       });
-    if (trackIndexAlreadyPresent) {
-        if (m_externalSubtitleTrackMap.value(syntheticIndex, -2) != -1) {
-            qCDebug(lcPlayback) << "Skipping external subtitle; index already present and resolved:" << syntheticIndex;
-            return;
-        }
-        qCDebug(lcPlayback) << "Retrying external subtitle sub-add for unresolved index:" << syntheticIndex;
+    if (trackIndexAlreadyPresent
+        && m_externalSubtitleTrackMap.value(syntheticIndex, -2) != -1) {
+        qCDebug(lcPlayback) << "Skipping external subtitle; index already present and resolved:" << syntheticIndex;
+        return;
     }
+
     QVariantMap option;
-    option[QStringLiteral("index")] = syntheticIndex;
-    option[QStringLiteral("displayTitle")] = displayTitle.trimmed().isEmpty()
-        ? QStringLiteral("External subtitle")
-        : displayTitle.trimmed();
-    option[QStringLiteral("language")] = language.trimmed();
-    option[QStringLiteral("codec")] = QString();
-    option[QStringLiteral("channels")] = 0;
-    option[QStringLiteral("channelLayout")] = QString();
-    option[QStringLiteral("isDefault")] = false;
-    option[QStringLiteral("isForced")] = false;
-    option[QStringLiteral("isHearingImpaired")] = false;
-    option[QStringLiteral("isExternal")] = true;
-    if (!trackIndexAlreadyPresent) {
+    if (trackIndexAlreadyPresent) {
+        for (const QVariant &trackVariant : m_availableSubtitleTracks) {
+            const QVariantMap existing = trackVariant.toMap();
+            if (existing.value(QStringLiteral("index")).toInt() == syntheticIndex) {
+                option = existing;
+                break;
+            }
+        }
+    }
+    if (option.isEmpty()) {
+        option[QStringLiteral("index")] = syntheticIndex;
+        option[QStringLiteral("displayTitle")] = displayTitle.trimmed().isEmpty()
+            ? QStringLiteral("External subtitle")
+            : displayTitle.trimmed();
+        option[QStringLiteral("language")] = language.trimmed();
+        option[QStringLiteral("codec")] = QString();
+        option[QStringLiteral("channels")] = 0;
+        option[QStringLiteral("channelLayout")] = QString();
+        option[QStringLiteral("isDefault")] = false;
+        option[QStringLiteral("isForced")] = false;
+        option[QStringLiteral("isHearingImpaired")] = false;
+        option[QStringLiteral("isExternal")] = true;
+        option[QStringLiteral("externalUrl")] = normalizedSubtitleUrl;
         m_availableSubtitleTracks.append(option);
         emit availableTracksChanged();
-        m_externalSubtitleTrackMap.insert(syntheticIndex, -1);
     }
-    m_pendingExternalSubtitleIndex = syntheticIndex;
+    m_externalSubtitleTrackMap.insert(syntheticIndex, -1);
+    if (select) {
+        m_pendingExternalSubtitleIndex = syntheticIndex;
+    }
 
     m_playerBackend->sendVariantCommand({
         QStringLiteral("sub-add"),
         normalizedSubtitleUrl,
-        QStringLiteral("select"),
+        select ? QStringLiteral("select") : QStringLiteral("auto"),
         option.value(QStringLiteral("displayTitle")).toString(),
-        language.trimmed()
+        option.value(QStringLiteral("language")).toString()
     });
 }
 
@@ -4481,12 +4883,6 @@ void PlayerController::syncBackendSubtitleTrack(int mpvTrackId)
             if (pendingIt != m_externalSubtitleTrackMap.end() && pendingIt.value() < 0) {
                 pendingIt.value() = mpvTrackId;
                 externalTrackIt = pendingIt;
-            } else {
-                auto selectedIt = m_externalSubtitleTrackMap.find(m_selectedSubtitleTrack);
-                if (selectedIt != m_externalSubtitleTrackMap.end() && selectedIt.value() < 0) {
-                    selectedIt.value() = mpvTrackId;
-                    externalTrackIt = selectedIt;
-                }
             }
         }
         if (externalTrackIt != m_externalSubtitleTrackMap.end()) {
@@ -4500,7 +4896,7 @@ void PlayerController::syncBackendSubtitleTrack(int mpvTrackId)
                 m_pendingExternalSubtitleIndex = -1;
             }
             if (m_activePlaybackSegmentIndex >= 0 && m_activePlaybackSegmentIndex < m_playbackSegments.size()) {
-                m_playbackSegments[m_activePlaybackSegmentIndex][QStringLiteral("subtitleIndex")] = -1;
+                m_playbackSegments[m_activePlaybackSegmentIndex][QStringLiteral("subtitleIndex")] = externalIndex;
             }
             m_pendingSubtitleTrackPersistenceFromBackend = false;
             return;
@@ -5173,6 +5569,12 @@ void PlayerController::stashPendingAutoplayContext()
 void PlayerController::clearPendingAutoplayContext()
 {
     stopAutoplayPlaybackInfoWait();
+    m_pendingAutoplayDescriptorContext.clear();
+    m_pendingAutoplayDescriptorItemId.clear();
+    m_pendingAutoplayDescriptorSource.clear();
+    m_pendingAutoplayDescriptorSessionId.clear();
+    m_pendingAutoplayDescriptorAudioTracks.clear();
+    m_pendingAutoplayDescriptorSubtitleTracks.clear();
     m_pendingAutoplayItemId.clear();
     m_pendingAutoplaySeriesId.clear();
     m_pendingAutoplaySeasonId.clear();
@@ -5235,31 +5637,23 @@ void PlayerController::fallbackToPendingAutoplayPlayback()
     const double framerate = m_pendingAutoplayFramerate;
     const bool isHdr = m_pendingAutoplayIsHDR;
     const bool toneMapToSdr = m_pendingAutoplayToneMapToSdr;
-    stopAutoplayPlaybackInfoWait();
-
-    const Bloom::PlaybackDescriptor descriptor =
-        m_playbackService->createPlaybackDescriptor(itemId, {}, -1, -1, startPositionMs);
-    if (!descriptor.stream.isValid()) {
-        qCWarning(lcPlayback) << "Autoplay provider returned no fallback stream request"
-                              << "itemId=" << itemId;
-        clearPendingAutoplayContext();
-        clearNextEpisodePrefetchState();
-        return;
-    }
-    m_nextPlaybackMethod = Bloom::playbackMethodName(descriptor.stream.method);
-    m_nextStreamPinsAudioTrack = descriptor.stream.pinsAudioTrack;
-    m_nextStreamPinsSubtitleTrack = descriptor.stream.pinsSubtitleTrack;
-    m_nextPinnedAudioTrack = descriptor.stream.pinnedAudioTrackId.toInt();
-    m_nextPinnedSubtitleTrack = descriptor.stream.pinnedSubtitleTrackId.toInt();
-    playUrl(descriptor.stream.url.toString(),
-            itemId,
-            startPositionMs,
-            seriesId,
-            targetSeasonId,
-            libraryId,
-            framerate,
-            isHdr,
-            toneMapToSdr);
+    m_pendingAutoplayDescriptorItemId = itemId;
+    m_pendingAutoplayDescriptorSource.clear();
+    m_pendingAutoplayDescriptorAudioIndex = -1;
+    m_pendingAutoplayDescriptorSubtitleIndex = -1;
+    m_pendingAutoplayDescriptorStartPositionMs = startPositionMs;
+    m_pendingAutoplayDescriptorSessionId.clear();
+    m_pendingAutoplayDescriptorAudioTracks.clear();
+    m_pendingAutoplayDescriptorSubtitleTracks.clear();
+    m_pendingAutoplayDescriptorContext =
+        QStringLiteral("autoplay|descriptor|") + itemId + QStringLiteral("|fallback");
+    m_playbackService->requestPlaybackDescriptor(itemId,
+                                                  {},
+                                                  -1,
+                                                  -1,
+                                                  startPositionMs,
+                                                  QString(),
+                                                  m_pendingAutoplayDescriptorContext);
 }
 
 void PlayerController::stopAutoplayPlaybackInfoWait()

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -699,6 +699,8 @@ private:
     void appendDescriptorExternalSubtitleTracks(QVariantList &availableSubtitleTracks,
                                                 const Bloom::PlaybackDescriptor &descriptor,
                                                 int *selectedSubtitleIndex) const;
+    void queueActiveSegmentExternalSubtitleTracks();
+    void applyPendingExternalSubtitleTracks();
     void addExternalSubtitleTrackInternal(const QString &subtitleUrl,
                                           const QString &displayTitle,
                                           const QString &language,
@@ -722,6 +724,7 @@ private:
     void fallbackToPendingAutoplayPlayback();
     [[nodiscard]] int pendingAutoplaySubtitleOverrideIndex() const;
     void stopAutoplayPlaybackInfoWait();
+    void armAutoplayPlaybackInfoWait();
     static qint64 resumePositionMs(const QVariantMap &item);
     QVariantMap selectMediaSourceForRequest(const QVariantList &mediaSources,
                                             const QString &forcedMediaSourceId,

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -8,6 +8,7 @@
 #include <QMetaObject>
 #include <QSet>
 #include <QStringList>
+#include <QUrl>
 #include <QVariantMap>
 #include <QVariantList>
 #include <QPointer>
@@ -17,6 +18,7 @@
 #include "backend/IPlayerBackend.h"
 #include "TrickplayProcessor.h"
 #include "../network/Types.h"
+#include "../models/MediaModels.h"
 #include "../utils/ConfigManager.h"
 #include "../utils/TrackPreferencesManager.h"
 #include "../utils/DisplayManager.h"
@@ -411,6 +413,18 @@ private slots:
     void onPlaybackInfoFailedForRequest(const QString &itemId,
                                         const QString &error,
                                         const QString &requestContext);
+    void onPlaybackDescriptorLoadedForRequest(const QString &itemId,
+                                              const Bloom::PlaybackDescriptor &descriptor,
+                                              const QString &requestContext);
+    void onPlaybackDescriptorFailedForRequest(const QString &itemId,
+                                              const QString &error,
+                                              const QString &requestContext);
+    void onPlaybackAudioSwitchedForRequest(const QString &sessionId,
+                                           const QUrl &reloadUrl,
+                                           const QString &requestContext);
+    void onPlaybackAudioSwitchFailedForRequest(const QString &sessionId,
+                                               const QString &error,
+                                               const QString &requestContext);
     void onAdditionalPartsLoaded(const QString &itemId, const QVariantList &parts);
     void onAdditionalPartsLoadedForRequest(const QString &itemId,
                                            const QVariantList &parts,
@@ -674,6 +688,24 @@ private:
     QVariantList buildAvailableTrackOptions(const QVariantMap &mediaSource, const QString &streamType) const;
     double videoFramerateForMediaSource(const QVariantMap &mediaSource) const;
     bool mediaSourceIsHdr(const QVariantMap &mediaSource) const;
+    void maybeResolvePendingRequestLibraryId(PendingPlaybackRequest &pending);
+    void maybeFinalizePendingPlaybackRequest(const QString &requestId);
+    void launchResolvedPlaybackRequest(const QString &requestId);
+    void failPendingPlaybackRequest(const QString &requestId, const QString &message);
+    void requestPlaybackDescriptors(const QString &requestId);
+    void maybeFinalizePlaybackDescriptors(const QString &requestId);
+    void applyPlaybackDescriptorToSegment(QVariantMap &segment,
+                                          const Bloom::PlaybackDescriptor &descriptor) const;
+    void appendDescriptorExternalSubtitleTracks(QVariantList &availableSubtitleTracks,
+                                                const Bloom::PlaybackDescriptor &descriptor,
+                                                int *selectedSubtitleIndex) const;
+    void addExternalSubtitleTrackInternal(const QString &subtitleUrl,
+                                          const QString &displayTitle,
+                                          const QString &language,
+                                          int sourceStreamIndexHint,
+                                          bool select);
+    QVariantMap buildPlaybackVersionDialogModel(const QString &requestId) const;
+    QString buildVersionSubtitle(const QVariantMap &mediaSource) const;
     /**
      * Convert a playback state enum value to a human-readable string.
      * @param state PlaybackState value to convert.
@@ -691,12 +723,6 @@ private:
     [[nodiscard]] int pendingAutoplaySubtitleOverrideIndex() const;
     void stopAutoplayPlaybackInfoWait();
     static qint64 resumePositionMs(const QVariantMap &item);
-    void maybeResolvePendingRequestLibraryId(PendingPlaybackRequest &pending);
-    void maybeFinalizePendingPlaybackRequest(const QString &requestId);
-    void launchResolvedPlaybackRequest(const QString &requestId);
-    void failPendingPlaybackRequest(const QString &requestId, const QString &message);
-    QVariantMap buildPlaybackVersionDialogModel(const QString &requestId) const;
-    QString buildVersionSubtitle(const QVariantMap &mediaSource) const;
     QVariantMap selectMediaSourceForRequest(const QVariantList &mediaSources,
                                             const QString &forcedMediaSourceId,
                                             bool useAffinityFallback) const;
@@ -741,13 +767,17 @@ private:
         QObject *restoreFocusTarget = nullptr;
         bool additionalPartsLoaded = false;
         bool versionSelectionRequested = false;
+        QHash<QString, PlaybackInfoResponse> playbackInfos;
+        QVariantList descriptorSegments;
+        QHash<QString, Bloom::PlaybackDescriptor> descriptors;
+        int pendingDescriptorCount = 0;
+        bool descriptorsRequested = false;
         QString chosenMediaSourceId;
         QVariantList additionalParts;
         QSet<QString> awaitedPlaybackInfoIds;
         QSet<QString> failedPlaybackInfoIds;
         bool primaryPlaybackInfoFailed = false;
         QString failureMessage;
-        QHash<QString, PlaybackInfoResponse> playbackInfos;
     };
 
     IPlayerBackend *m_playerBackend;
@@ -877,6 +907,18 @@ private:
     QHash<int, int> m_audioTrackReverseMap;    // mpv aid track ID (1-based) -> provider source index
     QHash<int, int> m_subtitleTrackReverseMap; // mpv sid track ID (1-based) -> provider source index
     QString m_mediaSourceId;            // Current media source ID
+    QVariantList m_pendingExternalSubtitleTracks;
+    QString m_pendingAutoplayDescriptorContext;
+    QString m_pendingAutoplayDescriptorItemId;
+    QVariantMap m_pendingAutoplayDescriptorSource;
+    int m_pendingAutoplayDescriptorAudioIndex = -1;
+    int m_pendingAutoplayDescriptorSubtitleIndex = -1;
+    qint64 m_pendingAutoplayDescriptorStartPositionMs = 0;
+    QString m_pendingAutoplayDescriptorSessionId;
+    QVariantList m_pendingAutoplayDescriptorAudioTracks;
+    QVariantList m_pendingAutoplayDescriptorSubtitleTracks;
+    QString m_pendingAudioSwitchContext;
+    int m_pendingAudioSwitchPreviousTrack = -2;
     QString m_playSessionId;            // Playback session ID for reporting
     QVariantList m_availableAudioTracks;
     QVariantList m_availableSubtitleTracks;

--- a/src/providers/IPlaybackProvider.h
+++ b/src/providers/IPlaybackProvider.h
@@ -218,11 +218,13 @@ public:
         const PlaybackProviderContext &context,
         const Bloom::MediaRef &media,
         const QVariantMap &providerSource,
+        int selectedAudioTrack,
         qint64 startPositionMs) const
     {
         Q_UNUSED(context)
         Q_UNUSED(media)
         Q_UNUSED(providerSource)
+        Q_UNUSED(selectedAudioTrack)
         Q_UNUSED(startPositionMs)
         return {};
     }

--- a/src/providers/IPlaybackProvider.h
+++ b/src/providers/IPlaybackProvider.h
@@ -1,9 +1,70 @@
 #pragma once
 
 #include "models/MediaModels.h"
+#include "network/Types.h"
 
 #include <QJsonObject>
 #include <QVariantMap>
+#include <QUrl>
+
+struct PlaybackProviderContext;
+
+struct PlaybackInfoRequest
+{
+    QString endpoint;
+    QString method = QStringLiteral("GET");
+    QJsonObject body;
+
+    [[nodiscard]] bool isValid() const { return !endpoint.isEmpty(); }
+};
+
+struct PlaybackInfoParseResult
+{
+    PlaybackInfoResponse response;
+    bool valid = false;
+    QString error;
+};
+
+struct PlaybackStartRequest
+{
+    QString endpoint;
+    QString method = QStringLiteral("POST");
+    QJsonObject body;
+
+    [[nodiscard]] bool isValid() const { return !endpoint.isEmpty(); }
+};
+
+struct PlaybackStartParseResult
+{
+    Bloom::PlaybackDescriptor descriptor;
+    bool valid = false;
+    QString error;
+};
+
+struct PlaybackAudioSwitchRequest
+{
+    QString endpoint;
+    QString method = QStringLiteral("PATCH");
+    QJsonObject body;
+
+    [[nodiscard]] bool isValid() const { return !endpoint.isEmpty(); }
+};
+
+struct PlaybackAudioSwitchParseResult
+{
+    QUrl reloadUrl;
+    bool valid = false;
+    QString error;
+};
+
+struct PlaybackRecoveryRequest
+{
+    QString endpoint;
+    QString method = QStringLiteral("POST");
+    QJsonObject body;
+
+    [[nodiscard]] bool isValid() const { return !endpoint.isEmpty(); }
+};
 
 enum class PlaybackReportEvent {
     Start,
@@ -32,6 +93,7 @@ struct PlaybackReport
 
 struct PlaybackReportRequest
 {
+    QString method = QStringLiteral("POST");
     QString endpoint;
     QJsonObject body;
     bool deferSessionExpiry = true;
@@ -76,6 +138,102 @@ public:
         const QString &itemId,
         int width,
         int tileIndex) const = 0;
+    virtual PlaybackInfoRequest createPlaybackInfoRequest(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QVariantMap &providerSource) const
+    {
+        Q_UNUSED(context)
+        Q_UNUSED(media)
+        Q_UNUSED(providerSource)
+        return {};
+    }
 
+    virtual PlaybackInfoParseResult parsePlaybackInfoResponse(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QJsonObject &wireResponse,
+        const QVariantMap &providerSource = {}) const
+    {
+        Q_UNUSED(context)
+        Q_UNUSED(media)
+        Q_UNUSED(wireResponse)
+        Q_UNUSED(providerSource)
+        return {};
+    }
+
+    virtual PlaybackStartRequest createPlaybackStartRequest(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QVariantMap &providerSource,
+        int selectedAudioTrack,
+        int selectedSubtitleTrack,
+        qint64 startPositionMs) const
+    {
+        Q_UNUSED(context)
+        Q_UNUSED(media)
+        Q_UNUSED(providerSource)
+        Q_UNUSED(selectedAudioTrack)
+        Q_UNUSED(selectedSubtitleTrack)
+        Q_UNUSED(startPositionMs)
+        return {};
+    }
+
+    virtual PlaybackStartParseResult parsePlaybackStartResponse(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QJsonObject &wireResponse,
+        const QVariantMap &providerSource = {}) const
+    {
+        Q_UNUSED(context)
+        Q_UNUSED(media)
+        Q_UNUSED(wireResponse)
+        Q_UNUSED(providerSource)
+        return {};
+    }
+
+    virtual PlaybackAudioSwitchRequest createAudioSwitchRequest(
+        const PlaybackProviderContext &context,
+        const QString &playbackSessionId,
+        int audioTrackIndex,
+        qint64 positionMs) const
+    {
+        Q_UNUSED(context)
+        Q_UNUSED(playbackSessionId)
+        Q_UNUSED(audioTrackIndex)
+        Q_UNUSED(positionMs)
+        return {};
+    }
+
+    virtual PlaybackAudioSwitchParseResult parseAudioSwitchResponse(
+        const PlaybackProviderContext &context,
+        const QJsonObject &wireResponse) const
+    {
+        Q_UNUSED(context)
+        Q_UNUSED(wireResponse)
+        return {};
+    }
+
+    virtual PlaybackRecoveryRequest createPlaybackRecoveryRequest(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QVariantMap &providerSource,
+        qint64 startPositionMs) const
+    {
+        Q_UNUSED(context)
+        Q_UNUSED(media)
+        Q_UNUSED(providerSource)
+        Q_UNUSED(startPositionMs)
+        return {};
+    }
+
+    virtual PlaybackStartParseResult parsePlaybackRecoveryResponse(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QJsonObject &wireResponse,
+        const QVariantMap &providerSource = {}) const
+    {
+        return parsePlaybackStartResponse(context, media, wireResponse, providerSource);
+    }
     virtual PlaybackReportRequest createReportRequest(const PlaybackReport &report) const = 0;
 };

--- a/src/providers/silo/SiloModelMapper.cpp
+++ b/src/providers/silo/SiloModelMapper.cpp
@@ -254,10 +254,14 @@ QVariantList tracks(const QJsonArray &wireTracks,
             mapped[QStringLiteral("sampleRate")] = wire.value(QStringLiteral("sample_rate")).toInt();
             mapped[QStringLiteral("bitDepth")] = wire.value(QStringLiteral("bit_depth")).toInt();
             mapped[QStringLiteral("resolution")] = wire.value(QStringLiteral("resolution")).toString();
+        } else if (kind.compare(QStringLiteral("Subtitle"), Qt::CaseInsensitive) == 0) {
             mapped[QStringLiteral("fileName")] = wire.value(QStringLiteral("file_name")).toString();
-            mapped[QStringLiteral("subtitleUrl")] = wire.value(QStringLiteral("url")).toString(
-                wire.value(QStringLiteral("downloaded_url")).toString(
-                    wire.value(QStringLiteral("external_url")).toString()));
+            const QString url = wire.value(QStringLiteral("url")).toString();
+            const QString downloadedUrl = wire.value(QStringLiteral("downloaded_url")).toString();
+            const QString externalUrl = wire.value(QStringLiteral("external_url")).toString();
+            mapped[QStringLiteral("externalUrl")] = !url.isEmpty()
+                ? url
+                : (!downloadedUrl.isEmpty() ? downloadedUrl : externalUrl);
             mapped[QStringLiteral("downloaded")] = wire.value(QStringLiteral("downloaded")).toBool();
             mapped[QStringLiteral("source")] = wire.value(QStringLiteral("source")).toString();
             mapped[QStringLiteral("path")] = wire.value(QStringLiteral("path")).toString();
@@ -799,6 +803,8 @@ MediaStreamInfo SiloModelMapper::mediaStream(const QJsonObject &wireTrack,
     result.isExternal = wireTrack.value(QStringLiteral("external")).toBool()
         || wireTrack.value(QStringLiteral("downloaded")).toBool()
         || !wireTrack.value(QStringLiteral("url")).toString().isEmpty()
+        || !wireTrack.value(QStringLiteral("downloaded_url")).toString().isEmpty()
+        || !wireTrack.value(QStringLiteral("external_url")).toString().isEmpty()
         || !wireTrack.value(QStringLiteral("path")).toString().isEmpty();
     result.isHearingImpaired = wireTrack.value(QStringLiteral("hearing_impaired")).toBool();
     result.channels = wireTrack.value(QStringLiteral("channels")).toInt();
@@ -848,9 +854,10 @@ PlaybackInfoResponse SiloModelMapper::playbackInfoFromVersions(const QJsonArray 
 
         const QJsonArray video = wire.value(QStringLiteral("video_tracks")).toArray();
         const QJsonArray audio = wire.value(QStringLiteral("audio_tracks")).toArray();
-        const QJsonArray subtitles = wire.value(QStringLiteral("subtitle_tracks")).isArray()
-            ? wire.value(QStringLiteral("subtitle_tracks")).toArray()
-            : wire.value(QStringLiteral("subtitles")).toArray();
+        QJsonArray subtitles = wire.value(QStringLiteral("subtitle_tracks")).toArray();
+        if (subtitles.isEmpty()) {
+            subtitles = wire.value(QStringLiteral("subtitles")).toArray();
+        }
         for (qsizetype i = 0; i < video.size(); ++i) {
             if (video.at(i).isObject()) {
                 source.mediaStreams.append(mediaStream(
@@ -887,8 +894,10 @@ PlaybackInfoResponse SiloModelMapper::playbackInfoFromVersions(const QJsonArray 
         if (source.defaultSubtitleStreamIndex < 0 && !subtitles.isEmpty()) {
             source.defaultSubtitleStreamIndex = 0;
         }
-        source.directStreamUrl = wire.value(QStringLiteral("stream_url")).toString(
-            wire.value(QStringLiteral("download_url")).toString());
+        const QString streamUrl = wire.value(QStringLiteral("stream_url")).toString();
+        source.directStreamUrl = streamUrl.isEmpty()
+            ? wire.value(QStringLiteral("download_url")).toString()
+            : streamUrl;
         source.transcodingUrl = wire.value(QStringLiteral("hls_url")).toString();
         response.mediaSources.append(source);
     }
@@ -897,23 +906,44 @@ PlaybackInfoResponse SiloModelMapper::playbackInfoFromVersions(const QJsonArray 
 
 PlaybackInfoResponse SiloModelMapper::playbackInfo(const QJsonObject &wireItem)
 {
-    if (wireItem.value(QStringLiteral("media_sources")).isArray()) {
-        return playbackInfoFromVersions(wireItem.value(QStringLiteral("media_sources")).toArray());
+    const QJsonObject nested = wireItem.value(QStringLiteral("playback_info")).isObject()
+        ? wireItem.value(QStringLiteral("playback_info")).toObject()
+        : QJsonObject{};
+    const auto mediaSourcesFrom = [](const QJsonObject &object) {
+        const QJsonArray mediaSources = object.value(QStringLiteral("media_sources")).toArray();
+        return mediaSources.isEmpty() ? QJsonArray{} : mediaSources;
+    };
+    QJsonArray versions = mediaSourcesFrom(wireItem);
+    if (!versions.isEmpty()) {
+        return playbackInfoFromVersions(versions);
     }
-    if (wireItem.value(QStringLiteral("playback_info")).isObject()) {
-        const QJsonObject info = wireItem.value(QStringLiteral("playback_info")).toObject();
-        if (info.value(QStringLiteral("media_sources")).isArray()) {
-            return playbackInfoFromVersions(info.value(QStringLiteral("media_sources")).toArray());
-        }
+    versions = mediaSourcesFrom(nested);
+    if (!versions.isEmpty()) {
+        return playbackInfoFromVersions(versions);
     }
-    const QJsonArray variants = wireItem.value(QStringLiteral("playback_variants")).toArray();
-    const QJsonArray variantVersions = flattenedPlaybackVersions(variants);
-    if (!variantVersions.isEmpty()) {
-        return playbackInfoFromVersions(variantVersions);
-    }
-    QJsonArray versions = wireItem.value(QStringLiteral("versions")).toArray();
+
+    const auto variantsFrom = [](const QJsonObject &object) {
+        return flattenedPlaybackVersions(
+            object.value(QStringLiteral("playback_variants")).toArray());
+    };
+    versions = variantsFrom(wireItem);
     if (versions.isEmpty()) {
-        versions = wireItem.value(QStringLiteral("files")).toArray();
+        versions = variantsFrom(nested);
+    }
+    if (!versions.isEmpty()) {
+        return playbackInfoFromVersions(versions);
+    }
+
+    const auto versionsOrFilesFrom = [](const QJsonObject &object) {
+        QJsonArray result = object.value(QStringLiteral("versions")).toArray();
+        if (result.isEmpty()) {
+            result = object.value(QStringLiteral("files")).toArray();
+        }
+        return result;
+    };
+    versions = versionsOrFilesFrom(wireItem);
+    if (versions.isEmpty()) {
+        versions = versionsOrFilesFrom(nested);
     }
     return playbackInfoFromVersions(versions);
 }
@@ -932,9 +962,13 @@ QVariantMap SiloModelMapper::mediaVersion(const QJsonObject &wireVersion,
                                             QStringLiteral("Video"), 0, &mediaStreams);
     const QVariantList audioTracks = tracks(wireVersion.value(QStringLiteral("audio_tracks")).toArray(),
                                             QStringLiteral("Audio"), 0, &mediaStreams);
+    QJsonArray subtitleWireTracks =
+        wireVersion.value(QStringLiteral("subtitle_tracks")).toArray();
+    if (subtitleWireTracks.isEmpty()) {
+        subtitleWireTracks = wireVersion.value(QStringLiteral("subtitles")).toArray();
+    }
     const QVariantList subtitleTracks = tracks(
-        wireVersion.value(QStringLiteral("subtitle_tracks")).toArray(),
-        QStringLiteral("Subtitle"), 0, &mediaStreams);
+        subtitleWireTracks, QStringLiteral("Subtitle"), 0, &mediaStreams);
 
     QVariantMap result{
         {QStringLiteral("id"), fileId},
@@ -1065,13 +1099,30 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
     state.lastPlayedAt = stateValue(QStringLiteral("last_played_at")).toString(
         stateValue(QStringLiteral("progress_updated_at")).toString());
 
-    const QJsonArray wirePlaybackVariants =
+    QJsonObject nestedPlaybackInfo;
+    if (wireItem.value(QStringLiteral("playback_info")).isObject()) {
+        nestedPlaybackInfo = wireItem.value(QStringLiteral("playback_info")).toObject();
+    }
+    QJsonArray wirePlaybackVariants =
         wireItem.value(QStringLiteral("playback_variants")).toArray();
-    QJsonArray wireVersions = wireItem.value(QStringLiteral("versions")).isArray()
-        ? wireItem.value(QStringLiteral("versions")).toArray()
-        : wireItem.value(QStringLiteral("files")).toArray();
-    if (wireVersions.isEmpty()) {
-        wireVersions = flattenedPlaybackVersions(wirePlaybackVariants);
+    if (wirePlaybackVariants.isEmpty()) {
+        wirePlaybackVariants = nestedPlaybackInfo.value(
+            QStringLiteral("playback_variants")).toArray();
+    }
+    const auto versionsFrom = [](const QJsonObject &object) {
+        QJsonArray versions = object.value(QStringLiteral("versions")).toArray();
+        if (versions.isEmpty()) {
+            versions = object.value(QStringLiteral("files")).toArray();
+        }
+        if (versions.isEmpty()) {
+            versions = flattenedPlaybackVersions(
+                object.value(QStringLiteral("playback_variants")).toArray());
+        }
+        return versions;
+    };
+    QJsonArray wireVersions = versionsFrom(wireItem);
+    if (wireVersions.isEmpty() && !nestedPlaybackInfo.isEmpty()) {
+        wireVersions = versionsFrom(nestedPlaybackInfo);
     }
     const QVariantList versions = mediaVersions(wireVersions, connectionId, itemId);
     const QVariantList mappedPlaybackVariants = playbackVariants(

--- a/src/providers/silo/SiloModelMapper.cpp
+++ b/src/providers/silo/SiloModelMapper.cpp
@@ -1,6 +1,6 @@
 #include "SiloModelMapper.h"
 
-#include <QDateTime>
+#include <algorithm>
 #include <QJsonDocument>
 #include <QJsonParseError>
 #include <QSet>
@@ -246,9 +246,14 @@ QVariantList tracks(const QJsonArray &wireTracks,
         } else if (kind.compare(QStringLiteral("Audio"), Qt::CaseInsensitive) == 0) {
             mapped[QStringLiteral("sampleRate")] = wire.value(QStringLiteral("sample_rate")).toInt();
             mapped[QStringLiteral("bitDepth")] = wire.value(QStringLiteral("bit_depth")).toInt();
-        } else {
             mapped[QStringLiteral("resolution")] = wire.value(QStringLiteral("resolution")).toString();
             mapped[QStringLiteral("fileName")] = wire.value(QStringLiteral("file_name")).toString();
+            mapped[QStringLiteral("subtitleUrl")] = wire.value(QStringLiteral("url")).toString(
+                wire.value(QStringLiteral("downloaded_url")).toString(
+                    wire.value(QStringLiteral("external_url")).toString()));
+            mapped[QStringLiteral("downloaded")] = wire.value(QStringLiteral("downloaded")).toBool();
+            mapped[QStringLiteral("source")] = wire.value(QStringLiteral("source")).toString();
+            mapped[QStringLiteral("path")] = wire.value(QStringLiteral("path")).toString();
         }
         result.append(mapped);
         if (mediaStreams) {
@@ -304,6 +309,118 @@ QVariantList subtitles(const QJsonArray &wireSubtitles)
     return tracks(wireSubtitles, QStringLiteral("Subtitle"), 0, nullptr);
 }
 
+struct OrderedPlaybackPart
+{
+    int index = 0;
+    QJsonObject wire;
+};
+
+int playbackPartIndex(const QJsonObject &part, int fallback)
+{
+    const QStringList keys{
+        QStringLiteral("part_index"),
+        QStringLiteral("presentation_part_index")
+    };
+    for (const QString &key : keys) {
+        if (part.contains(key)) {
+            const int index = part.value(key).toInt(fallback);
+            return index >= 0 ? index : fallback;
+        }
+    }
+    return fallback;
+}
+
+QList<OrderedPlaybackPart> orderedPlaybackParts(const QJsonObject &variant)
+{
+    QList<OrderedPlaybackPart> parts;
+    const QJsonArray wireParts = variant.value(QStringLiteral("parts")).toArray();
+    parts.reserve(wireParts.size());
+    for (qsizetype i = 0; i < wireParts.size(); ++i) {
+        if (!wireParts.at(i).isObject()) {
+            continue;
+        }
+        parts.append(OrderedPlaybackPart{
+            playbackPartIndex(wireParts.at(i).toObject(), static_cast<int>(i) + 1),
+            wireParts.at(i).toObject()
+        });
+    }
+    std::stable_sort(parts.begin(), parts.end(),
+                     [](const OrderedPlaybackPart &left, const OrderedPlaybackPart &right) {
+                         return left.index < right.index;
+                     });
+    return parts;
+}
+
+int playbackPartTotal(const QJsonObject &variant, int partCount)
+{
+    const int explicitTotal = variant.value(QStringLiteral("part_count")).toInt(0);
+    return explicitTotal > 0 ? explicitTotal : partCount;
+}
+
+QVariantList mappedPlaybackPartVersions(const QJsonArray &wireVersions,
+                                        int partIndex,
+                                        int partTotal,
+                                        const QString &connectionId,
+                                        const QString &itemId)
+{
+    QVariantList result;
+    result.reserve(wireVersions.size());
+    for (const QJsonValue &value : wireVersions) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const QVariantMap mapped = SiloModelMapper::mediaVersion(
+            value.toObject(), connectionId, itemId);
+        if (mapped.isEmpty()) {
+            continue;
+        }
+        QVariantMap annotated = mapped;
+        if (!annotated.contains(QStringLiteral("presentationPartIndex"))
+            && partIndex >= 0) {
+            annotated[QStringLiteral("presentationPartIndex")] = partIndex;
+        }
+        if (!annotated.contains(QStringLiteral("presentationPartTotal"))
+            && partTotal > 0) {
+            annotated[QStringLiteral("presentationPartTotal")] = partTotal;
+        }
+        result.append(annotated);
+    }
+    return result;
+}
+
+QJsonArray flattenedPlaybackVersions(const QJsonArray &wireVariants)
+{
+    QJsonArray result;
+    for (const QJsonValue &value : wireVariants) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const QJsonObject variant = value.toObject();
+        const QList<OrderedPlaybackPart> parts = orderedPlaybackParts(variant);
+        const int partTotal = playbackPartTotal(variant, parts.size());
+        for (const OrderedPlaybackPart &part : parts) {
+            for (const QJsonValue &versionValue :
+                 part.wire.value(QStringLiteral("versions")).toArray()) {
+                if (!versionValue.isObject()) {
+                    continue;
+                }
+                QJsonObject version = versionValue.toObject();
+                version.insert(QStringLiteral("playback_variant_id"),
+                               variant.value(QStringLiteral("variant_id")).toString());
+                if (!version.contains(QStringLiteral("presentation_part_index"))) {
+                    version.insert(QStringLiteral("presentation_part_index"), part.index);
+                }
+                if (partTotal > 0
+                    && !version.contains(QStringLiteral("presentation_part_total"))) {
+                    version.insert(QStringLiteral("presentation_part_total"), partTotal);
+                }
+                result.append(version);
+            }
+        }
+    }
+    return result;
+}
+
 QVariantList playbackVariants(const QJsonArray &wireVariants,
                               const QString &connectionId,
                               const QString &itemId)
@@ -315,19 +432,20 @@ QVariantList playbackVariants(const QJsonArray &wireVariants,
             continue;
         }
         const QJsonObject wire = value.toObject();
+        const QList<OrderedPlaybackPart> orderedParts = orderedPlaybackParts(wire);
+        const int partTotal = playbackPartTotal(wire, orderedParts.size());
         QVariantList parts;
-        for (const QJsonValue &partValue : wire.value(QStringLiteral("parts")).toArray()) {
-            if (!partValue.isObject()) {
-                continue;
-            }
-            const QJsonObject part = partValue.toObject();
+        parts.reserve(orderedParts.size());
+        for (const OrderedPlaybackPart &orderedPart : orderedParts) {
+            const QJsonObject part = orderedPart.wire;
             parts.append(QVariantMap{
-                {QStringLiteral("partIndex"), part.value(QStringLiteral("part_index")).toInt()},
+                {QStringLiteral("partIndex"), orderedPart.index},
                 {QStringLiteral("defaultFileId"), identityString(part.value(QStringLiteral("default_file_id")))},
                 {QStringLiteral("totalDurationMs"), SiloModelMapper::secondsToMilliseconds(
                      part.value(QStringLiteral("total_duration")).toDouble())},
-                {QStringLiteral("versions"), SiloModelMapper::mediaVersions(
-                     part.value(QStringLiteral("versions")).toArray(), connectionId, itemId)}
+                {QStringLiteral("versions"), mappedPlaybackPartVersions(
+                     part.value(QStringLiteral("versions")).toArray(),
+                     orderedPart.index, partTotal, connectionId, itemId)}
             });
         }
         result.append(QVariantMap{
@@ -336,7 +454,7 @@ QVariantList playbackVariants(const QJsonArray &wireVariants,
             {QStringLiteral("editionKey"), wire.value(QStringLiteral("edition_key")).toString()},
             {QStringLiteral("presentationKind"), wire.value(QStringLiteral("presentation_kind")).toString()},
             {QStringLiteral("presentationGroupKey"), wire.value(QStringLiteral("presentation_group_key")).toString()},
-            {QStringLiteral("partCount"), wire.value(QStringLiteral("part_count")).toInt()},
+            {QStringLiteral("partCount"), partTotal},
             {QStringLiteral("totalDurationMs"), SiloModelMapper::secondsToMilliseconds(
                  wire.value(QStringLiteral("total_duration")).toDouble())},
             {QStringLiteral("defaultFileId"), identityString(wire.value(QStringLiteral("default_file_id")))},
@@ -670,7 +788,10 @@ MediaStreamInfo SiloModelMapper::mediaStream(const QJsonObject &wireTrack,
     result.displayTitle = result.title;
     result.isDefault = wireTrack.value(QStringLiteral("default")).toBool();
     result.isForced = wireTrack.value(QStringLiteral("forced")).toBool();
-    result.isExternal = wireTrack.value(QStringLiteral("external")).toBool();
+    result.isExternal = wireTrack.value(QStringLiteral("external")).toBool()
+        || wireTrack.value(QStringLiteral("downloaded")).toBool()
+        || !wireTrack.value(QStringLiteral("url")).toString().isEmpty()
+        || !wireTrack.value(QStringLiteral("path")).toString().isEmpty();
     result.isHearingImpaired = wireTrack.value(QStringLiteral("hearing_impaired")).toBool();
     result.channels = wireTrack.value(QStringLiteral("channels")).toInt();
     result.channelLayout = wireTrack.value(QStringLiteral("layout")).toString();
@@ -686,6 +807,104 @@ MediaStreamInfo SiloModelMapper::mediaStream(const QJsonObject &wireTrack,
     result.dolbyVisionBlSignalCompatibilityId =
         wireTrack.value(QStringLiteral("dv_bl_compat_id")).toInt();
     return result;
+}
+
+PlaybackInfoResponse SiloModelMapper::playbackInfoFromVersions(const QJsonArray &wireVersions)
+{
+    PlaybackInfoResponse response;
+    response.mediaSources.reserve(wireVersions.size());
+    for (const QJsonValue &value : wireVersions) {
+        if (!value.isObject()) {
+            continue;
+        }
+        const QJsonObject wire = value.toObject();
+        const QString id = identityString(wire.value(QStringLiteral("file_id")));
+        if (id.isEmpty()) {
+            continue;
+        }
+        MediaSourceInfo source;
+        source.id = id;
+        source.name = wire.value(QStringLiteral("file_name")).toString();
+        source.path = wire.value(QStringLiteral("file_path")).toString();
+        source.container = wire.value(QStringLiteral("container")).toString();
+        source.size = jsonInteger(wire.value(QStringLiteral("file_size")));
+        source.bitRate = wire.value(QStringLiteral("bitrate")).toInt();
+        source.videoType = wire.value(QStringLiteral("codec_video")).toString();
+        source.durationMs = secondsToMilliseconds(wire.value(QStringLiteral("duration")).toDouble());
+        source.playbackVariantId =
+            wire.value(QStringLiteral("playback_variant_id")).toString();
+        source.presentationPartIndex =
+            wire.value(QStringLiteral("presentation_part_index")).toInt();
+        source.presentationPartTotal =
+            wire.value(QStringLiteral("presentation_part_total")).toInt();
+
+        const QJsonArray video = wire.value(QStringLiteral("video_tracks")).toArray();
+        const QJsonArray audio = wire.value(QStringLiteral("audio_tracks")).toArray();
+        const QJsonArray subtitles = wire.value(QStringLiteral("subtitle_tracks")).isArray()
+            ? wire.value(QStringLiteral("subtitle_tracks")).toArray()
+            : wire.value(QStringLiteral("subtitles")).toArray();
+        for (qsizetype i = 0; i < video.size(); ++i) {
+            if (video.at(i).isObject()) {
+                source.mediaStreams.append(mediaStream(
+                    video.at(i).toObject(), QStringLiteral("Video"), static_cast<int>(i)));
+            }
+        }
+        for (qsizetype i = 0; i < audio.size(); ++i) {
+            if (audio.at(i).isObject()) {
+                const MediaStreamInfo stream = mediaStream(
+                    audio.at(i).toObject(), QStringLiteral("Audio"), static_cast<int>(i));
+                if (source.defaultAudioStreamIndex < 0 && stream.isDefault) {
+                    source.defaultAudioStreamIndex = stream.index;
+                }
+                source.mediaStreams.append(stream);
+            }
+        }
+        for (qsizetype i = 0; i < subtitles.size(); ++i) {
+            if (subtitles.at(i).isObject()) {
+                const QJsonObject subtitle = subtitles.at(i).toObject();
+                const MediaStreamInfo stream = mediaStream(
+                    subtitle, QStringLiteral("Subtitle"), static_cast<int>(i));
+                if (source.defaultSubtitleStreamIndex < 0 && stream.isDefault) {
+                    source.defaultSubtitleStreamIndex = stream.index;
+                }
+                source.mediaStreams.append(stream);
+            }
+        }
+        if (source.defaultAudioStreamIndex < 0 && !audio.isEmpty()) {
+            source.defaultAudioStreamIndex = 0;
+        }
+        if (source.defaultSubtitleStreamIndex < 0 && !subtitles.isEmpty()) {
+            source.defaultSubtitleStreamIndex = 0;
+        }
+        source.directStreamUrl = wire.value(QStringLiteral("stream_url")).toString(
+            wire.value(QStringLiteral("download_url")).toString());
+        source.transcodingUrl = wire.value(QStringLiteral("hls_url")).toString();
+        response.mediaSources.append(source);
+    }
+    return response;
+}
+
+PlaybackInfoResponse SiloModelMapper::playbackInfo(const QJsonObject &wireItem)
+{
+    if (wireItem.value(QStringLiteral("media_sources")).isArray()) {
+        return playbackInfoFromVersions(wireItem.value(QStringLiteral("media_sources")).toArray());
+    }
+    if (wireItem.value(QStringLiteral("playback_info")).isObject()) {
+        const QJsonObject info = wireItem.value(QStringLiteral("playback_info")).toObject();
+        if (info.value(QStringLiteral("media_sources")).isArray()) {
+            return playbackInfoFromVersions(info.value(QStringLiteral("media_sources")).toArray());
+        }
+    }
+    const QJsonArray variants = wireItem.value(QStringLiteral("playback_variants")).toArray();
+    const QJsonArray variantVersions = flattenedPlaybackVersions(variants);
+    if (!variantVersions.isEmpty()) {
+        return playbackInfoFromVersions(variantVersions);
+    }
+    QJsonArray versions = wireItem.value(QStringLiteral("versions")).toArray();
+    if (versions.isEmpty()) {
+        versions = wireItem.value(QStringLiteral("files")).toArray();
+    }
+    return playbackInfoFromVersions(versions);
 }
 
 QVariantMap SiloModelMapper::mediaVersion(const QJsonObject &wireVersion,
@@ -715,18 +934,15 @@ QVariantMap SiloModelMapper::mediaVersion(const QJsonObject &wireVersion,
         {QStringLiteral("videoCodec"), wireVersion.value(QStringLiteral("codec_video")).toString()},
         {QStringLiteral("audioCodec"), wireVersion.value(QStringLiteral("codec_audio")).toString()},
         {QStringLiteral("hdr"), wireVersion.value(QStringLiteral("hdr")).toBool()},
-        {QStringLiteral("container"), wireVersion.value(QStringLiteral("container")).toString()},
-        {QStringLiteral("fileSize"), jsonInteger(wireVersion.value(QStringLiteral("file_size")))},
         {QStringLiteral("durationMs"), secondsToMilliseconds(
              wireVersion.value(QStringLiteral("duration")).toDouble())},
-        {QStringLiteral("bitrate"), wireVersion.value(QStringLiteral("bitrate")).toInt()},
-        {QStringLiteral("addedAt"), wireVersion.value(QStringLiteral("added_at")).toString()},
-        {QStringLiteral("edition"), wireVersion.value(QStringLiteral("edition_raw")).toString()},
-        {QStringLiteral("editionKey"), wireVersion.value(QStringLiteral("edition_key")).toString()},
-        {QStringLiteral("presentationKind"), wireVersion.value(QStringLiteral("presentation_kind")).toString()},
-        {QStringLiteral("presentationGroupKey"), wireVersion.value(QStringLiteral("presentation_group_key")).toString()},
-        {QStringLiteral("presentationPartIndex"), wireVersion.value(QStringLiteral("presentation_part_index")).toInt()},
-        {QStringLiteral("presentationPartTotal"), wireVersion.value(QStringLiteral("presentation_part_total")).toInt()},
+        {QStringLiteral("hdrType"), wireVersion.value(QStringLiteral("hdr_type")).toString(
+             wireVersion.value(QStringLiteral("video_range_type")).toString())},
+        {QStringLiteral("dolbyVision"), wireVersion.value(QStringLiteral("dolby_vision")).toString()},
+        {QStringLiteral("dolbyVisionProfile"), wireVersion.value(QStringLiteral("dv_profile")).toInt()},
+        {QStringLiteral("hdr10Plus"), wireVersion.value(QStringLiteral("hdr10_plus")).toBool()},
+        {QStringLiteral("width"), wireVersion.value(QStringLiteral("width")).toInt()},
+        {QStringLiteral("height"), wireVersion.value(QStringLiteral("height")).toInt()},
         {QStringLiteral("multiEpisodeStart"), wireVersion.value(QStringLiteral("multi_episode_start")).toInt()},
         {QStringLiteral("multiEpisodeEnd"), wireVersion.value(QStringLiteral("multi_episode_end")).toInt()},
         {QStringLiteral("effectiveAudioTrackIndex"), wireVersion.value(QStringLiteral("effective_audio_track_index")).toInt(-1)},
@@ -739,6 +955,14 @@ QVariantMap SiloModelMapper::mediaVersion(const QJsonObject &wireVersion,
              wireVersion.value(QStringLiteral("chapters")).toArray(), connectionId, itemId, fileId)},
         {QStringLiteral("markers"), markerVariants(wireVersion)}
     };
+    if (wireVersion.contains(QStringLiteral("presentation_part_index"))) {
+        result[QStringLiteral("presentationPartIndex")] =
+            wireVersion.value(QStringLiteral("presentation_part_index")).toInt();
+    }
+    if (wireVersion.contains(QStringLiteral("presentation_part_total"))) {
+        result[QStringLiteral("presentationPartTotal")] =
+            wireVersion.value(QStringLiteral("presentation_part_total")).toInt();
+    }
     if (wireVersion.value(QStringLiteral("file_path")).isString()) {
         result[QStringLiteral("filePath")] = wireVersion.value(QStringLiteral("file_path")).toString();
     }
@@ -830,10 +1054,21 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
     state.lastPlayedAt = stateValue(QStringLiteral("last_played_at")).toString(
         stateValue(QStringLiteral("progress_updated_at")).toString());
 
-    const QJsonArray wireVersions = wireItem.value(QStringLiteral("versions")).isArray()
+    const QJsonArray wirePlaybackVariants =
+        wireItem.value(QStringLiteral("playback_variants")).toArray();
+    QJsonArray wireVersions = wireItem.value(QStringLiteral("versions")).isArray()
         ? wireItem.value(QStringLiteral("versions")).toArray()
         : wireItem.value(QStringLiteral("files")).toArray();
+    if (wireVersions.isEmpty()) {
+        wireVersions = flattenedPlaybackVersions(wirePlaybackVariants);
+    }
     const QVariantList versions = mediaVersions(wireVersions, connectionId, itemId);
+    const QVariantList mappedPlaybackVariants = playbackVariants(
+        wirePlaybackVariants, connectionId, itemId);
+    const qint64 playbackVariantDurationMs = mappedPlaybackVariants.isEmpty()
+        ? 0
+        : mappedPlaybackVariants.first().toMap()
+              .value(QStringLiteral("totalDurationMs")).toLongLong();
     qint64 durationMs = 0;
     if (wireItem.value(QStringLiteral("duration_seconds")).isDouble()) {
         durationMs = secondsToMilliseconds(
@@ -841,6 +1076,8 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
     } else if (userData.value(QStringLiteral("duration_seconds")).isDouble()) {
         durationMs = secondsToMilliseconds(
             userData.value(QStringLiteral("duration_seconds")).toDouble());
+    } else if (playbackVariantDurationMs > 0) {
+        durationMs = playbackVariantDurationMs;
     } else if (!versions.isEmpty()) {
         durationMs = versions.first().toMap().value(QStringLiteral("durationMs")).toLongLong();
     } else if (wireItem.value(QStringLiteral("runtime")).isDouble()) {
@@ -850,6 +1087,13 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
     QString defaultFileId = identityString(wireItem.value(QStringLiteral("default_file_id")));
     if (defaultFileId.isEmpty()) {
         defaultFileId = identityString(wireItem.value(QStringLiteral("file_id")));
+    }
+    if (defaultFileId.isEmpty() && !mappedPlaybackVariants.isEmpty()) {
+        defaultFileId = mappedPlaybackVariants.first().toMap()
+                            .value(QStringLiteral("defaultFileId")).toString();
+    }
+    if (defaultFileId.isEmpty() && !versions.isEmpty()) {
+        defaultFileId = versions.first().toMap().value(QStringLiteral("fileId")).toString();
     }
 
     double communityRating = 0.0;
@@ -907,8 +1151,7 @@ QVariantMap SiloModelMapper::mediaItem(const QJsonObject &wireItem,
              || stateValue(QStringLiteral("is_in_progress")).toBool()},
         {QStringLiteral("people"), people(wireItem, connectionId)},
         {QStringLiteral("versions"), versions},
-        {QStringLiteral("playbackVariants"), playbackVariants(
-             wireItem.value(QStringLiteral("playback_variants")).toArray(), connectionId, itemId)},
+        {QStringLiteral("playbackVariants"), mappedPlaybackVariants},
         {QStringLiteral("subtitles"), subtitles(wireItem.value(QStringLiteral("subtitles")).toArray())},
         {QStringLiteral("markers"), markerVariants(wireItem)}
     };

--- a/src/providers/silo/SiloModelMapper.cpp
+++ b/src/providers/silo/SiloModelMapper.cpp
@@ -220,6 +220,14 @@ double frameRate(const QString &value)
     return denominatorOk && denominator != 0.0 ? numerator / denominator : 0.0;
 }
 
+int trackIndex(const QJsonObject &wireTrack, int fallback)
+{
+    if (!wireTrack.contains(QStringLiteral("index"))) {
+        return fallback;
+    }
+    return wireTrack.value(QStringLiteral("index")).toInt(fallback);
+}
+
 QVariantList tracks(const QJsonArray &wireTracks,
                     const QString &kind,
                     int initialIndex,
@@ -232,9 +240,8 @@ QVariantList tracks(const QJsonArray &wireTracks,
             continue;
         }
         const QJsonObject wire = wireTracks.at(offset).toObject();
-        const int index = wire.contains(QStringLiteral("index"))
-            ? wire.value(QStringLiteral("index")).toInt(initialIndex + static_cast<int>(offset))
-            : initialIndex + static_cast<int>(offset);
+        const int index = trackIndex(
+            wire, initialIndex + static_cast<int>(offset));
         MediaStreamInfo stream = SiloModelMapper::mediaStream(wire, kind, index);
         QVariantMap mapped = stream.toVariantMap();
         if (kind.compare(QStringLiteral("Video"), Qt::CaseInsensitive) == 0) {
@@ -340,7 +347,8 @@ QList<OrderedPlaybackPart> orderedPlaybackParts(const QJsonObject &variant)
             continue;
         }
         parts.append(OrderedPlaybackPart{
-            playbackPartIndex(wireParts.at(i).toObject(), static_cast<int>(i) + 1),
+            playbackPartIndex(wireParts.at(i).toObject(),
+                              static_cast<int>(parts.size()) + 1),
             wireParts.at(i).toObject()
         });
     }
@@ -846,13 +854,15 @@ PlaybackInfoResponse SiloModelMapper::playbackInfoFromVersions(const QJsonArray 
         for (qsizetype i = 0; i < video.size(); ++i) {
             if (video.at(i).isObject()) {
                 source.mediaStreams.append(mediaStream(
-                    video.at(i).toObject(), QStringLiteral("Video"), static_cast<int>(i)));
+                    video.at(i).toObject(), QStringLiteral("Video"),
+                    trackIndex(video.at(i).toObject(), static_cast<int>(i))));
             }
         }
         for (qsizetype i = 0; i < audio.size(); ++i) {
             if (audio.at(i).isObject()) {
                 const MediaStreamInfo stream = mediaStream(
-                    audio.at(i).toObject(), QStringLiteral("Audio"), static_cast<int>(i));
+                    audio.at(i).toObject(), QStringLiteral("Audio"),
+                    trackIndex(audio.at(i).toObject(), static_cast<int>(i)));
                 if (source.defaultAudioStreamIndex < 0 && stream.isDefault) {
                     source.defaultAudioStreamIndex = stream.index;
                 }
@@ -863,7 +873,8 @@ PlaybackInfoResponse SiloModelMapper::playbackInfoFromVersions(const QJsonArray 
             if (subtitles.at(i).isObject()) {
                 const QJsonObject subtitle = subtitles.at(i).toObject();
                 const MediaStreamInfo stream = mediaStream(
-                    subtitle, QStringLiteral("Subtitle"), static_cast<int>(i));
+                    subtitle, QStringLiteral("Subtitle"),
+                    trackIndex(subtitle, static_cast<int>(i)));
                 if (source.defaultSubtitleStreamIndex < 0 && stream.isDefault) {
                     source.defaultSubtitleStreamIndex = stream.index;
                 }

--- a/src/providers/silo/SiloModelMapper.h
+++ b/src/providers/silo/SiloModelMapper.h
@@ -14,6 +14,8 @@ class SiloModelMapper
 {
 public:
     static qint64 secondsToMilliseconds(double seconds);
+    static PlaybackInfoResponse playbackInfo(const QJsonObject &wireItem);
+    static PlaybackInfoResponse playbackInfoFromVersions(const QJsonArray &wireVersions);
 
     static ParsedItemsResult itemsResponse(const QByteArray &wireResponse,
                                            const QString &parentId);

--- a/src/providers/silo/SiloPlaybackProvider.cpp
+++ b/src/providers/silo/SiloPlaybackProvider.cpp
@@ -1,0 +1,524 @@
+#include "SiloPlaybackProvider.h"
+
+#include "providers/silo/SiloModelMapper.h"
+
+#include <QJsonArray>
+#include <QJsonValue>
+#include <QUrlQuery>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace {
+
+QString identity(const QJsonValue &value)
+{
+    if (value.isString()) {
+        return value.toString();
+    }
+    if (!value.isDouble()) {
+        return {};
+    }
+    const double number = value.toDouble();
+    constexpr double maxExact = 9007199254740991.0;
+    if (!std::isfinite(number) || std::trunc(number) != number || std::abs(number) > maxExact) {
+        return {};
+    }
+    return QString::number(static_cast<qint64>(number));
+}
+
+QString relativeOrAbsoluteUrl(const QUrl &serverUrl, const QString &wireUrl)
+{
+    const QString trimmed = wireUrl.trimmed();
+    if (trimmed.isEmpty()) {
+        return {};
+    }
+    QUrl url(trimmed);
+    if (!url.isRelative()) {
+        return trimmed;
+    }
+    if (!serverUrl.isValid()) {
+        return {};
+    }
+    QUrl origin = serverUrl;
+    origin.setPath(QStringLiteral("/"));
+    origin.setQuery(QString());
+    origin.setFragment(QString());
+    return origin.resolved(url).toString(QUrl::FullyEncoded);
+}
+
+Bloom::PlaybackMethod methodFor(const QString &wireMethod, QString *canonical = nullptr)
+{
+    const QString method = wireMethod.trimmed().toLower();
+    if (method == QStringLiteral("direct") || method == QStringLiteral("directplay")
+        || method == QStringLiteral("direct_play")) {
+        if (canonical) *canonical = QStringLiteral("DirectPlay");
+        return Bloom::PlaybackMethod::DirectPlay;
+    }
+    if (method == QStringLiteral("remux") || method == QStringLiteral("directstream")
+        || method == QStringLiteral("direct_stream")) {
+        if (canonical) *canonical = QStringLiteral("DirectStream");
+        return Bloom::PlaybackMethod::DirectStream;
+    }
+    if (method == QStringLiteral("hls") || method == QStringLiteral("transcode")
+        || method == QStringLiteral("transcoding")) {
+        if (canonical) *canonical = QStringLiteral("Transcode");
+        return Bloom::PlaybackMethod::Transcode;
+    }
+    return Bloom::PlaybackMethod::Unknown;
+}
+
+QString nativeTrackUrl(const QJsonObject &wire)
+{
+    for (const QString &key : {QStringLiteral("url"), QStringLiteral("external_url"),
+                               QStringLiteral("subtitle_url"), QStringLiteral("stream_url"),
+                               QStringLiteral("download_url"), QStringLiteral("downloaded_url")}) {
+        const QString value = wire.value(key).toString().trimmed();
+        if (!value.isEmpty()) {
+            return value;
+        }
+    }
+    return {};
+}
+QString nativeTrackUrl(const QVariantMap &stream)
+{
+    for (const QString &key : {QStringLiteral("externalUrl"), QStringLiteral("url"),
+                               QStringLiteral("external_url"), QStringLiteral("subtitleUrl"),
+                               QStringLiteral("subtitle_url"), QStringLiteral("streamUrl"),
+                               QStringLiteral("stream_url"), QStringLiteral("downloadUrl"),
+                               QStringLiteral("download_url")}) {
+        const QString value = stream.value(key).toString().trimmed();
+        if (!value.isEmpty()) {
+            return value;
+        }
+    }
+    return {};
+}
+
+
+Bloom::PlaybackTrack trackFromJson(const QJsonObject &wire, const QString &kind,
+                                   int fallbackIndex, const QUrl &serverUrl)
+{
+    Bloom::PlaybackTrack result;
+    const QString index = identity(wire.value(QStringLiteral("index")));
+    result.trackId = index.isEmpty() ? QString::number(fallbackIndex) : index;
+    result.kind = kind.toLower();
+    result.language = wire.value(QStringLiteral("language")).toString();
+    result.codec = wire.value(QStringLiteral("codec")).toString();
+    result.displayTitle = wire.value(QStringLiteral("title")).toString(
+        wire.value(QStringLiteral("embedded_title")).toString());
+    result.isDefault = wire.value(QStringLiteral("default")).toBool();
+    result.isForced = wire.value(QStringLiteral("forced")).toBool();
+    const QString wireUrl = nativeTrackUrl(wire);
+    result.isExternal = wire.value(QStringLiteral("external")).toBool()
+        || wire.value(QStringLiteral("downloaded")).toBool()
+        || !wireUrl.isEmpty()
+        || !wire.value(QStringLiteral("path")).toString().isEmpty();
+    result.isHearingImpaired = wire.value(QStringLiteral("hearing_impaired")).toBool();
+    if (result.kind == QStringLiteral("subtitle") && !wireUrl.isEmpty()) {
+        result.externalUrl = QUrl(relativeOrAbsoluteUrl(serverUrl, wireUrl));
+        if (!result.externalUrl.isValid() || result.externalUrl.isEmpty()) {
+            result.externalUrl = QUrl();
+        }
+    }
+    return result;
+}
+
+void appendTracks(const QJsonValue &value, const QString &kind, QList<Bloom::PlaybackTrack> &out,
+                  const QUrl &serverUrl)
+{
+    if (!value.isArray()) {
+        return;
+    }
+    const QJsonArray tracks = value.toArray();
+    for (qsizetype i = 0; i < tracks.size(); ++i) {
+        if (tracks.at(i).isObject()) {
+            out.append(trackFromJson(tracks.at(i).toObject(), kind, static_cast<int>(i), serverUrl));
+        }
+    }
+}
+
+void appendSubtitleUrls(const QJsonValue &value, Bloom::PlaybackDescriptor &descriptor,
+                        const QUrl &serverUrl)
+{
+    if (!value.isArray()) {
+        return;
+    }
+    const QJsonArray urls = value.toArray();
+    for (qsizetype i = 0; i < urls.size(); ++i) {
+        QString url;
+        int index = static_cast<int>(i);
+        QString language;
+        if (urls.at(i).isString()) {
+            url = urls.at(i).toString();
+        } else if (urls.at(i).isObject()) {
+            const QJsonObject object = urls.at(i).toObject();
+            url = object.value(QStringLiteral("url")).toString(
+                object.value(QStringLiteral("stream_url")).toString(
+                    object.value(QStringLiteral("subtitle_url")).toString()));
+            const QString wireIndex = identity(object.value(QStringLiteral("index")));
+            if (!wireIndex.isEmpty()) {
+                bool ok = false;
+                const int parsedIndex = wireIndex.toInt(&ok);
+                if (ok && parsedIndex >= 0) {
+                    index = parsedIndex;
+                }
+            }
+            language = object.value(QStringLiteral("language")).toString();
+        }
+        const QUrl resolvedUrl(relativeOrAbsoluteUrl(serverUrl, url));
+        if (!resolvedUrl.isValid() || resolvedUrl.isEmpty()) {
+            continue;
+        }
+
+        const QString trackId = QString::number(index);
+        auto existing = std::find_if(
+            descriptor.subtitleTracks.begin(), descriptor.subtitleTracks.end(),
+            [&trackId](const Bloom::PlaybackTrack &track) {
+                return track.trackId == trackId;
+            });
+        if (existing != descriptor.subtitleTracks.end()) {
+            existing->externalUrl = resolvedUrl;
+            existing->isExternal = true;
+            if (existing->language.isEmpty()) {
+                existing->language = language;
+            }
+            if (existing->displayTitle.isEmpty()) {
+                existing->displayTitle = language;
+            }
+            continue;
+        }
+
+        Bloom::PlaybackTrack track;
+        track.trackId = trackId;
+        track.kind = QStringLiteral("subtitle");
+        track.language = language;
+        track.isExternal = true;
+        track.externalUrl = resolvedUrl;
+        track.displayTitle = language;
+        descriptor.subtitleTracks.append(track);
+    }
+}
+QJsonObject capabilities()
+{
+    const QJsonArray video{QStringLiteral("h264"), QStringLiteral("hevc"), QStringLiteral("vp8"),
+                           QStringLiteral("vp9"), QStringLiteral("av1"), QStringLiteral("mpeg2video"),
+                           QStringLiteral("mpeg4"), QStringLiteral("vc1"), QStringLiteral("theora")};
+    const QJsonArray audio{QStringLiteral("aac"), QStringLiteral("ac3"), QStringLiteral("eac3"),
+                           QStringLiteral("dts"), QStringLiteral("truehd"), QStringLiteral("flac"),
+                           QStringLiteral("opus"), QStringLiteral("vorbis"), QStringLiteral("mp3"),
+                           QStringLiteral("alac")};
+    const QJsonArray containers{QStringLiteral("mp4"), QStringLiteral("mkv"), QStringLiteral("webm"),
+                                QStringLiteral("mov"), QStringLiteral("ts"), QStringLiteral("avi"),
+                                QStringLiteral("mpegts"), QStringLiteral("ogg"), QStringLiteral("flac")};
+    return {
+        {QStringLiteral("codecs_video"), video},
+        {QStringLiteral("codecs_audio"), audio},
+        {QStringLiteral("containers"), containers},
+        {QStringLiteral("max_resolution"), QStringLiteral("8k")},
+        {QStringLiteral("hdr"), true},
+        {QStringLiteral("audio_passthrough"),
+         QJsonObject{{QStringLiteral("passthrough_codecs"), audio},
+                     {QStringLiteral("spatializer_enabled"), false},
+                     {QStringLiteral("max_channels"), 8}}},
+        {QStringLiteral("supports_bitmap_subtitle_burn_in"), true}
+    };
+}
+
+void addNumeric(QJsonObject &object, const QString &key, const QVariant &value)
+{
+    bool ok = false;
+    const qlonglong number = value.toLongLong(&ok);
+    if (ok && number >= 0) {
+        object.insert(key, static_cast<double>(number));
+    }
+}
+
+Bloom::PlaybackDescriptor descriptorFromResponse(const PlaybackProviderContext &context,
+                                                 const Bloom::MediaRef &media,
+                                                 const QJsonObject &wire,
+                                                 const QVariantMap &source)
+{
+    const QString streamUrl = wire.value(QStringLiteral("stream_url")).toString(
+        wire.value(QStringLiteral("hls_url")).toString(
+        wire.value(QStringLiteral("transcode_url")).toString(
+        wire.value(QStringLiteral("url")).toString())));
+    const QString sessionId = identity(wire.value(QStringLiteral("session_id")));
+    const QString fileId = identity(wire.value(QStringLiteral("media_file_id")));
+    QString methodName;
+    const QString wireMethod = wire.value(QStringLiteral("play_method")).toString(
+        wire.value(QStringLiteral("method")).toString());
+    const Bloom::PlaybackMethod method = methodFor(wireMethod, &methodName);
+    if (sessionId.isEmpty() || fileId.isEmpty() || streamUrl.trimmed().isEmpty()
+        || method == Bloom::PlaybackMethod::Unknown) {
+        return {};
+    }
+    Bloom::PlaybackDescriptor descriptor;
+    descriptor.media = media;
+
+    descriptor.playbackSessionId = sessionId;
+    descriptor.mediaVersionId = fileId;
+    descriptor.stream.method = method;
+    descriptor.stream.url = QUrl(relativeOrAbsoluteUrl(context.serverUrl, streamUrl));
+    if (!descriptor.stream.url.isValid()) {
+        return {};
+    }
+    descriptor.stream.pinsAudioTrack = wire.value(QStringLiteral("audio_track_index")).isDouble();
+    descriptor.stream.pinsSubtitleTrack = wire.value(QStringLiteral("subtitle_track_index")).isDouble();
+    descriptor.stream.pinnedAudioTrackId = identity(wire.value(QStringLiteral("audio_track_index")));
+    descriptor.stream.pinnedSubtitleTrackId = identity(wire.value(QStringLiteral("subtitle_track_index")));
+
+    const QJsonObject info = wire.value(QStringLiteral("playback_info")).toObject();
+    QJsonValue duration = info.value(QStringLiteral("duration"));
+    if (!duration.isDouble()) {
+        duration = info.value(QStringLiteral("duration_seconds"));
+    }
+    if (!duration.isDouble()) {
+        duration = wire.value(QStringLiteral("duration_seconds"));
+    }
+    descriptor.durationMs = duration.isDouble()
+        ? SiloModelMapper::secondsToMilliseconds(duration.toDouble())
+        : source.value(QStringLiteral("durationMs")).toLongLong();
+    QJsonValue start = wire.value(QStringLiteral("position"));
+    if (!start.isDouble()) {
+        start = wire.value(QStringLiteral("start_position"));
+    }
+    if (!start.isDouble()) {
+        start = info.value(QStringLiteral("start_position"));
+    }
+    if (!start.isDouble()) {
+        start = info.value(QStringLiteral("start_position_seconds"));
+    }
+    if (!start.isDouble()) {
+        start = wire.value(QStringLiteral("start_position_seconds"));
+    }
+    descriptor.startPositionMs = start.isDouble()
+        ? SiloModelMapper::secondsToMilliseconds(start.toDouble()) : 0;
+    appendTracks(info.value(QStringLiteral("audio_tracks")), QStringLiteral("Audio"),
+                 descriptor.audioTracks, context.serverUrl);
+    appendTracks(info.value(QStringLiteral("subtitle_tracks")), QStringLiteral("Subtitle"),
+                 descriptor.subtitleTracks, context.serverUrl);
+    if (descriptor.audioTracks.isEmpty()) {
+        for (const QVariant &entry : source.value(QStringLiteral("audioTracks")).toList()) {
+            const QVariantMap track = entry.toMap();
+            Bloom::PlaybackTrack mapped;
+            mapped.trackId = QString::number(track.value(QStringLiteral("index"), -1).toInt());
+            mapped.kind = QStringLiteral("audio");
+            mapped.language = track.value(QStringLiteral("language")).toString();
+            mapped.codec = track.value(QStringLiteral("codec")).toString();
+            mapped.displayTitle = track.value(QStringLiteral("displayTitle")).toString();
+            mapped.isDefault = track.value(QStringLiteral("isDefault")).toBool();
+            descriptor.audioTracks.append(mapped);
+        }
+    }
+    appendSubtitleUrls(wire.value(QStringLiteral("subtitle_urls")).isArray()
+                           ? wire.value(QStringLiteral("subtitle_urls"))
+                           : wire.value(QStringLiteral("subtitles")),
+                       descriptor, context.serverUrl);
+    descriptor.reporting = {false, true, true, true};
+    if (!descriptor.audioTracks.isEmpty() && descriptor.stream.pinnedAudioTrackId.isEmpty()) {
+        descriptor.selectedAudioTrackId = descriptor.audioTracks.first().trackId;
+    } else {
+        descriptor.selectedAudioTrackId = descriptor.stream.pinnedAudioTrackId;
+    }
+    descriptor.selectedSubtitleTrackId = descriptor.stream.pinnedSubtitleTrackId;
+    return descriptor;
+}
+
+} // namespace
+
+Bloom::PlaybackDescriptor SiloPlaybackProvider::createDescriptor(
+    const PlaybackProviderContext &context, const Bloom::MediaRef &media,
+    const QVariantMap &providerSource, int selectedAudioTrack, int selectedSubtitleTrack,
+    qint64 startPositionMs, const QString &playbackSessionId) const
+{
+    Bloom::PlaybackDescriptor descriptor;
+    descriptor.media = media;
+    descriptor.mediaVersionId = providerSource.value(QStringLiteral("fileId"),
+                                                     providerSource.value(QStringLiteral("id"))).toString();
+    descriptor.playbackSessionId = playbackSessionId;
+    descriptor.durationMs = qMax<qint64>(0, providerSource.value(QStringLiteral("durationMs")).toLongLong());
+    descriptor.startPositionMs = qMax<qint64>(0, startPositionMs);
+    QString selectedMethod;
+    descriptor.stream.method = methodFor(
+        providerSource.value(QStringLiteral("playMethod")).toString(), &selectedMethod);
+    if (descriptor.stream.method == Bloom::PlaybackMethod::Unknown) {
+        descriptor.stream.method = Bloom::PlaybackMethod::DirectPlay;
+    }
+    const QString url = providerSource.value(QStringLiteral("streamUrl"),
+                                              providerSource.value(QStringLiteral("directStreamUrl"),
+                                              providerSource.value(QStringLiteral("transcodingUrl")))).toString();
+    descriptor.selectedAudioTrackId = selectedAudioTrack >= 0 ? QString::number(selectedAudioTrack) : QString();
+    descriptor.selectedSubtitleTrackId = selectedSubtitleTrack >= 0 ? QString::number(selectedSubtitleTrack) : QString();
+    for (const QVariant &entry : providerSource.value(QStringLiteral("mediaStreams")).toList()) {
+        const QVariantMap stream = entry.toMap();
+        Bloom::PlaybackTrack track;
+        track.trackId = QString::number(stream.value(QStringLiteral("index"), -1).toInt());
+        track.kind = stream.value(QStringLiteral("type")).toString().toLower();
+        track.language = stream.value(QStringLiteral("language")).toString();
+        track.codec = stream.value(QStringLiteral("codec")).toString();
+        track.displayTitle = stream.value(QStringLiteral("displayTitle")).toString();
+        track.isDefault = stream.value(QStringLiteral("isDefault")).toBool();
+        track.isForced = stream.value(QStringLiteral("isForced")).toBool();
+        const QString wireTrackUrl = nativeTrackUrl(stream);
+        track.isExternal = stream.value(QStringLiteral("isExternal")).toBool()
+            || !wireTrackUrl.isEmpty();
+        if (track.kind == QStringLiteral("subtitle") && !wireTrackUrl.isEmpty()) {
+            track.externalUrl = QUrl(relativeOrAbsoluteUrl(context.serverUrl, wireTrackUrl));
+            if (!track.externalUrl.isValid() || track.externalUrl.isEmpty()) {
+                track.externalUrl = QUrl();
+            }
+        }
+        if (track.kind == QStringLiteral("audio")) {
+            descriptor.audioTracks.append(track);
+        } else if (track.kind == QStringLiteral("subtitle")) {
+            descriptor.subtitleTracks.append(track);
+        }
+    }
+    descriptor.stream.pinsAudioTrack = selectedAudioTrack >= 0;
+    descriptor.stream.pinsSubtitleTrack = selectedSubtitleTrack >= 0;
+    descriptor.stream.pinnedAudioTrackId = descriptor.selectedAudioTrackId;
+    descriptor.stream.pinnedSubtitleTrackId = descriptor.selectedSubtitleTrackId;
+    descriptor.reporting = {false, true, true, true};
+    return descriptor;
+}
+
+QUrl SiloPlaybackProvider::createTrickplayTileUrl(const PlaybackProviderContext &, const QString &, int, int) const
+{
+    return {};
+}
+
+PlaybackInfoRequest SiloPlaybackProvider::createPlaybackInfoRequest(
+    const PlaybackProviderContext &, const Bloom::MediaRef &media, const QVariantMap &) const
+{
+    PlaybackInfoRequest request;
+    if (!media.itemId.isEmpty()) {
+        request.endpoint = QStringLiteral("/api/v1/catalog/items/%1")
+                               .arg(QString::fromLatin1(QUrl::toPercentEncoding(media.itemId)));
+    }
+    return request;
+}
+
+PlaybackInfoParseResult SiloPlaybackProvider::parsePlaybackInfoResponse(
+    const PlaybackProviderContext &, const Bloom::MediaRef &, const QJsonObject &wireResponse,
+    const QVariantMap &) const
+{
+    PlaybackInfoParseResult result;
+    result.response = SiloModelMapper::playbackInfo(wireResponse);
+    result.valid = !result.response.mediaSources.isEmpty();
+    if (!result.valid) {
+        result.error = QStringLiteral("Silo playback info did not contain media files");
+    }
+    return result;
+}
+
+PlaybackStartRequest SiloPlaybackProvider::createPlaybackStartRequest(
+    const PlaybackProviderContext &context, const Bloom::MediaRef &, const QVariantMap &source,
+    int selectedAudioTrack, int selectedSubtitleTrack, qint64 startPositionMs) const
+{
+    PlaybackStartRequest request;
+    request.endpoint = QStringLiteral("/api/v1/playback/start");
+    addNumeric(request.body, QStringLiteral("file_id"), source.value(
+        QStringLiteral("fileId"), source.value(QStringLiteral("id"),
+        source.value(QStringLiteral("mediaVersionId"), source.value(QStringLiteral("file_id"))))));
+    if (!request.body.contains(QStringLiteral("file_id"))) {
+        request.endpoint.clear();
+        return request;
+    }
+    request.body.insert(QStringLiteral("profile_id"), context.profileId);
+    request.body.insert(QStringLiteral("start_position"),
+                        qMax<qint64>(0, startPositionMs) / 1000.0);
+    if (selectedAudioTrack >= 0) {
+        request.body.insert(QStringLiteral("audio_track_index"), selectedAudioTrack);
+    }
+    Q_UNUSED(selectedSubtitleTrack)
+    const QJsonObject caps = capabilities();
+    for (auto it = caps.constBegin(); it != caps.constEnd(); ++it) {
+        request.body.insert(it.key(), it.value());
+    }
+    return request;
+}
+
+PlaybackStartParseResult SiloPlaybackProvider::parsePlaybackStartResponse(
+    const PlaybackProviderContext &context, const Bloom::MediaRef &media,
+    const QJsonObject &wireResponse, const QVariantMap &source) const
+{
+    PlaybackStartParseResult result;
+    result.descriptor = descriptorFromResponse(context, media, wireResponse, source);
+    result.valid = result.descriptor.isValid();
+    if (!result.valid) {
+        result.error = QStringLiteral("Malformed Silo playback start response");
+    }
+    return result;
+}
+
+PlaybackAudioSwitchRequest SiloPlaybackProvider::createAudioSwitchRequest(
+    const PlaybackProviderContext &, const QString &sessionId, int audioTrackIndex,
+    qint64 positionMs) const
+{
+    PlaybackAudioSwitchRequest request;
+    if (sessionId.isEmpty() || audioTrackIndex < 0) {
+        return request;
+    }
+    request.endpoint = QStringLiteral("/api/v1/playback/%1/audio")
+                           .arg(QString::fromLatin1(QUrl::toPercentEncoding(sessionId)));
+    request.body.insert(QStringLiteral("audio_track_index"), audioTrackIndex);
+    request.body.insert(QStringLiteral("position"), qMax<qint64>(0, positionMs) / 1000.0);
+    return request;
+}
+
+PlaybackAudioSwitchParseResult SiloPlaybackProvider::parseAudioSwitchResponse(
+    const PlaybackProviderContext &context, const QJsonObject &wireResponse) const
+{
+    PlaybackAudioSwitchParseResult result;
+    const QString url = wireResponse.value(QStringLiteral("reload_url")).toString(
+        wireResponse.value(QStringLiteral("stream_url")).toString());
+    const QString resolved = relativeOrAbsoluteUrl(context.serverUrl, url);
+    if (resolved.isEmpty()) {
+        result.error = QStringLiteral("Malformed Silo audio switch response");
+        return result;
+    }
+    result.reloadUrl = QUrl(resolved);
+    result.valid = result.reloadUrl.isValid();
+    return result;
+}
+
+PlaybackRecoveryRequest SiloPlaybackProvider::createPlaybackRecoveryRequest(
+    const PlaybackProviderContext &context, const Bloom::MediaRef &media,
+    const QVariantMap &source, qint64 startPositionMs) const
+{
+    const PlaybackStartRequest start = createPlaybackStartRequest(context, media, source, -1, -1, startPositionMs);
+    PlaybackRecoveryRequest request;
+    request.endpoint = start.endpoint;
+    request.body = start.body;
+    return request;
+}
+
+PlaybackStartParseResult SiloPlaybackProvider::parsePlaybackRecoveryResponse(
+    const PlaybackProviderContext &context, const Bloom::MediaRef &media,
+    const QJsonObject &wireResponse, const QVariantMap &source) const
+{
+    return parsePlaybackStartResponse(context, media, wireResponse, source);
+}
+
+PlaybackReportRequest SiloPlaybackProvider::createReportRequest(const PlaybackReport &report) const
+{
+    PlaybackReportRequest request;
+    if (report.event == PlaybackReportEvent::Start || report.playbackSessionId.isEmpty()) {
+        return request;
+    }
+    const QString session = QString::fromLatin1(QUrl::toPercentEncoding(report.playbackSessionId));
+    request.endpoint = QStringLiteral("/api/v1/playback/%1").arg(session);
+    if (report.event == PlaybackReportEvent::Stop) {
+        request.method = QStringLiteral("DELETE");
+        request.deferSessionExpiry = false;
+        return request;
+    }
+    request.endpoint += QStringLiteral("/progress");
+    request.method = QStringLiteral("POST");
+    request.body.insert(QStringLiteral("position"), qMax<qint64>(0, report.positionMs) / 1000.0);
+    request.body.insert(QStringLiteral("is_paused"),
+                        report.event == PlaybackReportEvent::Pause || report.isPaused);
+    return request;
+}

--- a/src/providers/silo/SiloPlaybackProvider.cpp
+++ b/src/providers/silo/SiloPlaybackProvider.cpp
@@ -3,6 +3,8 @@
 #include "providers/silo/SiloModelMapper.h"
 
 #include <QJsonArray>
+#include <QSet>
+
 #include <QJsonValue>
 #include <QUrlQuery>
 
@@ -28,24 +30,40 @@ QString identity(const QJsonValue &value)
     return QString::number(static_cast<qint64>(number));
 }
 
+bool isHttpUrl(const QUrl &url)
+{
+    if (!url.isValid() || url.isEmpty()) {
+        return false;
+    }
+    const QString scheme = url.scheme().toLower();
+    return (scheme == QStringLiteral("http") || scheme == QStringLiteral("https"))
+        && !url.host().isEmpty();
+}
+
 QString relativeOrAbsoluteUrl(const QUrl &serverUrl, const QString &wireUrl)
 {
     const QString trimmed = wireUrl.trimmed();
     if (trimmed.isEmpty()) {
         return {};
     }
-    QUrl url(trimmed);
-    if (!url.isRelative()) {
-        return trimmed;
+    const QUrl url(trimmed);
+    QUrl resolved;
+    if (url.isRelative()) {
+        if (!isHttpUrl(serverUrl)) {
+            return {};
+        }
+        QUrl origin = serverUrl;
+        origin.setPath(QStringLiteral("/"));
+        origin.setQuery(QString());
+        origin.setFragment(QString());
+        resolved = origin.resolved(url);
+    } else {
+        resolved = url;
     }
-    if (!serverUrl.isValid()) {
+    if (!isHttpUrl(resolved)) {
         return {};
     }
-    QUrl origin = serverUrl;
-    origin.setPath(QStringLiteral("/"));
-    origin.setQuery(QString());
-    origin.setFragment(QString());
-    return origin.resolved(url).toString(QUrl::FullyEncoded);
+    return resolved.toString(QUrl::FullyEncoded);
 }
 
 Bloom::PlaybackMethod methodFor(const QString &wireMethod, QString *canonical = nullptr)
@@ -118,8 +136,9 @@ Bloom::PlaybackTrack trackFromJson(const QJsonObject &wire, const QString &kind,
     result.isHearingImpaired = wire.value(QStringLiteral("hearing_impaired")).toBool();
     if (result.kind == QStringLiteral("subtitle") && !wireUrl.isEmpty()) {
         result.externalUrl = QUrl(relativeOrAbsoluteUrl(serverUrl, wireUrl));
-        if (!result.externalUrl.isValid() || result.externalUrl.isEmpty()) {
+        if (!isHttpUrl(result.externalUrl)) {
             result.externalUrl = QUrl();
+            result.isExternal = false;
         }
     }
     return result;
@@ -139,40 +158,46 @@ void appendTracks(const QJsonValue &value, const QString &kind, QList<Bloom::Pla
     }
 }
 
-void appendSubtitleUrls(const QJsonValue &value, Bloom::PlaybackDescriptor &descriptor,
-                        const QUrl &serverUrl)
+bool subtitleIndex(const QJsonValue &value, QString *result)
 {
-    if (!value.isArray()) {
+    if (result == nullptr) {
+        return false;
+    }
+    const QString wireIndex = identity(value);
+    if (wireIndex.isEmpty()) {
+        return false;
+    }
+    bool ok = false;
+    const qlonglong parsed = wireIndex.toLongLong(&ok);
+    if (!ok || parsed < 0 || parsed > std::numeric_limits<int>::max()) {
+        return false;
+    }
+    *result = QString::number(parsed);
+    return true;
+}
+
+void appendSubtitleUrl(const QString &url, const QString &language,
+                       const QString &explicitTrackId, Bloom::PlaybackDescriptor &descriptor,
+                       const QUrl &serverUrl, QSet<QString> &usedTrackIds, int *nextSyntheticId)
+{
+    const QUrl resolvedUrl(relativeOrAbsoluteUrl(serverUrl, url));
+    if (!isHttpUrl(resolvedUrl)) {
         return;
     }
-    const QJsonArray urls = value.toArray();
-    for (qsizetype i = 0; i < urls.size(); ++i) {
-        QString url;
-        int index = static_cast<int>(i);
-        QString language;
-        if (urls.at(i).isString()) {
-            url = urls.at(i).toString();
-        } else if (urls.at(i).isObject()) {
-            const QJsonObject object = urls.at(i).toObject();
-            url = object.value(QStringLiteral("url")).toString(
-                object.value(QStringLiteral("stream_url")).toString(
-                    object.value(QStringLiteral("subtitle_url")).toString()));
-            const QString wireIndex = identity(object.value(QStringLiteral("index")));
-            if (!wireIndex.isEmpty()) {
-                bool ok = false;
-                const int parsedIndex = wireIndex.toInt(&ok);
-                if (ok && parsedIndex >= 0) {
-                    index = parsedIndex;
-                }
-            }
-            language = object.value(QStringLiteral("language")).toString();
-        }
-        const QUrl resolvedUrl(relativeOrAbsoluteUrl(serverUrl, url));
-        if (!resolvedUrl.isValid() || resolvedUrl.isEmpty()) {
-            continue;
-        }
 
-        const QString trackId = QString::number(index);
+    QString trackId = explicitTrackId;
+    if (trackId.isEmpty()) {
+        if (nextSyntheticId == nullptr) {
+            return;
+        }
+        while (usedTrackIds.contains(QString::number(*nextSyntheticId))) {
+            --*nextSyntheticId;
+        }
+        trackId = QString::number(*nextSyntheticId);
+        --*nextSyntheticId;
+    }
+
+    if (!explicitTrackId.isEmpty()) {
         auto existing = std::find_if(
             descriptor.subtitleTracks.begin(), descriptor.subtitleTracks.end(),
             [&trackId](const Bloom::PlaybackTrack &track) {
@@ -187,17 +212,76 @@ void appendSubtitleUrls(const QJsonValue &value, Bloom::PlaybackDescriptor &desc
             if (existing->displayTitle.isEmpty()) {
                 existing->displayTitle = language;
             }
-            continue;
+            usedTrackIds.insert(trackId);
+            return;
         }
+    }
 
-        Bloom::PlaybackTrack track;
-        track.trackId = trackId;
-        track.kind = QStringLiteral("subtitle");
-        track.language = language;
-        track.isExternal = true;
-        track.externalUrl = resolvedUrl;
-        track.displayTitle = language;
-        descriptor.subtitleTracks.append(track);
+    Bloom::PlaybackTrack track;
+    track.trackId = trackId;
+    track.kind = QStringLiteral("subtitle");
+    track.language = language;
+    track.isExternal = true;
+    track.externalUrl = resolvedUrl;
+    track.displayTitle = language;
+    descriptor.subtitleTracks.append(track);
+    usedTrackIds.insert(trackId);
+}
+
+void appendSubtitleUrls(const QJsonValue &value, Bloom::PlaybackDescriptor &descriptor,
+                        const QUrl &serverUrl)
+{
+    if (!value.isArray() && !value.isObject()) {
+        return;
+    }
+
+    QSet<QString> usedTrackIds;
+    for (const Bloom::PlaybackTrack &track : descriptor.subtitleTracks) {
+        usedTrackIds.insert(track.trackId);
+    }
+    int nextSyntheticId = -1000;
+
+    const auto appendValue = [&descriptor, &serverUrl, &usedTrackIds, &nextSyntheticId](
+                                 const QJsonValue &entry,
+                                                const QString &fallbackIndex) {
+        QString explicitTrackId;
+        QString url;
+        QString language;
+        if (entry.isString()) {
+            url = entry.toString();
+        } else if (entry.isObject()) {
+            const QJsonObject object = entry.toObject();
+            url = object.value(QStringLiteral("url")).toString(
+                object.value(QStringLiteral("stream_url")).toString(
+                    object.value(QStringLiteral("subtitle_url")).toString()));
+            subtitleIndex(object.value(QStringLiteral("index")), &explicitTrackId);
+            language = object.value(QStringLiteral("language")).toString();
+        } else {
+            return;
+        }
+        if (explicitTrackId.isEmpty() && !fallbackIndex.isEmpty()) {
+            subtitleIndex(QJsonValue(fallbackIndex), &explicitTrackId);
+        }
+        appendSubtitleUrl(url, language, explicitTrackId, descriptor, serverUrl,
+                          usedTrackIds, &nextSyntheticId);
+    };
+
+    if (value.isArray()) {
+        const QJsonArray urls = value.toArray();
+        for (const QJsonValue &entry : urls) {
+            appendValue(entry, {});
+        }
+    } else {
+        const QJsonObject urls = value.toObject();
+        if (urls.contains(QStringLiteral("url"))
+            || urls.contains(QStringLiteral("stream_url"))
+            || urls.contains(QStringLiteral("subtitle_url"))) {
+            appendValue(urls, {});
+            return;
+        }
+        for (auto it = urls.constBegin(); it != urls.constEnd(); ++it) {
+            appendValue(it.value(), it.key());
+        }
     }
 }
 QJsonObject capabilities()
@@ -261,13 +345,17 @@ Bloom::PlaybackDescriptor descriptorFromResponse(const PlaybackProviderContext &
     descriptor.mediaVersionId = fileId;
     descriptor.stream.method = method;
     descriptor.stream.url = QUrl(relativeOrAbsoluteUrl(context.serverUrl, streamUrl));
-    if (!descriptor.stream.url.isValid()) {
+    if (!isHttpUrl(descriptor.stream.url)) {
         return {};
     }
-    descriptor.stream.pinsAudioTrack = wire.value(QStringLiteral("audio_track_index")).isDouble();
-    descriptor.stream.pinsSubtitleTrack = wire.value(QStringLiteral("subtitle_track_index")).isDouble();
-    descriptor.stream.pinnedAudioTrackId = identity(wire.value(QStringLiteral("audio_track_index")));
-    descriptor.stream.pinnedSubtitleTrackId = identity(wire.value(QStringLiteral("subtitle_track_index")));
+    QString pinnedAudioTrackId;
+    QString pinnedSubtitleTrackId;
+    descriptor.stream.pinsAudioTrack = subtitleIndex(
+        wire.value(QStringLiteral("audio_track_index")), &pinnedAudioTrackId);
+    descriptor.stream.pinsSubtitleTrack = subtitleIndex(
+        wire.value(QStringLiteral("subtitle_track_index")), &pinnedSubtitleTrackId);
+    descriptor.stream.pinnedAudioTrackId = pinnedAudioTrackId;
+    descriptor.stream.pinnedSubtitleTrackId = pinnedSubtitleTrackId;
 
     const QJsonObject info = wire.value(QStringLiteral("playback_info")).toObject();
     QJsonValue duration = info.value(QStringLiteral("duration"));
@@ -312,15 +400,21 @@ Bloom::PlaybackDescriptor descriptorFromResponse(const PlaybackProviderContext &
             descriptor.audioTracks.append(mapped);
         }
     }
-    appendSubtitleUrls(wire.value(QStringLiteral("subtitle_urls")).isArray()
-                           ? wire.value(QStringLiteral("subtitle_urls"))
+    const QJsonValue subtitleUrls = wire.value(QStringLiteral("subtitle_urls"));
+    appendSubtitleUrls((subtitleUrls.isArray() || subtitleUrls.isObject())
+                           ? subtitleUrls
                            : wire.value(QStringLiteral("subtitles")),
                        descriptor, context.serverUrl);
     descriptor.reporting = {false, true, true, true};
-    if (!descriptor.audioTracks.isEmpty() && descriptor.stream.pinnedAudioTrackId.isEmpty()) {
-        descriptor.selectedAudioTrackId = descriptor.audioTracks.first().trackId;
-    } else {
+    if (!descriptor.stream.pinnedAudioTrackId.isEmpty()) {
         descriptor.selectedAudioTrackId = descriptor.stream.pinnedAudioTrackId;
+    } else {
+        const auto defaultAudio = std::find_if(
+            descriptor.audioTracks.cbegin(), descriptor.audioTracks.cend(),
+            [](const Bloom::PlaybackTrack &track) { return track.isDefault; });
+        descriptor.selectedAudioTrackId = defaultAudio != descriptor.audioTracks.cend()
+            ? defaultAudio->trackId
+            : (descriptor.audioTracks.isEmpty() ? QString() : descriptor.audioTracks.first().trackId);
     }
     descriptor.selectedSubtitleTrackId = descriptor.stream.pinnedSubtitleTrackId;
     return descriptor;
@@ -349,8 +443,14 @@ Bloom::PlaybackDescriptor SiloPlaybackProvider::createDescriptor(
     const QString url = providerSource.value(QStringLiteral("streamUrl"),
                                               providerSource.value(QStringLiteral("directStreamUrl"),
                                               providerSource.value(QStringLiteral("transcodingUrl")))).toString();
-    descriptor.selectedAudioTrackId = selectedAudioTrack >= 0 ? QString::number(selectedAudioTrack) : QString();
-    descriptor.selectedSubtitleTrackId = selectedSubtitleTrack >= 0 ? QString::number(selectedSubtitleTrack) : QString();
+    descriptor.stream.url = QUrl(relativeOrAbsoluteUrl(context.serverUrl, url));
+    if (!isHttpUrl(descriptor.stream.url)) {
+        return descriptor;
+    }
+    descriptor.selectedAudioTrackId = selectedAudioTrack >= 0
+        ? QString::number(selectedAudioTrack) : QString();
+    descriptor.selectedSubtitleTrackId = selectedSubtitleTrack >= 0
+        ? QString::number(selectedSubtitleTrack) : QString();
     for (const QVariant &entry : providerSource.value(QStringLiteral("mediaStreams")).toList()) {
         const QVariantMap stream = entry.toMap();
         Bloom::PlaybackTrack track;
@@ -366,8 +466,9 @@ Bloom::PlaybackDescriptor SiloPlaybackProvider::createDescriptor(
             || !wireTrackUrl.isEmpty();
         if (track.kind == QStringLiteral("subtitle") && !wireTrackUrl.isEmpty()) {
             track.externalUrl = QUrl(relativeOrAbsoluteUrl(context.serverUrl, wireTrackUrl));
-            if (!track.externalUrl.isValid() || track.externalUrl.isEmpty()) {
+            if (!isHttpUrl(track.externalUrl)) {
                 track.externalUrl = QUrl();
+                track.isExternal = false;
             }
         }
         if (track.kind == QStringLiteral("audio")) {
@@ -376,10 +477,20 @@ Bloom::PlaybackDescriptor SiloPlaybackProvider::createDescriptor(
             descriptor.subtitleTracks.append(track);
         }
     }
+    if (descriptor.selectedAudioTrackId.isEmpty()) {
+        const auto defaultAudio = std::find_if(
+            descriptor.audioTracks.cbegin(), descriptor.audioTracks.cend(),
+            [](const Bloom::PlaybackTrack &track) { return track.isDefault; });
+        descriptor.selectedAudioTrackId = defaultAudio != descriptor.audioTracks.cend()
+            ? defaultAudio->trackId
+            : (descriptor.audioTracks.isEmpty() ? QString() : descriptor.audioTracks.first().trackId);
+    }
     descriptor.stream.pinsAudioTrack = selectedAudioTrack >= 0;
     descriptor.stream.pinsSubtitleTrack = selectedSubtitleTrack >= 0;
-    descriptor.stream.pinnedAudioTrackId = descriptor.selectedAudioTrackId;
-    descriptor.stream.pinnedSubtitleTrackId = descriptor.selectedSubtitleTrackId;
+    descriptor.stream.pinnedAudioTrackId = selectedAudioTrack >= 0
+        ? descriptor.selectedAudioTrackId : QString();
+    descriptor.stream.pinnedSubtitleTrackId = selectedSubtitleTrack >= 0
+        ? descriptor.selectedSubtitleTrackId : QString();
     descriptor.reporting = {false, true, true, true};
     return descriptor;
 }
@@ -426,13 +537,14 @@ PlaybackStartRequest SiloPlaybackProvider::createPlaybackStartRequest(
         request.endpoint.clear();
         return request;
     }
-    request.body.insert(QStringLiteral("profile_id"), context.profileId);
     request.body.insert(QStringLiteral("start_position"),
                         qMax<qint64>(0, startPositionMs) / 1000.0);
     if (selectedAudioTrack >= 0) {
         request.body.insert(QStringLiteral("audio_track_index"), selectedAudioTrack);
     }
-    Q_UNUSED(selectedSubtitleTrack)
+    if (!context.profileId.isEmpty()) {
+        request.body.insert(QStringLiteral("profile_id"), context.profileId);
+    }
     const QJsonObject caps = capabilities();
     for (auto it = caps.constBegin(); it != caps.constEnd(); ++it) {
         request.body.insert(it.key(), it.value());
@@ -486,9 +598,10 @@ PlaybackAudioSwitchParseResult SiloPlaybackProvider::parseAudioSwitchResponse(
 
 PlaybackRecoveryRequest SiloPlaybackProvider::createPlaybackRecoveryRequest(
     const PlaybackProviderContext &context, const Bloom::MediaRef &media,
-    const QVariantMap &source, qint64 startPositionMs) const
+    const QVariantMap &source, int selectedAudioTrack, qint64 startPositionMs) const
 {
-    const PlaybackStartRequest start = createPlaybackStartRequest(context, media, source, -1, -1, startPositionMs);
+    const PlaybackStartRequest start = createPlaybackStartRequest(
+        context, media, source, selectedAudioTrack, -1, startPositionMs);
     PlaybackRecoveryRequest request;
     request.endpoint = start.endpoint;
     request.body = start.body;

--- a/src/providers/silo/SiloPlaybackProvider.cpp
+++ b/src/providers/silo/SiloPlaybackProvider.cpp
@@ -517,7 +517,7 @@ PlaybackReportRequest SiloPlaybackProvider::createReportRequest(const PlaybackRe
     }
     request.endpoint += QStringLiteral("/progress");
     request.method = QStringLiteral("POST");
-    request.body.insert(QStringLiteral("position"), qMax<qint64>(0, report.positionMs) / 1000.0);
+    request.body.insert(QStringLiteral("seconds"), qMax<qint64>(0, report.positionMs) / 1000.0);
     request.body.insert(QStringLiteral("is_paused"),
                         report.event == PlaybackReportEvent::Pause || report.isPaused);
     return request;

--- a/src/providers/silo/SiloPlaybackProvider.h
+++ b/src/providers/silo/SiloPlaybackProvider.h
@@ -61,6 +61,7 @@ public:
         const PlaybackProviderContext &context,
         const Bloom::MediaRef &media,
         const QVariantMap &providerSource,
+        int selectedAudioTrack,
         qint64 startPositionMs) const override;
 
     PlaybackStartParseResult parsePlaybackRecoveryResponse(

--- a/src/providers/silo/SiloPlaybackProvider.h
+++ b/src/providers/silo/SiloPlaybackProvider.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "providers/IPlaybackProvider.h"
+
+class SiloPlaybackProvider final : public IPlaybackProvider
+{
+public:
+    Bloom::PlaybackDescriptor createDescriptor(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QVariantMap &providerSource,
+        int selectedAudioTrack,
+        int selectedSubtitleTrack,
+        qint64 startPositionMs,
+        const QString &playbackSessionId = QString()) const override;
+
+    QUrl createTrickplayTileUrl(
+        const PlaybackProviderContext &context,
+        const QString &itemId,
+        int width,
+        int tileIndex) const override;
+
+    PlaybackReportRequest createReportRequest(const PlaybackReport &report) const override;
+
+    PlaybackInfoRequest createPlaybackInfoRequest(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QVariantMap &providerSource) const override;
+
+    PlaybackInfoParseResult parsePlaybackInfoResponse(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QJsonObject &wireResponse,
+        const QVariantMap &providerSource = {}) const override;
+
+    PlaybackStartRequest createPlaybackStartRequest(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QVariantMap &providerSource,
+        int selectedAudioTrack,
+        int selectedSubtitleTrack,
+        qint64 startPositionMs) const override;
+
+    PlaybackStartParseResult parsePlaybackStartResponse(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QJsonObject &wireResponse,
+        const QVariantMap &providerSource = {}) const override;
+
+    PlaybackAudioSwitchRequest createAudioSwitchRequest(
+        const PlaybackProviderContext &context,
+        const QString &playbackSessionId,
+        int audioTrackIndex,
+        qint64 positionMs) const override;
+
+    PlaybackAudioSwitchParseResult parseAudioSwitchResponse(
+        const PlaybackProviderContext &context,
+        const QJsonObject &wireResponse) const override;
+
+    PlaybackRecoveryRequest createPlaybackRecoveryRequest(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QVariantMap &providerSource,
+        qint64 startPositionMs) const override;
+
+    PlaybackStartParseResult parsePlaybackRecoveryResponse(
+        const PlaybackProviderContext &context,
+        const Bloom::MediaRef &media,
+        const QJsonObject &wireResponse,
+        const QVariantMap &providerSource = {}) const override;
+};

--- a/src/providers/silo/SiloProviderAdapter.h
+++ b/src/providers/silo/SiloProviderAdapter.h
@@ -200,6 +200,8 @@ private:
         capabilities |= ProviderCapability::Profiles;
         capabilities |= ProviderCapability::ProfilePin;
         capabilities |= ProviderCapability::AuthSessions;
+        capabilities |= ProviderCapability::Catalog;
+        capabilities |= ProviderCapability::NativeState;
         capabilities |= ProviderCapability::Playback;
         capabilities |= ProviderCapability::PlaybackReporting;
         capabilities |= ProviderCapability::MediaSegments;

--- a/src/providers/silo/SiloProviderAdapter.h
+++ b/src/providers/silo/SiloProviderAdapter.h
@@ -4,8 +4,8 @@
 #include "providers/silo/SiloAuthenticator.h"
 #include "providers/silo/SiloCatalogProvider.h"
 #include "providers/silo/SiloModelMapper.h"
+#include "providers/silo/SiloPlaybackProvider.h"
 #include "providers/silo/SiloRequestFactory.h"
-
 #include <QUrl>
 
 class SiloProviderAdapter final : public IProviderAdapter
@@ -17,14 +17,12 @@ public:
     const IProviderAuthenticator *authenticator() const override { return &m_authenticator; }
     const IProviderRequestFactory *requestFactory() const override { return &m_requestFactory; }
 
-    // Native playback is intentionally not advertised until the dedicated playback phase.
-    const IPlaybackProvider *playbackProvider() const override { return nullptr; }
+    const IPlaybackProvider *playbackProvider() const override { return &m_playbackProvider; }
     const ICatalogProvider *catalogProvider() const override { return &m_catalogProvider; }
 
     PlaybackInfoResponse mapPlaybackInfo(const QJsonObject &wirePlaybackInfo) const override
     {
-        Q_UNUSED(wirePlaybackInfo)
-        return {};
+        return SiloModelMapper::playbackInfo(wirePlaybackInfo);
     }
 
     ProviderItemsResponseParser itemsResponseParser() const override
@@ -130,8 +128,10 @@ public:
             return endpointWithId(QStringLiteral("/api/v1/markers/items/%1"),
                                   context.itemId);
         case ProviderRoute::PlaybackInfo:
+            return endpointWithId(QStringLiteral("/api/v1/catalog/items/%1"),
+                                  context.itemId);
         case ProviderRoute::PlaybackCapability:
-            return std::nullopt;
+            return QStringLiteral("/api/v1/playback/capability");
         }
         return std::nullopt;
     }
@@ -200,8 +200,8 @@ private:
         capabilities |= ProviderCapability::Profiles;
         capabilities |= ProviderCapability::ProfilePin;
         capabilities |= ProviderCapability::AuthSessions;
-        capabilities |= ProviderCapability::Catalog;
-        capabilities |= ProviderCapability::NativeState;
+        capabilities |= ProviderCapability::Playback;
+        capabilities |= ProviderCapability::PlaybackReporting;
         capabilities |= ProviderCapability::MediaSegments;
         return capabilities;
     }
@@ -216,7 +216,8 @@ private:
         return format.arg(QString::fromLatin1(QUrl::toPercentEncoding(normalized)));
     }
 
-    SiloAuthenticator m_authenticator;
     SiloCatalogProvider m_catalogProvider;
+    SiloAuthenticator m_authenticator;
+    SiloPlaybackProvider m_playbackProvider;
     SiloRequestFactory m_requestFactory;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,8 @@ set(TEST_PROVIDER_BOUNDARY_SOURCES
     ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinModelMapper.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinPlaybackProvider.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinRequestFactory.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloModelMapper.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloPlaybackProvider.cpp
 )
 
 set(TEST_CONFIG_SOURCES
@@ -284,6 +286,28 @@ target_link_libraries(SiloAuthenticationTest
 )
 
 add_test(NAME SiloAuthenticationTest COMMAND SiloAuthenticationTest)
+add_executable(SiloPlaybackProviderTest
+    SiloPlaybackProviderTest.cpp
+    ${CMAKE_SOURCE_DIR}/src/models/MediaModels.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloModelMapper.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloPlaybackProvider.cpp
+)
+
+target_include_directories(SiloPlaybackProviderTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+target_link_libraries(SiloPlaybackProviderTest
+    PRIVATE
+        Qt6::Core
+        Qt6::Network
+        Qt6::Test
+)
+
+add_test(NAME SiloPlaybackProviderTest COMMAND SiloPlaybackProviderTest)
+
 
 add_executable(ProviderCatalogTest
     ProviderCatalogTest.cpp

--- a/tests/PlayerControllerAutoplayContextTest.cpp
+++ b/tests/PlayerControllerAutoplayContextTest.cpp
@@ -285,6 +285,39 @@ public:
         return descriptor;
     }
 
+    void requestPlaybackDescriptor(const QString &itemId,
+                                   const QVariantMap &providerSource,
+                                   int selectedAudioTrack,
+                                   int selectedSubtitleTrack,
+                                   qint64 startPositionMs,
+                                   const QString &playbackSessionId,
+                                   const QString &requestContext) override
+    {
+        const Bloom::PlaybackDescriptor descriptor = createPlaybackDescriptor(
+            itemId, providerSource, selectedAudioTrack, selectedSubtitleTrack,
+            startPositionMs, playbackSessionId);
+        if (descriptor.stream.isValid()) {
+            emit playbackDescriptorLoadedForRequest(itemId, descriptor, requestContext);
+        } else {
+            emit playbackDescriptorFailedForRequest(itemId,
+                                                     QStringLiteral("invalid descriptor"),
+                                                     requestContext);
+        }
+    }
+
+    bool switchPlaybackAudio(const QString &playbackSessionId,
+                             int audioTrackIndex,
+                             qint64 positionMs,
+                             const QString &requestContext) override
+    {
+        Q_UNUSED(audioTrackIndex);
+        Q_UNUSED(positionMs);
+        emit playbackAudioSwitchedForRequest(playbackSessionId,
+                                             QUrl(QStringLiteral("https://example.invalid/reloaded")),
+                                             requestContext);
+        return true;
+    }
+
     void getPlaybackInfo(const QString &itemId) override
     {
         requestedPlaybackInfoItemIds.append(itemId);

--- a/tests/PlayerControllerAutoplayContextTest.cpp
+++ b/tests/PlayerControllerAutoplayContextTest.cpp
@@ -546,6 +546,9 @@ private slots:
     void runtimeTrackSelectionUsesCanonicalMapAndSubtitleNone();
     void runtimeSubtitleDelayAppliesAndPersists();
     void backendTrackSyncUsesReverseMap();
+    void descriptorPinnedTrackIdsDefaultToMinusOne();
+    void nativeAudioReloadRetainsTrackMapping();
+    void externalSubtitleSelectionReaddsUnresolvedTrack();
 
 private:
     QTemporaryDir m_configHome;
@@ -3709,6 +3712,128 @@ void PlayerControllerAutoplayContextTest::backendTrackSyncUsesReverseMap()
     QCOMPARE(preferences.subtitle.mode, TrackPreferenceMode::ExplicitStream);
     QCOMPARE(preferences.subtitle.streamIndex, 12);
 }
+
+void PlayerControllerAutoplayContextTest::descriptorPinnedTrackIdsDefaultToMinusOne()
+{
+    ConfigManager config;
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+
+    Bloom::PlaybackDescriptor descriptor;
+    descriptor.stream.url = QUrl(QStringLiteral("https://example.invalid/stream"));
+    descriptor.stream.method = Bloom::PlaybackMethod::DirectPlay;
+    QVariantMap segment;
+    controller.applyPlaybackDescriptorToSegment(segment, descriptor);
+    QCOMPARE(segment.value(QStringLiteral("pinnedAudioTrack")).toInt(), -1);
+    QCOMPARE(segment.value(QStringLiteral("pinnedSubtitleTrack")).toInt(), -1);
+
+    descriptor.stream.pinnedAudioTrackId = QStringLiteral("not-a-number");
+    descriptor.stream.pinnedSubtitleTrackId = QStringLiteral("also-invalid");
+    controller.applyPlaybackDescriptorToSegment(segment, descriptor);
+    controller.m_pendingAutoplayDescriptorContext =
+        QStringLiteral("autoplay|descriptor|item-1");
+    controller.m_pendingAutoplayDescriptorItemId = QStringLiteral("item-1");
+    controller.m_pendingAutoplayDescriptorAudioIndex = -1;
+    controller.m_pendingAutoplayDescriptorSubtitleIndex = -1;
+    controller.onPlaybackDescriptorLoadedForRequest(
+        QStringLiteral("item-1"),
+        descriptor,
+        controller.m_pendingAutoplayDescriptorContext);
+    QCOMPARE(controller.m_nextPinnedAudioTrack, -1);
+    QCOMPARE(controller.m_nextPinnedSubtitleTrack, -1);
+    QCOMPARE(segment.value(QStringLiteral("pinnedAudioTrack")).toInt(), -1);
+    QCOMPARE(segment.value(QStringLiteral("pinnedSubtitleTrack")).toInt(), -1);
+}
+
+void PlayerControllerAutoplayContextTest::nativeAudioReloadRetainsTrackMapping()
+{
+    ConfigManager config;
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    FakePlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+
+    controller.m_playbackState = PlayerController::Playing;
+    controller.m_playSessionId = QStringLiteral("session-1");
+    controller.m_pendingAudioSwitchContext = QStringLiteral("audio|attempt|9");
+    controller.m_selectedAudioTrack = 9;
+    controller.m_activeMediaSource = buildMediaSource({
+        QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 4}},
+        QVariantMap{{QStringLiteral("type"), QStringLiteral("Audio")}, {QStringLiteral("index"), 9}}
+    });
+    controller.updateTrackMappings(controller.m_activeMediaSource);
+
+    controller.onPlaybackAudioSwitchedForRequest(
+        QStringLiteral("session-1"),
+        QUrl(QStringLiteral("https://example.invalid/reloaded")),
+        QStringLiteral("audio|attempt|9"));
+    backend.emitAudioTrackId(2);
+
+    QCOMPARE(controller.selectedAudioTrack(), 9);
+    QCOMPARE(controller.m_mpvAudioTrack, 2);
+}
+
+void PlayerControllerAutoplayContextTest::externalSubtitleSelectionReaddsUnresolvedTrack()
+{
+    ConfigManager config;
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+    controller.m_playbackState = PlayerController::Playing;
+
+    controller.addExternalSubtitleTrackInternal(
+        QStringLiteral("https://example.invalid/subtitle.vtt"),
+        QStringLiteral("English"),
+        QStringLiteral("eng"),
+        -1000,
+        false);
+    QCOMPARE(controller.m_externalSubtitleTrackMap.value(-1000), -1);
+    backend.variantCommands.clear();
+
+    controller.setSelectedSubtitleTrack(-1000);
+
+    QVERIFY(backend.variantCommands.contains(QVariantList{
+        QStringLiteral("sub-add"),
+        QStringLiteral("https://example.invalid/subtitle.vtt"),
+        QStringLiteral("select"),
+        QStringLiteral("English"),
+        QStringLiteral("eng")
+    }));
+}
+
 
 QTEST_MAIN(PlayerControllerAutoplayContextTest)
 #include "PlayerControllerAutoplayContextTest.moc"

--- a/tests/PlayerControllerAutoplayContextTest.cpp
+++ b/tests/PlayerControllerAutoplayContextTest.cpp
@@ -296,6 +296,10 @@ public:
         const Bloom::PlaybackDescriptor descriptor = createPlaybackDescriptor(
             itemId, providerSource, selectedAudioTrack, selectedSubtitleTrack,
             startPositionMs, playbackSessionId);
+        requestedDescriptorContexts.append(requestContext);
+        if (deferDescriptorRequests) {
+            return;
+        }
         if (descriptor.stream.isValid()) {
             emit playbackDescriptorLoadedForRequest(itemId, descriptor, requestContext);
         } else {
@@ -380,6 +384,8 @@ public:
     QStringList requestedPlaybackInfoContexts;
     QStringList requestedAdditionalPartsItemIds;
     QStringList requestedAdditionalPartsContexts;
+    bool deferDescriptorRequests = false;
+    QStringList requestedDescriptorContexts;
     mutable QStringList requestedDescriptorItemIds;
     mutable QStringList requestedDescriptorMediaSourceIds;
     mutable QList<int> requestedDescriptorAudioIndexes;
@@ -486,15 +492,17 @@ private slots:
     void explicitPausedStopReportsPausedState();
     void explicitMultipartStopReportsActiveSegmentContext();
     void playbackEndedUpgradesQueuedStopFinalization();
-    void nextEpisodeNavigationKeepsAwaitingUntilQueuedDelivery();
-    void upNextIdleParkingInvalidatesQueuedDisplayRestore();
-    void deferredPostPlaybackDisplayRestoreCanBeReleased();
-    void nextEpisodeNavigationUsesPendingTrackContext();
-    void nextEpisodeIgnoresMismatchedSeries();
-    void nextEpisodeIgnoresMismatchedConnection();
     void playbackPrefetchIgnoresGenericNextEpisodeResponses();
     void autoplayPlaybackInfoErrorFallsBackToBasicPlayback();
     void autoplayToneMapStateSurvivesPlaybackInfoFallback();
+    void staleNativeAudioSwitchResponseIsIgnoredAfterNonNativeSelection();
+    void autoplayDescriptorWaitIsBoundedAndFallbackIsOneShot();
+    void nextEpisodeNavigationUsesPendingTrackContext();
+    void nextEpisodeNavigationKeepsAwaitingUntilQueuedDelivery();
+    void upNextIdleParkingInvalidatesQueuedDisplayRestore();
+    void deferredPostPlaybackDisplayRestoreCanBeReleased();
+    void nextEpisodeIgnoresMismatchedSeries();
+    void nextEpisodeIgnoresMismatchedConnection();
     void displayHdrPolicyDoesNotToggleWhenToneMappingToSdr();
     void dolbyVisionWithHdr10BaseLayerDoesNotForceToneMap();
     void autoplayPlaybackInfoUsesStoredSubtitlePreferenceWhenOverrideUnset();
@@ -1487,6 +1495,99 @@ void PlayerControllerAutoplayContextTest::autoplayToneMapStateSurvivesPlaybackIn
     QCOMPARE(controller.m_currentItemId, QStringLiteral("episode-dv"));
     QVERIFY(controller.m_contentIsHDR);
     QVERIFY(controller.m_contentShouldToneMapToSdr);
+}
+
+void PlayerControllerAutoplayContextTest::staleNativeAudioSwitchResponseIsIgnoredAfterNonNativeSelection()
+{
+    ConfigManager config;
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    FakePlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+    controller.m_playbackState = PlayerController::Playing;
+    controller.m_streamPinsAudioTrack = true;
+    controller.m_playSessionId = QStringLiteral("session-audio");
+    controller.m_selectedAudioTrack = 3;
+    controller.m_pendingAudioSwitchContext = QStringLiteral("audio|7|4");
+    controller.m_pendingAudioSwitchPreviousTrack = 3;
+
+    controller.setSelectedAudioTrack(-1);
+
+    QVERIFY(controller.m_pendingAudioSwitchContext.isEmpty());
+    QCOMPARE(controller.selectedAudioTrack(), -1);
+    QVERIFY(QMetaObject::invokeMethod(&controller,
+                                      "onPlaybackAudioSwitchFailedForRequest",
+                                      Qt::DirectConnection,
+                                      Q_ARG(QString, QStringLiteral("session-audio")),
+                                      Q_ARG(QString, QStringLiteral("stale failure")),
+                                      Q_ARG(QString, QStringLiteral("audio|7|4"))));
+    QCOMPARE(controller.selectedAudioTrack(), -1);
+}
+
+void PlayerControllerAutoplayContextTest::autoplayDescriptorWaitIsBoundedAndFallbackIsOneShot()
+{
+    ConfigManager config;
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    FakePlaybackService playbackService(&authService);
+    playbackService.deferDescriptorRequests = true;
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+    controller.m_pendingAutoplaySeriesId = QStringLiteral("series-bound");
+    controller.m_pendingAutoplaySeasonId = QStringLiteral("season-bound");
+    controller.m_pendingAutoplayEpisodeData = QVariantMap{
+        {QStringLiteral("itemId"), QStringLiteral("episode-bound")},
+        {QStringLiteral("seasonId"), QStringLiteral("season-bound")}
+    };
+    controller.m_waitingForAutoplayPlaybackInfo = true;
+
+    PlaybackInfoResponse playbackInfo;
+    playbackInfo.playSessionId = QStringLiteral("session-bound");
+    MediaSourceInfo mediaSource;
+    mediaSource.id = QStringLiteral("source-bound");
+    mediaSource.mediaStreams = {
+        MediaStreamInfo{.index = 1, .type = QStringLiteral("Audio")}
+    };
+    playbackInfo.mediaSources.append(mediaSource);
+
+    QVERIFY(QMetaObject::invokeMethod(&controller,
+                                      "onPlaybackInfoLoaded",
+                                      Qt::DirectConnection,
+                                      Q_ARG(QString, QStringLiteral("episode-bound")),
+                                      Q_ARG(PlaybackInfoResponse, playbackInfo)));
+    QVERIFY(controller.m_waitingForAutoplayPlaybackInfo);
+    QCOMPARE(playbackService.requestedDescriptorContexts.size(), 1);
+
+    QVERIFY(QMetaObject::invokeMethod(&controller,
+                                      "onAutoplayPlaybackInfoTimeout",
+                                      Qt::DirectConnection));
+    QVERIFY(controller.m_waitingForAutoplayPlaybackInfo);
+    QCOMPARE(playbackService.requestedDescriptorContexts.size(), 2);
+
+    QVERIFY(QMetaObject::invokeMethod(&controller,
+                                      "onAutoplayPlaybackInfoTimeout",
+                                      Qt::DirectConnection));
+    QVERIFY(!controller.m_waitingForAutoplayPlaybackInfo);
+    QCOMPARE(playbackService.requestedDescriptorContexts.size(), 2);
 }
 
 void PlayerControllerAutoplayContextTest::displayHdrPolicyDoesNotToggleWhenToneMappingToSdr()
@@ -3300,9 +3401,24 @@ void PlayerControllerAutoplayContextTest::multipartIntermediateEndIsIgnoredUntil
             {QStringLiteral("playSessionId"), QStringLiteral("session-2")},
             {QStringLiteral("mediaSource"), part2Source},
             {QStringLiteral("audioIndex"), 2},
-            {QStringLiteral("subtitleIndex"), -1},
+            {QStringLiteral("subtitleIndex"), -1000},
             {QStringLiteral("availableAudioTracks"), controller.buildAvailableTrackOptions(part2Source, QStringLiteral("Audio"))},
-            {QStringLiteral("availableSubtitleTracks"), controller.buildAvailableTrackOptions(part2Source, QStringLiteral("Subtitle"))},
+            {QStringLiteral("availableSubtitleTracks"), QVariantList{
+                QVariantMap{
+                    {QStringLiteral("index"), -1000},
+                    {QStringLiteral("displayTitle"), QStringLiteral("Part 2 selected")},
+                    {QStringLiteral("language"), QStringLiteral("eng")},
+                    {QStringLiteral("isExternal"), true},
+                    {QStringLiteral("externalUrl"), QStringLiteral("https://example.invalid/part-2-selected.vtt")}
+                },
+                QVariantMap{
+                    {QStringLiteral("index"), -1001},
+                    {QStringLiteral("displayTitle"), QStringLiteral("Part 2 alternate")},
+                    {QStringLiteral("language"), QStringLiteral("fra")},
+                    {QStringLiteral("isExternal"), true},
+                    {QStringLiteral("externalUrl"), QStringLiteral("https://example.invalid/part-2-alternate.vtt")}
+                }
+            }},
             {QStringLiteral("durationMs"), 60000LL},
             {QStringLiteral("url"), QStringLiteral("https://example.invalid/part-2")}
         }
@@ -3321,6 +3437,22 @@ void PlayerControllerAutoplayContextTest::multipartIntermediateEndIsIgnoredUntil
     QCOMPARE(controller.m_mediaSourceId, QStringLiteral("part-2-source"));
     QCOMPARE(controller.m_playSessionId, QStringLiteral("session-2"));
     QCOMPARE(controller.activePlaybackSegmentItemId(), QStringLiteral("part-2"));
+    QCOMPARE(controller.m_externalSubtitleTrackMap.size(), 2);
+    QVERIFY(controller.m_externalSubtitleTrackMap.contains(-1000));
+    QVERIFY(controller.m_externalSubtitleTrackMap.contains(-1001));
+    QVERIFY(controller.m_pendingExternalSubtitleTracks.isEmpty());
+    QCOMPARE(backend.variantCommands.size(), 2);
+    QCOMPARE(backend.variantCommands.at(0).at(0).toString(), QStringLiteral("sub-add"));
+    QCOMPARE(backend.variantCommands.at(0).at(1).toString(),
+             QStringLiteral("https://example.invalid/part-2-alternate.vtt"));
+    QCOMPARE(backend.variantCommands.at(0).at(2).toString(), QStringLiteral("auto"));
+    QCOMPARE(backend.variantCommands.at(1).at(1).toString(),
+             QStringLiteral("https://example.invalid/part-2-selected.vtt"));
+    QCOMPARE(backend.variantCommands.at(1).at(2).toString(), QStringLiteral("select"));
+
+    // Re-emitting the same playlist position must not add duplicate subtitle tracks.
+    controller.onPlaylistPositionChanged(1);
+    QCOMPARE(backend.variantCommands.size(), 2);
 }
 
 void PlayerControllerAutoplayContextTest::versionAffinityPrefersMatchingParentPath()

--- a/tests/ProviderCatalogTest.cpp
+++ b/tests/ProviderCatalogTest.cpp
@@ -23,6 +23,7 @@ private slots:
     void jellyfinMutationsAndPaginationRemainCompatible();
     void siloTrackIndicesAndMultipartFallbackStayContiguous();
     void siloCanonicalIdentityVersionsMultipartAndStateUseMilliseconds();
+    void siloPlaybackFallbacksAndExternalSubtitleMetadata();
     void canonicalArtworkAndPlaybackChapterMetadataRemainProviderNeutral();
     void siloEpisodeParentAndBoundedTimes();
     void siloNumericSeasonRoutesAndEnvelopeOperation();
@@ -372,6 +373,98 @@ void ProviderCatalogTest::siloCanonicalIdentityVersionsMultipartAndStateUseMilli
     QCOMPARE(state.value(QStringLiteral("durationMs")).toLongLong(), 123456);
     QVERIFY(state.value(QStringLiteral("watched")).toBool());
 }
+
+void ProviderCatalogTest::siloPlaybackFallbacksAndExternalSubtitleMetadata()
+{
+    const QJsonObject version{
+        {QStringLiteral("file_id"), QStringLiteral("file-subtitles")},
+        {QStringLiteral("audio_tracks"), QJsonArray{
+             QJsonObject{{QStringLiteral("url"), QStringLiteral("https://audio.invalid")}}
+         }},
+        {QStringLiteral("subtitle_tracks"), QJsonArray{}},
+        {QStringLiteral("subtitles"), QJsonArray{
+             QJsonObject{
+                 {QStringLiteral("language"), QStringLiteral("eng")},
+                 {QStringLiteral("downloaded_url"),
+                  QStringLiteral("https://subtitles.invalid/downloaded.vtt")}
+             },
+             QJsonObject{
+                 {QStringLiteral("language"), QStringLiteral("deu")},
+                 {QStringLiteral("external_url"),
+                  QStringLiteral("https://subtitles.invalid/external.vtt")}
+             }
+         }},
+        {QStringLiteral("stream_url"), QString()},
+        {QStringLiteral("download_url"), QStringLiteral("https://media.invalid/download")}
+    };
+
+    const QVariantMap mappedVersion = SiloModelMapper::mediaVersion(
+        version, QStringLiteral("silo"), QStringLiteral("item"));
+    const QVariantList audioTracks = mappedVersion.value(QStringLiteral("audioTracks")).toList();
+    QVERIFY(!audioTracks.constFirst().toMap().contains(QStringLiteral("externalUrl")));
+    const QVariantList subtitleTracks =
+        mappedVersion.value(QStringLiteral("subtitleTracks")).toList();
+    QCOMPARE(subtitleTracks.size(), 2);
+    QCOMPARE(subtitleTracks.at(0).toMap().value(QStringLiteral("externalUrl")).toString(),
+             QStringLiteral("https://subtitles.invalid/downloaded.vtt"));
+    QCOMPARE(subtitleTracks.at(1).toMap().value(QStringLiteral("externalUrl")).toString(),
+             QStringLiteral("https://subtitles.invalid/external.vtt"));
+
+    const PlaybackInfoResponse nestedVersions = SiloModelMapper::playbackInfo(
+        QJsonObject{
+            {QStringLiteral("media_sources"), QJsonArray{}},
+            {QStringLiteral("playback_info"), QJsonObject{
+                 {QStringLiteral("versions"), QJsonArray{version}}
+             }}
+        });
+    QCOMPARE(nestedVersions.mediaSources.size(), 1);
+    QCOMPARE(nestedVersions.mediaSources.first().id, QStringLiteral("file-subtitles"));
+    QCOMPARE(nestedVersions.mediaSources.first().directStreamUrl,
+             QStringLiteral("https://media.invalid/download"));
+
+    const QJsonObject variantVersion{
+        {QStringLiteral("file_id"), QStringLiteral("file-variant")}
+    };
+    const QJsonArray variants{
+        QJsonObject{
+            {QStringLiteral("variant_id"), QStringLiteral("variant")},
+            {QStringLiteral("parts"), QJsonArray{
+                 QJsonObject{
+                     {QStringLiteral("versions"), QJsonArray{variantVersion}}
+                 }
+             }}
+        }
+    };
+    const PlaybackInfoResponse rootVariants = SiloModelMapper::playbackInfo(
+        QJsonObject{
+            {QStringLiteral("media_sources"), QJsonArray{}},
+            {QStringLiteral("playback_variants"), variants}
+        });
+    QCOMPARE(rootVariants.mediaSources.size(), 1);
+    QCOMPARE(rootVariants.mediaSources.first().id, QStringLiteral("file-variant"));
+
+    const PlaybackInfoResponse nestedVariants = SiloModelMapper::playbackInfo(
+        QJsonObject{
+            {QStringLiteral("media_sources"), QJsonArray{}},
+            {QStringLiteral("playback_info"), QJsonObject{
+                 {QStringLiteral("playback_variants"), variants}
+             }}
+        });
+    QCOMPARE(nestedVariants.mediaSources.size(), 1);
+    QCOMPARE(nestedVariants.mediaSources.first().id, QStringLiteral("file-variant"));
+
+    const QJsonObject fileVersion{
+        {QStringLiteral("file_id"), QStringLiteral("file-fallback")}
+    };
+    const PlaybackInfoResponse files = SiloModelMapper::playbackInfo(
+        QJsonObject{
+            {QStringLiteral("media_sources"), QJsonArray{}},
+            {QStringLiteral("files"), QJsonArray{fileVersion}}
+        });
+    QCOMPARE(files.mediaSources.size(), 1);
+    QCOMPARE(files.mediaSources.first().id, QStringLiteral("file-fallback"));
+}
+
 
 void ProviderCatalogTest::canonicalArtworkAndPlaybackChapterMetadataRemainProviderNeutral()
 {

--- a/tests/ProviderCatalogTest.cpp
+++ b/tests/ProviderCatalogTest.cpp
@@ -10,6 +10,7 @@
 #include "providers/ICatalogProvider.h"
 #include "providers/jellyfin/JellyfinProviderAdapter.h"
 #include "providers/silo/SiloModelMapper.h"
+#include "providers/silo/SiloProviderAdapter.h"
 #include "providers/silo/SiloCatalogProvider.h"
 
 class ProviderCatalogTest : public QObject
@@ -20,6 +21,7 @@ private slots:
     void jellyfinItemsRequestRetainsNativeContract();
     void jellyfinReservedIdentifiersAndLimitsRemainOpaque();
     void jellyfinMutationsAndPaginationRemainCompatible();
+    void siloTrackIndicesAndMultipartFallbackStayContiguous();
     void siloCanonicalIdentityVersionsMultipartAndStateUseMilliseconds();
     void canonicalArtworkAndPlaybackChapterMetadataRemainProviderNeutral();
     void siloEpisodeParentAndBoundedTimes();
@@ -177,6 +179,72 @@ void ProviderCatalogTest::jellyfinMutationsAndPaginationRemainCompatible()
              QStringLiteral("\"items-v3\""));
     QCOMPARE(response.snapshot.value(QStringLiteral("lastModified")).toString(),
              QStringLiteral("Fri, 07 Aug 2026 11:00:00 GMT"));
+}
+
+void ProviderCatalogTest::siloTrackIndicesAndMultipartFallbackStayContiguous()
+{
+    const QJsonObject version{
+        {QStringLiteral("file_id"), QStringLiteral("file-1")},
+        {QStringLiteral("audio_tracks"), QJsonArray{
+             QJsonValue(QStringLiteral("malformed")),
+             QJsonObject{{QStringLiteral("index"), 7},
+                          {QStringLiteral("language"), QStringLiteral("eng")}},
+             QJsonObject{{QStringLiteral("language"), QStringLiteral("deu")}}
+         }}
+    };
+    const QJsonObject secondVersion{
+        {QStringLiteral("file_id"), QStringLiteral("file-2")}
+    };
+    const QJsonObject item{
+        {QStringLiteral("content_id"), QStringLiteral("content-1")},
+        {QStringLiteral("type"), QStringLiteral("movie")},
+        {QStringLiteral("title"), QStringLiteral("Example")},
+        {QStringLiteral("versions"), QJsonArray{version}},
+        {QStringLiteral("playback_variants"), QJsonArray{
+             QJsonObject{
+                 {QStringLiteral("variant_id"), QStringLiteral("variant-1")},
+                 {QStringLiteral("part_count"), 2},
+                 {QStringLiteral("parts"), QJsonArray{
+                      QJsonValue(QStringLiteral("malformed")),
+                      QJsonObject{
+                          {QStringLiteral("versions"), QJsonArray{version}}
+                      },
+                      QJsonObject{
+                          {QStringLiteral("versions"), QJsonArray{secondVersion}}
+                      }
+                  }}
+             }
+         }}
+    };
+
+    const QVariantMap mapped = SiloModelMapper::mediaItem(
+        item, QStringLiteral("connection-silo"));
+    const QVariantList tracks = mapped.value(QStringLiteral("versions"))
+                                    .toList().constFirst().toMap()
+                                    .value(QStringLiteral("audioTracks")).toList();
+    QCOMPARE(tracks.size(), 2);
+    QCOMPARE(tracks.at(0).toMap().value(QStringLiteral("index")).toInt(), 7);
+    QCOMPARE(tracks.at(1).toMap().value(QStringLiteral("index")).toInt(), 2);
+
+    const QVariantList parts = mapped.value(QStringLiteral("playbackVariants"))
+                                   .toList().constFirst().toMap()
+                                   .value(QStringLiteral("parts")).toList();
+    QCOMPARE(parts.size(), 2);
+    QCOMPARE(parts.at(0).toMap().value(QStringLiteral("partIndex")).toInt(), 1);
+    QCOMPARE(parts.at(1).toMap().value(QStringLiteral("partIndex")).toInt(), 2);
+
+    const PlaybackInfoResponse playback = SiloModelMapper::playbackInfo(item);
+    QCOMPARE(playback.mediaSources.size(), 2);
+    const QList<MediaStreamInfo> streams = playback.mediaSources.first().mediaStreams;
+    QCOMPARE(streams.size(), 2);
+    QCOMPARE(streams.at(0).index, 7);
+    QCOMPARE(streams.at(1).index, 2);
+
+    SiloProviderAdapter adapter;
+    QVERIFY(adapter.supportsCapability(ProviderCapability::Catalog));
+    QVERIFY(adapter.supportsCapability(ProviderCapability::NativeState));
+    QVERIFY(adapter.supportsCapability(ProviderCapability::Playback));
+    QVERIFY(adapter.supportsCapability(ProviderCapability::PlaybackReporting));
 }
 
 void ProviderCatalogTest::siloCanonicalIdentityVersionsMultipartAndStateUseMilliseconds()

--- a/tests/SiloPlaybackProviderTest.cpp
+++ b/tests/SiloPlaybackProviderTest.cpp
@@ -18,6 +18,9 @@ private slots:
     void resolvesAudioSwitchUrlsAndRejectsMalformedResponses();
     void createsAudioSwitchRequestWithNativeRouteAndBody();
     void createsProgressAndStopReports();
+    void supportsSubtitleUrlObjectsAndSyntheticIndices();
+    void validatesHttpPlaybackUrlsAndDescriptorConstruction();
+    void omitsEmptyProfileAndPreservesRecoveryAudio();
 };
 
 namespace {
@@ -140,6 +143,8 @@ void SiloPlaybackProviderTest::parsesDirectRemuxAndHlsResponses()
     QCOMPARE(direct.descriptor.audioTracks.size(), 1);
     QCOMPARE(direct.descriptor.audioTracks.first().trackId, QStringLiteral("2"));
     QCOMPARE(direct.descriptor.selectedAudioTrackId, QStringLiteral("2"));
+    QVERIFY(!direct.descriptor.stream.pinsAudioTrack);
+    QVERIFY(direct.descriptor.stream.pinnedAudioTrackId.isEmpty());
     QCOMPARE(direct.descriptor.subtitleTracks.size(), 1);
     QCOMPARE(direct.descriptor.subtitleTracks.first().displayTitle, QStringLiteral("English CC"));
     QVERIFY(direct.descriptor.reporting.progress);
@@ -180,7 +185,7 @@ void SiloPlaybackProviderTest::parsesDirectRemuxAndHlsResponses()
     QCOMPARE(externalObject.language, QStringLiteral("fra"));
     const Bloom::PlaybackTrack &externalString = withExternal.descriptor.subtitleTracks.at(2);
     QVERIFY(externalString.isExternal);
-    QCOMPARE(externalString.trackId, QStringLiteral("1"));
+    QCOMPARE(externalString.trackId, QStringLiteral("-1000"));
 }
 
 void SiloPlaybackProviderTest::rejectsMalformedStartResponses()
@@ -225,7 +230,10 @@ void SiloPlaybackProviderTest::resolvesAudioSwitchUrlsAndRejectsMalformedRespons
         context(), QJsonObject{{QStringLiteral("stream_url"), signedAbsolute}});
     QVERIFY(absolute.valid);
     QCOMPARE(absolute.reloadUrl.toString(QUrl::FullyEncoded), signedAbsolute);
-
+    QVERIFY(!provider.parseAudioSwitchResponse(
+                  context(), QJsonObject{{QStringLiteral("reload_url"),
+                                          QStringLiteral("file:///tmp/reload.m3u8")}})
+                  .valid);
     QVERIFY(!provider.parseAudioSwitchResponse(context(), {}).valid);
     PlaybackProviderContext invalidContext = context();
     invalidContext.serverUrl = QUrl();
@@ -289,8 +297,94 @@ void SiloPlaybackProviderTest::createsProgressAndStopReports()
     QCOMPARE(stopRequest.endpoint, QStringLiteral("/api/v1/playback/session%2Fone%3Fx%3D2"));
     QVERIFY(stopRequest.body.isEmpty());
     QVERIFY(!stopRequest.deferSessionExpiry);
-
     QVERIFY(!provider.createReportRequest({}).isValid());
+}
+
+void SiloPlaybackProviderTest::supportsSubtitleUrlObjectsAndSyntheticIndices()
+{
+    SiloPlaybackProvider provider;
+    QJsonObject arrayResponse = playbackResponse(QStringLiteral("direct"),
+                                                 QStringLiteral("/stream.mkv"));
+    arrayResponse.insert(QStringLiteral("subtitle_urls"), QJsonArray{
+        QStringLiteral("/subs/without-index.vtt"),
+        QJsonObject{{QStringLiteral("index"), 3},
+                     {QStringLiteral("url"), QStringLiteral("/subs/explicit.vtt")}}});
+    const auto arrayResult = provider.parsePlaybackStartResponse(context(), media(), arrayResponse);
+    QVERIFY(arrayResult.valid);
+    QCOMPARE(arrayResult.descriptor.subtitleTracks.size(), 2);
+    QCOMPARE(arrayResult.descriptor.subtitleTracks.at(0).trackId, QStringLiteral("3"));
+    QCOMPARE(arrayResult.descriptor.subtitleTracks.at(0).externalUrl.toString(),
+             QStringLiteral("https://silo.example.test:8443/subs/explicit.vtt"));
+    QCOMPARE(arrayResult.descriptor.subtitleTracks.at(1).trackId, QStringLiteral("-1000"));
+
+    QJsonObject objectResponse = playbackResponse(QStringLiteral("direct"),
+                                                   QStringLiteral("/stream.mkv"));
+    objectResponse.insert(QStringLiteral("subtitle_urls"),
+                          QJsonObject{{QStringLiteral("8"),
+                                       QStringLiteral("/subs/object.vtt")}});
+    const auto objectResult = provider.parsePlaybackStartResponse(context(), media(), objectResponse);
+    QVERIFY(objectResult.valid);
+    QCOMPARE(objectResult.descriptor.subtitleTracks.size(), 2);
+    QCOMPARE(objectResult.descriptor.subtitleTracks.at(1).trackId, QStringLiteral("8"));
+    QVERIFY(objectResult.descriptor.subtitleTracks.at(1).isExternal);
+}
+
+void SiloPlaybackProviderTest::validatesHttpPlaybackUrlsAndDescriptorConstruction()
+{
+    SiloPlaybackProvider provider;
+    QJsonObject malicious = playbackResponse(QStringLiteral("direct"),
+                                             QStringLiteral("file:///tmp/movie.mkv"));
+    QVERIFY(!provider.parsePlaybackStartResponse(context(), media(), malicious).valid);
+
+    QJsonObject maliciousSubtitle = playbackResponse(QStringLiteral("direct"),
+                                                     QStringLiteral("/stream.mkv"));
+    maliciousSubtitle.insert(QStringLiteral("subtitle_urls"),
+                             QJsonArray{QStringLiteral("file:///tmp/subtitle.vtt")});
+    const auto subtitleResult =
+        provider.parsePlaybackStartResponse(context(), media(), maliciousSubtitle);
+    QVERIFY(subtitleResult.valid);
+    QCOMPARE(subtitleResult.descriptor.subtitleTracks.size(), 1);
+
+    const QVariantList streams{
+        QVariantMap{{QStringLiteral("index"), 2},
+                     {QStringLiteral("type"), QStringLiteral("Audio")},
+                     {QStringLiteral("language"), QStringLiteral("fra")}},
+        QVariantMap{{QStringLiteral("index"), 1},
+                     {QStringLiteral("type"), QStringLiteral("Audio")},
+                     {QStringLiteral("language"), QStringLiteral("eng")},
+                     {QStringLiteral("isDefault"), true}}};
+    const QVariantMap source{{QStringLiteral("fileId"), QStringLiteral("99")},
+                             {QStringLiteral("streamUrl"), QStringLiteral("/native.mkv")},
+                             {QStringLiteral("mediaStreams"), streams}};
+    const auto descriptor = provider.createDescriptor(context(), media(), source, -1, -1, 0);
+    QVERIFY(descriptor.isValid());
+    QCOMPARE(descriptor.stream.url.toString(QUrl::FullyEncoded),
+             QStringLiteral("https://silo.example.test:8443/native.mkv"));
+    QCOMPARE(descriptor.selectedAudioTrackId, QStringLiteral("1"));
+    QVERIFY(!descriptor.stream.pinsAudioTrack);
+    QVERIFY(descriptor.stream.pinnedAudioTrackId.isEmpty());
+
+    const QVariantMap invalidSource{{QStringLiteral("fileId"), QStringLiteral("99")},
+                                    {QStringLiteral("streamUrl"), QStringLiteral("javascript:alert(1)")}};
+    QVERIFY(!provider.createDescriptor(context(), media(), invalidSource, -1, -1, 0).isValid());
+}
+
+void SiloPlaybackProviderTest::omitsEmptyProfileAndPreservesRecoveryAudio()
+{
+    SiloPlaybackProvider provider;
+    PlaybackProviderContext noProfile = context();
+    noProfile.profileId.clear();
+    const QVariantMap source{{QStringLiteral("fileId"), QStringLiteral("99")}};
+    const PlaybackStartRequest start =
+        provider.createPlaybackStartRequest(noProfile, media(), source, -1, -1, 0);
+    QVERIFY(start.isValid());
+    QVERIFY(!start.body.contains(QStringLiteral("profile_id")));
+
+    const PlaybackRecoveryRequest recovery =
+        provider.createPlaybackRecoveryRequest(context(), media(), source, 7, 2501);
+    QVERIFY(recovery.isValid());
+    QCOMPARE(recovery.body.value(QStringLiteral("audio_track_index")).toInteger(), qint64(7));
+    QCOMPARE(recovery.body.value(QStringLiteral("start_position")).toDouble(), 2.501);
 }
 
 QTEST_MAIN(SiloPlaybackProviderTest)

--- a/tests/SiloPlaybackProviderTest.cpp
+++ b/tests/SiloPlaybackProviderTest.cpp
@@ -261,7 +261,8 @@ void SiloPlaybackProviderTest::createsProgressAndStopReports()
     QCOMPARE(progressRequest.method, QStringLiteral("POST"));
     QCOMPARE(progressRequest.endpoint,
              QStringLiteral("/api/v1/playback/session%2Fone%3Fx%3D2/progress"));
-    QCOMPARE(progressRequest.body.value(QStringLiteral("position")).toDouble(), 3.456);
+    QCOMPARE(progressRequest.body.value(QStringLiteral("seconds")).toDouble(), 3.456);
+    QVERIFY(!progressRequest.body.contains(QStringLiteral("position")));
     QCOMPARE(progressRequest.body.value(QStringLiteral("is_paused")).toBool(), false);
     QVERIFY(progressRequest.deferSessionExpiry);
 
@@ -269,6 +270,14 @@ void SiloPlaybackProviderTest::createsProgressAndStopReports()
     progress.isPaused = false;
     const PlaybackReportRequest pauseRequest = provider.createReportRequest(progress);
     QCOMPARE(pauseRequest.body.value(QStringLiteral("is_paused")).toBool(), true);
+    QCOMPARE(pauseRequest.body.value(QStringLiteral("seconds")).toDouble(), 3.456);
+    QVERIFY(!pauseRequest.body.contains(QStringLiteral("position")));
+
+    progress.event = PlaybackReportEvent::Resume;
+    const PlaybackReportRequest resumeRequest = provider.createReportRequest(progress);
+    QCOMPARE(resumeRequest.body.value(QStringLiteral("seconds")).toDouble(), 3.456);
+    QCOMPARE(resumeRequest.body.value(QStringLiteral("is_paused")).toBool(), false);
+    QVERIFY(!resumeRequest.body.contains(QStringLiteral("position")));
 
     progress.event = PlaybackReportEvent::Start;
     QVERIFY(!provider.createReportRequest(progress).isValid());

--- a/tests/SiloPlaybackProviderTest.cpp
+++ b/tests/SiloPlaybackProviderTest.cpp
@@ -1,0 +1,288 @@
+#include <QtTest/QtTest>
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QUrl>
+
+#include "providers/silo/SiloPlaybackProvider.h"
+
+class SiloPlaybackProviderTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void legacyStartRequestUsesEnvelopeAndCapabilities();
+    void startRequestAcceptsAlternateFileIdentifiers();
+    void parsesDirectRemuxAndHlsResponses();
+    void rejectsMalformedStartResponses();
+    void resolvesAudioSwitchUrlsAndRejectsMalformedResponses();
+    void createsAudioSwitchRequestWithNativeRouteAndBody();
+    void createsProgressAndStopReports();
+};
+
+namespace {
+PlaybackProviderContext context()
+{
+    PlaybackProviderContext result;
+    result.serverUrl = QUrl(QStringLiteral("https://silo.example.test:8443/base?ignored=1"));
+    result.profileId = QStringLiteral("profile-7");
+    return result;
+}
+
+Bloom::MediaRef media()
+{
+    return {QStringLiteral("connection-1"), QStringLiteral("item-42")};
+}
+
+QJsonObject playbackResponse(const QString &method, const QString &url)
+{
+    return {
+        {QStringLiteral("session_id"), QStringLiteral("session-42")},
+        {QStringLiteral("media_file_id"), QStringLiteral("file-42")},
+        {QStringLiteral("play_method"), method},
+        {QStringLiteral("position"), 12.345},
+        {QStringLiteral("stream_url"), url},
+        {QStringLiteral("playback_info"), QJsonObject{
+            {QStringLiteral("duration"), 123.456},
+            {QStringLiteral("start_position"), 12.345},
+            {QStringLiteral("audio_tracks"), QJsonArray{
+                QJsonObject{{QStringLiteral("index"), 2},
+                             {QStringLiteral("language"), QStringLiteral("eng")},
+                             {QStringLiteral("codec"), QStringLiteral("aac")},
+                             {QStringLiteral("title"), QStringLiteral("English")},
+                             {QStringLiteral("default"), true}},
+            }},
+            {QStringLiteral("subtitle_tracks"), QJsonArray{
+                QJsonObject{{QStringLiteral("index"), 3},
+                             {QStringLiteral("language"), QStringLiteral("eng")},
+                             {QStringLiteral("title"), QStringLiteral("English CC")},
+                             {QStringLiteral("hearing_impaired"), true}},
+            }},
+        }},
+    };
+}
+
+void verifyCapabilities(const QJsonObject &capabilities)
+{
+    QVERIFY(capabilities.value(QStringLiteral("codecs_video")).toArray()
+                .contains(QJsonValue(QStringLiteral("h264"))));
+    QVERIFY(capabilities.value(QStringLiteral("codecs_audio")).toArray()
+                .contains(QJsonValue(QStringLiteral("aac"))));
+    QVERIFY(capabilities.value(QStringLiteral("containers")).toArray()
+                .contains(QJsonValue(QStringLiteral("mkv"))));
+    QCOMPARE(capabilities.value(QStringLiteral("max_resolution")).toString(), QStringLiteral("8k"));
+    QVERIFY(capabilities.value(QStringLiteral("hdr")).isBool());
+    QVERIFY(capabilities.value(QStringLiteral("hdr")).toBool());
+    const QJsonObject passthrough = capabilities.value(QStringLiteral("audio_passthrough")).toObject();
+    QVERIFY(passthrough.value(QStringLiteral("passthrough_codecs")).isArray());
+    QVERIFY(!passthrough.value(QStringLiteral("passthrough_codecs")).toArray().isEmpty());
+    QVERIFY(passthrough.value(QStringLiteral("spatializer_enabled")).isBool());
+    QVERIFY(passthrough.value(QStringLiteral("max_channels")).isDouble());
+    QVERIFY(capabilities.value(QStringLiteral("supports_bitmap_subtitle_burn_in")).toBool());
+}
+} // namespace
+
+void SiloPlaybackProviderTest::legacyStartRequestUsesEnvelopeAndCapabilities()
+{
+    SiloPlaybackProvider provider;
+    QVariantMap source{{QStringLiteral("fileId"), QStringLiteral("99")}};
+    const PlaybackStartRequest request = provider.createPlaybackStartRequest(
+        context(), media(), source, 2, 5, 2501);
+
+    QVERIFY(request.isValid());
+    QCOMPARE(request.method, QStringLiteral("POST"));
+    QCOMPARE(request.endpoint, QStringLiteral("/api/v1/playback/start"));
+    QCOMPARE(request.body.value(QStringLiteral("file_id")).toInteger(), qint64(99));
+    QCOMPARE(request.body.value(QStringLiteral("profile_id")).toString(), QStringLiteral("profile-7"));
+    QCOMPARE(request.body.value(QStringLiteral("audio_track_index")).toInteger(), qint64(2));
+    QCOMPARE(request.body.value(QStringLiteral("start_position")).toDouble(), 2.501);
+    QVERIFY(!request.body.contains(QStringLiteral("subtitle_track_index")));
+    QVERIFY(!request.body.contains(QStringLiteral("capabilities")));
+    verifyCapabilities(request.body);
+}
+
+void SiloPlaybackProviderTest::startRequestAcceptsAlternateFileIdentifiers()
+{
+    SiloPlaybackProvider provider;
+
+    const QVariantMap idSource{{QStringLiteral("id"), QStringLiteral("17")}};
+    const PlaybackStartRequest idRequest = provider.createPlaybackStartRequest(
+        context(), media(), idSource, -1, -1, 0);
+    QVERIFY(idRequest.isValid());
+    QCOMPARE(idRequest.body.value(QStringLiteral("file_id")).toInteger(), qint64(17));
+
+    const QVariantMap versionSource{{QStringLiteral("mediaVersionId"), QStringLiteral("7")}};
+    const PlaybackStartRequest versionRequest = provider.createPlaybackStartRequest(
+        context(), media(), versionSource, -1, -1, 1000);
+    QVERIFY(versionRequest.isValid());
+    QCOMPARE(versionRequest.body.value(QStringLiteral("file_id")).toInteger(), qint64(7));
+
+    const PlaybackStartRequest missing = provider.createPlaybackStartRequest(
+        context(), media(), {}, -1, -1, 0);
+    QVERIFY(!missing.isValid());
+    QVERIFY(missing.endpoint.isEmpty());
+}
+
+void SiloPlaybackProviderTest::parsesDirectRemuxAndHlsResponses()
+{
+    SiloPlaybackProvider provider;
+    const QString signedAbsolute = QStringLiteral(
+        "https://cdn.example.test/movie.mkv?token=abc%2F%2B%3D&sig=a%26b");
+    const auto direct = provider.parsePlaybackStartResponse(
+        context(), media(), playbackResponse(QStringLiteral("direct"), signedAbsolute));
+    QVERIFY(direct.valid);
+    QCOMPARE(direct.descriptor.stream.method, Bloom::PlaybackMethod::DirectPlay);
+    QCOMPARE(direct.descriptor.stream.url.toString(QUrl::FullyEncoded), signedAbsolute);
+    QCOMPARE(direct.descriptor.mediaVersionId, QStringLiteral("file-42"));
+    QCOMPARE(direct.descriptor.playbackSessionId, QStringLiteral("session-42"));
+    QCOMPARE(direct.descriptor.durationMs, qint64(123456));
+    QCOMPARE(direct.descriptor.startPositionMs, qint64(12345));
+    QCOMPARE(direct.descriptor.audioTracks.size(), 1);
+    QCOMPARE(direct.descriptor.audioTracks.first().trackId, QStringLiteral("2"));
+    QCOMPARE(direct.descriptor.selectedAudioTrackId, QStringLiteral("2"));
+    QCOMPARE(direct.descriptor.subtitleTracks.size(), 1);
+    QCOMPARE(direct.descriptor.subtitleTracks.first().displayTitle, QStringLiteral("English CC"));
+    QVERIFY(direct.descriptor.reporting.progress);
+    QVERIFY(direct.descriptor.reporting.pause);
+    QVERIFY(!direct.descriptor.reporting.start);
+
+    const auto remux = provider.parsePlaybackStartResponse(
+        context(), media(), playbackResponse(
+            QStringLiteral("remux"),
+            QStringLiteral("/media/remux.mkv?token=abc%2F%2B%3D&sig=a%26b")));
+    QVERIFY(remux.valid);
+    QCOMPARE(remux.descriptor.stream.method, Bloom::PlaybackMethod::DirectStream);
+    QCOMPARE(remux.descriptor.stream.url.toString(QUrl::FullyEncoded),
+             QStringLiteral("https://silo.example.test:8443/media/remux.mkv?token=abc%2F%2B%3D&sig=a%26b"));
+
+    QJsonObject hls = playbackResponse(QStringLiteral("hls"), QStringLiteral("unused"));
+    hls.remove(QStringLiteral("stream_url"));
+    hls.insert(QStringLiteral("hls_url"),
+               QStringLiteral("/hls/session.m3u8?sig=one%2Ftwo%26three"));
+    const auto transcode = provider.parsePlaybackStartResponse(context(), media(), hls);
+    QVERIFY(transcode.valid);
+    QCOMPARE(transcode.descriptor.stream.method, Bloom::PlaybackMethod::Transcode);
+    QCOMPARE(transcode.descriptor.stream.url.toString(QUrl::FullyEncoded),
+             QStringLiteral("https://silo.example.test:8443/hls/session.m3u8?sig=one%2Ftwo%26three"));
+
+    QJsonObject external = playbackResponse(QStringLiteral("direct"), signedAbsolute);
+    external.insert(QStringLiteral("subtitle_urls"), QJsonArray{
+        QJsonObject{{QStringLiteral("index"), 9},
+                     {QStringLiteral("url"), QStringLiteral("/subs/movie.fr.vtt")},
+                     {QStringLiteral("language"), QStringLiteral("fra")}},
+        QStringLiteral("https://cdn.example.test/movie.en.vtt?sig=x%2Fy")});
+    const auto withExternal = provider.parsePlaybackStartResponse(context(), media(), external);
+    QVERIFY(withExternal.valid);
+    QCOMPARE(withExternal.descriptor.subtitleTracks.size(), 3);
+    const Bloom::PlaybackTrack &externalObject = withExternal.descriptor.subtitleTracks.at(1);
+    QVERIFY(externalObject.isExternal);
+    QCOMPARE(externalObject.trackId, QStringLiteral("9"));
+    QCOMPARE(externalObject.language, QStringLiteral("fra"));
+    const Bloom::PlaybackTrack &externalString = withExternal.descriptor.subtitleTracks.at(2);
+    QVERIFY(externalString.isExternal);
+    QCOMPARE(externalString.trackId, QStringLiteral("1"));
+}
+
+void SiloPlaybackProviderTest::rejectsMalformedStartResponses()
+{
+    SiloPlaybackProvider provider;
+    const QJsonObject valid = playbackResponse(QStringLiteral("direct"), QStringLiteral("/stream.mkv"));
+
+    const QList<QString> missingFields{QStringLiteral("session_id"), QStringLiteral("media_file_id"),
+                                       QStringLiteral("stream_url"), QStringLiteral("play_method")};
+    for (const QString &field : missingFields) {
+        QJsonObject malformed = valid;
+        malformed.remove(field);
+        const auto result = provider.parsePlaybackStartResponse(context(), media(), malformed);
+        QVERIFY2(!result.valid, qPrintable(QStringLiteral("field remained optional: %1").arg(field)));
+        QVERIFY(!result.descriptor.isValid());
+        QVERIFY(!result.error.isEmpty());
+    }
+
+    QJsonObject unknownMethod = valid;
+    unknownMethod.insert(QStringLiteral("play_method"), QStringLiteral("unsupported"));
+    QVERIFY(!provider.parsePlaybackStartResponse(context(), media(), unknownMethod).valid);
+
+    QJsonObject noServerForRelative = valid;
+    noServerForRelative.insert(QStringLiteral("stream_url"), QStringLiteral("/stream.mkv"));
+    PlaybackProviderContext invalidContext = context();
+    invalidContext.serverUrl = QUrl();
+    QVERIFY(!provider.parsePlaybackStartResponse(invalidContext, media(), noServerForRelative).valid);
+}
+
+void SiloPlaybackProviderTest::resolvesAudioSwitchUrlsAndRejectsMalformedResponses()
+{
+    SiloPlaybackProvider provider;
+    const QString signedRelative = QStringLiteral("/reload.m3u8?token=a%2Fb&sig=x%26y");
+    const auto relative = provider.parseAudioSwitchResponse(
+        context(), QJsonObject{{QStringLiteral("reload_url"), signedRelative}});
+    QVERIFY(relative.valid);
+    QCOMPARE(relative.reloadUrl.toString(QUrl::FullyEncoded),
+             QStringLiteral("https://silo.example.test:8443/reload.m3u8?token=a%2Fb&sig=x%26y"));
+
+    const QString signedAbsolute = QStringLiteral("https://cdn.example.test/reload.m3u8?sig=x%2Fy");
+    const auto absolute = provider.parseAudioSwitchResponse(
+        context(), QJsonObject{{QStringLiteral("stream_url"), signedAbsolute}});
+    QVERIFY(absolute.valid);
+    QCOMPARE(absolute.reloadUrl.toString(QUrl::FullyEncoded), signedAbsolute);
+
+    QVERIFY(!provider.parseAudioSwitchResponse(context(), {}).valid);
+    PlaybackProviderContext invalidContext = context();
+    invalidContext.serverUrl = QUrl();
+    QVERIFY(!provider.parseAudioSwitchResponse(
+                  invalidContext, QJsonObject{{QStringLiteral("reload_url"), signedRelative}})
+                  .valid);
+}
+
+void SiloPlaybackProviderTest::createsAudioSwitchRequestWithNativeRouteAndBody()
+{
+    SiloPlaybackProvider provider;
+    const PlaybackAudioSwitchRequest request = provider.createAudioSwitchRequest(
+        context(), QStringLiteral("session/one?x=2"), 7, 12345);
+    QVERIFY(request.isValid());
+    QCOMPARE(request.method, QStringLiteral("PATCH"));
+    QCOMPARE(request.endpoint, QStringLiteral("/api/v1/playback/session%2Fone%3Fx%3D2/audio"));
+    QCOMPARE(request.body.value(QStringLiteral("audio_track_index")).toInteger(), qint64(7));
+    QCOMPARE(request.body.value(QStringLiteral("position")).toDouble(), 12.345);
+
+    QVERIFY(!provider.createAudioSwitchRequest(context(), {}, 7, 0).isValid());
+    QVERIFY(!provider.createAudioSwitchRequest(context(), QStringLiteral("session"), -1, 0).isValid());
+}
+
+void SiloPlaybackProviderTest::createsProgressAndStopReports()
+{
+    SiloPlaybackProvider provider;
+    PlaybackReport progress;
+    progress.event = PlaybackReportEvent::Progress;
+    progress.playbackSessionId = QStringLiteral("session/one?x=2");
+    progress.positionMs = 3456;
+    const PlaybackReportRequest progressRequest = provider.createReportRequest(progress);
+    QVERIFY(progressRequest.isValid());
+    QCOMPARE(progressRequest.method, QStringLiteral("POST"));
+    QCOMPARE(progressRequest.endpoint,
+             QStringLiteral("/api/v1/playback/session%2Fone%3Fx%3D2/progress"));
+    QCOMPARE(progressRequest.body.value(QStringLiteral("position")).toDouble(), 3.456);
+    QCOMPARE(progressRequest.body.value(QStringLiteral("is_paused")).toBool(), false);
+    QVERIFY(progressRequest.deferSessionExpiry);
+
+    progress.event = PlaybackReportEvent::Pause;
+    progress.isPaused = false;
+    const PlaybackReportRequest pauseRequest = provider.createReportRequest(progress);
+    QCOMPARE(pauseRequest.body.value(QStringLiteral("is_paused")).toBool(), true);
+
+    progress.event = PlaybackReportEvent::Start;
+    QVERIFY(!provider.createReportRequest(progress).isValid());
+
+    progress.event = PlaybackReportEvent::Stop;
+    const PlaybackReportRequest stopRequest = provider.createReportRequest(progress);
+    QVERIFY(stopRequest.isValid());
+    QCOMPARE(stopRequest.method, QStringLiteral("DELETE"));
+    QCOMPARE(stopRequest.endpoint, QStringLiteral("/api/v1/playback/session%2Fone%3Fx%3D2"));
+    QVERIFY(stopRequest.body.isEmpty());
+    QVERIFY(!stopRequest.deferSessionExpiry);
+
+    QVERIFY(!provider.createReportRequest({}).isValid());
+}
+
+QTEST_MAIN(SiloPlaybackProviderTest)
+#include "SiloPlaybackProviderTest.moc"

--- a/tests/contracts/provider-contracts.json
+++ b/tests/contracts/provider-contracts.json
@@ -747,8 +747,11 @@
         "path": "/api/v1/playback/start",
         "outcome": "supported",
         "capability": {"state": "available", "discovery": "absence of protocol_version selects the legacy decoder"},
-        "requestSemantics": ["JSON includes file_id, optional matching profile_id, play_method or client codec/container/HDR capabilities, start_position seconds, and optional audio_track_index", "X-Profile-Id is mandatory and file_id must be accessible to that profile"],
-        "requiredSemantics": ["Without protocol_version 3 the legacy decoder selects direct, remux, or transcode and returns HTTP 201", "Response includes session_id, media_file_id, play_method, position, stream_url, audio_track_index, duration_seconds, subtitle_urls, and playback_info", "Relative or absolute stream/subtitle URLs and signed query parameters remain opaque", "Alternate-version selection is reflected by media_file_id and multipart ordering remains in catalog playback_variants"],
+        "requestSemantics": ["JSON includes numeric file_id, optional matching profile_id, play_method or mpv codec/container/HDR/resolution/passthrough/bitmap-subtitle capabilities, start_position seconds, and optional audio_track_index; no native variant field is sent", "The selected catalog version and multipart part are identified by file_id"],
+        "requiredSemantics": ["Without protocol_version 3 the legacy decoder selects direct, remux, or HLS/transcode and returns HTTP 201", "Response includes session_id, media_file_id, play_method, position, stream_url, audio_track_index, duration_seconds, subtitle_urls, and playback_info", "Relative or absolute stream/subtitle URLs and signed query parameters remain opaque and range-capable direct URLs are preserved", "Alternate-version selection is reflected by media_file_id and multipart playback uses sequential native sessions per file_id", "Native start failures and expired stream locations are surfaced for recovery/refetch rather than silently falling back to Jellyfin"],
+        "implementationEvidence": ["src/providers/silo/SiloPlaybackProvider.cpp", "src/providers/silo/SiloPlaybackProvider.h"],
+        "liveProbe": true,
+        "requiresMutationFlag": true,
         "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/playback.go"]
       },
       {
@@ -758,8 +761,11 @@
         "path": "/api/v1/playback/{session_id}/progress",
         "outcome": "supported",
         "capability": {"state": "available", "discovery": "legacy playback session"},
-        "requestSemantics": ["JSON contains position seconds and is_paused"],
-        "requiredSemantics": ["Only the session owner may update progress", "Update returns 204 and best-effort persists resume/completion state to the selected profile", "Pause and resume transitions update scrobble state without ending the session"],
+        "requestSemantics": ["JSON contains seconds and is_paused"],
+        "liveProbe": true,
+        "requiresMutationFlag": true,
+        "requiredSemantics": ["Only the session owner may update progress", "Update returns 204 and best-effort persists resume/completion state to the selected profile using seconds", "Pause and resume transitions update scrobble state without ending the session"],
+        "implementationEvidence": ["src/providers/silo/SiloPlaybackProvider.cpp", "src/providers/silo/SiloPlaybackProvider.h"],
         "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/playback.go"]
       },
       {
@@ -768,9 +774,12 @@
         "method": "DELETE",
         "path": "/api/v1/playback/{session_id}",
         "outcome": "supported",
+        "liveProbe": true,
+        "requiresMutationFlag": true,
         "capability": {"state": "available", "discovery": "legacy playback session"},
         "requestSemantics": ["Bearer account must own session_id"],
         "requiredSemantics": ["Stop persists final session progress, tears down stream/transcode resources, and returns 204", "Missing sessions use the playback_session_not_found error rather than succeeding silently"],
+        "implementationEvidence": ["src/providers/silo/SiloPlaybackProvider.cpp", "src/providers/silo/SiloPlaybackProvider.h"],
         "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/playback.go"]
       },
       {
@@ -778,7 +787,7 @@
         "issue": 79,
         "method": "POST",
         "path": "/api/v1/playback/transcode/start",
-        "outcome": "supported",
+        "outcome": "partial",
         "capability": {"state": "conditional", "discovery": "legacy start play_method plus user/server transcode policy"},
         "requestSemantics": ["JSON names session_id, seek_seconds, target codecs/resolution/bitrate, segment_duration, and subtitle burn-in selection"],
         "requiredSemantics": ["Response has manifest_url, duration_seconds, player_start_seconds, stream_origin_seconds, timeline_offset_seconds, and can_seek_anywhere", "Signed manifest URLs are replaced after recipe, seek, quality, file, or subtitle changes", "Server policy may return transcoding_disabled, audio_transcoding_disabled, no_alternate_version, or subtitle_source_unavailable instead of claiming support"],
@@ -789,10 +798,13 @@
         "issue": 79,
         "method": "PATCH",
         "path": "/api/v1/playback/{session_id}/audio",
+        "liveProbe": true,
+        "requiresMutationFlag": true,
         "outcome": "supported",
         "capability": {"state": "conditional", "discovery": "audio track inventory in catalog versions"},
-        "requestSemantics": ["JSON contains audio_track_index and position seconds"],
+        "requestSemantics": ["JSON contains audio_track_index"],
         "requiredSemantics": ["Out-of-range indices return 400 and other-account sessions return 403", "Success returns audio_track_index, effective play_method, replacement stream_url, switch_mode reload, and playback_info", "A track change may promote direct play to remux or audio transcode and must replace the signed stream recipe"],
+        "implementationEvidence": ["src/providers/silo/SiloPlaybackProvider.cpp", "src/providers/silo/SiloPlaybackProvider.h"],
         "evidenceSources": ["https://github.com/Silo-Server/silo-server/blob/8044eb84dd0cfa512ce8f2448cfd51cb7899a4c6/internal/api/handlers/playback.go"]
       },
       {

--- a/tests/contracts/provider_contracts_test.py
+++ b/tests/contracts/provider_contracts_test.py
@@ -70,6 +70,52 @@ class ProviderContractValidationTest(unittest.TestCase):
         self.assertNotIn("server_id", detection["requiredFields"])
         self.assertIn("server_id", detection["optionalFields"])
         validate_contract_data(data)
+    def test_native_playback_routes_and_semantics_are_pinned(self):
+        requirements = {
+            requirement["id"]: requirement
+            for requirement in self.valid_data["nativeSiloContract"]["requirements"]
+        }
+        expected_routes = {
+            "native.playback.capability": ("GET", "/api/v1/playback/capability"),
+            "native.playback.start-legacy": ("POST", "/api/v1/playback/start"),
+            "native.playback.progress": ("POST", "/api/v1/playback/{session_id}/progress"),
+            "native.playback.stop": ("DELETE", "/api/v1/playback/{session_id}"),
+            "native.playback.track": ("PATCH", "/api/v1/playback/{session_id}/audio"),
+        }
+        for contract_id, route in expected_routes.items():
+            with self.subTest(contract_id=contract_id):
+                requirement = requirements[contract_id]
+                semantics = " ".join(requirement["requestSemantics"] + requirement["requiredSemantics"]).lower()
+                expected_term = {
+                    "native.playback.capability": "protocol v3",
+                    "native.playback.start-legacy": "file_id",
+                    "native.playback.progress": "seconds",
+                    "native.playback.stop": "tears down",
+                    "native.playback.track": "audio_track_index",
+                }[contract_id]
+                self.assertIn(expected_term, semantics)
+
+        start = requirements["native.playback.start-legacy"]
+        start_semantics = " ".join(start["requestSemantics"] + start["requiredSemantics"]).lower()
+        for term in ("start_position", "audio_track_index", "codec", "container", "hdr", "subtitle", "stream_url", "playback_info", "range", "multipart"):
+            self.assertIn(term, start_semantics)
+
+    def test_native_playback_pin_identity_and_implementation_evidence(self):
+        native = self.valid_data["nativeSiloContract"]
+        snapshot = self.valid_data["snapshot"]
+        self.assertEqual(native["sourceRevision"], snapshot["siloRevision"])
+        self.assertEqual(snapshot["siloImageTag"], snapshot["siloRevision"][:7])
+        for requirement in native["requirements"]:
+            if requirement["id"] in {"native.playback.start-legacy", "native.playback.progress", "native.playback.stop", "native.playback.track"}:
+                self.assertTrue(requirement["implementationEvidence"])
+                self.assertTrue(all(path.startswith("src/") for path in requirement["implementationEvidence"]))
+
+    def test_rejects_native_playback_pin_drift(self):
+        data = copy.deepcopy(self.valid_data)
+        data["nativeSiloContract"]["sourceRevision"] = "0" * 40
+        with self.assertRaisesRegex(ContractValidationError, "sourceRevision must match"):
+            validate_contract_data(data)
+
     def test_rejects_native_route_shape_drift(self):
         data = copy.deepcopy(self.valid_data)
         page = next(
@@ -79,7 +125,10 @@ class ProviderContractValidationTest(unittest.TestCase):
         )
         page["path"] = "/api/v1/catalog/search"
 
-        with self.assertRaisesRegex(ContractValidationError, "route shape drifted"):
+        with self.assertRaisesRegex(
+            ContractValidationError,
+            r"native\.catalog\.page route shape drifted from the pinned native contract",
+        ):
             validate_contract_data(data)
 
     def test_rejects_native_auth_and_catalog_shape_drift(self):
@@ -91,7 +140,7 @@ class ProviderContractValidationTest(unittest.TestCase):
         )
         login["requiredSemantics"] = ["HTTP 200"]
 
-        with self.assertRaisesRegex(ContractValidationError, "not only an HTTP status"):
+        with self.assertRaisesRegex(ContractValidationError, "missing deterministic shape semantics"):
             validate_contract_data(data)
 
     def test_native_deployment_is_distinct_from_compatibility_mode(self):
@@ -109,11 +158,11 @@ class ProviderContractValidationTest(unittest.TestCase):
         self.assertNotEqual(native["id"], compatibility["id"])
         self.assertNotEqual(native["supportLabel"], compatibility["supportLabel"])
         validate_contract_data(self.valid_data)
-
     def test_rejects_native_contract_without_live_probe(self):
         data = copy.deepcopy(self.valid_data)
         for requirement in data["nativeSiloContract"]["requirements"]:
             requirement.pop("liveProbe", None)
+            requirement.pop("requiresMutationFlag", None)
 
         with self.assertRaisesRegex(ContractValidationError, "at least one liveProbe"):
             validate_contract_data(data)
@@ -200,6 +249,29 @@ class ProviderContractValidationTest(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertTrue(results[0].passed)
         self.assertIn("server_id=omitted", results[0].evidence)
+    def test_native_playback_probe_requires_explicit_mutation_flag(self):
+        class RecordingTransport:
+            def __init__(self):
+                self.calls = []
+
+            def request(self, method, path, **kwargs):
+                self.calls.append((method, path, kwargs))
+                return Response(200, {"Content-Type": "application/json"}, b'{"status": "ok"}')
+
+        transport = RecordingTransport()
+        probe = DRIVERS["silo-native-v1"](transport, "", "", "0.0-contract")
+        expected = {
+            "native.health": "partial",
+            "native.playback.start-legacy": "supported",
+            "native.playback.progress": "supported",
+            "native.playback.stop": "supported",
+            "native.playback.track": "supported",
+        }
+        results = probe.run(expected, allow_mutations=False)
+
+        self.assertEqual([(call[0], call[1]) for call in transport.calls], [("GET", "/api/v1/health")])
+        self.assertEqual({result.observed for result in results[1:]}, {"inconclusive"})
+        self.assertTrue(all(result.passed for result in results))
 
     def test_native_live_probe_rejects_success_shaped_bad_health(self):
         class BadHealthTransport:

--- a/tests/contracts/provider_contracts_test.py
+++ b/tests/contracts/provider_contracts_test.py
@@ -82,9 +82,11 @@ class ProviderContractValidationTest(unittest.TestCase):
             "native.playback.stop": ("DELETE", "/api/v1/playback/{session_id}"),
             "native.playback.track": ("PATCH", "/api/v1/playback/{session_id}/audio"),
         }
-        for contract_id, route in expected_routes.items():
+        for contract_id, (expected_method, expected_path) in expected_routes.items():
             with self.subTest(contract_id=contract_id):
                 requirement = requirements[contract_id]
+                self.assertEqual(requirement["method"], expected_method)
+                self.assertEqual(requirement["path"], expected_path)
                 semantics = " ".join(requirement["requestSemantics"] + requirement["requiredSemantics"]).lower()
                 expected_term = {
                     "native.playback.capability": "protocol v3",

--- a/tests/contracts/run_live_contracts.py
+++ b/tests/contracts/run_live_contracts.py
@@ -556,7 +556,7 @@ class MediaBrowserV1Probe:
 
 
 class SiloNativeV1Probe:
-    """Probe native Silo health, auth, profiles, catalog, and artwork when credentials are supplied."""
+    """Probe native Silo reads and an opt-in legacy playback lifecycle."""
 
     requires_credentials = False
 
@@ -627,9 +627,14 @@ class SiloNativeV1Probe:
         return []
 
     @staticmethod
+    def _identity(value: Any):
+        return (isinstance(value, str) and bool(value.strip())) or (
+            isinstance(value, int) and not isinstance(value, bool)
+        )
+
+    @staticmethod
     def _non_empty_string(value: Any):
         return isinstance(value, str) and bool(value.strip())
-
     def _record(self, results: list[ProbeResult], expected: dict[str, str], contract: str, observed: str, evidence: str):
         wanted = expected.get(contract)
         if wanted is None:
@@ -663,7 +668,23 @@ class SiloNativeV1Probe:
 
     def run(self, expected: dict[str, str], allow_mutations: bool):
         results: list[ProbeResult] = []
+        playback_contracts = (
+            "native.playback.capability",
+            "native.playback.start-legacy",
+            "native.playback.progress",
+            "native.playback.stop",
+            "native.playback.track",
+        )
         self._health(expected, results)
+        if not allow_mutations:
+            for contract in playback_contracts:
+                self._record(
+                    results,
+                    expected,
+                    contract,
+                    "inconclusive",
+                    "destructive native playback lifecycle probe requires --allow-mutations and fixture credentials",
+                )
         if not self.username or not self.password:
             return results
 
@@ -949,6 +970,125 @@ class SiloNativeV1Probe:
                 "supported" if artwork_ok else "partial",
                 f"opaque artwork URL returned HTTP {artwork_response.status}, {content_type!r}, {len(artwork_response.body)} bytes",
             )
+
+        if not allow_mutations:
+            recorded_contracts = {result.contract for result in results}
+            for contract in playback_contracts:
+                if contract not in recorded_contracts:
+                    self._record(
+                        results,
+                        expected,
+                        contract,
+                        "inconclusive",
+                        "destructive native playback lifecycle probe requires --allow-mutations and fixture credentials",
+                    )
+        else:
+            candidate = next(
+                (
+                    version
+                    for version in versions
+                    if isinstance(version, dict) and str(version.get("file_id", "")).isdigit()
+                ),
+                None,
+            )
+            if candidate is None:
+                for contract in playback_contracts:
+                    self._record(results, expected, contract, "inconclusive", "catalog detail has no numeric file_id suitable for a safe playback fixture")
+            else:
+                file_id = int(candidate["file_id"])
+                start_body = {
+                    "file_id": file_id,
+                    "start_position": 0,
+                    "codecs_video": ["h264", "hevc"],
+                    "codecs_audio": ["aac", "ac3"],
+                    "containers": ["mp4", "mkv", "webm"],
+                    "max_resolution": "8k",
+                    "hdr": True,
+                    "audio_passthrough": {
+                        "passthrough_codecs": ["aac", "ac3"],
+                        "spatializer_enabled": False,
+                        "max_channels": 8,
+                    },
+                    "supports_bitmap_subtitle_burn_in": True,
+                }
+                if self.profile_id:
+                    start_body["profile_id"] = self.profile_id
+                start_response = self.request("POST", "/api/v1/playback/start", **scoped, json_body=start_body)
+                start_payload = self._object(start_response.json())
+                session_id = start_payload.get("session_id", "")
+                position = start_payload.get("position", start_payload.get("start_position"))
+                start_ok = (
+                    start_response.status == 201
+                    and self._identity(session_id)
+                    and self._identity(start_payload.get("media_file_id"))
+                    and self._non_empty_string(start_payload.get("play_method"))
+                    and isinstance(position, (int, float))
+                    and self._non_empty_string(start_payload.get("stream_url"))
+                    and isinstance(start_payload.get("subtitle_urls"), (dict, list))
+                    and isinstance(start_payload.get("playback_info"), dict)
+                )
+                self._record(
+                    results,
+                    expected,
+                    "native.playback.start-legacy",
+                    "supported" if start_ok else "partial" if start_response.status == 201 else "missing",
+                    f"legacy start returned HTTP {start_response.status} with session/file/method/URL/playback_info shape={start_ok}",
+                )
+                if not start_ok:
+                    for contract in playback_contracts[2:]:
+                        self._record(results, expected, contract, "inconclusive", "legacy start did not create a session")
+                else:
+                    progress = self.request(
+                        "POST",
+                        f"/api/v1/playback/{urllib.parse.quote(str(session_id), safe='')}/progress",
+                        **scoped,
+                        json_body={"seconds": 0, "is_paused": True},
+                    )
+                    self._record(
+                        results,
+                        expected,
+                        "native.playback.progress",
+                        "supported" if progress.status == 204 else "partial",
+                        f"native progress returned HTTP {progress.status} with position seconds and pause state",
+                    )
+                    audio_tracks = candidate.get("audio_tracks", candidate.get("audioStreams", []))
+                    if isinstance(audio_tracks, list) and len(audio_tracks) > 1:
+                        track = self.request(
+                            "PATCH",
+                            f"/api/v1/playback/{urllib.parse.quote(str(session_id), safe='')}/audio",
+                            **scoped,
+                            json_body={"audio_track_index": 1},
+                        )
+                        track_payload = self._object(track.json())
+                        track_ok = (
+                            track.status == 200
+                            and isinstance(track_payload.get("audio_track_index"), int)
+                            and self._non_empty_string(track_payload.get("stream_url"))
+                            and track_payload.get("switch_mode") == "reload"
+                        )
+                        self._record(
+                            results,
+                            expected,
+                            "native.playback.track",
+                            "supported" if track_ok else "partial",
+                            f"native audio switch returned HTTP {track.status} with reload URL/effective track shape={track_ok}",
+                        )
+                    else:
+                        self._record(results, expected, "native.playback.track", "inconclusive", "selected version exposes fewer than two audio tracks")
+                    stop = self.request(
+                        "DELETE",
+                        f"/api/v1/playback/{urllib.parse.quote(str(session_id), safe='')}",
+                        **scoped,
+                    )
+                    self._record(
+                        results,
+                        expected,
+                        "native.playback.stop",
+                        "supported" if stop.status == 204 else "partial",
+                        f"native stop returned HTTP {stop.status}; session cleanup was requested",
+                    )
+                self._record(results, expected, "native.playback.capability", "inconclusive", "legacy lifecycle probe intentionally does not infer mpv support from protocol-v3 capability")
+
 
         sessions = self.request("GET", "/api/v1/auth/sessions", token=self.access_token)
         session_items = self._array(sessions.json() if sessions.status == 200 else None, "sessions")

--- a/tests/contracts/validate_contracts.py
+++ b/tests/contracts/validate_contracts.py
@@ -219,6 +219,14 @@ def validate_contract_data(data: dict[str, Any]):
         "native.state.watched": ("POST/DELETE", "/api/v1/watched/{id}"),
         "native.state.favorite": ("GET/PUT/DELETE", "/api/v1/favorites/{item_id}"),
         "native.artwork.refetch": ("GET", "opaque URLs from catalog, detail, person, and chapter resources"),
+        "native.playback.capability": ("GET", "/api/v1/playback/capability"),
+        "native.playback.start-legacy": ("POST", "/api/v1/playback/start"),
+        "native.playback.progress": ("POST", "/api/v1/playback/{session_id}/progress"),
+        "native.playback.stop": ("DELETE", "/api/v1/playback/{session_id}"),
+        "native.playback.transcode": ("POST", "/api/v1/playback/transcode/start"),
+        "native.playback.track": ("PATCH", "/api/v1/playback/{session_id}/audio"),
+        "native.markers": ("GET", "/api/v1/markers/items/{id} and /api/v1/markers/files/{fileId}"),
+        "native.chapters": ("GET", "/api/v1/catalog/items/{id} and /api/v1/catalog/items/{id}/versions"),
     }
     native_shape_terms = {
         "native.auth.providers": ("id", "display name", "mode", "default"),
@@ -235,6 +243,13 @@ def validate_contract_data(data: dict[str, Any]):
         "native.state.watched": ("content id", "affected count", "played"),
         "native.state.favorite": ("204", "idempotent", "user state"),
         "native.artwork.refetch": ("artwork urls", "fetch locations", "refetch", "signed query"),
+        "native.playback.capability": ("protocol v3", "media3 only", "disabled"),
+        "native.playback.progress": ("seconds", "is paused", "session owner"),
+        "native.playback.stop": ("final session progress", "tears down", "session"),
+        "native.playback.transcode": ("session id", "manifest url", "duration", "timeline offset", "signed"),
+        "native.playback.track": ("audio track index", "replacement stream url", "switch mode", "reload"),
+        "native.markers": ("file id", "intro", "credits", "recap", "preview", "provenance"),
+        "native.chapters": ("file id", "start seconds", "end seconds", "thumbnail"),
     }
     _require(
         all(term in server_id_policy for term in ("optional", "deterministic", "unique")),
@@ -276,14 +291,25 @@ def validate_contract_data(data: dict[str, Any]):
         required_semantics = requirement.get("requiredSemantics")
         _require(isinstance(request_semantics, list) and request_semantics, f"{requirement_id} needs requestSemantics")
         _require(isinstance(required_semantics, list) and required_semantics, f"{requirement_id} needs requiredSemantics")
-        _require(
-            all(isinstance(rule, str) and rule.strip() for rule in request_semantics + required_semantics),
-            f"{requirement_id} semantics must be non-empty strings",
-        )
-        _require(
-            any(_has_behavior_semantics(rule) for rule in required_semantics),
-            f"{requirement_id} must assert payload or behavior semantics, not only an HTTP status",
-        )
+        implementation_evidence = requirement.get("implementationEvidence")
+        if requirement_id in {"native.playback.start-legacy", "native.playback.progress", "native.playback.stop", "native.playback.track"}:
+            _require(
+                isinstance(implementation_evidence, list) and implementation_evidence,
+                f"{requirement_id} needs implementationEvidence",
+            )
+        if implementation_evidence is not None:
+            _require(
+                isinstance(implementation_evidence, list)
+                and all(isinstance(path, str) and path and not Path(path).is_absolute() for path in implementation_evidence),
+                f"{requirement_id} implementationEvidence must contain relative paths",
+            )
+            repo_root = Path(__file__).resolve().parents[2]
+            _require(
+                all((repo_root / path).is_file() for path in implementation_evidence),
+                f"{requirement_id} implementationEvidence path does not exist",
+            )
+        evidence_sources = requirement.get("evidenceSources")
+        _require(isinstance(evidence_sources, list) and evidence_sources, f"{requirement_id} needs pinned evidenceSources")
         if requirement_id in native_shape_terms:
             semantic_text = " ".join(request_semantics + required_semantics).lower()
             semantic_text = re.sub(r"[_-]+", " ", semantic_text)
@@ -293,14 +319,20 @@ def validate_contract_data(data: dict[str, Any]):
                 f"{requirement_id} is missing deterministic shape semantics: {', '.join(missing_terms)}",
             )
 
-        evidence_sources = requirement.get("evidenceSources")
-        _require(isinstance(evidence_sources, list) and evidence_sources, f"{requirement_id} needs pinned evidenceSources")
         _require(
             all(isinstance(url, str) and url.startswith(evidence_prefix) for url in evidence_sources),
             f"{requirement_id} evidenceSources must be pinned to native sourceRevision",
         )
         _require(isinstance(requirement.get("liveProbe", False), bool), f"{requirement_id} liveProbe must be boolean")
-        if requirement.get("liveProbe", False):
+        requires_mutation_flag = requirement.get("requiresMutationFlag", False)
+        _require(isinstance(requires_mutation_flag, bool), f"{requirement_id} requiresMutationFlag must be boolean")
+        if requires_mutation_flag:
+            _require(requirement.get("liveProbe", False), f"{requirement_id} mutation probes must set liveProbe")
+            _require(
+                requirement_id in {"native.playback.start-legacy", "native.playback.progress", "native.playback.stop", "native.playback.track"},
+                f"{requirement_id} is not an approved mutation probe",
+            )
+        if requirement.get("liveProbe", False) and not requires_mutation_flag:
             _require(
                 requirement["method"] == "GET" and requirement["path"] == "/api/v1/health",
                 f"{requirement_id} liveProbe must be deterministic and read-only",


### PR DESCRIPTION
## Summary
- add provider-owned native Silo playback start, descriptor parsing, reporting, recovery, and audio switching through the pinned legacy envelope
- preserve alternate-version and multipart file identity with sequential native sessions and opaque signed URLs
- add deterministic provider/controller/contract coverage and document the mpv-specific protocol boundary

Closes #79
Part of #73

## Verification
- ./scripts/dev-build.sh --tests
- ctest --test-dir build-dev --output-on-failure -R '^(ProviderContractValidationTest|ProviderCatalogTest|SiloPlaybackProviderTest|PlayerControllerAutoplayContextTest)$'
- python3 -m unittest tests/contracts/provider_contracts_test.py
- ctest --test-dir build-dev --output-on-failure
- headless Bloom startup smoke (QT_QPA_PLATFORM=offscreen)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native Silo playback lifecycle with asynchronous descriptor and audio switch support
> - Introduces `SiloPlaybackProvider` implementing `IPlaybackProvider` with request/response handling for start, progress, stop, audio switch, and recovery against the Silo legacy envelope.
> - `PlayerController` now defers playback until a descriptor arrives asynchronously via `PlaybackService::requestPlaybackDescriptor`, replacing the previous synchronous descriptor creation and immediate play flow.
> - Native audio switching reloads media at the current file-relative position via mpv `loadfile replace`; failures roll back track selection and notify observers.
> - External subtitle tracks from descriptors are queued and applied automatically on transition to Playing/Buffering, with synthetic negative indices used for tracks not yet resolved by mpv.
> - `PlaybackService` gains request-generation tracking (`beginRequest`/`endRequest`/`isCurrentRequest`) to suppress stale callbacks across auth or provider changes, and defers Stop reports until all in-flight Progress reports for the same session complete.
> - Contract validation in `validate_contracts.py` now enforces `implementationEvidence` path presence for native playback requirements and gates live mutation probes behind `requiresMutationFlag`.
> - Risk: autoplay and multipart playback flows are now fully asynchronous; any provider or network failure during descriptor fetch will stall playback until timeout, then fall back via a one-shot `|fallback` descriptor request.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70036b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added experimental native Silo playback support.
  - Improved playback for multipart media, external subtitles, HDR/video variants, and alternate audio tracks.
  - Added playback recovery, progress reporting, stopping, and session handling.
  - Improved support for direct, remuxed, and HLS playback sources.

- **Bug Fixes**
  - Relative playback URLs and segment seeking now resolve more reliably.
  - Failed or outdated playback requests are handled safely without replacing current playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->