### PR TITLE
refactor(config): make persistence atomic and bounded

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,16 @@ Responsibilities
 - Persist app-specific settings: `playbackCompletionThreshold`, `autoplayNextEpisode`, `backdropRotationInterval`, `screensaver*`, mpv extra flags.
 - Emit change signals to allow QML to react to setting updates.
 
+Persistence lifecycle
+- `ConfigStorage` owns checked filesystem reads, recovery backups, and atomic `QSaveFile` replacement. It has no schema or migration policy.
+- `ConfigManager` remains the stable QML-facing façade. Setters update the in-memory document and emit their change signal synchronously.
+- High-frequency values such as playback volume, audio delay, UI/theme-song volume, backdrop interval, and manual DPI scale use a 350 ms trailing debounce before writing the full document. A later immediate save also flushes those in-memory changes.
+- Connection/credential-reference changes, active-connection changes, legacy-credential cleanup, and logout/session cleanup persist immediately.
+- Pending changes flush on `QCoreApplication::aboutToQuit`, `ConfigManager` destruction, explicit `save()`, and `flushPendingSave()`.
+- Write/open/commit failures keep the document dirty for a later retry, populate `lastPersistenceError`, and emit `persistenceFailed(message)`. Successful persistence clears the error and emits `configurationPersisted()`.
+- ConfigManager starts with a valid current default document so isolated consumers remain safe before `load()`. Schema migrations and repair run only from `load()`; persistence never invokes migration code and refuses to overwrite the last known-good file with an invalid in-memory document.
+- Invalid JSON and failed-schema/migration input is moved to a recovery filename using a Windows-safe UTC timestamp such as `app.json.corrupt-20260810T142233123Z` before defaults are atomically written. If the backup cannot be created, Bloom uses defaults in memory without overwriting the original.
+
 Best practices
 - Add Q_PROPERTY for each new setting to enable reactive QML bindings.
 - Read settings at point-of-use in C++ to avoid stale cache; if you must cache, connect to change signals to refresh the cache.
@@ -76,7 +86,8 @@ MPV profile management
 
 When adding settings
 - Update `ConfigManager.h` (Q_PROPERTY & signals).
-- Implement getters/setters in `ConfigManager.cpp` that persist to `app.json` and emit signals on change.
+- Implement getters/setters in `ConfigManager.cpp` that update the in-memory document and emit signals on change.
+- Use immediate `save()` for identity, credentials/credential references, logout cleanup, or other state that must survive the next process boundary. Use `scheduleSave()` only for high-frequency UI/session values; destruction and application shutdown are guaranteed flush boundaries.
 - Update docs (this file) and add UI controls in `SettingsScreen.qml` where appropriate.
 
 Logging settings

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,6 +100,8 @@ qt_add_executable(Bloom
     updates/UpdateService.cpp
     utils/ConfigManager.cpp
     utils/ConfigManager.h
+    utils/ConfigStorage.cpp
+    utils/ConfigStorage.h
     utils/AudioOutputRouter.cpp
     utils/AudioOutputRouter.h
     utils/MpvArgFilter.cpp

--- a/src/ui/SettingsScreen.qml
+++ b/src/ui/SettingsScreen.qml
@@ -10,7 +10,8 @@ import "settings"
  *
  * Layout: narrow left rail (section list) + wide right content panel.
  * Each section is a standalone FocusScope inside a StackLayout.
- * All settings are persisted immediately via ConfigManager.
+ * Settings update immediately in memory. ConfigManager atomically persists
+ * ordinary changes and coalesces high-frequency slider/session values.
  */
 FocusScope {
     id: root

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -614,7 +614,29 @@ bool migrateLegacyWindowsConfigDirIfNeeded(const QString &targetDirPath)
 
 ConfigManager::ConfigManager(QObject *parent)
     : QObject(parent)
+    , m_storage(getConfigPath())
 {
+    // Keep the in-memory façade valid even for isolated consumers that set a
+    // value before calling load(). load() replaces this snapshot when a
+    // persisted document exists.
+    m_config = defaultConfig();
+
+    m_saveTimer.setSingleShot(true);
+    m_saveTimer.setInterval(kSaveDebounceMs);
+    connect(&m_saveTimer, &QTimer::timeout, this, [this]() {
+        persistConfig();
+    });
+
+    if (QCoreApplication *app = QCoreApplication::instance()) {
+        connect(app, &QCoreApplication::aboutToQuit, this, [this]() {
+            flushPendingSave();
+        });
+    }
+}
+
+ConfigManager::~ConfigManager()
+{
+    flushPendingSave();
 }
 
 QString ConfigManager::getConfigDir()
@@ -790,38 +812,44 @@ bool ConfigManager::ensureConfigDirExists()
 
 void ConfigManager::load()
 {
+    m_saveTimer.stop();
+    m_persistenceDirty = false;
+
     // Ensure config directory exists
     ensureConfigDirExists();
     
     QString path = getConfigPath();
-    QFile file(path);
-    if (!file.exists()) {
+    if (!QFileInfo::exists(path)) {
         qWarning() << "Config file not found, creating default:" << path;
         m_config = defaultConfig();
         save();
         return;
     }
 
-    if (!file.open(QIODevice::ReadOnly)) {
-        qWarning() << "Could not open config file for reading:" << path << ", using defaults";
+    QByteArray data;
+    QString storageError;
+    if (!m_storage.read(&data, &storageError)) {
+        qWarning().noquote() << storageError << "- using defaults";
+        setPersistenceError(storageError);
+        emit persistenceFailed(storageError);
         m_config = defaultConfig();
         return;
     }
+    setPersistenceError(QString());
 
-    QByteArray data = file.readAll();
     QJsonParseError parseError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &parseError);
     if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
         qWarning() << "Invalid config file (JSON parse error):" << parseError.errorString();
-        // Backup the bad file
-        QString backup = path + ".corrupt-" + QDateTime::currentDateTime().toString(Qt::ISODate);
-        if (QFile::exists(backup)) {
-            QFile::remove(backup);
-        }
-        if (!QFile::rename(path, backup)) {
-            qWarning() << "Could not rename corrupt config file to backup:" << backup;
+        QString backupPath;
+        if (!m_storage.backup(QStringLiteral("corrupt"), &backupPath, &storageError)) {
+            qWarning().noquote() << storageError;
+            setPersistenceError(storageError);
+            emit persistenceFailed(storageError);
+            m_config = defaultConfig();
+            return;
         } else {
-            qWarning() << "Backed up corrupt config to" << backup;
+            qWarning() << "Backed up corrupt config to" << backupPath;
         }
         m_config = defaultConfig();
         save();
@@ -834,9 +862,14 @@ void ConfigManager::load()
     // Run migrations, ensure config is at the current version
     if (!migrateConfig()) {
         qWarning() << "Config migration failed -- resetting config to defaults";
-        QString backup = path + ".migratefail-" + QDateTime::currentDateTime().toString(Qt::ISODate);
-        if (QFile::exists(backup)) QFile::remove(backup);
-        QFile::rename(path, backup);
+        QString backupPath;
+        if (!m_storage.backup(QStringLiteral("migratefail"), &backupPath, &storageError)) {
+            qWarning().noquote() << storageError;
+            setPersistenceError(storageError);
+            emit persistenceFailed(storageError);
+            m_config = defaultConfig();
+            return;
+        }
         m_config = defaultConfig();
         save();
         return;
@@ -844,9 +877,14 @@ void ConfigManager::load()
 
     if (!validateConfig(m_config)) {
         qWarning() << "Config failed schema validation -- resetting to defaults";
-        QString backup = path + ".badschema-" + QDateTime::currentDateTime().toString(Qt::ISODate);
-        if (QFile::exists(backup)) QFile::remove(backup);
-        QFile::rename(path, backup);
+        QString backupPath;
+        if (!m_storage.backup(QStringLiteral("badschema"), &backupPath, &storageError)) {
+            qWarning().noquote() << storageError;
+            setPersistenceError(storageError);
+            emit persistenceFailed(storageError);
+            m_config = defaultConfig();
+            return;
+        }
         m_config = defaultConfig();
         save();
         return;
@@ -858,43 +896,78 @@ void ConfigManager::load()
     qDebug() << "Loaded config from" << path;
 }
 
-void ConfigManager::save()
+bool ConfigManager::save()
 {
-    QString path = getConfigPath();
-    QFile file(path);
-    
-    // Ensure directory exists
-    QFileInfo info(path);
-    QDir dir = info.absoluteDir();
-    if (!dir.exists()) {
-        dir.mkpath(".");
+    m_saveTimer.stop();
+    m_persistenceDirty = true;
+    return persistConfig();
+}
+
+bool ConfigManager::flushPendingSave()
+{
+    m_saveTimer.stop();
+    if (!m_persistenceDirty) {
+        return true;
+    }
+    return persistConfig();
+}
+
+QString ConfigManager::getLastPersistenceError() const
+{
+    return m_lastPersistenceError;
+}
+
+void ConfigManager::scheduleSave()
+{
+    m_persistenceDirty = true;
+    m_saveTimer.start();
+}
+
+bool ConfigManager::persistConfig()
+{
+    // Schema migrations and repair are exclusively load-time operations.
+    // Refuse to replace the last known-good file if an internal mutation ever
+    // leaves an invalid document.
+    if (!validateConfig(m_config)) {
+        const QString error = QStringLiteral(
+            "Refusing to persist an invalid configuration document");
+        m_persistenceDirty = true;
+        setPersistenceError(error);
+        qCWarning(lcConfig).noquote() << "ConfigManager:" << error;
+        emit persistenceFailed(error);
+        return false;
     }
 
-    if (!file.open(QIODevice::WriteOnly)) {
-        qWarning() << "Could not open config file for writing:" << path;
+    const QByteArray data = QJsonDocument(m_config).toJson(QJsonDocument::Indented);
+    QString error;
+    if (!m_storage.writeAtomically(data, &error)) {
+        m_persistenceDirty = true;
+        setPersistenceError(error);
+        qCWarning(lcConfig).noquote() << "ConfigManager:" << error;
+        emit persistenceFailed(error);
+        return false;
+    }
+
+    m_persistenceDirty = false;
+    setPersistenceError(QString());
+    qCDebug(lcConfig) << "ConfigManager: Saved config atomically to" << m_storage.path();
+    emit configurationPersisted();
+    return true;
+}
+
+void ConfigManager::setPersistenceError(const QString &message)
+{
+    if (m_lastPersistenceError == message) {
         return;
     }
-    // Ensure current version and settings exist before saving
-    if (!m_config.contains("version")) {
-        m_config["version"] = kCurrentConfigVersion;
-    }
-    if (!m_config.contains("settings") || !m_config["settings"].isObject()) {
-        // If the config is in legacy format (top-level keys), migrate/move to settings
-        migrateConfig();
-        if (!m_config.contains("settings") || !m_config["settings"].isObject()) {
-            m_config["settings"] = QJsonObject();
-        }
-    }
-
-    QJsonDocument doc(m_config);
-    file.write(doc.toJson(QJsonDocument::Indented));
-    qDebug() << "Saved config to" << path;
+    m_lastPersistenceError = message;
+    emit persistenceErrorChanged();
 }
 
 void ConfigManager::exitApplication()
 {
     // Save configuration before exiting
-    save();
+    flushPendingSave();
     
     // Exit the application
     QCoreApplication::quit();
@@ -1626,7 +1699,7 @@ void ConfigManager::setPlaybackCompletionThreshold(int percent)
     playback["completion_threshold"] = percent;
     settings["playback"] = playback;
     m_config["settings"] = settings;
-    save();
+    scheduleSave();
     emit playbackCompletionThresholdChanged();
 }
 
@@ -1694,7 +1767,7 @@ void ConfigManager::setAudioDelay(int ms)
     playback["audio_delay"] = ms;
     settings["playback"] = playback;
     m_config["settings"] = settings;
-    save();
+    scheduleSave();
     emit audioDelayChanged();
 }
 
@@ -1776,7 +1849,7 @@ void ConfigManager::setPlaybackVolume(int volume)
     playback["playback_volume"] = clamped;
     settings["playback"] = playback;
     m_config["settings"] = settings;
-    save();
+    scheduleSave();
     emit playbackVolumeChanged();
 }
 
@@ -2133,7 +2206,7 @@ void ConfigManager::setThemeSongVolume(int level)
     playback["theme_song_volume"] = clamped;
     settings["playback"] = playback;
     m_config["settings"] = settings;
-    save();
+    scheduleSave();
     emit themeSongVolumeChanged();
 }
 
@@ -2406,7 +2479,7 @@ void ConfigManager::setManualDpiScaleOverride(qreal scale)
     }
     settings["manualDpiScaleOverride"] = clamped;
     m_config["settings"] = settings;
-    save();
+    scheduleSave();
     qDebug() << "ConfigManager: Emitting manualDpiScaleOverrideChanged() signal";
     emit manualDpiScaleOverrideChanged();
 }
@@ -2962,7 +3035,7 @@ void ConfigManager::setUiSoundsVolume(int level)
     playback["ui_sounds_volume"] = clamped;
     settings["playback"] = playback;
     m_config["settings"] = settings;
-    save();
+    scheduleSave();
     emit uiSoundsVolumeChanged();
 }
 
@@ -2995,7 +3068,7 @@ void ConfigManager::setBackdropRotationInterval(int ms)
     ui["backdrop_rotation_interval"] = ms;
     settings["ui"] = ui;
     m_config["settings"] = settings;
-    save();
+    scheduleSave();
     emit backdropRotationIntervalChanged();
 }
 

--- a/src/utils/ConfigManager.h
+++ b/src/utils/ConfigManager.h
@@ -5,12 +5,14 @@
 #include <QJsonArray>
 #include <QString>
 #include <QStringList>
+#include <QTimer>
 #include <QVariantList>
 #include <QVariantMap>
 
 #include <optional>
 
 #include "providers/ServerConnection.h"
+#include "utils/ConfigStorage.h"
 
 /**
  * @brief MPV Profile data structure
@@ -171,9 +173,11 @@ class ConfigManager : public QObject
     Q_PROPERTY(QString logLevel READ getLogLevel WRITE setLogLevel NOTIFY logLevelChanged)
     Q_PROPERTY(QVariantList supportedTrackLanguages READ getSupportedTrackLanguages CONSTANT)
     Q_PROPERTY(QVariantMap inputBindings READ getInputBindings WRITE setInputBindings NOTIFY inputBindingsChanged)
+    Q_PROPERTY(QString lastPersistenceError READ getLastPersistenceError NOTIFY persistenceErrorChanged)
     
 public:
     explicit ConfigManager(QObject *parent = nullptr);
+    ~ConfigManager() override;
     
     // Device ID - unique per installation, includes hostname
     // Generated on first launch and stored in settings
@@ -184,7 +188,9 @@ public:
     QString getUserDeviceId(const QString &userId) const;
 
     void load();
-    void save();
+    bool save();
+    bool flushPendingSave();
+    QString getLastPersistenceError() const;
     
     // Application exit - saves config and quits
     Q_INVOKABLE void exitApplication();
@@ -598,6 +604,9 @@ signals:
     void skippedUpdateVersionChanged();
     void logLevelChanged();
     void inputBindingsChanged();
+    void configurationPersisted();
+    void persistenceErrorChanged();
+    void persistenceFailed(const QString &message);
 
     void heroBannerEnabledChanged();
     void heroBannerSourceChanged();
@@ -631,9 +640,17 @@ private:
     QJsonObject readHeroBannerObject() const;
     void writeHeroBannerObject(const QJsonObject &heroBanner);
     bool envOverridesRoundedPreprocess(bool current) const;
+    void scheduleSave();
+    bool persistConfig();
+    void setPersistenceError(const QString &message);
 
     QJsonObject m_config;
+    ConfigStorage m_storage;
+    QTimer m_saveTimer;
+    QString m_lastPersistenceError;
+    bool m_persistenceDirty = false;
 
     static constexpr int kCurrentConfigVersion = 30;
+    static constexpr int kSaveDebounceMs = 350;
     QJsonObject defaultConfig() const;
 };

--- a/src/utils/ConfigStorage.cpp
+++ b/src/utils/ConfigStorage.cpp
@@ -1,0 +1,144 @@
+#include "ConfigStorage.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QSaveFile>
+
+#include <utility>
+
+namespace {
+
+void setError(QString *error, const QString &message)
+{
+    if (error) {
+        *error = message;
+    }
+}
+
+QString portableTimestamp()
+{
+    return QDateTime::currentDateTimeUtc().toString(QStringLiteral("yyyyMMdd'T'HHmmsszzz'Z'"));
+}
+
+} // namespace
+
+ConfigStorage::ConfigStorage(QString path)
+    : m_path(std::move(path))
+{
+}
+
+QString ConfigStorage::path() const
+{
+    return m_path;
+}
+
+bool ConfigStorage::read(QByteArray *data, QString *error) const
+{
+    if (!data) {
+        setError(error, QStringLiteral("No destination was provided for the configuration data"));
+        return false;
+    }
+
+    QFile file(m_path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        setError(error,
+                 QStringLiteral("Could not open %1 for reading: %2")
+                     .arg(m_path, file.errorString()));
+        return false;
+    }
+
+    *data = file.readAll();
+    if (file.error() != QFileDevice::NoError) {
+        setError(error,
+                 QStringLiteral("Could not read %1: %2")
+                     .arg(m_path, file.errorString()));
+        return false;
+    }
+
+    if (error) {
+        error->clear();
+    }
+    return true;
+}
+
+bool ConfigStorage::writeAtomically(const QByteArray &data, QString *error) const
+{
+    const QFileInfo info(m_path);
+    QDir directory = info.absoluteDir();
+    if (!directory.exists() && !directory.mkpath(QStringLiteral("."))) {
+        setError(error,
+                 QStringLiteral("Could not create configuration directory %1")
+                     .arg(directory.absolutePath()));
+        return false;
+    }
+
+    QSaveFile file(m_path);
+    file.setDirectWriteFallback(false);
+    if (!file.open(QIODevice::WriteOnly)) {
+        setError(error,
+                 QStringLiteral("Could not open %1 for atomic writing: %2")
+                     .arg(m_path, file.errorString()));
+        return false;
+    }
+
+    const qint64 written = file.write(data);
+    if (written != data.size()) {
+        const QString detail = file.errorString();
+        file.cancelWriting();
+        setError(error,
+                 QStringLiteral("Could not write the complete configuration to %1 "
+                                "(%2 of %3 bytes): %4")
+                     .arg(m_path)
+                     .arg(written)
+                     .arg(data.size())
+                     .arg(detail));
+        return false;
+    }
+
+    if (!file.commit()) {
+        setError(error,
+                 QStringLiteral("Could not commit the atomic configuration write to %1: %2")
+                     .arg(m_path, file.errorString()));
+        return false;
+    }
+
+    if (error) {
+        error->clear();
+    }
+    return true;
+}
+
+bool ConfigStorage::backup(const QString &reason, QString *backupPath, QString *error) const
+{
+    if (!QFileInfo::exists(m_path)) {
+        setError(error, QStringLiteral("Configuration file %1 does not exist").arg(m_path));
+        return false;
+    }
+
+    const QString normalizedReason = reason.trimmed().isEmpty()
+        ? QStringLiteral("backup")
+        : reason.trimmed();
+    const QString basePath = QStringLiteral("%1.%2-%3")
+                                 .arg(m_path, normalizedReason, portableTimestamp());
+    QString candidate = basePath;
+    for (int suffix = 1; QFileInfo::exists(candidate); ++suffix) {
+        candidate = QStringLiteral("%1-%2").arg(basePath).arg(suffix);
+    }
+
+    if (!QFile::rename(m_path, candidate)) {
+        setError(error,
+                 QStringLiteral("Could not move %1 to recovery backup %2")
+                     .arg(m_path, candidate));
+        return false;
+    }
+
+    if (backupPath) {
+        *backupPath = candidate;
+    }
+    if (error) {
+        error->clear();
+    }
+    return true;
+}

--- a/src/utils/ConfigStorage.h
+++ b/src/utils/ConfigStorage.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+
+/**
+ * Filesystem repository for Bloom's JSON configuration document.
+ *
+ * ConfigStorage deliberately knows nothing about config schemas or migrations.
+ * ConfigManager owns those policies; this class only provides checked reads,
+ * atomic replacement writes, and portable recovery backups.
+ */
+class ConfigStorage
+{
+public:
+    explicit ConfigStorage(QString path);
+
+    QString path() const;
+    bool read(QByteArray *data, QString *error) const;
+    bool writeAtomically(const QByteArray &data, QString *error) const;
+    bool backup(const QString &reason, QString *backupPath, QString *error) const;
+
+private:
+    QString m_path;
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_CONFIG_SOURCES
     ${CMAKE_SOURCE_DIR}/src/profiles/BloomProfile.cpp
     ${CMAKE_SOURCE_DIR}/src/security/CredentialStore.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/ConfigManager.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/ConfigStorage.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/MpvArgFilter.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/LoggingConfig.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/Logger.cpp

--- a/tests/ConfigManagerThemeTest.cpp
+++ b/tests/ConfigManagerThemeTest.cpp
@@ -20,6 +20,12 @@ private slots:
     void screensaverDefaultsAndSettersPersist();
     void heroBannerEpisodeSynopsisDefaultsAndSettersPersist();
     void themeVariantSettersPersistAndEmit();
+    void rapidSettingsCoalescePersistence();
+    void immediateSettingsFlushPendingPersistence();
+    void destructorFlushesPendingPersistence();
+    void persistenceFailuresAreReportedAndRetryable();
+    void corruptBackupFilenameIsPortable();
+    void saveDoesNotRunLoadTimeMigrations();
     void v19MigrationAddsThemeVariantSettings();
     void v20MigrationRenamesDefaultProfileAssignments();
     void v21MigrationAddsArtProfilesWithoutChangingAssignments();
@@ -389,6 +395,148 @@ void ConfigManagerThemeTest::themeVariantSettersPersistAndEmit()
     reloaded.load();
     QCOMPARE(reloaded.getThemeFlavor(), QStringLiteral("mocha"));
     QCOMPARE(reloaded.getThemeColorScheme(), QStringLiteral("mauve"));
+}
+
+void ConfigManagerThemeTest::rapidSettingsCoalescePersistence()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation configIsolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    QSignalSpy persistedSpy(&config, &ConfigManager::configurationPersisted);
+
+    config.setPlaybackVolume(101);
+    config.setPlaybackVolume(102);
+    config.setPlaybackVolume(103);
+
+    QCOMPARE(config.getPlaybackVolume(), 103);
+    QCOMPARE(persistedSpy.count(), 0);
+    QTRY_COMPARE_WITH_TIMEOUT(persistedSpy.count(), 1, 1000);
+
+    ConfigManager reloaded;
+    reloaded.load();
+    QCOMPARE(reloaded.getPlaybackVolume(), 103);
+}
+
+void ConfigManagerThemeTest::immediateSettingsFlushPendingPersistence()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation configIsolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    QSignalSpy persistedSpy(&config, &ConfigManager::configurationPersisted);
+
+    config.setPlaybackVolume(117);
+    QCOMPARE(persistedSpy.count(), 0);
+    config.setTheme(QStringLiteral("Catppuccin"));
+    QCOMPARE(persistedSpy.count(), 1);
+
+    ConfigManager reloaded;
+    reloaded.load();
+    QCOMPARE(reloaded.getPlaybackVolume(), 117);
+    QCOMPARE(reloaded.getTheme(), QStringLiteral("Catppuccin"));
+}
+
+void ConfigManagerThemeTest::destructorFlushesPendingPersistence()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation configIsolation(tempDir.path());
+
+    {
+        ConfigManager config;
+        config.load();
+        config.setAudioDelay(275);
+    }
+
+    ConfigManager reloaded;
+    reloaded.load();
+    QCOMPARE(reloaded.getAudioDelay(), 275);
+}
+
+void ConfigManagerThemeTest::persistenceFailuresAreReportedAndRetryable()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation configIsolation(tempDir.path());
+
+    ConfigManager config;
+    config.load();
+    config.setPlaybackVolume(125);
+
+    const QString configPath = ConfigManager::getConfigPath();
+    QVERIFY(QFile::remove(configPath));
+    QVERIFY(QDir().mkpath(configPath));
+
+    QSignalSpy failureSpy(&config, &ConfigManager::persistenceFailed);
+    QVERIFY(!config.flushPendingSave());
+    QCOMPARE(failureSpy.count(), 1);
+    QVERIFY(!config.getLastPersistenceError().isEmpty());
+
+    QDir configDir(ConfigManager::getConfigDir());
+    QVERIFY(configDir.rmdir(QStringLiteral("app.json")));
+    QVERIFY(config.flushPendingSave());
+    QVERIFY(config.getLastPersistenceError().isEmpty());
+
+    QFile persisted(configPath);
+    QVERIFY(persisted.open(QIODevice::ReadOnly));
+    const QJsonDocument document = QJsonDocument::fromJson(persisted.readAll());
+    QVERIFY(document.isObject());
+    QCOMPARE(document.object().value(QStringLiteral("settings")).toObject()
+                 .value(QStringLiteral("playback")).toObject()
+                 .value(QStringLiteral("playback_volume")).toInt(),
+             125);
+}
+
+void ConfigManagerThemeTest::corruptBackupFilenameIsPortable()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation configIsolation(tempDir.path());
+
+    QVERIFY(QDir().mkpath(ConfigManager::getConfigDir()));
+    QFile corrupt(ConfigManager::getConfigPath());
+    QVERIFY(corrupt.open(QIODevice::WriteOnly));
+    QCOMPARE(corrupt.write("{ definitely not JSON"), qint64(21));
+    corrupt.close();
+
+    ConfigManager config;
+    config.load();
+
+    const QStringList backups = QDir(ConfigManager::getConfigDir()).entryList(
+        {QStringLiteral("app.json.corrupt-*")}, QDir::Files);
+    QCOMPARE(backups.size(), 1);
+    QVERIFY(!backups.constFirst().contains(QLatin1Char(':')));
+
+    QFile replacement(ConfigManager::getConfigPath());
+    QVERIFY(replacement.open(QIODevice::ReadOnly));
+    QVERIFY(QJsonDocument::fromJson(replacement.readAll()).isObject());
+}
+
+void ConfigManagerThemeTest::saveDoesNotRunLoadTimeMigrations()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    ScopedConfigIsolation configIsolation(tempDir.path());
+
+    ConfigManager config;
+    QVERIFY(config.save());
+
+    QFile file(ConfigManager::getConfigPath());
+    QVERIFY(file.open(QIODevice::ReadOnly));
+    const QJsonObject root = QJsonDocument::fromJson(file.readAll()).object();
+    QCOMPARE(root.value(QStringLiteral("version")).toInt(), 30);
+    const QJsonObject settings = root.value(QStringLiteral("settings")).toObject();
+    QCOMPARE(settings.value(QStringLiteral("playback")).toObject()
+                 .value(QStringLiteral("completion_threshold")).toInt(),
+             90);
+    QCOMPARE(settings.value(QStringLiteral("connections")).toObject()
+                 .value(QStringLiteral("version")).toInt(),
+             1);
 }
 
 void ConfigManagerThemeTest::v19MigrationAddsThemeVariantSettings()


### PR DESCRIPTION
## Summary

- extract schema-free `ConfigStorage` with checked reads, atomic `QSaveFile` commits, and Windows-safe recovery backups
- keep ConfigManager as the stable QML facade while debouncing high-frequency settings and immediately flushing identity/session-critical changes
- make persistence failures observable and retryable, keep migrations load-only, and flush pending state at explicit save, shutdown, and destruction boundaries
- add regression coverage for write coalescing, immediate/destructor flushes, failure recovery, portable backups, and migration-free saves

## Verification

- `./scripts/dev-build.sh --tests`
- `nix develop --command ctest --test-dir build-dev --output-on-failure` (28/28)
- `nix flake check --print-build-logs` (Release app, QML lint, and Nix test derivation passed; 26/26 derivation tests)
- `git diff --check`

## Documentation

- updated `docs/config.md` with storage ownership, debounce/flush boundaries, failure behavior, and migration policy
- updated the Settings screen implementation note to reflect immediate in-memory and coalesced atomic persistence

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `ConfigManager` persistence atomic and debounced
> - Introduces a new [`ConfigStorage`](https://github.com/crowquillx/Bloom/pull/121/files#diff-2166ab2537e31e2f9919cca6e3ddaa7df0c4f11c81f06ed75e8e2923528a138a) class handling atomic writes via `QSaveFile`, checked reads, and timestamped backup of corrupt or invalid config files.
> - High-frequency setters (volume, audio delay, DPI scale, etc.) now call `scheduleSave()` to coalesce writes behind a 350 ms debounce timer instead of writing on every change.
> - Pending saves are flushed synchronously on `exitApplication()`, destructor, and `flushPendingSave()` calls, ensuring no data loss on quit.
> - Adds `persistenceFailed(QString)` signal, `lastPersistenceError` Q_PROPERTY, and `configurationPersisted` signal to expose write outcomes to QML consumers.
> - Behavioral Change: `save()` now returns `bool` and defers the actual write to `persistConfig()`; corrupt config files are moved to a portable timestamped backup rather than silently overwritten.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4051bb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->