### PR TITLE
feat(providers): complete Silo capability parity

### DIFF
--- a/docs/media-segments.md
+++ b/docs/media-segments.md
@@ -1,15 +1,17 @@
 Media Segment Providers
 
 Overview
-- `PlaybackService::getMediaSegments()` is the only playback-facing entry point.
-- Jellyfin server segments are loaded first from Intro Skipper when available.
-- `MediaSegmentProviderService` can then query external providers and merge only missing segment types.
+- `PlaybackService::getMediaSegments()` is the provider-neutral playback entry point.
+- The active provider's server segments are loaded before any external lookup.
+- Native Silo markers use `/api/v1/markers/files/{file_id}` for the selected playback version or multipart file, falling back to `/api/v1/markers/items/{content_id}` only when no file identity is available. They remain authoritative for every segment type Silo returns.
+- On Jellyfin, Bloom uses the optional Intro Skipper plugin route (`/Episode/{id}/IntroSkipperSegments`) as the server-marker source. A missing plugin is an expected optional capability, not a playback error.
+- Only after the server response is normalized does `MediaSegmentProviderService` query configured external providers to fill missing types.
 
 Precedence
-- Jellyfin server segments always win for their type.
-- Provider order defaults to TheIntroDB, then IntroDB.
-- If Jellyfin provides an intro and TheIntroDB provides intro plus credits, Bloom keeps Jellyfin's intro and adds TheIntroDB credits.
-
+- Native Silo server segments win per segment type.
+- Jellyfin Intro Skipper server segments win per segment type when the Jellyfin provider is active; the plugin route is the Jellyfin fallback for server markers, not proof that every Jellyfin deployment has markers.
+- External provider order defaults to TheIntroDB, then IntroDB.
+- `mergeSegmentsByType` keeps the first server segment for each type and only adds a later provider's type when no server segment of that type exists. For example, a server intro plus TheIntroDB intro/credits keeps the server intro and adds only credits.
 Provider parsing
 - TheIntroDB v2 uses `GET https://api.theintrodb.org/v2/media?tmdb_id=...`; TV requests also include `season` and `episode`. Reads are anonymous.
 - TheIntroDB segment arrays map `intro` to Intro, `recap` to Recap, `credits` to Outro, and `preview` to Preview. `start_ms: null` means zero; `end_ms: null` uses the item duration if known or the segment is dropped.

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -163,7 +163,7 @@ Track Preference Persistence
 - When navigating to a new episode in the same season, explicit preferences and subtitle delay are restored. If track preferences are missing or invalid for the new source, Bloom falls back through the standard resolution order.
 - Use `PlayerController.getLastAudioTrackForSeason(seasonId)` and `getLastSubtitleTrackForSeason(seasonId)` to retrieve.
 - Use `PlayerController.setExplicitSeasonAudioPreference(seasonId, index)` and `setExplicitSeasonSubtitlePreference(seasonId, index)` to save.
-- `SeriesSeasonEpisodeView` preloads Jellyfin chapter metadata for the highlighted episode and keeps a `Chapters` rail between `Episodes` and `Cast & Crew`; missing chapters resolve to a quiet reserved empty state.
+- `SeriesSeasonEpisodeView` preloads provider-neutral chapter metadata for the highlighted episode and keeps a `Chapters` rail between `Episodes` and `Cast & Crew`; missing chapters resolve to a quiet reserved empty state.
 - Activating a chapter card reuses the normal episode playback request, including track preference/version-prompt handling, and sets canonical `startPositionMs` so playback begins at the selected chapter.
 
 ### Movies (Per-Movie)
@@ -246,14 +246,14 @@ UI Components for Track Selection
   - Progress row: clickable seek track, current/total time labels, and keyboard seek via left/right.
   - Escape and controller B first dismiss visible playback chrome (full controls, seek preview, volume OSD, skip-intro popup, or open track/volume panels); a second press stops playback when the overlay is already hidden. The header back control exits playback immediately while controls are visible.
   - Trickplay preview bubble: renders processed Jellyfin trickplay thumbnails from `PlayerController` and is hidden entirely when trickplay images are unavailable.
-  - Chapter mode: `Down` enters a Jellyfin-backed horizontal chapter rail when the active item exposes `Chapters`; `Up` returns to transport controls and `Escape`/`Back` hides the overlay. `Left`/`Right` browse chapter cards, while `Enter`/`Space` seeks to the focused chapter and keeps the rail open until normal inactivity dismissal.
-  - Chapter cards use the item chapter thumbnail when Jellyfin provides usable chapter image metadata. Missing chapter artwork renders a neutral themed placeholder tile instead of reusing episode/poster artwork.
-  - Chapter thumbnail diagnostics are logged during playback chapter normalization: loaded chapter metadata, generated Jellyfin chapter-image URLs, and image-cache transport/decode failures. These logs are intended for server/client compatibility debugging when the rail falls back to placeholders.
+  - Chapter mode: `Down` enters a provider-backed horizontal chapter rail when the active item exposes `Chapters`; `Up` returns to transport controls and `Escape`/`Back` hides the overlay. `Left`/`Right` browse chapter cards, while `Enter`/`Space` seeks to the focused chapter and keeps the rail open until normal inactivity dismissal.
+  - Chapter cards use the active provider's chapter thumbnail when usable chapter image metadata is available. Missing chapter artwork renders a neutral themed placeholder tile instead of reusing episode/poster artwork.
+  - Chapter thumbnail diagnostics are logged during provider-neutral chapter normalization: loaded chapter metadata, generated provider image URLs, and image-cache transport/decode failures. These logs are intended for server/client compatibility debugging when the rail falls back to placeholders.
   - Intro/outro skip UX: transient "Skip Intro"/"Skip Credits" pop-up button auto-focuses when a segment window starts, then a compact persistent skip button remains available until that segment ends.
     - Popup timing is controlled by `ConfigManager.skipButtonAutoHideSeconds` (`settings.playback.skip_button_auto_hide_seconds`, range 0-120; 0 disables popup only). The popup is still dismissed as soon as the active intro/outro segment ends.
     - Optional automatic skip is controlled by `ConfigManager.autoSkipIntro` and `ConfigManager.autoSkipOutro`; each auto-skip applies at most once per playback item even if the user seeks back.
-    - Segment source precedence is Jellyfin server data first, then configured external providers. Server segments win per segment type; external providers may fill missing types such as recap, intro, credits, or preview.
-    - External provider order defaults to TheIntroDB then IntroDB. Reads are anonymous. TheIntroDB requires TMDB metadata; IntroDB requires series IMDb metadata plus season/episode numbers.
+    - Segment source precedence is provider-neutral: native Silo marker responses win per segment type; when Jellyfin is active, the optional Intro Skipper plugin is the server-marker source and wins per type. External providers are queried only after the active server response and may fill missing types such as recap, intro, credits, or preview.
+    - External provider order defaults to TheIntroDB then IntroDB. Reads are anonymous. TheIntroDB requires TMDB metadata; IntroDB requires series IMDb metadata plus season/episode.
 
 Playback overlay metadata
 - `PlayerController` exposes `overlayTitle`, `overlaySubtitle`, `overlayBackdropUrl`, and `overlayLogoUrl` for the native overlay (header, buffering card, and backdrop).

--- a/docs/provider-compatibility.md
+++ b/docs/provider-compatibility.md
@@ -14,13 +14,13 @@ These labels describe a connection's protocol mode, not an application-wide prov
 
 Contract outcomes are:
 
-| Outcome | Meaning |
+| Matrix label | Meaning |
 |---|---|
 | `supported` | The required payload and observable behavior work. |
 | `partial` | The core journey works, but requested behavior or data is ignored or absent. |
 | `stubbed` | A route returns a success-shaped placeholder without the required behavior. |
-| `missing` | The route is absent or cannot provide fields Bloom needs. |
-| `not-applicable` | A deployment does not expose that protocol surface. |
+| `missing` | **Unavailable**: the route is absent or cannot provide fields Bloom needs. This is never a claim of support. |
+| `not-applicable` | **Intentionally out-of-scope**: Bloom does not claim this optional protocol surface in the pinned baseline. |
 
 ## Reproducible server pins
 
@@ -173,6 +173,17 @@ This is the human-readable summary. Exact call sites, required semantics, and ev
 | External subtitle `DeliveryUrl` | Partial in Bloom | Partial in Bloom | Servers can advertise it; Bloom currently drops the URL before playback. |
 | Conditional JSON `ETag`/`304` | Supported | Missing | Functional refresh, but no efficient not-modified path. |
 | Expired/revoked token returns `401` | Supported | Supported | Bloom centralizes catalog, playback, and remote-session expiry policy through the shared transport/session façade. |
+| Similar recommendations | Supported | Missing | Jellyfin's similar rail is consumed by Bloom; compatibility has no equivalent route and native Silo is a separate surface. |
+| Server home sections | Supported | Partial | Core library/latest/Next Up sections degrade safely; optional hero/backdrop/random/screensaver sections are unavailable on compatibility. |
+| Alternate versions | Supported | Missing | Jellyfin media sources are selectable; compatibility has no equivalent alternate-version contract. |
+| Multipart reporting | Supported | Missing | Jellyfin reports physical parts while preserving logical aggregate progress; compatibility cannot discover parts. |
+| Auth sessions versus playback sessions | Supported | Missing | Bloom keeps remote auth-session list/revoke separate from playback reports; compatibility list/revoke is stubbed or absent. |
+| Client-local profile track preferences | Supported | Partial | Explicit movie/season choices are local and provider-neutral, but compatibility lacks hierarchy and the file is connection-scoped rather than profile-scoped. |
+| Household overview, watchlist, watch together | Intentionally out-of-scope | Intentionally out-of-scope | These optional follow-ups are not claimed by the pinned Bloom contract; favorites and playback reports are not substitutes. |
+| Requests, notifications, downloads | Intentionally out-of-scope | Intentionally out-of-scope | Seerr requests are an external integration; no provider-native request, notification, or offline-download surface is implemented. |
+| Audiobooks and ebooks | Intentionally out-of-scope | Intentionally out-of-scope | Item type mapping is not audiobook/ebook UX or reader support. |
+
+The table uses human words for readability: **Missing** is the matrix's canonical `missing` (**unavailable**) outcome, while **Intentionally out-of-scope** is canonical `not-applicable`. Neither category is supported. A `stubbed` route (such as compatibility `GET /Sessions`) is recorded separately because a success-shaped placeholder is not an unavailable route.
 
 ### Meaningful assertions for live runs
 
@@ -207,7 +218,7 @@ The native baseline is source-grounded in Silo revision `8044eb84dd0cfa512ce8f24
 | Playback capability | Partial | Protocol v3 truthfully reports disabled state and runtime-probed transformations, but advertises `media3_only`; that is not an mpv capability and does not describe the legacy envelope. |
 | Legacy start/progress/stop | Supported | Omit `protocol_version: 3`; preserve session/file identity, seconds, opaque URLs, pause state, and teardown. |
 | Legacy transcode and audio switch | Partial/conditional | Start can return HLS/transcode and audio switch returns replacement URLs when policy/runtime permits; Bloom does not claim a standalone transcode route beyond the implemented native start/audio-switch paths. |
-| Markers and chapters | Supported when media/routes expose them | Markers cover intro, credits, recap, and preview with provenance; chapters are file-version scoped and use seconds plus optional opaque thumbnail URLs. |
+| Markers and chapters | Supported when media/routes expose them | Native markers cover intro, credits, recap, and preview with provenance; native chapters are file-version scoped, use seconds, and carry optional opaque thumbnail URLs. |
 | Native trickplay | Missing | No native metadata/tile route or capability is registered. Hide/degrade seek previews. |
 | Native media theme songs | Missing | `/api/v1/theme/*` is UI branding, not playable item theme media. Hide/degrade theme-song playback. |
 
@@ -247,7 +258,7 @@ GET  /api/v1/catalog/series/{id}/seasons/{number}
 GET  /api/v1/catalog/series/{id}/seasons/{number}/episodes
 ```
 
-Use `content_id` for catalog, detail, hierarchy, watched, and favorite identity. Preserve `file_id` for playback/version selection. Detail/version responses carry provider IDs, technical tracks, alternate editions, multipart `playback_variants`, marker ranges, and per-version chapters when data exists. Silo durations, progress, markers, and chapters use seconds; convert once at Bloom's adapter boundary.
+Use `content_id` for catalog, detail, hierarchy, watched, and favorite identity. Preserve `file_id` for playback/version and chapter selection. Detail/version responses carry provider IDs, technical tracks, alternate editions, multipart `playback_variants`, marker ranges, and per-version chapters when data exists. Silo durations, progress, markers, and chapters use seconds; Jellyfin ticks and chapter-image routes stay inside its adapter. Convert once at Bloom's provider boundary.
 
 GET `/catalog` supports snapshot-aware offset pagination and reports `total_exact`. POST `/catalog/query` is useful for structured filters but is not an equivalent paging capability at the pin: it omits snapshots and conservatively leaves `total_exact` false. The adapter must choose based on those explicit response capabilities rather than silently pretending a filter or count mode is stronger than it is.
 

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation {
   doCheck = true;
   checkPhase = ''
     runHook preCheck
-    python3 -m unittest "$src/tests/contracts/provider_contracts_test.py"
+    python3 "$src/tests/contracts/provider_contracts_test.py"
     export QT_QPA_PLATFORM=offscreen
     ctest --output-on-failure \
       --exclude-regex '^(VisualRegressionTest|SeriesDetailsCacheTest)$'

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation {
       ProviderCatalogTest \
       SiloCatalogServiceTest \
       ArtworkRefreshTest \
+      SiloPlaybackProviderTest \
       CanonicalModelsTest \
       InputBindingManagerTest \
       PlayerBackendFactoryTest \

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -1059,13 +1059,20 @@ void AuthenticationService::revokeAuthSession(const QString &sessionId)
         [this, endpoint = *endpoint]() {
             return networkManager()->deleteResource(createRequest(endpoint));
         },
-        [this, generation, revokingCurrent](QNetworkReply *) {
+        [this, generation, revokingCurrent, sessionId](QNetworkReply *) {
             if (generation != m_stateGeneration) {
                 return;
             }
             if (revokingCurrent) {
                 logout();
             } else {
+                for (qsizetype i = m_authSessions.size() - 1; i >= 0; --i) {
+                    if (m_authSessions.at(i).toMap().value(
+                            QStringLiteral("id")).toString() == sessionId) {
+                        m_authSessions.removeAt(i);
+                    }
+                }
+                emit authSessionsChanged();
                 loadAuthSessions();
             }
         },

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -161,6 +161,19 @@ ProviderKind AuthenticationService::activeProviderKind() const
         : m_activeConnection.providerKind;
 }
 
+bool AuthenticationService::supportsCapability(ProviderCapability capability) const
+{
+    return m_providerAdapter && m_providerAdapter->supportsCapability(capability);
+}
+
+std::optional<QString> AuthenticationService::endpointFor(
+    ProviderRoute route, const ProviderRouteContext &context) const
+{
+    return m_providerAdapter
+        ? m_providerAdapter->endpointFor(route, context)
+        : std::nullopt;
+}
+
 PlaybackInfoResponse AuthenticationService::mapPlaybackInfo(
     const QJsonObject &wirePlaybackInfo) const
 {
@@ -190,6 +203,16 @@ TrickplayTileInfoMap AuthenticationService::mapTrickplayInfo(
     return m_providerAdapter
         ? m_providerAdapter->mapTrickplayInfo(wireItem)
         : TrickplayTileInfoMap{};
+}
+
+QList<MediaSegmentInfo> AuthenticationService::mapMediaSegments(
+    const QString &itemId, const QJsonObject &wireSegments) const
+{
+    if (!m_providerAdapter) {
+        return {};
+    }
+    const auto mapped = m_providerAdapter->mapMediaSegments(itemId, wireSegments);
+    return mapped.value_or(QList<MediaSegmentInfo>{});
 }
 
 QList<MediaSegmentInfo> AuthenticationService::mapIntroSkipperSegments(
@@ -427,7 +450,6 @@ void AuthenticationService::setProviderSelection(const QString &selection)
     const bool wasAuthenticated = isAuthenticated();
     clearAccountStateInternal(true, wasAuthenticated);
     m_providerSelection = normalized;
-    emit providerSelectionChanged();
 
     if (normalized != QStringLiteral("auto")) {
         const ProviderKind kind = normalized == QStringLiteral("silo")
@@ -436,6 +458,7 @@ void AuthenticationService::setProviderSelection(const QString &selection)
             activateProvider(adapter);
         }
     }
+    emit providerSelectionChanged();
 }
 
 void AuthenticationService::authenticate(const QString &serverUrl,
@@ -966,7 +989,6 @@ void AuthenticationService::loadAuthSessions()
             const auto mapped = m_providerAdapter->mapAuthSessions(
                 responseArray(reply->readAll(), QStringLiteral("sessions")));
             if (!mapped.has_value()) {
-                replaceAuthSessions({});
                 emit loginError(tr("The provider returned an invalid session list."));
                 return;
             }
@@ -974,7 +996,6 @@ void AuthenticationService::loadAuthSessions()
         },
         [this, generation](const NetworkError &error) {
             if (generation == m_stateGeneration) {
-                replaceAuthSessions({});
                 emit loginError(tr("Unable to load authentication sessions: %1")
                                     .arg(error.userMessage));
             }
@@ -1050,7 +1071,6 @@ void AuthenticationService::revokeAuthSession(const QString &sessionId)
         },
         [this, generation](const NetworkError &error) {
             if (generation == m_stateGeneration) {
-                replaceAuthSessions({});
                 emit loginError(tr("Unable to revoke authentication session: %1")
                                     .arg(error.userMessage));
             }

--- a/src/network/AuthenticationService.h
+++ b/src/network/AuthenticationService.h
@@ -15,15 +15,15 @@
 #include <functional>
 #include <memory>
 
+#include <optional>
 #include "network/Types.h"
 #include "providers/IProviderAuthenticator.h"
 #include "providers/IProviderRequestFactory.h"
+#include "providers/IProviderAdapter.h"
 #include "providers/ServerConnection.h"
 #include "security/CredentialStore.h"
 
 class ICatalogProvider;
-class IPlaybackProvider;
-class IProviderAdapter;
 class ISecretStore;
 class ConfigManager;
 class HttpTransport;
@@ -93,6 +93,9 @@ public:
     const IPlaybackProvider *playbackProvider() const;
     const ICatalogProvider *catalogProvider() const;
     ProviderKind activeProviderKind() const;
+    bool supportsCapability(ProviderCapability capability) const;
+    std::optional<QString> endpointFor(ProviderRoute route,
+                                       const ProviderRouteContext &context = {}) const;
     PlaybackInfoResponse mapPlaybackInfo(const QJsonObject &wirePlaybackInfo) const;
     ParsedItemsResult parseItemsResponse(const QByteArray &wireResponse,
                                          const QString &parentId) const;
@@ -100,6 +103,8 @@ public:
         itemsResponseParser() const;
     TrickplayTileInfoMap mapTrickplayInfo(const QJsonObject &wireItem) const;
     QList<MediaSegmentInfo> mapIntroSkipperSegments(
+        const QString &itemId, const QJsonObject &wireSegments) const;
+    QList<MediaSegmentInfo> mapMediaSegments(
         const QString &itemId, const QJsonObject &wireSegments) const;
     QVariantList mapRemoteSessions(const QJsonArray &wireSessions,
                                    const QString &connectionId) const;

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -861,58 +861,73 @@ void PlaybackService::getAdditionalParts(const QString &itemId,
         });
 }
 
-void PlaybackService::getMediaSegments(const QString &itemId)
+void PlaybackService::getMediaSegments(const QString &itemId, const QString &fileId)
 {
-    if (!m_authService->isAuthenticated()) {
+    if (!m_authService || !m_authService->isAuthenticated()) {
         qCDebug(lcPlayback) << "getMediaSegments: Not authenticated, skipping";
         emit mediaSegmentsLoaded(itemId, QList<MediaSegmentInfo>());
         return;
     }
-    
+
+    const bool nativeProvider = m_authService->activeProviderKind() == ProviderKind::Silo;
+    QString endpoint;
+    if (nativeProvider) {
+        ProviderRouteContext routeContext;
+        routeContext.itemId = itemId;
+        routeContext.fileId = fileId;
+        const auto nativeEndpoint = m_authService->endpointFor(
+            ProviderRoute::MediaSegments, routeContext);
+        if (!m_authService->supportsCapability(ProviderCapability::MediaSegments)
+            || !nativeEndpoint.has_value()) {
+            // Native providers must not fall through to Jellyfin routes when a
+            // capability is absent. External providers may still fill markers.
+            maybeLoadExternalMediaSegments(itemId, {});
+            return;
+        }
+        endpoint = *nativeEndpoint;
+    } else {
+        // GET /Episode/{id}/IntroSkipperSegments
+        // This endpoint is provided by the "Intro Skipper" plugin on Jellyfin.
+        endpoint = QString("/Episode/%1/IntroSkipperSegments").arg(itemId);
+    }
+
     qCDebug(lcPlayback) << "Getting media segments for item:" << itemId;
-    
-    // GET /Episode/{id}/IntroSkipperSegments
-    // This endpoint is provided by the "Intro Skipper" plugin on the Jellyfin server
-    // If not available (404), we silently return empty segments
-    QString endpoint = QString("/Episode/%1/IntroSkipperSegments").arg(itemId);
-    
     QNetworkRequest request = m_authService->createRequest(endpoint);
     QNetworkReply *reply = m_authService->networkManager()->get(request);
-    
-    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId]() {
+
+    connect(reply, &QNetworkReply::finished, this, [this, reply, itemId, nativeProvider]() {
         reply->deleteLater();
-        
-        int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-        
-        // Check for session expiry (defer during playback)
+        const int httpStatus =
+            reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+
         if (httpStatus == 401) {
             qCWarning(lcPlayback) << "Session expired while fetching media segments for" << itemId;
             m_authService->checkForSessionExpiry(reply, true);
-            finishMediaSegments(itemId, QList<MediaSegmentInfo>());
+            finishMediaSegments(itemId, {});
             return;
         }
-        
-        // 404 is expected if Intro Skipper plugin is not installed
-        // Just emit empty segments silently
+
         if (httpStatus == 404) {
-            qCDebug(lcPlayback) << "Intro Skipper plugin not available for" << itemId;
-            maybeLoadExternalMediaSegments(itemId, QList<MediaSegmentInfo>());
+            if (!nativeProvider) {
+                qCDebug(lcPlayback) << "Intro Skipper plugin not available for" << itemId;
+            }
+            maybeLoadExternalMediaSegments(itemId, {});
             return;
         }
-        
+
         if (reply->error() != QNetworkReply::NoError) {
             qCWarning(lcPlayback) << "Failed to get media segments for" << itemId
-                                       << "Error:" << reply->errorString();
-            maybeLoadExternalMediaSegments(itemId, QList<MediaSegmentInfo>());
+                                   << "Error:" << reply->errorString();
+            maybeLoadExternalMediaSegments(itemId, {});
             return;
         }
-        
-        QByteArray data = reply->readAll();
-        QJsonDocument doc = QJsonDocument::fromJson(data);
-        QJsonObject obj = doc.object();
-        
-        maybeLoadExternalMediaSegments(
-            itemId, m_authService->mapIntroSkipperSegments(itemId, obj));
+
+        const QJsonDocument document = QJsonDocument::fromJson(reply->readAll());
+        const QJsonObject object = document.object();
+        const QList<MediaSegmentInfo> segments = nativeProvider
+            ? m_authService->mapMediaSegments(itemId, object)
+            : m_authService->mapIntroSkipperSegments(itemId, object);
+        maybeLoadExternalMediaSegments(itemId, segments);
     });
 }
 
@@ -934,16 +949,31 @@ void PlaybackService::maybeLoadExternalMediaSegments(const QString &itemId, cons
 
 void PlaybackService::loadMediaSegmentLookupContext(const QString &itemId, const QList<MediaSegmentInfo> &serverSegments)
 {
-    const QString fields = QStringLiteral("ProviderIds,ParentIndexNumber,IndexNumber,SeriesId,RunTimeTicks,Type");
-    const QString endpoint = QString("/Users/%1/Items/%2?Fields=%3")
-        .arg(m_authService->getUserId(), itemId, fields);
+    const bool nativeProvider = m_authService->activeProviderKind() == ProviderKind::Silo;
+    QString endpoint;
+    if (nativeProvider) {
+        ProviderRouteContext routeContext;
+        routeContext.itemId = itemId;
+        const auto nativeEndpoint = m_authService->endpointFor(
+            ProviderRoute::CatalogItem, routeContext);
+        if (!nativeEndpoint.has_value()) {
+            finishMediaSegments(itemId, serverSegments);
+            return;
+        }
+        endpoint = *nativeEndpoint;
+    } else {
+        const QString fields =
+            QStringLiteral("ProviderIds,ParentIndexNumber,IndexNumber,SeriesId,RunTimeTicks,Type");
+        endpoint = QString("/Users/%1/Items/%2?Fields=%3")
+            .arg(m_authService->getUserId(), itemId, fields);
+    }
 
     sendRequestWithRetry(endpoint,
         [this, endpoint]() {
             QNetworkRequest request = m_authService->createRequest(endpoint);
             return m_authService->networkManager()->get(request);
         },
-        [this, itemId, serverSegments](QNetworkReply *reply) {
+        [this, itemId, serverSegments, nativeProvider](QNetworkReply *reply) {
             const QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
             const QVariantMap item = m_authService->mapMediaItem(doc.object(), QString());
             MediaSegmentLookupContext context;
@@ -972,8 +1002,26 @@ void PlaybackService::loadMediaSegmentLookupContext(const QString &itemId, const
                 return;
             }
 
-            const QString seriesEndpoint = QString("/Users/%1/Items/%2?Fields=ProviderIds")
-                .arg(m_authService->getUserId(), context.seriesId);
+            QString seriesEndpoint;
+            if (nativeProvider) {
+                ProviderRouteContext seriesContext;
+                seriesContext.itemId = context.seriesId;
+                const auto nativeSeriesEndpoint = m_authService->endpointFor(
+                    ProviderRoute::CatalogItem, seriesContext);
+                if (!nativeSeriesEndpoint.has_value()) {
+                    QPointer<PlaybackService> self(this);
+                    m_mediaSegmentProviderService->fetchExternalSegments(context, serverSegments,
+                        [self, itemId, serverSegments](const QList<MediaSegmentInfo> &segments) {
+                            if (!self) return;
+                            self->finishExternalMediaSegments(itemId, serverSegments, segments);
+                        });
+                    return;
+                }
+                seriesEndpoint = *nativeSeriesEndpoint;
+            } else {
+                seriesEndpoint = QString("/Users/%1/Items/%2?Fields=ProviderIds")
+                    .arg(m_authService->getUserId(), context.seriesId);
+            }
             sendRequestWithRetry(seriesEndpoint,
                 [this, seriesEndpoint]() {
                     QNetworkRequest request = m_authService->createRequest(seriesEndpoint);
@@ -1009,9 +1057,7 @@ void PlaybackService::loadMediaSegmentLookupContext(const QString &itemId, const
         },
         [this, itemId, serverSegments](const NetworkError &error) {
             Q_UNUSED(error);
-            if (serverSegments.isEmpty()) {
-                finishMediaSegments(itemId, serverSegments);
-            }
+            finishMediaSegments(itemId, serverSegments);
         });
 }
 
@@ -1019,10 +1065,15 @@ void PlaybackService::finishExternalMediaSegments(const QString &itemId,
                                                   const QList<MediaSegmentInfo> &serverSegments,
                                                   const QList<MediaSegmentInfo> &mergedSegments)
 {
-    if (mergedSegments.size() > serverSegments.size() || serverSegments.isEmpty()) {
-        finishMediaSegments(itemId, mergedSegments);
-    }
+    // Preserve every server-owned type while filling only types absent from
+    // the server response. The provider service normally already performs
+    // this merge; repeating it here keeps this boundary deterministic.
+    finishMediaSegments(itemId,
+                        MediaSegmentProviderService::mergeSegmentsByType(
+                            serverSegments, mergedSegments));
 }
+
+
 
 void PlaybackService::finishMediaSegments(const QString &itemId, const QList<MediaSegmentInfo> &segments)
 {
@@ -1041,19 +1092,21 @@ void PlaybackService::finishMediaSegments(const QString &itemId, const QList<Med
 
 void PlaybackService::getTrickplayInfo(const QString &itemId)
 {
-    if (!m_authService->isAuthenticated()) {
+    if (!m_authService || !m_authService->isAuthenticated()) {
         qCDebug(lcPlayback) << "getTrickplayInfo: Not authenticated, skipping";
         emit trickplayInfoLoaded(itemId, QMap<int, TrickplayTileInfo>());
         return;
     }
-    
+
+    if (m_authService->activeProviderKind() == ProviderKind::Silo) {
+        // Trickplay is not part of the advertised native contract. Do not
+        // probe Jellyfin metadata routes for native sessions.
+        emit trickplayInfoLoaded(itemId, QMap<int, TrickplayTileInfo>());
+        return;
+    }
+
     qCDebug(lcPlayback) << "Getting trickplay info for item:" << itemId;
-    
-    // GET /Items/{itemId}?Fields=Trickplay
-    // The dedicated /Videos/{itemId}/Trickplay endpoint may not exist on all Jellyfin versions,
-    // but the Trickplay field is available in the Item response
-    QString endpoint = QString("/Items/%1?Fields=Trickplay").arg(itemId);
-    
+    const QString endpoint = QString("/Items/%1?Fields=Trickplay").arg(itemId);
     sendRequestWithRetry(endpoint,
         [this, endpoint]() {
             QNetworkRequest request = m_authService->createRequest(endpoint);

--- a/src/network/PlaybackService.cpp
+++ b/src/network/PlaybackService.cpp
@@ -861,6 +861,11 @@ void PlaybackService::getAdditionalParts(const QString &itemId,
         });
 }
 
+void PlaybackService::getMediaSegments(const QString &itemId)
+{
+    getMediaSegments(itemId, QString());
+}
+
 void PlaybackService::getMediaSegments(const QString &itemId, const QString &fileId)
 {
     if (!m_authService || !m_authService->isAuthenticated()) {

--- a/src/network/PlaybackService.h
+++ b/src/network/PlaybackService.h
@@ -80,7 +80,8 @@ public:
     virtual void getAdditionalParts(const QString &itemId, const QString &requestContext);
     
     // Media Segments - Get intro/outro markers for skip functionality
-    Q_INVOKABLE void getMediaSegments(const QString &itemId);
+    Q_INVOKABLE void getMediaSegments(const QString &itemId,
+                                      const QString &fileId = QString());
     
     // Trickplay - Get thumbnail tile information for seek preview
     Q_INVOKABLE void getTrickplayInfo(const QString &itemId);

--- a/src/network/PlaybackService.h
+++ b/src/network/PlaybackService.h
@@ -80,8 +80,8 @@ public:
     virtual void getAdditionalParts(const QString &itemId, const QString &requestContext);
     
     // Media Segments - Get intro/outro markers for skip functionality
-    Q_INVOKABLE void getMediaSegments(const QString &itemId,
-                                      const QString &fileId = QString());
+    Q_INVOKABLE void getMediaSegments(const QString &itemId);
+    Q_INVOKABLE void getMediaSegments(const QString &itemId, const QString &fileId);
     
     // Trickplay - Get thumbnail tile information for seek preview
     Q_INVOKABLE void getTrickplayInfo(const QString &itemId);

--- a/src/network/SessionService.cpp
+++ b/src/network/SessionService.cpp
@@ -16,7 +16,29 @@ SessionService::SessionService(AuthenticationService *authService, QObject *pare
 {
     if (authService) {
         m_deviceId = getDeviceId();
+        connect(authService, &AuthenticationService::authSessionsChanged,
+                this, &SessionService::syncAuthenticationSessions);
+        connect(authService, &AuthenticationService::providerSelectionChanged,
+                this, &SessionService::sessionTypeChanged);
+        connect(authService, &AuthenticationService::authenticatedChanged,
+                this, &SessionService::sessionTypeChanged);
+        connect(authService, &AuthenticationService::loginError, this,
+                [this](const QString &error) {
+            if (!authenticationSessionMode()
+                || (!m_authLoadPending && m_pendingRevokeSessionId.isEmpty())) {
+                return;
+            }
+            m_authLoadPending = false;
+            m_pendingRevokeSessionId.clear();
+            m_pendingRevokeWasCurrent = false;
+            setIsLoading(false);
+            setErrorString(error);
+        });
         connect(authService, &AuthenticationService::loggedOut, this, [this]() {
+            const bool selfRevoked = m_pendingRevokeWasCurrent;
+            m_authLoadPending = false;
+            m_pendingRevokeSessionId.clear();
+            m_pendingRevokeWasCurrent = false;
             m_sessions.clear();
             m_currentSessionId.clear();
             m_errorString.clear();
@@ -25,7 +47,79 @@ SessionService::SessionService(AuthenticationService *authService, QObject *pare
             emit currentSessionIdChanged();
             emit errorStringChanged();
             emit isLoadingChanged();
+            if (selfRevoked) {
+                emit selfSessionRevoked();
+            }
         });
+    }
+}
+
+bool SessionService::authenticationSessionMode() const
+{
+    return m_authService
+        && m_authService->activeProviderKind() == ProviderKind::Silo;
+}
+
+QString SessionService::sessionTypeLabel() const
+{
+    return authenticationSessionMode()
+        ? QStringLiteral("Authentication Sessions")
+        : QStringLiteral("Playback Sessions");
+}
+
+QString SessionService::sessionTypeDescription() const
+{
+    return authenticationSessionMode()
+        ? QStringLiteral("Devices signed in to this account")
+        : QStringLiteral("Devices currently connected for playback");
+}
+
+void SessionService::syncAuthenticationSessions()
+{
+    if (!authenticationSessionMode() || !m_authService) {
+        return;
+    }
+
+    const QString previousCurrent = m_currentSessionId;
+    m_sessions = m_authService->authSessions();
+    m_currentSessionId.clear();
+    for (const QVariant &value : m_sessions) {
+        const QVariantMap session = value.toMap();
+        if (session.value(QStringLiteral("isCurrent")).toBool()) {
+            m_currentSessionId = session.value(QStringLiteral("id")).toString();
+            break;
+        }
+    }
+
+    emit sessionsChanged();
+    if (previousCurrent != m_currentSessionId) {
+        emit currentSessionIdChanged();
+    }
+
+    const QString revokedId = m_pendingRevokeSessionId;
+    if (!revokedId.isEmpty()) {
+        bool stillPresent = false;
+        for (const QVariant &value : m_sessions) {
+            if (value.toMap().value(QStringLiteral("id")).toString() == revokedId) {
+                stillPresent = true;
+                break;
+            }
+        }
+        if (!stillPresent) {
+            const bool revokedCurrent = m_pendingRevokeWasCurrent;
+            m_pendingRevokeSessionId.clear();
+            setIsLoading(false);
+            if (!revokedCurrent) {
+                m_pendingRevokeWasCurrent = false;
+                emit sessionRevoked(revokedId);
+            }
+        }
+    }
+
+    if (m_authLoadPending) {
+        m_authLoadPending = false;
+        setIsLoading(false);
+        emit sessionsLoaded();
     }
 }
 
@@ -36,14 +130,35 @@ void SessionService::fetchActiveSessions()
         emit operationFailed(m_errorString);
         return;
     }
-    if (!m_transport) {
-        setErrorString("Network transport unavailable");
-        emit operationFailed(m_errorString);
+
+    if (authenticationSessionMode() && m_isLoading) {
         return;
     }
 
     setIsLoading(true);
     setErrorString(QString());
+
+    if (!m_sessions.isEmpty()) {
+        m_sessions.clear();
+        emit sessionsChanged();
+    }
+    if (!m_currentSessionId.isEmpty()) {
+        m_currentSessionId.clear();
+        emit currentSessionIdChanged();
+    }
+
+    if (authenticationSessionMode()) {
+        m_authLoadPending = true;
+        m_authService->loadAuthSessions();
+        return;
+    }
+
+    if (!m_transport) {
+        setIsLoading(false);
+        setErrorString("Network transport unavailable");
+        emit operationFailed(m_errorString);
+        return;
+    }
 
     const QString endpoint = QStringLiteral("/Sessions");
     HttpRequestOptions options;
@@ -76,17 +191,30 @@ void SessionService::revokeSession(const QString &sessionId)
         emit operationFailed(m_errorString);
         return;
     }
-    if (!m_transport) {
-        setErrorString("Network transport unavailable");
-        emit operationFailed(m_errorString);
+
+    if (authenticationSessionMode() && m_isLoading) {
         return;
     }
 
     setIsLoading(true);
     setErrorString(QString());
 
-    // Jellyfin uses POST /Sessions/{id}/Logout to revoke a session
-    QString endpoint = QString("/Sessions/%1/Logout").arg(sessionId);
+    if (authenticationSessionMode()) {
+        m_pendingRevokeSessionId = sessionId;
+        m_pendingRevokeWasCurrent = isCurrentSession(sessionId);
+        m_authService->revokeAuthSession(sessionId);
+        return;
+    }
+
+    if (!m_transport) {
+        setIsLoading(false);
+        setErrorString("Network transport unavailable");
+        emit operationFailed(m_errorString);
+        return;
+    }
+
+    // Jellyfin uses POST /Sessions/{id}/Logout to revoke a session.
+    const QString endpoint = QString("/Sessions/%1/Logout").arg(sessionId);
     HttpRequestOptions options;
     options.retryEnabled = false;
     options.unauthorizedPolicy = UnauthorizedPolicy::ExpireSession;
@@ -107,7 +235,6 @@ void SessionService::revokeSession(const QString &sessionId)
         },
         options);
 }
-
 void SessionService::revokeAllOtherSessions()
 {
     if (!m_authService || !m_authService->isAuthenticated()) {
@@ -116,27 +243,45 @@ void SessionService::revokeAllOtherSessions()
         return;
     }
 
-    // First refresh the session list
-    fetchActiveSessions();
-
-    // Wait for sessions to load, then revoke all except current
+    // Install the one-shot handler before refreshing. Unsupported providers
+    // may publish an empty auth-session list synchronously.
     connect(this, &SessionService::sessionsLoaded, this, [this]() {
         int revokedCount = 0;
-        for (const QVariant &var : m_sessions) {
-            QVariantMap session = var.toMap();
-            QString sessionId = session["id"].toString();
-            
-            if (!sessionId.isEmpty() && sessionId != m_currentSessionId) {
-                revokeSession(sessionId);
-                revokedCount++;
+        // Never turn an unknown native current session into "revoke everyone".
+        if (!authenticationSessionMode() || !m_currentSessionId.isEmpty()) {
+            for (const QVariant &var : m_sessions) {
+                const QVariantMap session = var.toMap();
+                const QString sessionId = session.value(QStringLiteral("id")).toString();
+                if (!sessionId.isEmpty() && sessionId != m_currentSessionId) {
+                    revokeSession(sessionId);
+                    ++revokedCount;
+                }
             }
         }
         emit allOtherSessionsRevoked(revokedCount);
     }, Qt::SingleShotConnection);
+
+    fetchActiveSessions();
 }
 
 void SessionService::identifyCurrentSession()
 {
+    if (authenticationSessionMode()) {
+        const QString previousCurrent = m_currentSessionId;
+        m_currentSessionId.clear();
+        for (const QVariant &value : m_sessions) {
+            const QVariantMap session = value.toMap();
+            if (session.value(QStringLiteral("isCurrent")).toBool()) {
+                m_currentSessionId = session.value(QStringLiteral("id")).toString();
+                break;
+            }
+        }
+        if (previousCurrent != m_currentSessionId) {
+            emit currentSessionIdChanged();
+        }
+        return;
+    }
+
     if (m_deviceId.isEmpty()) {
         m_deviceId = getDeviceId();
     }
@@ -145,13 +290,12 @@ void SessionService::identifyCurrentSession()
         return;
     }
 
-    // Find the session matching our device ID
+    // Find the session matching our device ID.
     for (const QVariant &var : m_sessions) {
-        QVariantMap session = var.toMap();
-        QString sessionDeviceId = session["deviceId"].toString();
-        
+        const QVariantMap session = var.toMap();
+        const QString sessionDeviceId = session.value(QStringLiteral("deviceId")).toString();
         if (sessionDeviceId == m_deviceId) {
-            QString newSessionId = session["id"].toString();
+            const QString newSessionId = session.value(QStringLiteral("id")).toString();
             if (newSessionId != m_currentSessionId) {
                 m_currentSessionId = newSessionId;
                 emit currentSessionIdChanged();

--- a/src/network/SessionService.cpp
+++ b/src/network/SessionService.cpp
@@ -138,6 +138,12 @@ void SessionService::fetchActiveSessions()
     setIsLoading(true);
     setErrorString(QString());
 
+    if (authenticationSessionMode()) {
+        m_authLoadPending = true;
+        m_authService->loadAuthSessions();
+        return;
+    }
+
     if (!m_sessions.isEmpty()) {
         m_sessions.clear();
         emit sessionsChanged();
@@ -145,12 +151,6 @@ void SessionService::fetchActiveSessions()
     if (!m_currentSessionId.isEmpty()) {
         m_currentSessionId.clear();
         emit currentSessionIdChanged();
-    }
-
-    if (authenticationSessionMode()) {
-        m_authLoadPending = true;
-        m_authService->loadAuthSessions();
-        return;
     }
 
     if (!m_transport) {

--- a/src/network/SessionService.cpp
+++ b/src/network/SessionService.cpp
@@ -63,15 +63,15 @@ bool SessionService::authenticationSessionMode() const
 QString SessionService::sessionTypeLabel() const
 {
     return authenticationSessionMode()
-        ? QStringLiteral("Authentication Sessions")
-        : QStringLiteral("Playback Sessions");
+        ? tr("Authentication Sessions")
+        : tr("Playback Sessions");
 }
 
 QString SessionService::sessionTypeDescription() const
 {
     return authenticationSessionMode()
-        ? QStringLiteral("Devices signed in to this account")
-        : QStringLiteral("Devices currently connected for playback");
+        ? tr("Devices signed in to this account")
+        : tr("Devices currently connected for playback");
 }
 
 void SessionService::syncAuthenticationSessions()
@@ -243,19 +243,22 @@ void SessionService::revokeAllOtherSessions()
         return;
     }
 
-    // Install the one-shot handler before refreshing. Unsupported providers
-    // may publish an empty auth-session list synchronously.
+    if (authenticationSessionMode()) {
+        setErrorString(tr("Bulk authentication-session revocation is not supported."));
+        emit operationFailed(m_errorString);
+        return;
+    }
+
+    // Refresh the Jellyfin playback-session list before revoking every session
+    // except the current device.
     connect(this, &SessionService::sessionsLoaded, this, [this]() {
         int revokedCount = 0;
-        // Never turn an unknown native current session into "revoke everyone".
-        if (!authenticationSessionMode() || !m_currentSessionId.isEmpty()) {
-            for (const QVariant &var : m_sessions) {
-                const QVariantMap session = var.toMap();
-                const QString sessionId = session.value(QStringLiteral("id")).toString();
-                if (!sessionId.isEmpty() && sessionId != m_currentSessionId) {
-                    revokeSession(sessionId);
-                    ++revokedCount;
-                }
+        for (const QVariant &var : m_sessions) {
+            const QVariantMap session = var.toMap();
+            const QString sessionId = session.value(QStringLiteral("id")).toString();
+            if (!sessionId.isEmpty() && sessionId != m_currentSessionId) {
+                revokeSession(sessionId);
+                ++revokedCount;
             }
         }
         emit allOtherSessionsRevoked(revokedCount);

--- a/src/network/SessionService.h
+++ b/src/network/SessionService.h
@@ -9,13 +9,11 @@ class AuthenticationService;
 class HttpTransport;
 
 /**
- * @brief Wraps Jellyfin /Sessions API for session management.
+ * @brief Presents the active provider's remotely managed sessions.
  *
- * Provides:
- * - Fetch active sessions from Jellyfin server
- * - Revoke specific sessions
- * - Revoke all other sessions (logout everywhere else)
- * - Detect self-session revocation
+ * Jellyfin exposes playback sessions through /Sessions. Providers that expose
+ * authentication sessions (currently Silo) are delegated to
+ * AuthenticationService so this class never probes Jellyfin routes for them.
  */
 class SessionService : public QObject
 {
@@ -24,6 +22,9 @@ class SessionService : public QObject
     Q_PROPERTY(bool isLoading READ isLoading NOTIFY isLoadingChanged)
     Q_PROPERTY(QString errorString READ errorString NOTIFY errorStringChanged)
     Q_PROPERTY(QString currentSessionId READ currentSessionId NOTIFY currentSessionIdChanged)
+    Q_PROPERTY(bool authenticationSessionMode READ authenticationSessionMode NOTIFY sessionTypeChanged)
+    Q_PROPERTY(QString sessionTypeLabel READ sessionTypeLabel NOTIFY sessionTypeChanged)
+    Q_PROPERTY(QString sessionTypeDescription READ sessionTypeDescription NOTIFY sessionTypeChanged)
 
 public:
     explicit SessionService(AuthenticationService *authService, QObject *parent = nullptr);
@@ -33,14 +34,18 @@ public:
     QString errorString() const { return m_errorString; }
     QString currentSessionId() const { return m_currentSessionId; }
 
+    bool authenticationSessionMode() const;
+    QString sessionTypeLabel() const;
+    QString sessionTypeDescription() const;
+
     /**
-     * @brief Fetch all active sessions from the Jellyfin server
+     * @brief Fetch provider-supported authentication or playback sessions.
      */
     Q_INVOKABLE void fetchActiveSessions();
 
     /**
-     * @brief Revoke a specific session by ID
-     * @param sessionId The session ID to revoke
+     * @brief Revoke a specific session by ID.
+     * @param sessionId The session ID to revoke.
      */
     Q_INVOKABLE void revokeSession(const QString &sessionId);
 
@@ -71,6 +76,7 @@ signals:
     void isLoadingChanged();
     void errorStringChanged();
     void currentSessionIdChanged();
+    void sessionTypeChanged();
     void sessionsLoaded();
     void sessionRevoked(QString sessionId);
     void allOtherSessionsRevoked(int count);
@@ -80,6 +86,7 @@ signals:
 private slots:
     void onFetchSessionsFinished(QNetworkReply *reply);
     void onRevokeSessionFinished(QNetworkReply *reply, QString sessionId);
+    void syncAuthenticationSessions();
 
 private:
     AuthenticationService *m_authService;
@@ -88,6 +95,9 @@ private:
     bool m_isLoading = false;
     QString m_errorString;
     QString m_currentSessionId;
+    bool m_authLoadPending = false;
+    QString m_pendingRevokeSessionId;
+    bool m_pendingRevokeWasCurrent = false;
     QString m_deviceId;
 
     void setIsLoading(bool loading);

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -3712,6 +3712,10 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
         m_hasEvaluatedCompletionForAttempt = false;
         cancelPendingDisplayRestore(true);
         clearPlaybackSegments();
+        if (!m_mediaSourceId.isEmpty()) {
+            m_mediaSourceId.clear();
+            emit mediaSourceIdChanged();
+        }
         for (const QVariant &segment : requestedPlaybackSegments) {
             QVariantMap segmentMap = segment.toMap();
             segmentMap[QStringLiteral("playbackAttemptId")] =

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -3197,7 +3197,7 @@ void PlayerController::applyPlaybackSegment(int index, bool reportSegmentStart)
 
     const QString activeItemId = segment.value(QStringLiteral("itemId")).toString();
     if (!activeItemId.isEmpty()) {
-        m_playbackService->getMediaSegments(activeItemId);
+        m_playbackService->getMediaSegments(activeItemId, m_mediaSourceId);
         m_playbackService->getTrickplayInfo(activeItemId);
     }
 
@@ -3773,7 +3773,7 @@ void PlayerController::playUrl(const QString &url, const QString &itemId, qint64
         emit trickplayStateChanged();
         if (!itemId.isEmpty()) {
             m_libraryService->getChapters(itemId);
-            m_playbackService->getMediaSegments(itemId);
+            m_playbackService->getMediaSegments(itemId, m_mediaSourceId);
             m_playbackService->getTrickplayInfo(itemId);
         }
 

--- a/src/providers/IProviderAdapter.h
+++ b/src/providers/IProviderAdapter.h
@@ -44,6 +44,7 @@ struct ProviderRouteContext {
     QString accountId;
     QString profileId;
     QString itemId;
+    QString fileId;
     QString sessionId;
 };
 

--- a/src/providers/silo/SiloProviderAdapter.h
+++ b/src/providers/silo/SiloProviderAdapter.h
@@ -125,8 +125,11 @@ public:
             return endpointWithId(QStringLiteral("/api/v1/watched/%1"),
                                   context.itemId);
         case ProviderRoute::MediaSegments:
-            return endpointWithId(QStringLiteral("/api/v1/markers/items/%1"),
-                                  context.itemId);
+            return context.fileId.isEmpty()
+                ? endpointWithId(QStringLiteral("/api/v1/markers/items/%1"),
+                                 context.itemId)
+                : endpointWithId(QStringLiteral("/api/v1/markers/files/%1"),
+                                 context.fileId);
         case ProviderRoute::PlaybackInfo:
             return endpointWithId(QStringLiteral("/api/v1/catalog/items/%1"),
                                   context.itemId);

--- a/src/ui/ActiveSessionsScreen.qml
+++ b/src/ui/ActiveSessionsScreen.qml
@@ -5,6 +5,7 @@ import BloomUI
 
 FocusScope {
     id: root
+    focus: true
 
     property var sessionService: null
     property var sessionManager: null
@@ -12,18 +13,35 @@ FocusScope {
 
     signal backRequested
 
+    Keys.onEscapePressed: function(event) {
+        root.backRequested()
+        event.accepted = true
+    }
+    Keys.onBackPressed: function(event) {
+        root.backRequested()
+        event.accepted = true
+    }
+
     function refresh() {
         if (sessionService) {
             sessionService.fetchActiveSessions();
         }
     }
 
-    // Auto-refresh when screen becomes visible
+    Component.onCompleted: Qt.callLater(function() {
+        if (root.visible) backButton.forceActiveFocus()
+    })
+
+    // Auto-refresh when screen becomes visible.
     onVisibleChanged: {
         if (visible) {
-            refresh();
+            refresh()
+            Qt.callLater(function() { backButton.forceActiveFocus() })
         }
     }
+
+    readonly property bool authenticationMode: sessionService
+        && sessionService.authenticationSessionMode
 
     // Handle self-session revocation
     Connections {
@@ -54,7 +72,6 @@ FocusScope {
         RowLayout {
             Layout.fillWidth: true
             spacing: Theme.spacingMedium
-
             A11yButton {
                 id: backButton
                 text: "\ue92f"  // Back arrow icon
@@ -70,7 +87,9 @@ FocusScope {
             }
 
             Label {
-                text: "Active Sessions"
+                text: root.sessionService
+                    ? root.sessionService.sessionTypeLabel
+                    : qsTr("Playback Sessions")
                 font.pixelSize: Theme.fontSizeHeader
                 font.weight: Font.Bold
                 color: Theme.textPrimary
@@ -84,31 +103,43 @@ FocusScope {
                 font.pixelSize: Theme.iconSizeSmall
                 Layout.preferredWidth: Theme.iconSizeMedium
                 Layout.preferredHeight: Theme.iconSizeMedium
-                toolTipText: "Refresh"
+                toolTipText: qsTr("Refresh")
+                enabled: root.sessionService && !root.sessionService.isLoading
 
                 onActivated: refresh()
 
                 KeyNavigation.left: backButton
+                KeyNavigation.right: revokeAllButton.visible ? revokeAllButton : backButton
                 KeyNavigation.down: sessionsList
             }
 
             A11yButton {
                 id: revokeAllButton
-                text: "Revoke All Others"
+                text: root.sessionService
+                    ? qsTr("Revoke All Other %1").arg(root.sessionService.sessionTypeLabel)
+                    : qsTr("Revoke All Other Playback Sessions")
                 font.pixelSize: Theme.fontSizeBody
                 height: Theme.iconSizeMedium
-                enabled: root.sessionService && root.sessionService.sessions.length > 1
+                enabled: root.sessionService && !root.sessionService.isLoading
+                    && root.sessionService.sessions.length > 1
+                visible: !root.authenticationMode
                 opacity: enabled ? 1.0 : 0.5
 
                 onActivated: {
-                    if (root.sessionService) {
-                        root.sessionService.revokeAllOtherSessions();
-                    }
+                    if (root.sessionService) root.sessionService.revokeAllOtherSessions()
                 }
 
                 KeyNavigation.left: refreshButton
                 KeyNavigation.down: sessionsList
             }
+        }
+
+        Label {
+            text: root.sessionService ? root.sessionService.sessionTypeDescription : ""
+            visible: text.length > 0
+            Layout.fillWidth: true
+            color: Theme.textSecondary
+            font.pixelSize: Theme.fontSizeBody
         }
 
         // Loading indicator
@@ -146,28 +177,36 @@ FocusScope {
                 id: sessionDelegate
                 width: sessionsList.width
                 height: 80
-                property bool isCurrent: model.id === (root.sessionService ? root.sessionService.currentSessionId : "")
-
+                property bool isCurrent: root.authenticationMode
+                    ? !!model.isCurrent
+                    : model.id === (root.sessionService ? root.sessionService.currentSessionId : "")
+                property bool highlighted: ListView.isCurrentItem && sessionsList.activeFocus
+                function requestRevoke() {
+                    if (!isCurrent && revokeButton.enabled && root.sessionService) {
+                        root.sessionService.revokeSession(model.id)
+                    }
+                }
                 // Background
                 Rectangle {
                     anchors.fill: parent
-                    color: sessionDelegate.activeFocus ? Theme.accentColor : (isCurrent ? Theme.accentColor + "20" : Theme.backgroundSecondary)
+                    z: -1
+                    color: sessionDelegate.highlighted ? Theme.accentColor : (isCurrent ? Theme.accentColor + "20" : Theme.backgroundSecondary)
                     radius: Theme.radiusMedium
                     border.width: isCurrent ? 2 : 0
                     border.color: Theme.accentColor
                 }
 
                 RowLayout {
+                    z: 1
                     anchors.fill: parent
                     anchors.margins: Theme.spacingMedium
                     spacing: Theme.spacingMedium
-
                     // Device icon
                     Label {
-                        text: getDeviceIcon(model.client)
+                        text: getDeviceIcon(root.authenticationMode ? model.deviceName : model.client)
                         font.family: Icons.materialFamily
                         font.pixelSize: Theme.iconSizeMedium
-                        color: sessionDelegate.activeFocus ? Theme.textPrimary : Theme.textSecondary
+                        color: sessionDelegate.highlighted ? Theme.textPrimary : Theme.textSecondary
                         Layout.alignment: Qt.AlignVCenter
                     }
 
@@ -180,15 +219,14 @@ FocusScope {
                             spacing: Theme.spacingSmall
 
                             Label {
-                                text: model.deviceName || "Unknown Device"
+                                text: model.deviceName || qsTr("Unknown Device")
                                 font.pixelSize: Theme.fontSizeBody
                                 font.weight: Font.Medium
-                                color: sessionDelegate.activeFocus ? Theme.textPrimary : Theme.textPrimary
+                                color: Theme.textPrimary
                                 Layout.fillWidth: true
                                 elide: Text.ElideRight
                             }
 
-                            // Current session badge
                             Rectangle {
                                 visible: sessionDelegate.isCurrent
                                 implicitWidth: currentSessionLabel.implicitWidth + Theme.spacingSmall * 2
@@ -199,7 +237,7 @@ FocusScope {
                                 Label {
                                     id: currentSessionLabel
                                     anchors.centerIn: parent
-                                    text: "This Device"
+                                    text: root.authenticationMode ? qsTr("Current") : qsTr("This Device")
                                     font.pixelSize: Theme.fontSizeCaption
                                     font.weight: Font.Bold
                                     color: Theme.textPrimary
@@ -208,15 +246,19 @@ FocusScope {
                         }
 
                         Label {
-                            text: model.client + (model.clientVersion ? " " + model.clientVersion : "")
+                            text: root.authenticationMode
+                                ? qsTr("IP address: %1").arg(model.ipAddress || qsTr("Unknown"))
+                                : model.client + (model.clientVersion ? " " + model.clientVersion : "")
                             font.pixelSize: Theme.fontSizeCaption
-                            color: sessionDelegate.activeFocus ? Theme.textSecondary : Theme.textMuted
+                            color: sessionDelegate.highlighted ? Theme.textSecondary : Theme.textMuted
                         }
 
                         Label {
-                            text: "Last active: " + formatDate(model.lastActivityDate)
+                            text: root.authenticationMode
+                                ? qsTr("Created: %1").arg(formatDate(model.createdAt))
+                                : qsTr("Last active: %1").arg(formatDate(model.lastActivityDate))
                             font.pixelSize: Theme.fontSizeCaption
-                            color: sessionDelegate.activeFocus ? Theme.textSecondary : Theme.textMuted
+                            color: sessionDelegate.highlighted ? Theme.textSecondary : Theme.textMuted
                         }
                     }
 
@@ -224,33 +266,33 @@ FocusScope {
                     A11yButton {
                         id: revokeButton
                         visible: !sessionDelegate.isCurrent
-                        enabled: visible
+                        enabled: visible && root.sessionService
+                            && !root.sessionService.isLoading
                         text: "\ue14c"  // Close/cancel icon
                         font.family: Icons.materialFamily
                         font.pixelSize: Theme.iconSizeSmall
                         Layout.preferredWidth: Theme.iconSizeMedium
                         Layout.preferredHeight: Theme.iconSizeMedium
-                        toolTipText: "Revoke session"
+                        toolTipText: root.authenticationMode
+                            ? qsTr("Revoke authentication session")
+                            : qsTr("Revoke playback session")
 
-                        onActivated: {
-                            if (root.sessionService) {
-                                root.sessionService.revokeSession(model.id);
-                            }
-                        }
+                        onActivated: sessionDelegate.requestRevoke()
 
                         KeyNavigation.left: sessionDelegate
                     }
                 }
 
-                Keys.onReturnPressed: {
-                    if (!sessionDelegate.isCurrent && revokeButton.visible) {
-                        revokeButton.clicked();
-                    }
-                }
+                Keys.onReturnPressed: sessionDelegate.requestRevoke()
+                Keys.onEnterPressed: sessionDelegate.requestRevoke()
 
                 MouseArea {
+                    z: 0
                     anchors.fill: parent
-                    onClicked: sessionDelegate.forceActiveFocus()
+                    onClicked: {
+                        sessionsList.currentIndex = index
+                        sessionsList.forceActiveFocus()
+                    }
                 }
             }
 
@@ -258,11 +300,20 @@ FocusScope {
             Label {
                 visible: parent.count === 0 && (!root.sessionService || !root.sessionService.isLoading)
                 anchors.centerIn: parent
-                text: "No active sessions found"
+                text: root.sessionService
+                    ? qsTr("No %1 found").arg(root.sessionService.sessionTypeLabel.toLowerCase())
+                    : qsTr("No playback sessions found")
                 font.pixelSize: Theme.fontSizeBody
                 color: Theme.textMuted
             }
+            Keys.onReturnPressed: {
+                if (currentItem) currentItem.requestRevoke()
+            }
+            Keys.onEnterPressed: {
+                if (currentItem) currentItem.requestRevoke()
+            }
         }
+
     }
 
     WheelStepScroller {

--- a/src/ui/ActiveSessionsScreen.qml
+++ b/src/ui/ActiveSessionsScreen.qml
@@ -182,7 +182,8 @@ FocusScope {
                     : model.id === (root.sessionService ? root.sessionService.currentSessionId : "")
                 property bool highlighted: ListView.isCurrentItem && sessionsList.activeFocus
                 function requestRevoke() {
-                    if (!isCurrent && revokeButton.enabled && root.sessionService) {
+                    if ((!isCurrent || root.authenticationMode)
+                        && revokeButton.enabled && root.sessionService) {
                         root.sessionService.revokeSession(model.id)
                     }
                 }
@@ -190,7 +191,12 @@ FocusScope {
                 Rectangle {
                     anchors.fill: parent
                     z: -1
-                    color: sessionDelegate.highlighted ? Theme.accentColor : (isCurrent ? Theme.accentColor + "20" : Theme.backgroundSecondary)
+                    color: sessionDelegate.highlighted
+                        ? Theme.accentColor
+                        : (isCurrent
+                            ? Qt.rgba(Theme.accentColor.r, Theme.accentColor.g,
+                                      Theme.accentColor.b, 0.12)
+                            : Theme.backgroundSecondary)
                     radius: Theme.radiusMedium
                     border.width: isCurrent ? 2 : 0
                     border.color: Theme.accentColor
@@ -265,7 +271,7 @@ FocusScope {
                     // Revoke button (only for other sessions)
                     A11yButton {
                         id: revokeButton
-                        visible: !sessionDelegate.isCurrent
+                        visible: !sessionDelegate.isCurrent || root.authenticationMode
                         enabled: visible && root.sessionService
                             && !root.sessionService.isLoading
                         text: "\ue14c"  // Close/cancel icon
@@ -283,13 +289,15 @@ FocusScope {
                     }
                 }
 
-                Keys.onReturnPressed: sessionDelegate.requestRevoke()
-                Keys.onEnterPressed: sessionDelegate.requestRevoke()
 
                 MouseArea {
                     z: 0
                     anchors.fill: parent
+                    cursorShape: InputModeManager.pointerActive
+                        ? Qt.PointingHandCursor : Qt.BlankCursor
                     onClicked: {
+                        InputModeManager.setNavigationMode("pointer")
+                        InputModeManager.hideCursor(false)
                         sessionsList.currentIndex = index
                         sessionsList.forceActiveFocus()
                     }

--- a/src/ui/SettingsScreen.qml
+++ b/src/ui/SettingsScreen.qml
@@ -429,6 +429,7 @@ FocusScope {
     // ========================================
 
     RowLayout {
+        enabled: !root.activeSessionsVisible
         anchors.fill: parent
         anchors.margins: Theme.paddingLarge
         spacing: Theme.spacingLarge

--- a/src/ui/SettingsScreen.qml
+++ b/src/ui/SettingsScreen.qml
@@ -95,7 +95,19 @@ FocusScope {
     }
 
     signal signOutRequested()
+    property bool activeSessionsVisible: false
 
+    function openActiveSessions() {
+        activeSessionsVisible = true
+        Qt.callLater(function() {
+            if (activeSessionsVisible) activeSessionsScreen.forceActiveFocus()
+        })
+    }
+
+    function closeActiveSessions() {
+        activeSessionsVisible = false
+        Qt.callLater(function() { aboutAccountSection.enterFromRail() })
+    }
     function openNewProfileDialog(returnFocusTarget) {
         newProfileDialog.restoreFocusTarget = returnFocusTarget || null
         newProfileDialog.open()
@@ -485,8 +497,21 @@ FocusScope {
                 qtVersion: typeof qtVersion !== "undefined" ? qtVersion : ""
                 onRequestReturnToRail: root.returnToRail()
                 onSignOutRequested: root.signOutRequested()
+                onSessionsRequested: root.openActiveSessions()
             }
         }
+    }
+
+    ActiveSessionsScreen {
+        id: activeSessionsScreen
+        anchors.fill: parent
+        z: 20
+        visible: root.activeSessionsVisible
+        enabled: visible
+        focus: visible
+        sessionService: typeof SessionService !== "undefined" ? SessionService : null
+        authService: typeof AuthenticationService !== "undefined" ? AuthenticationService : null
+        onBackRequested: root.closeActiveSessions()
     }
 
     ToastNotification {

--- a/src/ui/WindowManager.cpp
+++ b/src/ui/WindowManager.cpp
@@ -18,10 +18,11 @@
 #include "viewmodels/MovieDetailsViewModel.h"
 #include "viewmodels/UpNextRecommendationsViewModel.h"
 #include "network/AuthenticationService.h"
+#include "network/SessionService.h"
+#include "network/SeerrService.h"
 #include "providers/ActiveArtworkProvider.h"
 #include "network/LibraryService.h"
 #include "network/PlaybackService.h"
-#include "network/SeerrService.h"
 #include "updates/UpdateService.h"
 #include "core/ServiceLocator.h"
 #include "config/version.h"
@@ -166,13 +167,12 @@ void WindowManager::exposeContextProperties(ApplicationInitializer& appInit)
     context->setContextProperty("UiSoundController", ServiceLocator::get<UiSoundController>());
     context->setContextProperty("ScreensaverController", ServiceLocator::get<ScreensaverController>());
     context->setContextProperty("SystemPowerController", ServiceLocator::get<SystemPowerController>());
-
     context->setContextProperty("AuthenticationService", ServiceLocator::get<AuthenticationService>());
+    context->setContextProperty("SessionService", ServiceLocator::get<SessionService>());
     context->setContextProperty("LibraryService", ServiceLocator::get<LibraryService>());
     context->setContextProperty("PlaybackService", ServiceLocator::get<PlaybackService>());
     context->setContextProperty("SeerrService", ServiceLocator::get<SeerrService>());
     context->setContextProperty("UpdateService", ServiceLocator::get<UpdateService>());
-
     // App metadata for QML
     context->setContextProperty("appVersion", QCoreApplication::applicationVersion());
     context->setContextProperty("qtVersion", QString(qVersion()));

--- a/src/ui/settings/AboutAccountSettings.qml
+++ b/src/ui/settings/AboutAccountSettings.qml
@@ -650,7 +650,8 @@ FocusScope {
                         }
                         Keys.onDownPressed: function(event) {
                             if (!popup.visible) {
-                                activeSessionsBtn.forceActiveFocus()
+                                (activeSessionsBtn.enabled
+                                    ? activeSessionsBtn : signOutBtn).forceActiveFocus()
                                 event.accepted = true
                             }
                         }
@@ -804,7 +805,8 @@ FocusScope {
                         }
                     }
                     Keys.onUpPressed: function(event) {
-                        activeSessionsBtn.forceActiveFocus()
+                        (activeSessionsBtn.enabled
+                            ? activeSessionsBtn : logLevelCombo).forceActiveFocus()
                         event.accepted = true
                     }
                     Keys.onReturnPressed: root.signOutRequested()

--- a/src/ui/settings/AboutAccountSettings.qml
+++ b/src/ui/settings/AboutAccountSettings.qml
@@ -8,6 +8,7 @@ FocusScope {
 
     signal requestReturnToRail()
     signal signOutRequested()
+    signal sessionsRequested()
 
     readonly property Item preferredEntryItem: autoUpdateCheckToggle
     property Item _lastFocusedItem: null
@@ -649,7 +650,7 @@ FocusScope {
                         }
                         Keys.onDownPressed: function(event) {
                             if (!popup.visible) {
-                                signOutBtn.forceActiveFocus()
+                                activeSessionsBtn.forceActiveFocus()
                                 event.accepted = true
                             }
                         }
@@ -738,8 +739,59 @@ FocusScope {
                     label: qsTr("User")
                     value: ConfigManager.username || qsTr("Unknown")
                 }
+                // Session management is available for both providers, but the
+                // destination labels the provider-supported session type.
+                Button {
+                    id: activeSessionsBtn
+                    focusPolicy: Qt.StrongFocus
+                    enabled: typeof SessionService !== "undefined"
+                        && typeof AuthenticationService !== "undefined"
+                        && AuthenticationService.authenticated
+                    Layout.fillWidth: true
+                    onClicked: root.sessionsRequested()
+                    onActiveFocusChanged: {
+                        if (activeFocus) {
+                            root._lastFocusedItem = this
+                            flickable.ensureFocusVisible(this)
+                        }
+                    }
+                    Keys.onUpPressed: function(event) {
+                        logLevelCombo.forceActiveFocus()
+                        event.accepted = true
+                    }
+                    Keys.onDownPressed: function(event) {
+                        signOutBtn.forceActiveFocus()
+                        event.accepted = true
+                    }
+                    Keys.onReturnPressed: root.sessionsRequested()
+                    Keys.onEnterPressed: root.sessionsRequested()
+
+                    contentItem: Text {
+                        text: typeof SessionService !== "undefined"
+                            ? qsTr("Manage %1").arg(SessionService.sessionTypeLabel)
+                            : qsTr("Manage Sessions")
+                        font.pixelSize: Theme.fontSizeBody
+                        font.family: Theme.fontPrimary
+                        color: Theme.textPrimary
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                    }
+
+                    background: Rectangle {
+                        implicitHeight: Theme.buttonHeightSmall
+                        radius: Theme.radiusSmall
+                        color: activeSessionsBtn.activeFocus || activeSessionsBtn.hovered
+                            ? Theme.buttonSecondaryBackgroundHover
+                            : Theme.buttonSecondaryBackground
+                        border.color: activeSessionsBtn.activeFocus
+                            ? Theme.focusBorder : Theme.buttonSecondaryBorder
+                        border.width: activeSessionsBtn.activeFocus ? 2 : Theme.buttonBorderWidth
+                        opacity: activeSessionsBtn.enabled ? 1.0 : 0.5
+                    }
+                }
 
                 // Sign Out button
+
                 Button {
                     id: signOutBtn
                     focusPolicy: Qt.StrongFocus
@@ -752,7 +804,7 @@ FocusScope {
                         }
                     }
                     Keys.onUpPressed: function(event) {
-                        logLevelCombo.forceActiveFocus()
+                        activeSessionsBtn.forceActiveFocus()
                         event.accepted = true
                     }
                     Keys.onReturnPressed: root.signOutRequested()

--- a/tests/SiloAuthenticationTest.cpp
+++ b/tests/SiloAuthenticationTest.cpp
@@ -171,6 +171,7 @@ private slots:
     void failedSharedRefreshExpiresSessionOnce();
     void profileTokenIsBoundToSelectionAndClearedOnSwitch();
     void serviceLoadsRevokedSessionsAndCallsRevokeEndpoint();
+    void failedSessionLoadPreservesKnownSessions();
     void profileVerificationNeverReceivesStaleProfileHeaders();
     void nullTransportFailsAuthenticationWithoutCrashing();
     void emptyProfilesAfterSwitchLeaveVisibleErrorAndAuthenticatedStep();
@@ -424,6 +425,12 @@ void SiloAuthenticationTest::adapterExposesProfileAndSessionRoutes()
     ProviderRouteContext context;
     context.profileId = QStringLiteral("profile/with space");
     context.sessionId = QStringLiteral("session/with space");
+    context.itemId = QStringLiteral("content/with space");
+    const auto itemMarkers =
+        adapter.endpointFor(ProviderRoute::MediaSegments, context);
+    context.fileId = QStringLiteral("file/with space");
+    const auto fileMarkers =
+        adapter.endpointFor(ProviderRoute::MediaSegments, context);
 
     const auto profiles = adapter.endpointFor(ProviderRoute::Profiles);
     const auto pin = adapter.endpointFor(ProviderRoute::VerifyProfilePin, context);
@@ -437,12 +444,18 @@ void SiloAuthenticationTest::adapterExposesProfileAndSessionRoutes()
     QVERIFY(revoke.has_value());
     QVERIFY(health.has_value());
     QVERIFY(logout.has_value());
+    QVERIFY(itemMarkers.has_value());
+    QVERIFY(fileMarkers.has_value());
     QCOMPARE(*profiles, QStringLiteral("/api/v1/profiles"));
     QCOMPARE(*pin,
              QStringLiteral("/api/v1/profiles/profile%2Fwith%20space/verify-pin"));
     QCOMPARE(*sessions, QStringLiteral("/api/v1/auth/sessions"));
     QCOMPARE(*revoke,
              QStringLiteral("/api/v1/auth/sessions/session%2Fwith%20space"));
+    QCOMPARE(*itemMarkers,
+             QStringLiteral("/api/v1/markers/items/content%2Fwith%20space"));
+    QCOMPARE(*fileMarkers,
+             QStringLiteral("/api/v1/markers/files/file%2Fwith%20space"));
     QCOMPARE(*health, QStringLiteral("/api/v1/health"));
     QCOMPARE(*logout, QStringLiteral("/api/v1/auth/logout"));
 }
@@ -778,6 +791,41 @@ void SiloAuthenticationTest::serviceLoadsRevokedSessionsAndCallsRevokeEndpoint()
     QCOMPARE(manager.requests.at(initialRequestCount + 1)
                  .request.rawHeader("Authorization"),
              QByteArrayLiteral("Bearer access-1"));
+}
+
+void SiloAuthenticationTest::failedSessionLoadPreservesKnownSessions()
+{
+    FakeNetworkAccessManager manager;
+    manager.responses = {
+        response(200, successfulLogin()),
+        response(200, singleUnlockedProfile())
+    };
+    HttpTransport transport(&manager);
+    SiloProviderAdapter adapter;
+    AuthenticationService service(nullptr, &transport, &adapter);
+    service.setProviderSelection(QStringLiteral("silo"));
+    service.authenticate(QStringLiteral("https://silo.example.test"),
+                         QStringLiteral("Alice"),
+                         QStringLiteral("password"));
+    QTRY_VERIFY_WITH_TIMEOUT(service.isAuthenticated(), 1000);
+
+    manager.responses.append(response(
+        200,
+        QByteArrayLiteral(
+            R"({"sessions":[{"id":"session-current","device_name":"Living Room","is_current":true}]})")));
+    service.loadAuthSessions();
+    QTRY_COMPARE_WITH_TIMEOUT(service.authSessions().size(), 1, 1000);
+
+    QSignalSpy errorSpy(&service, &AuthenticationService::loginError);
+    manager.responses.append(response(
+        400,
+        QByteArrayLiteral(R"({"error":"invalid_request","message":"Request rejected"})")));
+    service.loadAuthSessions();
+    QTRY_COMPARE_WITH_TIMEOUT(errorSpy.size(), 1, 1000);
+    QCOMPARE(service.authSessions().size(), 1);
+    QCOMPARE(service.authSessions().first().toMap()
+                 .value(QStringLiteral("id")).toString(),
+             QStringLiteral("session-current"));
 }
 void SiloAuthenticationTest::refreshWithoutRotationRetainsPreviousToken()
 {

--- a/tests/contracts/provider-contracts.json
+++ b/tests/contracts/provider-contracts.json
@@ -12,8 +12,8 @@
     "supported": "Bloom-required behavior and payload semantics are present.",
     "partial": "The core path is usable, but some requested behavior or data is ignored or absent.",
     "stubbed": "The route returns a success-shaped placeholder without the required behavior.",
-    "missing": "The route is absent or cannot provide fields Bloom requires.",
-    "not-applicable": "The deployment does not expose this protocol surface."
+    "missing": "Unavailable: the route is absent or cannot provide fields Bloom requires; never treat this as supported.",
+    "not-applicable": "Intentionally out-of-scope: the deployment does not expose this protocol surface and Bloom makes no claim."
   },
   "surfaces": [
     {
@@ -81,7 +81,21 @@
     "metadata.theme-songs",
     "subtitles.delivery-url",
     "cache.conditional-refresh",
-    "errors.expired-session"
+    "errors.expired-session",
+    "catalog.recommendations",
+    "catalog.server-sections",
+    "playback.versions",
+    "playback.multipart-reporting",
+    "sessions.auth-playback-separation",
+    "preferences.profile-track-local",
+    "optional.household-overview",
+    "optional.watchlist",
+    "optional.watch-together",
+    "optional.requests",
+    "optional.notifications",
+    "optional.downloads",
+    "optional.audiobooks",
+    "optional.ebooks"
   ],
   "contracts": [
     {
@@ -216,6 +230,7 @@
     },
     {
       "id": "artwork.standard",
+      "issue": 80,
       "journey": "artwork",
       "bloomCaller": "LibraryService::getImageUrl/getCachedImageUrl",
       "method": "GET",
@@ -229,6 +244,7 @@
     },
     {
       "id": "artwork.chapter",
+      "issue": 80,
       "journey": "artwork",
       "bloomCaller": "LibraryService::getCachedChapterThumbnailUrl",
       "method": "GET",
@@ -268,6 +284,7 @@
     },
     {
       "id": "playback.additional-parts",
+      "issue": 80,
       "journey": "playback",
       "bloomCaller": "PlaybackService::getAdditionalParts",
       "method": "GET",
@@ -281,6 +298,7 @@
     },
     {
       "id": "playback.trickplay",
+      "issue": 80,
       "journey": "playback",
       "bloomCaller": "PlaybackService::getTrickplayInfo/TrickplayProcessor",
       "method": "GET",
@@ -294,6 +312,7 @@
     },
     {
       "id": "playback.report",
+      "issue": 80,
       "journey": "playback",
       "bloomCaller": "PlaybackService::reportPlaybackStarted/Progress/Paused/Resumed/Stopped",
       "method": "POST",
@@ -346,6 +365,7 @@
     },
     {
       "id": "segments.plugin-intro-skipper",
+      "issue": 80,
       "journey": "segments",
       "bloomCaller": "PlaybackService::getMediaSegments",
       "method": "GET",
@@ -359,6 +379,7 @@
     },
     {
       "id": "segments.standard",
+      "issue": 80,
       "journey": "segments",
       "bloomCaller": "Not currently called; target for canonical adapter work",
       "method": "GET",
@@ -372,6 +393,7 @@
     },
     {
       "id": "sessions.list",
+      "issue": 80,
       "journey": "sessions",
       "bloomCaller": "SessionService::refreshSessions",
       "method": "GET",
@@ -385,6 +407,7 @@
     },
     {
       "id": "sessions.revoke",
+      "issue": 80,
       "journey": "sessions",
       "bloomCaller": "SessionService::terminateSession",
       "method": "POST",
@@ -411,6 +434,7 @@
     },
     {
       "id": "metadata.theme-songs",
+      "issue": 80,
       "journey": "metadata",
       "bloomCaller": "LibraryService::getThemeSongs",
       "method": "GET",
@@ -459,6 +483,202 @@
       "expectations": {
         "jellyfin-supported": {"outcome": "supported", "evidence": "Control for current Jellyfin session expiry behavior."},
         "silo-8044eb8-compat": {"outcome": "supported", "evidence": "Compat token authentication rejects missing/expired/revoked sessions with 401."}
+      }
+    },
+    {
+      "id": "catalog.recommendations",
+      "issue": 80,
+      "journey": "catalog",
+      "bloomCaller": "LibraryService::getSimilarItems and UpNextRecommendationsViewModel",
+      "method": "GET",
+      "path": "/Items/{itemId}/Similar",
+      "requestSemantics": ["Bloom requests similar titles by the current logical item identity and applies a bounded result limit"],
+      "requiredSemantics": ["Returned items have stable catalog identity and media type", "Recommendation failures degrade to an empty optional rail without breaking playback or navigation"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Jellyfin Similar route and Bloom's similar-item mapper provide the optional recommendation rail."},
+        "silo-8044eb8-compat": {"outcome": "missing", "evidence": "The compatibility surface has no usable similar-items route; native Silo recommendations are a separate protocol and are not a compat claim."}
+      }
+    },
+    {
+      "id": "catalog.server-sections",
+      "issue": 80,
+      "journey": "catalog",
+      "bloomCaller": "LibraryService home, hero, backdrop, random and screensaver section loaders",
+      "method": "GET",
+      "path": "provider-specific home section routes",
+      "requestSemantics": ["Bloom requests profile-scoped section items with stable ordering and bounded windows"],
+      "requiredSemantics": ["Each section either returns the requested item shape or explicitly reports unsupported", "An unavailable optional section does not replace the main library and Next Up content"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Jellyfin provider implements the section operations used by Bloom."},
+        "silo-8044eb8-compat": {"outcome": "partial", "evidence": "Compat can provide core libraries/latest/Next Up but does not provide all Bloom hero, backdrop, random or screensaver section semantics."}
+      }
+    },
+    {
+      "id": "playback.versions",
+      "issue": 80,
+      "journey": "playback",
+      "bloomCaller": "PlaybackService::getPlaybackInfo and PlayerController version selection",
+      "method": "GET",
+      "path": "/Items/{itemId}?Fields=MediaSources and /Videos/{itemId}/AdditionalParts",
+      "requestSemantics": ["Bloom requests all available media sources and ordered physical parts before user-initiated playback"],
+      "requiredSemantics": ["Versions retain stable source identity and selectable stream metadata", "Missing alternate-version or part data degrades to the available source rather than inventing a URL"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "PlaybackInfo and AdditionalParts are used for the version picker and multipart queue."},
+        "silo-8044eb8-compat": {"outcome": "missing", "evidence": "Compat does not register AdditionalParts or equivalent alternate-version semantics; native Silo versions are intentionally a different surface."}
+      }
+    },
+    {
+      "id": "playback.multipart-reporting",
+      "issue": 80,
+      "journey": "playback",
+      "bloomCaller": "PlayerController multipart segment handoff and PlaybackService reporting",
+      "method": "POST",
+      "path": "/Sessions/Playing* per physical part",
+      "requestSemantics": ["Bloom keeps logical-item identity separate from the active physical reporting segment", "Each physical part supplies its own media source and play-session identity"],
+      "requiredSemantics": ["Progress is aggregated across ordered parts", "Part handoff does not trigger terminal completion until the final part", "Reports preserve selected source and stream identities"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Current controller queues Jellyfin parts and reports per-part sessions while retaining aggregate progress."},
+        "silo-8044eb8-compat": {"outcome": "missing", "evidence": "Compat lacks multipart discovery, so there is no supported multipart reporting lifecycle to map."}
+      }
+    },
+    {
+      "id": "sessions.auth-playback-separation",
+      "issue": 80,
+      "journey": "sessions",
+      "bloomCaller": "SessionService remote auth-session list/revoke versus PlaybackService playback reporting",
+      "method": "GET/POST",
+      "path": "/Sessions and /Sessions/Playing*",
+      "requestSemantics": ["Authentication sessions are listed/revoked independently from transient playback sessions", "Playback reports carry play-session and media-source identity"],
+      "requiredSemantics": ["Revoking an auth session does not tear down the caller's local playback state before normal teardown", "Playback stop remains a playback lifecycle operation, not an auth-session revoke"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Bloom uses SessionService for remote session operations and PlaybackService for Playing lifecycle reports."},
+        "silo-8044eb8-compat": {"outcome": "missing", "evidence": "Compat session listing is a stub and remote session logout is absent; its playback reports cannot substitute for auth-session management."}
+      }
+    },
+    {
+      "id": "preferences.profile-track-local",
+      "issue": 80,
+      "journey": "client-state",
+      "bloomCaller": "TrackPreferencesManager and PlayerController audio/subtitle selection",
+      "method": "LOCAL",
+      "path": "track_preferences.json",
+      "requestSemantics": ["Explicit audio/subtitle choices are persisted locally by connection and movie/season scope", "Unset choices remain provider/file defaults and are not written"],
+      "requiredSemantics": ["A saved choice is restored only when its stream index is valid for the current source", "Provider playback does not require a server-side preference endpoint"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "supported", "evidence": "Bloom persists explicit per-season/per-movie track choices locally and applies them before playback."},
+        "silo-8044eb8-compat": {"outcome": "partial", "evidence": "The client-local path works with Silo tracks, but the file is connection-scoped rather than provider-profile-scoped and hierarchy lookup is unavailable."}
+      }
+    },
+    {
+      "id": "optional.household-overview",
+      "issue": 80,
+      "journey": "optional-follow-up",
+      "bloomCaller": "Future household overview surface",
+      "method": "N/A",
+      "path": "provider-specific household overview",
+      "requestSemantics": ["No Bloom request is made for this optional follow-up"],
+      "requiredSemantics": ["The matrix must not imply that a deployment supports an unimplemented household overview contract"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "not-applicable", "evidence": "No pinned Bloom protocol contract or current client surface exists for household overview."},
+        "silo-8044eb8-compat": {"outcome": "not-applicable", "evidence": "No compatibility route or current Bloom surface is claimed for household overview."}
+      }
+    },
+    {
+      "id": "optional.watchlist",
+      "issue": 80,
+      "journey": "optional-follow-up",
+      "bloomCaller": "Future watchlist surface",
+      "method": "N/A",
+      "path": "provider-specific watchlist",
+      "requestSemantics": ["No Bloom request is made for this optional follow-up"],
+      "requiredSemantics": ["Watchlist support is not inferred from favorite or played state"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "not-applicable", "evidence": "Bloom currently has favorite and played state, not a distinct watchlist contract."},
+        "silo-8044eb8-compat": {"outcome": "not-applicable", "evidence": "No distinct compatibility watchlist route is pinned or consumed."}
+      }
+    },
+    {
+      "id": "optional.watch-together",
+      "issue": 80,
+      "journey": "optional-follow-up",
+      "bloomCaller": "Future synchronized viewing surface",
+      "method": "N/A",
+      "path": "provider-specific watch-together",
+      "requestSemantics": ["No Bloom request is made for this optional follow-up"],
+      "requiredSemantics": ["Playback session reporting must not be presented as synchronized multi-user viewing"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "not-applicable", "evidence": "No watch-together client or server contract is implemented by Bloom."},
+        "silo-8044eb8-compat": {"outcome": "not-applicable", "evidence": "No compatibility watch-together route is pinned or consumed."}
+      }
+    },
+    {
+      "id": "optional.requests",
+      "issue": 80,
+      "journey": "optional-follow-up",
+      "bloomCaller": "Future media-request surface",
+      "method": "N/A",
+      "path": "external request service",
+      "requestSemantics": ["No provider request route is made by the Bloom catalog contract"],
+      "requiredSemantics": ["Optional external request integration remains distinct from provider catalog and playback support"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "not-applicable", "evidence": "Bloom's Seerr integration is an optional external service, not a Jellyfin provider contract."},
+        "silo-8044eb8-compat": {"outcome": "not-applicable", "evidence": "No Silo compatibility request route is pinned or consumed by Bloom."}
+      }
+    },
+    {
+      "id": "optional.notifications",
+      "issue": 80,
+      "journey": "optional-follow-up",
+      "bloomCaller": "Future provider notification surface",
+      "method": "N/A",
+      "path": "provider-specific notifications",
+      "requestSemantics": ["No provider notification stream or polling route is made"],
+      "requiredSemantics": ["Authentication expiry and playback errors are not treated as provider notifications"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "not-applicable", "evidence": "No Bloom notification contract is implemented or pinned."},
+        "silo-8044eb8-compat": {"outcome": "not-applicable", "evidence": "No compatibility notification route is pinned or consumed."}
+      }
+    },
+    {
+      "id": "optional.downloads",
+      "issue": 80,
+      "journey": "optional-follow-up",
+      "bloomCaller": "Future offline-download surface",
+      "method": "N/A",
+      "path": "provider-specific downloads",
+      "requestSemantics": ["No download job or offline media request is made"],
+      "requiredSemantics": ["Direct playback URLs and subtitle delivery are not download support"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "not-applicable", "evidence": "Bloom has no offline-download client contract."},
+        "silo-8044eb8-compat": {"outcome": "not-applicable", "evidence": "No compatibility download route is pinned or consumed."}
+      }
+    },
+    {
+      "id": "optional.audiobooks",
+      "issue": 80,
+      "journey": "optional-follow-up",
+      "bloomCaller": "Future audiobook catalog and playback surface",
+      "method": "N/A",
+      "path": "provider-specific audiobook catalog",
+      "requestSemantics": ["No audiobook-specific catalog or playback request is made"],
+      "requiredSemantics": ["Mapping an item type to AudioBook does not establish audiobook feature support"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "not-applicable", "evidence": "Bloom's current catalog/playback contract does not implement audiobook UX or semantics."},
+        "silo-8044eb8-compat": {"outcome": "not-applicable", "evidence": "Silo type mapping alone is not a pinned compatibility audiobook contract."}
+      }
+    },
+    {
+      "id": "optional.ebooks",
+      "issue": 80,
+      "journey": "optional-follow-up",
+      "bloomCaller": "Future ebook catalog and reader surface",
+      "method": "N/A",
+      "path": "provider-specific ebook catalog",
+      "requestSemantics": ["No ebook-specific catalog or reader request is made"],
+      "requiredSemantics": ["Mapping an item type to Book does not establish ebook reader support"],
+      "expectations": {
+        "jellyfin-supported": {"outcome": "not-applicable", "evidence": "Bloom's current client has no ebook reader or provider-neutral ebook contract."},
+        "silo-8044eb8-compat": {"outcome": "not-applicable", "evidence": "Silo type mapping alone is not a pinned compatibility ebook contract."}
       }
     }
   ],

--- a/tests/contracts/provider_contracts_test.py
+++ b/tests/contracts/provider_contracts_test.py
@@ -119,10 +119,42 @@ class ProviderContractValidationTest(unittest.TestCase):
         self.assertIn("not-applicable", labels)
         self.assertIn("unavailable", labels["missing"].lower())
         self.assertIn("out-of-scope", labels["not-applicable"].lower())
-        for contract in self.valid_data["contracts"]:
-            for expectation in contract["expectations"].values():
-                if expectation["outcome"] in {"missing", "not-applicable"}:
-                    self.assertNotEqual(expectation["outcome"], "supported")
+        rows = {row["id"]: row for row in self.valid_data["contracts"]}
+        compat_missing = {
+            "artwork.chapter",
+            "playback.additional-parts",
+            "playback.trickplay",
+            "segments.plugin-intro-skipper",
+            "sessions.revoke",
+            "catalog.recommendations",
+            "playback.versions",
+            "playback.multipart-reporting",
+            "sessions.auth-playback-separation",
+        }
+        for contract_id in compat_missing:
+            self.assertEqual(
+                rows[contract_id]["expectations"]["silo-8044eb8-compat"]["outcome"],
+                "missing",
+                contract_id,
+            )
+
+        for contract_id in (
+            "optional.household-overview",
+            "optional.watchlist",
+            "optional.watch-together",
+            "optional.requests",
+            "optional.notifications",
+            "optional.downloads",
+            "optional.audiobooks",
+            "optional.ebooks",
+        ):
+            self.assertTrue(
+                all(
+                    expectation["outcome"] == "not-applicable"
+                    for expectation in rows[contract_id]["expectations"].values()
+                ),
+                contract_id,
+            )
 
     def test_rejects_non_object_native_detection(self):
         data = copy.deepcopy(self.valid_data)

--- a/tests/contracts/provider_contracts_test.py
+++ b/tests/contracts/provider_contracts_test.py
@@ -57,6 +57,73 @@ class ProviderContractValidationTest(unittest.TestCase):
         with self.assertRaisesRegex(ContractValidationError, "missing contracts"):
             validate_contract_data(data)
 
+    def test_issue_80_rows_cover_scope_and_canonical_outcomes(self):
+        expected_ids = {
+            "artwork.standard",
+            "artwork.chapter",
+            "playback.additional-parts",
+            "playback.trickplay",
+            "playback.report",
+            "segments.plugin-intro-skipper",
+            "segments.standard",
+            "sessions.list",
+            "sessions.revoke",
+            "metadata.theme-songs",
+            "catalog.recommendations",
+            "catalog.server-sections",
+            "playback.versions",
+            "playback.multipart-reporting",
+            "sessions.auth-playback-separation",
+            "preferences.profile-track-local",
+            "optional.household-overview",
+            "optional.watchlist",
+            "optional.watch-together",
+            "optional.requests",
+            "optional.notifications",
+            "optional.downloads",
+            "optional.audiobooks",
+            "optional.ebooks",
+        }
+        rows = [contract for contract in self.valid_data["contracts"] if contract.get("issue") == 80]
+        self.assertEqual({row["id"] for row in rows}, expected_ids)
+        self.assertTrue(expected_ids.issubset(set(self.valid_data["coverageRequirements"])))
+
+        deployments = {"jellyfin-supported", "silo-8044eb8-compat"}
+        observed_outcomes = set()
+        for row in rows:
+            self.assertEqual(set(row["expectations"]), deployments, row["id"])
+            self.assertTrue(row["requestSemantics"], row["id"])
+            self.assertTrue(row["requiredSemantics"], row["id"])
+            for expectation in row["expectations"].values():
+                outcome = expectation["outcome"]
+                self.assertIn(outcome, self.valid_data["outcomes"])
+                observed_outcomes.add(outcome)
+        self.assertTrue(
+            {"supported", "partial", "missing", "not-applicable"}.issubset(observed_outcomes)
+        )
+
+        optional_rows = [row for row in rows if row["journey"] == "optional-follow-up"]
+        self.assertEqual(len(optional_rows), 8)
+        for row in optional_rows:
+            self.assertTrue(
+                all(
+                    expectation["outcome"] == "not-applicable"
+                    for expectation in row["expectations"].values()
+                ),
+                row["id"],
+            )
+
+    def test_canonical_unavailable_and_out_of_scope_labels_are_not_supported(self):
+        labels = self.valid_data["outcomes"]
+        self.assertIn("missing", labels)
+        self.assertIn("not-applicable", labels)
+        self.assertIn("unavailable", labels["missing"].lower())
+        self.assertIn("out-of-scope", labels["not-applicable"].lower())
+        for contract in self.valid_data["contracts"]:
+            for expectation in contract["expectations"].values():
+                if expectation["outcome"] in {"missing", "not-applicable"}:
+                    self.assertNotEqual(expectation["outcome"], "supported")
+
     def test_rejects_non_object_native_detection(self):
         data = copy.deepcopy(self.valid_data)
         data["nativeSiloContract"]["detection"] = "present-but-invalid"


### PR DESCRIPTION
## Summary
- route native Silo markers and chapters through provider-owned contracts with server-first per-type precedence and exact file/version marker identity
- present provider-correct authentication versus playback sessions in Settings with keyboard/gamepad navigation and safe revocation serialization
- record the complete issue #80 capability matrix, including intentionally unavailable optional features and pinned-contract evidence

## Verification
- `./scripts/dev-build.sh --tests`
- `ctest --test-dir build-dev --output-on-failure` (28/28)
- `python3 tests/contracts/validate_contracts.py tests/contracts/provider-contracts.json` (43 contracts, 3 deployments)
- `python3 -m unittest tests/contracts/provider_contracts_test.py` (27 tests)
- offscreen Bloom startup smoke: no new QML ReferenceError/TypeError

Closes #80
Part of #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added provider-aware session management, including authentication sessions, session labels, refresh, revocation, and current-session indicators.
  - Added a Manage Sessions view with keyboard navigation, focus handling, loading states, and localized session details.
  - Improved media marker support for item- and file-level playback, including deterministic merging across sources.

- **Bug Fixes**
  - Failed session refreshes now preserve previously loaded sessions.
  - Playback metadata and chapter behavior now work consistently across supported providers.

- **Documentation**
  - Clarified provider compatibility outcomes, media-segment precedence, chapter metadata, and supported session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Silo native session management, media segments, and trickplay capability parity
> - `SessionService` gains two operating modes: authentication session mode (for native Silo providers) and playback session mode (for Jellyfin). Fetch, revoke, and bulk-revoke operations delegate to `AuthenticationService` in auth mode and surface appropriate errors when operations are unsupported.
> - `PlaybackService.getMediaSegments` now accepts an optional `fileId`, resolves provider-specific endpoints via `AuthenticationService`, skips Jellyfin routes for native providers when `MediaSegments` capability is absent, and uses per-provider JSON parsers.
> - `PlaybackService.getTrickplayInfo` short-circuits with an empty result for Silo native providers instead of probing Jellyfin endpoints.
> - `ActiveSessionsScreen` and `AboutAccountSettings` expose a mode-aware session management UI with dynamic labels, per-mode revoke rules, and keyboard navigation; `SettingsScreen` hosts the sessions screen as an in-place overlay.
> - `AuthenticationService` adds `supportsCapability`, `endpointFor`, and `mapMediaSegments` methods; failed session loads no longer clear existing session state.
> - Risk: `finishExternalMediaSegments` now unconditionally merges by type (server segments win per type), changing prior behavior where external counts determined merge priority.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d01b3a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->