### PR TITLE
fix(images): load Silo artwork across providers

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -8,7 +8,8 @@ Hybrid mode prefers cached pre-rounded PNGs, falls back to the shader path, and 
 - Env overrides: `BLOOM_ROUNDED_IMAGE_MODE`, `BLOOM_ROUNDED_PREPROCESS` / `BLOOM_ROUNDED_IMAGE_PREPROCESS` (`0/1` or `true/false`).
 
 ## Pre-rounded path (ImageCacheProvider)
-- Provider artwork is identified by a token-free `ArtworkRef` cache key (`connectionId`, item, kind/index/tag, and requested width). Authenticated URLs and headers are resolved only on a cache miss and are never persisted or logged.
+- Provider artwork is identified by a token-free `ArtworkRef` cache key (`connectionId`, item, owner kind, kind/index/tag, and requested width). Authenticated URLs and headers are resolved only on a cache miss and are never persisted or logged. UI code passes the complete reference to `LibraryService.getCachedArtworkUrlFromRef(...)`; this preserves native Silo's in-memory opaque source while deriving width-specific cache identities.
+- Linux builds and portable artifacts ship Qt Image Formats so Silo's native S3 artwork and Jellyfin-compat image redirects can decode WebP responses. `ArtworkRefreshTest` guards the runtime decoder, and portable packaging rejects an artifact missing `libqwebp.so`.
 - Rounded variants are stored beside originals and keyed by the `ArtworkRef` identity + radius + size.
 - Generation triggers after cache hits/misses when preprocessing is enabled; emits `roundedImageReady(url, fileUrl)` once written.
 - Defaults: radius `Theme.imageRadius`, size `640x960` (poster). Callers may pass custom radius/size to `requestRoundedImage(url, radius, w, h)`.

--- a/docs/images.md
+++ b/docs/images.md
@@ -8,7 +8,7 @@ Hybrid mode prefers cached pre-rounded PNGs, falls back to the shader path, and 
 - Env overrides: `BLOOM_ROUNDED_IMAGE_MODE`, `BLOOM_ROUNDED_PREPROCESS` / `BLOOM_ROUNDED_IMAGE_PREPROCESS` (`0/1` or `true/false`).
 
 ## Pre-rounded path (ImageCacheProvider)
-- Provider artwork is identified by a token-free `ArtworkRef` cache key (`connectionId`, item, owner kind, kind/index/tag, and requested width). Authenticated URLs and headers are resolved only on a cache miss and are never persisted or logged. UI code passes the complete reference to `LibraryService.getCachedArtworkUrlFromRef(...)`; this preserves native Silo's in-memory opaque source while deriving width-specific cache identities.
+- Provider artwork is identified by a token-free `ArtworkRef` cache key (`connectionId`, item, owner kind, kind/index/tag, and requested width). Authenticated URLs and headers are resolved only on a cache miss and are never persisted or logged. UI code passes the complete reference to `LibraryService.getCachedArtworkUrlFromRef(...)`; this preserves native Silo's in-memory opaque source while deriving width-specific cache identities. Transient sources remain available for the authenticated session regardless of catalog size and are cleared when account state resets.
 - Linux builds and portable artifacts ship Qt Image Formats so Silo's native S3 artwork and Jellyfin-compat image redirects can decode WebP responses. `ArtworkRefreshTest` guards the runtime decoder, and portable packaging rejects an artifact missing `libqwebp.so`.
 - Rounded variants are stored beside originals and keyed by the `ArtworkRef` identity + radius + size.
 - Generation triggers after cache hits/misses when preprocessing is enabled; emits `roundedImageReady(url, fileUrl)` once written.

--- a/flake.nix
+++ b/flake.nix
@@ -53,8 +53,7 @@
                   python3
                   skopeo
                 ];
-                runtimeEnv.GDK_PIXBUF_MODULE_FILE =
-                  "${pkgs.librsvg}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache";
+                runtimeEnv.GDK_PIXBUF_MODULE_FILE = "${pkgs.librsvg}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache";
                 inherit text;
               }
             }/bin/${name}";
@@ -152,6 +151,7 @@
                 pkgs.lib.makeSearchPath "lib/qt-6/plugins" [
                   pkgs.qt6.qtbase
                   pkgs.qt6.qtdeclarative
+                  pkgs.qt6.qtimageformats
                   pkgs.qt6.qtmultimedia
                   pkgs.qt6.qtsvg
                   pkgs.qt6.qtwayland

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qt5compat
     qt6.qtbase
     qt6.qtdeclarative
+    qt6.qtimageformats
     qt6.qtmultimedia
     qt6.qtshadertools
     qt6.qtsvg
@@ -77,6 +78,10 @@ stdenv.mkDerivation (finalAttrs: {
     "--set-default"
     "QT_MEDIA_BACKEND"
     "ffmpeg"
+    "--prefix"
+    "QT_PLUGIN_PATH"
+    ":"
+    "${qt6.qtimageformats}/lib/qt-6/plugins"
     "--prefix"
     "PATH"
     ":"

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
     qt6.qt5compat
     qt6.qtbase
     qt6.qtdeclarative
+    qt6.qtimageformats
     qt6.qtmultimedia
     qt6.qtshadertools
     qt6.qtsvg
@@ -81,6 +82,12 @@ stdenv.mkDerivation {
     runHook preCheck
     python3 "$src/tests/contracts/provider_contracts_test.py"
     export QT_QPA_PLATFORM=offscreen
+    export QT_PLUGIN_PATH="${
+      lib.makeSearchPath "lib/qt-6/plugins" [
+        qt6.qtbase
+        qt6.qtimageformats
+      ]
+    }''${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}"
     ctest --output-on-failure \
       --exclude-regex '^(VisualRegressionTest|SeriesDetailsCacheTest)$'
     runHook postCheck

--- a/packaging/portable/build.sh
+++ b/packaging/portable/build.sh
@@ -26,7 +26,7 @@ QT_PLUGIN_SHA="$(jq_read "['portable']['linuxdeploy_qt_sha256']")"
 python3 -m venv /opt/aqt
 /opt/aqt/bin/pip install --no-cache-dir 'aqtinstall==3.3.*'
 /opt/aqt/bin/aqt install-qt linux desktop "$QT_VERSION" linux_gcc_64 \
-    -O /opt/Qt -m qtmultimedia qtshadertools qt5compat \
+    -O /opt/Qt -m qtimageformats qtmultimedia qtshadertools qt5compat \
     qtwaylandcompositor
 
 QT_ROOT="/opt/Qt/$QT_VERSION/gcc_64"
@@ -85,6 +85,11 @@ for platform_plugin in libqoffscreen.so libqwayland.so libqxcb.so; do
         exit 1
     }
 done
+
+test -f "$APPDIR/usr/plugins/imageformats/libqwebp.so" || {
+    echo "Missing deployed Qt WebP image plugin: libqwebp.so" >&2
+    exit 1
+}
 
 while IFS= read -r -d '' elf; do
     if unresolved="$(ldd "$elf" 2>/dev/null | grep 'not found' || true)" && [[ -n "$unresolved" ]]; then

--- a/src/models/MediaModels.cpp
+++ b/src/models/MediaModels.cpp
@@ -1,6 +1,6 @@
 #include "MediaModels.h"
 
-#include <QCache>
+#include <QHash>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMutex>
@@ -10,7 +10,7 @@
 namespace {
 
 QMutex transientArtworkSourceMutex;
-QCache<QString, QString> transientArtworkSources(512);
+QHash<QString, QString> transientArtworkSources;
 
 void rememberTransientArtworkSource(const QString &cacheKey, const QString &sourceUrl)
 {
@@ -18,14 +18,13 @@ void rememberTransientArtworkSource(const QString &cacheKey, const QString &sour
         return;
     }
     QMutexLocker locker(&transientArtworkSourceMutex);
-    transientArtworkSources.insert(cacheKey, new QString(sourceUrl));
+    transientArtworkSources.insert(cacheKey, sourceUrl);
 }
 
 QString transientArtworkSource(const QString &cacheKey)
 {
     QMutexLocker locker(&transientArtworkSourceMutex);
-    const QString *source = transientArtworkSources.object(cacheKey);
-    return source ? *source : QString();
+    return transientArtworkSources.value(cacheKey);
 }
 
 } // namespace
@@ -82,6 +81,12 @@ ArtworkOwnerKind artworkOwnerKindFromName(const QString &name)
 QString ArtworkRef::transientSourceUrlForCacheKey(const QString &key)
 {
     return transientArtworkSource(key);
+}
+
+void ArtworkRef::clearTransientSourceUrls()
+{
+    QMutexLocker locker(&transientArtworkSourceMutex);
+    transientArtworkSources.clear();
 }
 
 bool MediaRef::isValid() const

--- a/src/models/MediaModels.h
+++ b/src/models/MediaModels.h
@@ -61,6 +61,8 @@ struct ArtworkRef {
     // Resolves the in-process source associated with a token-free cache key.
     // The value is intentionally unavailable after process restart.
     static QString transientSourceUrlForCacheKey(const QString &key);
+    // Discards opaque sources when the authenticated account context resets.
+    static void clearTransientSourceUrls();
     static ArtworkRef fromCacheKey(const QString &key);
     static ArtworkRef fromVariantMap(const QVariantMap &map);
 };

--- a/src/network/AuthenticationService.cpp
+++ b/src/network/AuthenticationService.cpp
@@ -1,5 +1,6 @@
 #include "AuthenticationService.h"
 #include "HttpTransport.h"
+#include "models/MediaModels.h"
 #include "../security/ISecretStore.h"
 #include "../utils/ConfigManager.h"
 #include "providers/IProviderAdapter.h"
@@ -1199,6 +1200,7 @@ void AuthenticationService::restoreSession(const QString &serverUrl,
         && (m_activeConnection.baseUrl != normalizedServerUrl
             || m_activeConnection.accountId != userId);
     if (switchingAccount) {
+        Bloom::ArtworkRef::clearTransientSourceUrls();
         m_refreshToken.clear();
         m_profileToken.clear();
         m_pendingProfileId.clear();
@@ -1324,6 +1326,7 @@ void AuthenticationService::clearAccountStateInternal(bool removeCredentials,
     if (m_transport) {
         m_transport->cancelAll();
     }
+    Bloom::ArtworkRef::clearTransientSourceUrls();
     const bool wasAuthenticated = isAuthenticated();
     ++m_stateGeneration;
 

--- a/src/network/LibraryService.cpp
+++ b/src/network/LibraryService.cpp
@@ -1374,6 +1374,27 @@ QString LibraryService::getCachedArtworkUrlForConnection(const QString &connecti
     return cachedArtworkSource(artwork);
 }
 
+QString LibraryService::getCachedArtworkUrlFromRef(const QVariantMap &artworkMap,
+                                                    int width)
+{
+    Bloom::ArtworkRef artwork = Bloom::ArtworkRef::fromVariantMap(artworkMap);
+    if (!artwork.isValid()) {
+        return {};
+    }
+
+    // Native Silo's fetch location is intentionally absent from the QVariantMap.
+    // Recover it from the mapper-created, token-free cache key before changing
+    // the requested width, then let cacheKey() register the width-specific key.
+    const QString sourceCacheKey = artworkMap.value(QStringLiteral("cacheKey")).toString();
+    const Bloom::ArtworkRef sourceIdentity = Bloom::ArtworkRef::fromCacheKey(sourceCacheKey);
+    if (sourceIdentity.isValid() && sourceIdentity == artwork) {
+        artwork.sourceUrl = Bloom::ArtworkRef::transientSourceUrlForCacheKey(sourceCacheKey);
+    }
+
+    artwork.requestedWidth = width > 0 ? width : 1920;
+    return cachedArtworkSource(artwork);
+}
+
 QString LibraryService::getCachedChapterThumbnailUrl(const QString &itemId, int chapterIndex, const QString &imageTag, const QString &imagePath, int width)
 {
     if (itemId.isEmpty() || chapterIndex < 0) {
@@ -1390,11 +1411,16 @@ QString LibraryService::getCachedChapterThumbnailUrl(const QString &itemId, int 
         width = 480;
     }
 
-    const QString cachedUrl = getCachedArtworkUrl(itemId,
-                                                   QStringLiteral("chapter"),
-                                                   chapterIndex,
-                                                   imageTag,
-                                                   width);
+    Bloom::ArtworkRef artwork;
+    artwork.connectionId = activeConnectionId(m_authService);
+    artwork.itemId = itemId;
+    artwork.kind = Bloom::ArtworkKind::Chapter;
+    artwork.ownerKind = Bloom::ArtworkOwnerKind::Chapter;
+    artwork.index = chapterIndex;
+    artwork.tag = imageTag.trimmed();
+    artwork.requestedWidth = width;
+    artwork.sourceUrl = imagePath.trimmed();
+    const QString cachedUrl = cachedArtworkSource(artwork);
     qCInfo(lcLibrary) << "LibraryService: Chapter thumbnail request"
             << "item" << itemId
             << "index" << chapterIndex

--- a/src/network/LibraryService.h
+++ b/src/network/LibraryService.h
@@ -154,6 +154,8 @@ public:
                                                                   int imageIndex,
                                                                   const QString &imageTag,
                                                                   int width);
+    Q_INVOKABLE virtual QString getCachedArtworkUrlFromRef(const QVariantMap &artwork,
+                                                           int width);
     Q_INVOKABLE virtual QString getCachedChapterThumbnailUrl(const QString &itemId, int chapterIndex, const QString &imageTag, const QString &imagePath = QString(), int width = 480);
 
     QNetworkReply* pingServer();

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -6363,13 +6363,7 @@ void PlayerController::onChaptersLoaded(const QString &connectionId,
         const QVariantMap artwork = chapter.value(QStringLiteral("artwork")).toMap();
         const QString thumbnailUrl = artwork.isEmpty()
             ? QString()
-            : m_libraryService->getCachedArtworkUrlForConnection(
-                  artwork.value(QStringLiteral("connectionId")).toString(),
-                  artwork.value(QStringLiteral("itemId")).toString(),
-                  artwork.value(QStringLiteral("kind")).toString(),
-                  artwork.value(QStringLiteral("index")).toInt(),
-                  artwork.value(QStringLiteral("tag")).toString(),
-                  640);
+            : m_libraryService->getCachedArtworkUrlFromRef(artwork, 640);
         chapter.insert(QStringLiteral("index"), index);
         chapter.insert(QStringLiteral("thumbnailUrl"), thumbnailUrl);
         chapterModels.append(chapter);

--- a/src/test/MockLibraryService.cpp
+++ b/src/test/MockLibraryService.cpp
@@ -652,6 +652,18 @@ QString MockLibraryService::getCachedArtworkUrlForConnection(const QString &conn
     return getCachedArtworkUrl(itemId, imageType, imageIndex, imageTag, width);
 }
 
+QString MockLibraryService::getCachedArtworkUrlFromRef(const QVariantMap &artwork,
+                                                       int width)
+{
+    return getCachedArtworkUrlForConnection(
+        artwork.value(QStringLiteral("connectionId")).toString(),
+        artwork.value(QStringLiteral("itemId")).toString(),
+        artwork.value(QStringLiteral("kind")).toString(),
+        artwork.value(QStringLiteral("index")).toInt(),
+        artwork.value(QStringLiteral("tag")).toString(),
+        width);
+}
+
 QJsonObject MockLibraryService::findItemById(const QString &itemId) const
 {
     // Search in all collections

--- a/src/test/MockLibraryService.h
+++ b/src/test/MockLibraryService.h
@@ -94,6 +94,8 @@ public:
                                                           int imageIndex,
                                                           const QString &imageTag,
                                                           int width) override;
+    Q_INVOKABLE QString getCachedArtworkUrlFromRef(const QVariantMap &artwork,
+                                                   int width) override;
 
 private:
     QJsonObject m_fixture;

--- a/src/ui/HeroBanner.qml
+++ b/src/ui/HeroBanner.qml
@@ -51,13 +51,7 @@ FocusScope {
     function artworkUrlFromRef(artwork, width) {
         if (!artwork || !artwork.itemId)
             return ""
-        return LibraryService.getCachedArtworkUrlForConnection(
-                    artwork.connectionId || "",
-                    artwork.itemId,
-                    artwork.kind || "primary",
-                    artwork.index || 0,
-                    artwork.tag || "",
-                    width || 0)
+        return LibraryService.getCachedArtworkUrlFromRef(artwork, width || 0)
     }
 
     function imageUrl(item, type, width) {

--- a/src/ui/HomeScreen.qml
+++ b/src/ui/HomeScreen.qml
@@ -93,13 +93,7 @@ FocusScope {
     function artworkUrlFromRef(artwork, width) {
         if (!artwork || !artwork.itemId)
             return ""
-        return LibraryService.getCachedArtworkUrlForConnection(
-                    artwork.connectionId || "",
-                    artwork.itemId,
-                    artwork.kind || "primary",
-                    artwork.index || 0,
-                    artwork.tag || "",
-                    width || 0)
+        return LibraryService.getCachedArtworkUrlFromRef(artwork, width || 0)
     }
 
     function acceptsConnectionResponse(connectionId) {
@@ -494,13 +488,7 @@ FocusScope {
         var candidate = backdropCandidates[candidateIndex]
         
         // Construct backdrop URL from canonical ArtworkRef fields
-        var url = LibraryService.getCachedArtworkUrlForConnection(
-                    candidate.connectionId || "",
-                    candidate.itemId,
-                    candidate.kind || "backdrop",
-                    candidate.index || 0,
-                    candidate.tag || "",
-                    1920)
+        var url = LibraryService.getCachedArtworkUrlFromRef(candidate, 1920)
         
         currentBackdropUrl = url
     }

--- a/src/ui/HomeScreen.qml
+++ b/src/ui/HomeScreen.qml
@@ -448,13 +448,10 @@ FocusScope {
             if (!art || !art.itemId)
                 continue
 
-            const candidate = {
+            const candidate = Object.assign({}, art, {
                 connectionId: art.connectionId || item.connectionId || "",
-                itemId: art.itemId,
-                kind: art.kind || "backdrop",
-                index: art.index || 0,
-                tag: art.tag || ""
-            }
+                kind: art.kind || "backdrop"
+            })
             const key = backdropCandidateKey(candidate)
             if (!seen[key]) {
                 seen[key] = true

--- a/src/ui/LibraryScreen.qml
+++ b/src/ui/LibraryScreen.qml
@@ -687,13 +687,7 @@ FocusScope {
                     overlayLogoUrl = SeriesDetailsViewModel.logoUrl
                 } else if (root.currentSeriesData && root.currentSeriesData.logoArtwork) {
                     const artwork = root.currentSeriesData.logoArtwork
-                    overlayLogoUrl = LibraryService.getCachedArtworkUrlForConnection(
-                                artwork.connectionId || "",
-                                artwork.itemId || "",
-                                artwork.kind || "logo",
-                                artwork.index || 0,
-                                artwork.tag || "",
-                                600)
+                    overlayLogoUrl = LibraryService.getCachedArtworkUrlFromRef(artwork, 600)
                 }
                 root.requestPlaybackWithResolvedLibrary({
                     itemId: episodeId,
@@ -2547,13 +2541,7 @@ FocusScope {
             const kind = artwork.kind || fallbackKind
             if (!kind)
                 return
-            const url = LibraryService.getCachedArtworkUrlForConnection(
-                        artwork.connectionId || "",
-                        artwork.itemId,
-                        kind,
-                        artwork.index || 0,
-                        artwork.tag || "",
-                        width)
+            const url = LibraryService.getCachedArtworkUrlFromRef(artwork, width)
             if (url && candidates.indexOf(url) === -1)
                 candidates.push(url)
         }

--- a/src/ui/LibraryScreen.qml
+++ b/src/ui/LibraryScreen.qml
@@ -2541,7 +2541,8 @@ FocusScope {
             const kind = artwork.kind || fallbackKind
             if (!kind)
                 return
-            const url = LibraryService.getCachedArtworkUrlFromRef(artwork, width)
+            const resolvedArtwork = Object.assign({}, artwork, { kind: kind })
+            const url = LibraryService.getCachedArtworkUrlFromRef(resolvedArtwork, width)
             if (url && candidates.indexOf(url) === -1)
                 candidates.push(url)
         }

--- a/src/ui/MovieDetailsView.qml
+++ b/src/ui/MovieDetailsView.qml
@@ -68,13 +68,7 @@ FocusScope {
         if (!artwork || !artwork.itemId) {
             return ""
         }
-        return LibraryService.getCachedArtworkUrlForConnection(
-                    artwork.connectionId || "",
-                    artwork.itemId,
-                    artwork.kind || "primary",
-                    artwork.index || 0,
-                    artwork.tag || "",
-                    width || 420)
+        return LibraryService.getCachedArtworkUrlFromRef(artwork, width || 420)
     }
 
     component RecommendationPosterCard: Item {

--- a/src/ui/PersonCard.qml
+++ b/src/ui/PersonCard.qml
@@ -37,13 +37,7 @@ FocusScope {
                 source: {
                     const artwork = personCard.itemData.artwork
                     if (artwork && artwork.itemId) {
-                        return LibraryService.getCachedArtworkUrlForConnection(
-                                    artwork.connectionId || "",
-                                    artwork.itemId,
-                                    artwork.kind || "primary",
-                                    artwork.index || 0,
-                                    artwork.tag || "",
-                                    360)
+                        return LibraryService.getCachedArtworkUrlFromRef(artwork, 360)
                     }
                     return ""
                 }

--- a/src/ui/ScreensaverOverlay.qml
+++ b/src/ui/ScreensaverOverlay.qml
@@ -118,7 +118,8 @@ Item {
         if (!kind) {
             return ""
         }
-        return LibraryService.getCachedArtworkUrlFromRef(artwork, width)
+        const resolvedArtwork = Object.assign({}, artwork, { kind: kind })
+        return LibraryService.getCachedArtworkUrlFromRef(resolvedArtwork, width)
     }
 
     function backdropUrlFor(item) {

--- a/src/ui/ScreensaverOverlay.qml
+++ b/src/ui/ScreensaverOverlay.qml
@@ -118,13 +118,7 @@ Item {
         if (!kind) {
             return ""
         }
-        return LibraryService.getCachedArtworkUrlForConnection(
-                    artwork.connectionId || "",
-                    artwork.itemId,
-                    kind,
-                    artwork.index || 0,
-                    artwork.tag || "",
-                    width)
+        return LibraryService.getCachedArtworkUrlFromRef(artwork, width)
     }
 
     function backdropUrlFor(item) {

--- a/src/ui/SearchResultCard.qml
+++ b/src/ui/SearchResultCard.qml
@@ -49,13 +49,7 @@ Item {
         if (!artwork || !artwork.itemId) {
             return ""
         }
-        return LibraryService.getCachedArtworkUrlForConnection(
-                    artwork.connectionId || "",
-                    artwork.itemId,
-                    artwork.kind || "primary",
-                    artwork.index || 0,
-                    artwork.tag || "",
-                    300)
+        return LibraryService.getCachedArtworkUrlFromRef(artwork, 300)
     }
     
     // ========================================

--- a/src/ui/SeriesDetailsView.qml
+++ b/src/ui/SeriesDetailsView.qml
@@ -74,13 +74,7 @@ FocusScope {
             }
             const artwork = itemData.primaryArtwork
             if (artwork && artwork.itemId) {
-                return LibraryService.getCachedArtworkUrlForConnection(
-                            artwork.connectionId || "",
-                            artwork.itemId,
-                            artwork.kind || "primary",
-                            artwork.index || 0,
-                            artwork.tag || "",
-                            420)
+                return LibraryService.getCachedArtworkUrlFromRef(artwork, 420)
             }
             return ""
         }

--- a/src/ui/SeriesSeasonEpisodeView.qml
+++ b/src/ui/SeriesSeasonEpisodeView.qml
@@ -258,13 +258,7 @@ FocusScope {
             var season = SeriesDetailsViewModel.seasonsModel.getItem(SeriesDetailsViewModel.selectedSeasonIndex)
             const artwork = season ? season.logoArtwork : null
             if (artwork && artwork.itemId) {
-                return LibraryService.getCachedArtworkUrlForConnection(
-                            artwork.connectionId || "",
-                            artwork.itemId,
-                            artwork.kind || "logo",
-                            artwork.index || 0,
-                            artwork.tag || "",
-                            600)
+                return LibraryService.getCachedArtworkUrlFromRef(artwork, 600)
             }
         }
         // Fallback to series logo

--- a/src/ui/SettingsScreen.qml
+++ b/src/ui/SettingsScreen.qml
@@ -253,13 +253,7 @@ FocusScope {
         if (backdropCandidates.length === 0) { currentBackdropUrl = ""; return }
         const randomIndex = Math.floor(Math.random() * backdropCandidates.length)
         const artwork = backdropCandidates[randomIndex]
-        currentBackdropUrl = LibraryService.getCachedArtworkUrlForConnection(
-                    artwork.connectionId || "",
-                    artwork.itemId,
-                    artwork.kind || "backdrop",
-                    artwork.index || 0,
-                    artwork.tag || "",
-                    1920)
+        currentBackdropUrl = LibraryService.getCachedArtworkUrlFromRef(artwork, 1920)
     }
 
     Connections {

--- a/src/ui/UpNextScreen.qml
+++ b/src/ui/UpNextScreen.qml
@@ -82,13 +82,7 @@ FocusScope {
         if (!artwork || !artwork.itemId || typeof LibraryService === "undefined") {
             return ""
         }
-        return LibraryService.getCachedArtworkUrlForConnection(
-                    artwork.connectionId || "",
-                    artwork.itemId,
-                    artwork.kind || "primary",
-                    artwork.index || 0,
-                    artwork.tag || "",
-                    width || 960)
+        return LibraryService.getCachedArtworkUrlFromRef(artwork, width || 960)
     }
 
     function formatRuntime(milliseconds) {

--- a/src/viewmodels/LibraryViewModel.cpp
+++ b/src/viewmodels/LibraryViewModel.cpp
@@ -835,13 +835,8 @@ QString LibraryViewModel::getImageUrl(const QJsonObject &item) const
         const QString kind = artwork.value(QStringLiteral("kind")).toString();
         const QString tag = artwork.value(QStringLiteral("tag")).toString();
         if (!connectionId.isEmpty() && !itemId.isEmpty() && !kind.isEmpty() && !tag.isEmpty()) {
-            return m_libraryService->getCachedArtworkUrlForConnection(
-                connectionId,
-                itemId,
-                kind,
-                artwork.value(QStringLiteral("index")).toInt(),
-                tag,
-                640);
+            return m_libraryService->getCachedArtworkUrlFromRef(
+                artwork.toVariantMap(), 640);
         }
     }
 

--- a/src/viewmodels/MovieDetailsViewModel.cpp
+++ b/src/viewmodels/MovieDetailsViewModel.cpp
@@ -572,12 +572,7 @@ QString MovieDetailsViewModel::cachedArtworkUrl(const QVariantMap &artwork, int 
     if (!ref.isValid()) {
         return {};
     }
-    return m_libraryService->getCachedArtworkUrlForConnection(ref.connectionId,
-                                                               ref.itemId,
-                                                               Bloom::artworkKindName(ref.kind),
-                                                  ref.index,
-                                                  ref.tag,
-                                                  width);
+    return m_libraryService->getCachedArtworkUrlFromRef(artwork, width);
 }
 
 QVariantList MovieDetailsViewModel::mapCanonicalPeople(const QVariantList &people) const

--- a/src/viewmodels/SeriesDetailsViewModel.cpp
+++ b/src/viewmodels/SeriesDetailsViewModel.cpp
@@ -441,13 +441,7 @@ QString SeasonsModel::getImageUrl(const QVariantMap &item) const
     if (artwork.isEmpty()) {
         return {};
     }
-    return m_libraryService->getCachedArtworkUrlForConnection(
-        artwork.value(QStringLiteral("connectionId")).toString(),
-        artwork.value(QStringLiteral("itemId")).toString(),
-        artwork.value(QStringLiteral("kind")).toString(),
-        artwork.value(QStringLiteral("index")).toInt(),
-        artwork.value(QStringLiteral("tag")).toString(),
-        400);
+    return m_libraryService->getCachedArtworkUrlFromRef(artwork, 400);
 }
 
 
@@ -587,13 +581,7 @@ QString EpisodesModel::getImageUrl(const QVariantMap &item) const
         if (artwork.isEmpty()) {
             continue;
         }
-        return m_libraryService->getCachedArtworkUrlForConnection(
-            artwork.value(QStringLiteral("connectionId")).toString(),
-            artwork.value(QStringLiteral("itemId")).toString(),
-            artwork.value(QStringLiteral("kind")).toString(),
-            artwork.value(QStringLiteral("index")).toInt(),
-            artwork.value(QStringLiteral("tag")).toString(),
-            640);
+        return m_libraryService->getCachedArtworkUrlFromRef(artwork, 640);
     }
     return {};
 }
@@ -1926,11 +1914,5 @@ QString SeriesDetailsViewModel::buildArtworkUrl(const QVariantMap &artwork, int 
     if (!m_libraryService || artwork.isEmpty()) {
         return {};
     }
-    return m_libraryService->getCachedArtworkUrlForConnection(
-        artwork.value(QStringLiteral("connectionId")).toString(),
-        artwork.value(QStringLiteral("itemId")).toString(),
-        artwork.value(QStringLiteral("kind")).toString(),
-        artwork.value(QStringLiteral("index")).toInt(),
-        artwork.value(QStringLiteral("tag")).toString(),
-        width);
+    return m_libraryService->getCachedArtworkUrlFromRef(artwork, width);
 }

--- a/tests/ArtworkRefreshTest.cpp
+++ b/tests/ArtworkRefreshTest.cpp
@@ -174,6 +174,7 @@ private slots:
     void initTestCase();
     void webpDecoderIsAvailable();
     void widthAdjustedReferenceRetainsTransientSource();
+    void transientSourcesSurviveLargeCatalogAndClearExplicitly();
     void missingArtworkDegradesWithoutRefresh();
     void tokenFreeCacheMissRetainsTransientSourceUrl();
     void signedUrlIsNotPartOfCacheIdentity();
@@ -223,6 +224,27 @@ void ArtworkRefreshTest::widthAdjustedReferenceRetainsTransientSource()
     QCOMPARE(adjusted.requestedWidth, 640);
     QCOMPARE(Bloom::ArtworkRef::transientSourceUrlForCacheKey(adjustedKey),
              original.sourceUrl);
+}
+
+void ArtworkRefreshTest::transientSourcesSurviveLargeCatalogAndClearExplicitly()
+{
+    Bloom::ArtworkRef first = artworkRef();
+    first.itemId = QStringLiteral("item-0");
+    first.sourceUrl = QStringLiteral("https://images.example.test/item-0.webp");
+    const QString firstKey = first.cacheKey();
+
+    for (int index = 1; index < 1024; ++index) {
+        Bloom::ArtworkRef artwork = first;
+        artwork.itemId = QStringLiteral("item-%1").arg(index);
+        artwork.sourceUrl = QStringLiteral("https://images.example.test/item-%1.webp")
+                                .arg(index);
+        artwork.cacheKey();
+    }
+
+    QCOMPARE(Bloom::ArtworkRef::transientSourceUrlForCacheKey(firstKey),
+             first.sourceUrl);
+    Bloom::ArtworkRef::clearTransientSourceUrls();
+    QVERIFY(Bloom::ArtworkRef::transientSourceUrlForCacheKey(firstKey).isEmpty());
 }
 
 void ArtworkRefreshTest::missingArtworkDegradesWithoutRefresh()

--- a/tests/ArtworkRefreshTest.cpp
+++ b/tests/ArtworkRefreshTest.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <QHostAddress>
+#include <QImageReader>
 #include <QNetworkRequest>
 #include <QPointer>
 #include <QQuickImageResponse>
@@ -14,6 +15,7 @@
 
 #include "network/AuthenticationService.h"
 #include "network/HttpTransport.h"
+#include "network/LibraryService.h"
 #include "models/MediaModels.h"
 #include "providers/IArtworkProvider.h"
 #include "providers/silo/SiloArtworkProvider.h"
@@ -170,6 +172,8 @@ class ArtworkRefreshTest : public QObject
 
 private slots:
     void initTestCase();
+    void webpDecoderIsAvailable();
+    void widthAdjustedReferenceRetainsTransientSource();
     void missingArtworkDegradesWithoutRefresh();
     void tokenFreeCacheMissRetainsTransientSourceUrl();
     void signedUrlIsNotPartOfCacheIdentity();
@@ -188,6 +192,37 @@ void ArtworkRefreshTest::initTestCase()
     QVERIFY(m_temporaryDirectory.isValid());
     m_configIsolation = std::make_unique<ScopedConfigIsolation>(
         m_temporaryDirectory.path());
+}
+
+void ArtworkRefreshTest::webpDecoderIsAvailable()
+{
+    const QList<QByteArray> formats = QImageReader::supportedImageFormats();
+    QVERIFY2(formats.contains(QByteArrayLiteral("webp")),
+             "Bloom's runtime must ship Qt's WebP image-format plugin");
+}
+
+void ArtworkRefreshTest::widthAdjustedReferenceRetainsTransientSource()
+{
+    Bloom::ArtworkRef original = artworkRef();
+    original.ownerKind = Bloom::ArtworkOwnerKind::Person;
+    original.requestedWidth = 0;
+    original.sourceUrl = QStringLiteral(
+        "https://images.example.test/person.webp?X-Amz-Signature=transient");
+    const QVariantMap emitted = original.toVariantMap();
+
+    LibraryService service(nullptr);
+    const QString cachedUrl = service.getCachedArtworkUrlFromRef(emitted, 640);
+    const QString prefix = QStringLiteral("image://cached/");
+    QVERIFY(cachedUrl.startsWith(prefix));
+    const QString adjustedKey = QUrl::fromPercentEncoding(
+        cachedUrl.mid(prefix.size()).toUtf8());
+    const Bloom::ArtworkRef adjusted = Bloom::ArtworkRef::fromCacheKey(adjustedKey);
+
+    QVERIFY(adjusted.isValid());
+    QCOMPARE(adjusted.ownerKind, Bloom::ArtworkOwnerKind::Person);
+    QCOMPARE(adjusted.requestedWidth, 640);
+    QCOMPARE(Bloom::ArtworkRef::transientSourceUrlForCacheKey(adjustedKey),
+             original.sourceUrl);
 }
 
 void ArtworkRefreshTest::missingArtworkDegradesWithoutRefresh()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -367,6 +367,8 @@ add_executable(ArtworkRefreshTest
     ArtworkRefreshTest.cpp
     TestConfigIsolation.h
     ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
     ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloModelMapper.cpp
     ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloArtworkProvider.cpp

--- a/tests/SimilarItemsRetryTest.cpp
+++ b/tests/SimilarItemsRetryTest.cpp
@@ -58,6 +58,17 @@ public:
             .arg(width);
     }
 
+    QString getCachedArtworkUrlFromRef(const QVariantMap &artwork, int width) override
+    {
+        return getCachedArtworkUrlForConnection(
+            artwork.value(QStringLiteral("connectionId")).toString(),
+            artwork.value(QStringLiteral("itemId")).toString(),
+            artwork.value(QStringLiteral("kind")).toString(),
+            artwork.value(QStringLiteral("index")).toInt(),
+            artwork.value(QStringLiteral("tag")).toString(),
+            width);
+    }
+
     QStringList requestedIds;
 };
 
@@ -133,6 +144,17 @@ public:
         Q_UNUSED(imageType)
         Q_UNUSED(imageTag)
         return QStringLiteral("chapter://%1/%2/%3").arg(itemId).arg(imageIndex).arg(width);
+    }
+
+    QString getCachedArtworkUrlFromRef(const QVariantMap &artwork, int width) override
+    {
+        return getCachedArtworkUrlForConnection(
+            artwork.value(QStringLiteral("connectionId")).toString(),
+            artwork.value(QStringLiteral("itemId")).toString(),
+            artwork.value(QStringLiteral("kind")).toString(),
+            artwork.value(QStringLiteral("index")).toInt(),
+            artwork.value(QStringLiteral("tag")).toString(),
+            width);
     }
 
     QStringList requests;


### PR DESCRIPTION
## Summary

- preserve native Silo artwork source metadata while deriving width-specific cache identities
- pass complete canonical artwork references through image consumers, including chapter ownership/source data
- ship Qt Image Formats/WebP support in Nix and portable Linux builds, with runtime and packaging guards

## Root cause

Native Silo registers opaque artwork sources against its original token-free cache key. Bloom was rebuilding those keys from partial fields at a different requested width, dropping the transient source and artwork owner kind. Separately, Linux build outputs did not consistently expose Qt's WebP image plugin, which is needed for Silo S3 artwork and Jellyfin-compatible redirects.

## Verification

- `nix flake check` (26/26 CTest targets passed; package, QML lint, metadata, and release checks passed)
- `./scripts/dev-build.sh --tests --jobs 4`
- live native Silo login: downloaded and decoded JPEG/WebP artwork and generated rounded PNG cache entries
- live Silo Jellyfin-compatible login: downloaded and decoded redirected WebP artwork and generated rounded PNG cache entries
- no server configuration or data changes were made

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Silo artwork loading across providers by introducing `getCachedArtworkUrlFromRef`
> - Adds `LibraryService.getCachedArtworkUrlFromRef(ref, width)` as the canonical API for resolving cached artwork URLs from an `ArtworkRef` map, replacing scattered `getCachedArtworkUrlForConnection` calls across all QML files and C++ view models.
> - Switches transient artwork source storage from a fixed-capacity `QCache` to an unbounded `QHash`, preventing eviction of source URLs for large catalogs; sources are now cleared explicitly via `ArtworkRef::clearTransientSourceUrls()` on account switch or logout.
> - Adds `qt6.qtimageformats` to the Nix dev shell, package derivation, and test runner, and deploys the Qt WebP plugin in the portable build — with a CI check that `libqwebp.so` is present.
> - Behavioral Change: transient artwork source URLs now persist in memory indefinitely until an account state change clears them, rather than being silently evicted by cache capacity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 330bf8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artwork URLs now resolve from complete artwork references, improving consistency across posters, backdrops, logos, thumbnails, and screensaver images.
  * Artwork cache identities now include the requested image width.
  * Linux and portable packages include WebP image support.

* **Bug Fixes**
  * Transient artwork source URLs are preserved when converting artwork references to cached URLs.
  * Portable builds now validate that WebP decoding support is available.

* **Tests**
  * Added coverage for width-specific artwork caching and runtime WebP support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->