### PR TITLE
refactor(build): reuse production targets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,8 +198,10 @@ jobs:
       - name: Cache mpv SDK
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: third_party\mpv\mpv-sdk
-          key: mpv-sdk-${{ runner.os }}-${{ hashFiles('packaging/dependencies.json') }}
+          # Cache only the pinned archive. build.ps1 verifies its SHA-256 before
+          # extracting it, so restored cache contents never bypass validation.
+          path: third_party\mpv\*.7z
+          key: mpv-sdk-archive-${{ runner.os }}-${{ hashFiles('packaging/dependencies.json') }}
       - name: Install Qt
         if: steps.cache-qt.outputs.cache-hit != 'true'
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ permissions:
 
 env:
   CACHIX_CACHE: crowquillx-bloom
-  BLOOM_BUILD_JOBS: '2'
 
 jobs:
   metadata:
@@ -105,8 +104,8 @@ jobs:
             .#checks.x86_64-linux.tests \
             .#checks.x86_64-linux.metadata \
             .#checks.x86_64-linux.release-manifest \
-            --print-build-logs --option max-jobs 1 --option cores 2
-          retry nix build .#bloom --print-build-logs --option max-jobs 1 --option cores 2
+            --print-build-logs --option max-jobs 1 --option cores 4
+          retry nix build .#bloom --print-build-logs --option max-jobs 1 --option cores 4
 
   portable-linux:
     name: Portable Linux artifacts
@@ -196,6 +195,11 @@ jobs:
         with:
           path: ${{ runner.tool_cache }}\Qt
           key: qt-${{ env.BLOOM_QT_VERSION }}-${{ env.BLOOM_QT_ARCH }}-${{ hashFiles('packaging/dependencies.json') }}
+      - name: Cache mpv SDK
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: third_party\mpv\mpv-sdk
+          key: mpv-sdk-${{ runner.os }}-${{ hashFiles('packaging/dependencies.json') }}
       - name: Install Qt
         if: steps.cache-qt.outputs.cache-hit != 'true'
         shell: pwsh
@@ -238,8 +242,13 @@ jobs:
           ./scripts/build.ps1 -BuildDir build-windows -InstallDir install-windows `
             -QtDir "$env:QT_ROOT_DIR" -Generator Ninja `
             -BuildChannel "${{ needs.metadata.outputs.channel }}" `
-            -BuildId "${{ needs.metadata.outputs.build_id }}" `
+            -BuildId "${{ needs.metadata.outputs.build_id }}" -BuildTests `
             -GitSha "${{ needs.metadata.outputs.git_sha }}" -Clean
+      - name: Run tests
+        shell: pwsh
+        run: |
+          ./scripts/run-windows-tests.ps1 -BuildDir build-windows `
+            -InstallDir install-windows -Config Release -OutputOnFailure
       - name: Package portable build
         shell: pwsh
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,12 @@ Use `nix build` and `nix flake check` for clean final verification. Portable
 Linux artifacts are orchestrated by Nix through a pinned Ubuntu compatibility
 container; Windows remains a native MSVC build.
 
+CMake production code is organized into reusable `Bloom::*` libraries. Tests
+must link production targets instead of compiling shared `.cpp` files
+independently and should prefer the narrowest practical target; keep dependency
+direction acyclic from models through configuration/transport, providers, and
+network services.
+
 When to update: Only edit this file for architecture, conventions, or global policy changes. Implementation details live in `docs/*` and should be updated there.
 
 Documentation & update policy:

--- a/docs/build.md
+++ b/docs/build.md
@@ -161,7 +161,7 @@ something to run. Environment-sensitive visual tests remain opt-in through
 `-BuildVisualTests`:
 
 ```powershell
-.\scripts\build.ps1 -Clean -BuildTests
+.\scripts\build.ps1 -Clean -BuildTests -BuildVisualTests
 .\scripts\run-windows-tests.ps1 -Config Release -OutputOnFailure
 ```
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -56,7 +56,7 @@ verification.
 ## Local checks
 
 ```bash
-BLOOM_BUILD_JOBS=2 nix flake check --print-build-logs \
+nix flake check --print-build-logs \
   --option max-jobs 1 --option cores 2
 ```
 
@@ -68,6 +68,20 @@ tests. Live provider/server, display, GPU, and playback contracts that require
 hosts or runtime hardware remain manual validation; unavailable environments
 are recorded as unavailable rather than treated as automated passes.
 
+Production models, configuration, transport, provider, and network code is
+compiled through reusable `Bloom::*` CMake libraries. Tests link those targets
+instead of recompiling the same `.cpp` files into every executable. Keep new
+production sources in the narrowest reusable layer and link tests to production
+targets; do not add a second test-only compilation of shared implementation
+files. Clean Nix builds use Ninja, matching the incremental development path.
+The Nix source sets contain only build inputs, so documentation and workflow
+changes do not invalidate unrelated C++ derivations.
+
+Measured on the pinned Release toolchain on August 10, 2026, the test build
+phase fell from 13m24s at the former two-core baseline to 4m47s with reusable
+targets and two-core Ninja, then to 2m46s with the four-core CI setting. All 26
+Nix-selected tests passed in each optimized run.
+
 The CI `nix` job wraps each `nix build` invocation in a retry loop with
 exponential backoff. `cache.nixos.org` nar downloads occasionally drop
 mid-transfer on GitHub-hosted runners (broken pipe or `HTTP 416` on a resumed
@@ -76,11 +90,11 @@ otherwise-unrelated derivations such as `qml-lint`. The retry recovers from
 these transient substituter failures without code changes; a genuinely missing
 path still fails after three attempts.
 
-Each Nix derivation caps C++ compilation at two concurrent jobs by default.
-The command above also serializes derivations, preventing concurrent flake
-checks from saturating interactive workstations.
-Set `BLOOM_BUILD_JOBS` only when a controlled builder needs a different
-per-derivation limit.
+Each Nix derivation honors Nix's standard `cores` setting. The command above
+uses two compile jobs and serializes derivations, preventing concurrent flake
+checks from saturating interactive workstations. CI uses four compile jobs to
+match the hosted runner; controlled builders can choose another value with
+`--option cores`.
 
 ## Portable Linux artifacts
 
@@ -136,21 +150,24 @@ Windows remains a native MSVC build because Qt and embedded libmpv are runtime
 validated in that environment:
 
 ```powershell
-.\scripts\build.ps1 -Clean
+.\scripts\build.ps1 -Clean -BuildTests
 .\scripts\run-windows-tests.ps1 -Config Release -OutputOnFailure
 .\scripts\package-windows.ps1 -InstallDir install-windows -OutputDir Bloom-Windows
 ```
 
-`build.ps1` defaults to `-DBUILD_TESTING=OFF` on Windows (CI builds the
-application only). Pass `-BuildTests` to configure and build the test
-targets so `run-windows-tests.ps1` has something to run:
+`build.ps1` defaults to `-DBUILD_TESTING=OFF`. Pass `-BuildTests` to configure
+and build the deterministic test targets so `run-windows-tests.ps1` has
+something to run. Environment-sensitive visual tests remain opt-in through
+`-BuildVisualTests`:
 
 ```powershell
 .\scripts\build.ps1 -Clean -BuildTests
 .\scripts\run-windows-tests.ps1 -Config Release -OutputOnFailure
 ```
 
-The Windows scripts and GitHub workflow read Qt and libmpv pins from
+Windows CI builds the application and deterministic tests in one CMake graph,
+runs CTest with failure output, and caches the checksum-pinned Qt and mpv SDKs.
+The Windows scripts and workflow read those pins from
 `packaging/dependencies.json`.
 
 Windows CI installs NSIS through `.github/actions/setup-nsis`. The action first

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -15,7 +15,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "bloom";
   version = lib.strings.removeSuffix "\n" (builtins.readFile ../VERSION);
-  src = lib.cleanSource ../.;
+  src = import ./source.nix { inherit lib; };
 
   strictDeps = true;
 
@@ -44,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
+    "-GNinja"
     (lib.cmakeBool "BUILD_TESTING" false)
     (lib.cmakeBool "BLOOM_BUNDLE_LIBMPV" false)
     (lib.cmakeFeature "BLOOM_BUILD_CHANNEL" "stable")
@@ -53,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = false;
   buildPhase = ''
     runHook preBuild
-    cmake --build . --parallel "''${BLOOM_BUILD_JOBS:-2}"
+    cmake --build . --parallel "$NIX_BUILD_CORES"
     runHook postBuild
   '';
 

--- a/nix/qml-lint.nix
+++ b/nix/qml-lint.nix
@@ -13,7 +13,7 @@
 stdenv.mkDerivation {
   pname = "bloom-qml-lint";
   version = lib.strings.removeSuffix "\n" (builtins.readFile ../VERSION);
-  src = lib.cleanSource ../.;
+  src = import ./source.nix { inherit lib; };
 
   nativeBuildInputs = [
     cmake
@@ -35,13 +35,14 @@ stdenv.mkDerivation {
     qt6.qtwayland
   ];
   cmakeFlags = [
+    "-GNinja"
     (lib.cmakeBool "BUILD_TESTING" false)
     (lib.cmakeBool "BLOOM_BUNDLE_LIBMPV" false)
   ];
   enableParallelBuilding = false;
   buildPhase = ''
     runHook preBuild
-    cmake --build . --parallel "''${BLOOM_BUILD_JOBS:-2}" --target \
+    cmake --build . --parallel "$NIX_BUILD_CORES" --target \
       Bloom_copy_qml Bloom_copy_res Bloom_qmltyperegistration
     mapfile -t qml_files < <(find src/BloomUI/ui -type f -name '*.qml' | sort)
     qmllint -I src -I ${qt6.qtdeclarative}/lib/qt-6/qml "''${qml_files[@]}"

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -1,0 +1,17 @@
+{
+  lib,
+  includeTests ? false,
+}:
+
+lib.fileset.toSource {
+  root = ../.;
+  fileset = lib.fileset.unions (
+    [
+      ../CMakeLists.txt
+      ../VERSION
+      ../config
+      ../src
+    ]
+    ++ lib.optionals includeTests [ ../tests ]
+  );
+}

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -15,7 +15,10 @@
 stdenv.mkDerivation {
   pname = "bloom-tests";
   version = lib.strings.removeSuffix "\n" (builtins.readFile ../VERSION);
-  src = lib.cleanSource ../.;
+  src = import ./source.nix {
+    inherit lib;
+    includeTests = true;
+  };
 
   nativeBuildInputs = [
     cmake
@@ -42,6 +45,7 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
+    "-GNinja"
     (lib.cmakeBool "BUILD_TESTING" true)
     (lib.cmakeBool "BLOOM_BUNDLE_LIBMPV" false)
     (lib.cmakeBool "BLOOM_BUILD_VISUAL_TESTS" false)
@@ -49,7 +53,7 @@ stdenv.mkDerivation {
   enableParallelBuilding = false;
   buildPhase = ''
     runHook preBuild
-    cmake --build . --parallel "''${BLOOM_BUILD_JOBS:-2}" --target \
+    cmake --build . --parallel "$NIX_BUILD_CORES" --target \
       BaseViewModelTest \
       LibraryCacheStoreTest \
       LibraryItemQueryTest \

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -32,6 +32,13 @@
 .PARAMETER GitSha
     Git commit SHA embedded in the application.
 
+.PARAMETER BuildTests
+    Configure and build deterministic unit and contract test targets.
+
+.PARAMETER BuildVisualTests
+    Build the environment-sensitive visual regression target. Implies only the
+    CMake option; use together with BuildTests.
+
 .PARAMETER Clean
     If set, removes the build directory before building.
 
@@ -55,6 +62,7 @@ param (
     [string]$GitSha = "",
     [bool]$AutoFetchMpvSdk = $true,
     [switch]$BuildTests,
+    [switch]$BuildVisualTests,
     [switch]$Clean
 )
 
@@ -62,6 +70,9 @@ $ErrorActionPreference = "Stop"
 
 if ($BuildChannel -notin @("stable", "dev")) {
     throw "BuildChannel must be 'stable' or 'dev' (got '$BuildChannel')."
+}
+if ($BuildVisualTests -and -not $BuildTests) {
+    throw "BuildVisualTests requires BuildTests."
 }
 
 if ([string]::IsNullOrWhiteSpace($BuildId)) {
@@ -454,6 +465,7 @@ $CMakeArgs = @(
     "-DCMAKE_BUILD_TYPE=$Config",
     "-DCMAKE_INSTALL_PREFIX=$InstallDir",
     "-DBUILD_TESTING=$($BuildTests.ToString())",
+    "-DBLOOM_BUILD_VISUAL_TESTS=$($BuildVisualTests.ToString())",
     "-DBLOOM_BUILD_CHANNEL=$BuildChannel",
     "-DBLOOM_BUILD_ID=$BuildId",
     "-DBLOOM_GIT_SHA=$GitSha"

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -271,29 +271,36 @@ function Fetch-MpvSdk {
     $mpvSdkFile = "mpv-dev-x86_64-$mpvSdkVersion.7z"
     $downloadUrl = "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/$mpvReleaseTag/$mpvSdkFile"
 
-    Write-Host "Attempting to fetch pinned mpv-dev SDK: $mpvSdkFile" -ForegroundColor Cyan
-
     $downloadPath = Join-Path $DestinationRoot $mpvSdkFile
-    & curl.exe -fL --retry 3 --retry-all-errors --output $downloadPath $downloadUrl
-    if ($LASTEXITCODE -ne 0) {
-        throw "Failed to download $mpvSdkFile from $downloadUrl"
+    if (Test-Path $downloadPath) {
+        Write-Host "Using cached pinned mpv-dev SDK archive: $mpvSdkFile" -ForegroundColor Cyan
+    } else {
+        Write-Host "Attempting to fetch pinned mpv-dev SDK: $mpvSdkFile" -ForegroundColor Cyan
+        & curl.exe -fL --retry 3 --retry-all-errors --output $downloadPath $downloadUrl
+        if ($LASTEXITCODE -ne 0) {
+            Remove-Item -Force $downloadPath -ErrorAction SilentlyContinue
+            throw "Failed to download $mpvSdkFile from $downloadUrl"
+        }
     }
+
     $downloadedFile = Get-Item $downloadPath -ErrorAction Stop
     if ($downloadedFile.Length -lt 1048576) {
+        Remove-Item -Force $downloadPath -ErrorAction SilentlyContinue
         throw "Downloaded file is unexpectedly small ($($downloadedFile.Length) bytes): $downloadPath"
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($mpvSdkSha256)) {
-        Write-Host "Verifying mpv-dev SDK SHA256 checksum..." -ForegroundColor Cyan
-        $actualHash = (Get-FileHash -Algorithm SHA256 -Path $downloadPath).Hash
-        $expectedHash = $mpvSdkSha256.ToUpperInvariant()
-        if ($actualHash -ne $expectedHash) {
-            throw "mpv-dev SDK SHA256 mismatch: expected $expectedHash, got $actualHash. Downloaded file: $downloadPath"
-        }
-        Write-Host "Checksum verified: $actualHash" -ForegroundColor Gray
-    } else {
-        Write-Warning "No windows_sdk_sha256 pin found in dependency manifest; skipping checksum verification."
+    if ([string]::IsNullOrWhiteSpace($mpvSdkSha256)) {
+        throw "Dependency manifest is missing the required windows_sdk_sha256 pin."
     }
+
+    Write-Host "Verifying mpv-dev SDK SHA256 checksum..." -ForegroundColor Cyan
+    $actualHash = (Get-FileHash -Algorithm SHA256 -Path $downloadPath).Hash
+    $expectedHash = $mpvSdkSha256.ToUpperInvariant()
+    if ($actualHash -ne $expectedHash) {
+        Remove-Item -Force $downloadPath -ErrorAction SilentlyContinue
+        throw "mpv-dev SDK SHA256 mismatch: expected $expectedHash, got $actualHash. Archive removed: $downloadPath"
+    }
+    Write-Host "Checksum verified: $actualHash" -ForegroundColor Gray
 
     $extractRoot = Join-Path $DestinationRoot "mpv-sdk"
     if (Test-Path $extractRoot) {

--- a/scripts/run-windows-tests.ps1
+++ b/scripts/run-windows-tests.ps1
@@ -123,7 +123,7 @@ if ($exitCode -ne 0) {
             }
 
             Write-Host "=== $testName ===" -ForegroundColor Yellow
-            & $testExecutable -v1
+            & $testExecutable -v1 -o "-,txt"
             Write-Host "$testName diagnostic exit code: $LASTEXITCODE" -ForegroundColor Yellow
         }
     }

--- a/scripts/run-windows-tests.ps1
+++ b/scripts/run-windows-tests.ps1
@@ -123,8 +123,16 @@ if ($exitCode -ne 0) {
             }
 
             Write-Host "=== $testName ===" -ForegroundColor Yellow
-            & $testExecutable -v1 -o "-,txt"
-            Write-Host "$testName diagnostic exit code: $LASTEXITCODE" -ForegroundColor Yellow
+            $diagnosticPath = Join-Path $testsDir "$testName-diagnostic.txt"
+            & $testExecutable -v2 -o "$diagnosticPath,txt"
+            $diagnosticExitCode = $LASTEXITCODE
+            if (Test-Path $diagnosticPath) {
+                Get-Content $diagnosticPath
+                Remove-Item $diagnosticPath -Force
+            } else {
+                Write-Warning "QtTest did not create diagnostic output for $testName"
+            }
+            Write-Host "$testName diagnostic exit code: $diagnosticExitCode" -ForegroundColor Yellow
         }
     }
     exit $exitCode

--- a/scripts/run-windows-tests.ps1
+++ b/scripts/run-windows-tests.ps1
@@ -107,5 +107,25 @@ Write-Host "Running ctest $($ctestArgs -join ' ')" -ForegroundColor Cyan
 $exitCode = $LASTEXITCODE
 
 if ($exitCode -ne 0) {
+    $failedTestsPath = Join-Path $testsDir "Testing\Temporary\LastTestsFailed.log"
+    if (Test-Path $failedTestsPath) {
+        Write-Host "Re-running failed test executables with verbose QtTest output" -ForegroundColor Yellow
+        foreach ($failedTest in (Get-Content $failedTestsPath)) {
+            $testName = ($failedTest -split ":", 2)[-1].Trim()
+            $testExecutable = @(
+                (Join-Path $testsDir "$Config\$testName.exe"),
+                (Join-Path $testsDir "$testName.exe")
+            ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+
+            if (-not $testExecutable) {
+                Write-Warning "Could not locate failed test executable: $testName"
+                continue
+            }
+
+            Write-Host "=== $testName ===" -ForegroundColor Yellow
+            & $testExecutable -v1
+            Write-Host "$testName diagnostic exit code: $LASTEXITCODE" -ForegroundColor Yellow
+        }
+    }
     exit $exitCode
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@ configure_file(config/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/config/version.h)
 
 include(GNUInstallDirs)
 
+include(cmake/BloomLibraries.cmake)
+
 qt_add_executable(Bloom
     core/ApplicationInitializer.cpp
     ui/WindowManager.cpp
@@ -11,41 +13,19 @@ qt_add_executable(Bloom
     main.cpp
     core/ServiceLocator.h
     core/ServiceLocator.cpp
-    providers/ServerConnection.h
-    providers/ServerConnection.cpp
-    profiles/BloomProfile.h
-    profiles/BloomProfile.cpp
     profiles/BloomProfileRepository.h
     profiles/BloomProfileRepository.cpp
     providers/IProviderAdapter.h
     providers/ICatalogProvider.h
     providers/IArtworkProvider.h
-    providers/ActiveArtworkProvider.h
-    providers/ActiveArtworkProvider.cpp
     providers/IProviderAuthenticator.h
     providers/IProviderRequestFactory.h
-    providers/jellyfin/JellyfinAuthenticator.h
-    providers/jellyfin/JellyfinAuthenticator.cpp
-    providers/jellyfin/JellyfinArtworkProvider.h
-    providers/jellyfin/JellyfinArtworkProvider.cpp
     providers/jellyfin/JellyfinCatalogProvider.h
-    providers/jellyfin/JellyfinRequestFactory.h
-    providers/jellyfin/JellyfinRequestFactory.cpp
-    providers/jellyfin/JellyfinModelMapper.h
-    providers/jellyfin/JellyfinModelMapper.cpp
     providers/IPlaybackProvider.h
-    providers/jellyfin/JellyfinPlaybackProvider.h
-    providers/jellyfin/JellyfinPlaybackProvider.cpp
     providers/jellyfin/JellyfinProviderAdapter.h
     providers/silo/SiloAuthenticator.h
-    providers/silo/SiloArtworkProvider.h
-    providers/silo/SiloArtworkProvider.cpp
     providers/silo/SiloCatalogProvider.h
     providers/silo/SiloRequestFactory.h
-    providers/silo/SiloModelMapper.h
-    providers/silo/SiloPlaybackProvider.h
-    providers/silo/SiloPlaybackProvider.cpp
-    providers/silo/SiloModelMapper.cpp
     providers/silo/SiloProviderAdapter.h
     resources/fonts.qrc
     resources/sounds.qrc
@@ -65,28 +45,6 @@ qt_add_executable(Bloom
     player/backend/PlayerBackendFactory.cpp
     player/backend/MpvEmbeddedShaderUtils.h
     player/backend/MpvEmbeddedShaderUtils.cpp
-    network/AuthenticationService.h
-    network/AuthenticationService.cpp
-    network/HttpTransport.h
-    network/HttpTransport.cpp
-    network/LibraryService.h
-    network/LibraryService.cpp
-    network/NextEpisodeResolver.h
-    network/NextEpisodeResolver.cpp
-    network/PlaybackService.h
-    network/PlaybackService.cpp
-    network/MediaSegmentProviderService.h
-    network/MediaSegmentProviderService.cpp
-    network/SeerrService.h
-    network/SeerrService.cpp
-    network/Types.h
-    network/Types.cpp
-    models/MediaModels.h
-    models/MediaModels.cpp
-    network/SessionManager.h
-    network/SessionManager.cpp
-    network/SessionService.h
-    network/SessionService.cpp
     updates/UpdateTypes.h
     updates/IUpdateProvider.h
     updates/IUpdateProvider.cpp
@@ -98,14 +56,8 @@ qt_add_executable(Bloom
     updates/WindowsNsisUpdateApplier.cpp
     updates/UpdateService.h
     updates/UpdateService.cpp
-    utils/ConfigManager.cpp
-    utils/ConfigManager.h
-    utils/ConfigStorage.cpp
-    utils/ConfigStorage.h
     utils/AudioOutputRouter.cpp
     utils/AudioOutputRouter.h
-    utils/MpvArgFilter.cpp
-    utils/MpvArgFilter.h
     utils/DetailViewCache.h
     utils/TrackPreferencesManager.cpp
     utils/TrackPreferencesManager.h
@@ -123,12 +75,6 @@ qt_add_executable(Bloom
     utils/SystemPowerController.cpp
     utils/GpuMemoryTrimmer.h
     utils/GpuMemoryTrimmer.cpp
-    utils/Logger.h
-    utils/Logger.cpp
-    utils/LoggingConfig.h
-    utils/LoggingConfig.cpp
-    utils/BloomLogging.h
-    utils/BloomLogging.cpp
     viewmodels/BaseViewModel.h
     viewmodels/BaseViewModel.cpp
     viewmodels/LibraryViewModel.h
@@ -148,8 +94,6 @@ qt_add_executable(Bloom
     ui/ResponsiveLayoutManager.h
     ui/ResponsiveLayoutManager.cpp
     security/ISecretStore.h
-    security/CredentialStore.h
-    security/CredentialStore.cpp
     security/SecretStoreFactory.h
     security/SecretStoreFactory.cpp
     security/SecretStoreLinux.h
@@ -470,6 +414,7 @@ endif()
 
 target_link_libraries(Bloom
     PRIVATE
+    Bloom::Network
     Qt6::Core
     Qt6::Gui
     Qt6::Quick

--- a/src/cmake/BloomLibraries.cmake
+++ b/src/cmake/BloomLibraries.cmake
@@ -1,0 +1,118 @@
+# Reusable production libraries shared by the application and unit tests.
+# Keep dependency direction acyclic:
+#   Models -> Config / Transport -> Providers -> Network
+
+add_library(BloomModels STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/models/MediaModels.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/network/Types.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils/BloomLogging.cpp
+)
+add_library(Bloom::Models ALIAS BloomModels)
+target_include_directories(BloomModels
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+)
+target_link_libraries(BloomModels
+    PUBLIC
+        Qt6::Core
+        Qt6::Network
+)
+
+add_library(BloomConfig STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/providers/ServerConnection.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/profiles/BloomProfile.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/security/CredentialStore.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils/ConfigManager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils/ConfigStorage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils/MpvArgFilter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils/LoggingConfig.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils/Logger.cpp
+)
+add_library(Bloom::Config ALIAS BloomConfig)
+target_include_directories(BloomConfig
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+)
+target_link_libraries(BloomConfig
+    PUBLIC
+        Bloom::Models
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Network
+)
+
+add_library(BloomTransport STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/network/HttpTransport.cpp
+)
+add_library(Bloom::Transport ALIAS BloomTransport)
+target_include_directories(BloomTransport
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+)
+target_link_libraries(BloomTransport
+    PUBLIC
+        Bloom::Models
+        Qt6::Core
+        Qt6::Network
+)
+
+add_library(BloomProviders STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/providers/jellyfin/JellyfinAuthenticator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/providers/jellyfin/JellyfinModelMapper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/providers/jellyfin/JellyfinPlaybackProvider.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/providers/jellyfin/JellyfinRequestFactory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/providers/silo/SiloModelMapper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/providers/silo/SiloPlaybackProvider.cpp
+)
+add_library(Bloom::Providers ALIAS BloomProviders)
+target_include_directories(BloomProviders
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+)
+target_link_libraries(BloomProviders
+    PUBLIC
+        Bloom::Config
+        Bloom::Transport
+        Qt6::Core
+        Qt6::Network
+)
+
+add_library(BloomNetwork STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/providers/ActiveArtworkProvider.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/providers/jellyfin/JellyfinArtworkProvider.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/providers/silo/SiloArtworkProvider.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/network/AuthenticationService.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/network/LibraryService.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/network/NextEpisodeResolver.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/network/PlaybackService.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/network/MediaSegmentProviderService.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/network/SeerrService.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/network/SessionManager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/network/SessionService.cpp
+)
+add_library(Bloom::Network ALIAS BloomNetwork)
+target_include_directories(BloomNetwork
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+)
+target_link_libraries(BloomNetwork
+    PUBLIC
+        Bloom::Providers
+        Qt6::Concurrent
+        Qt6::Core
+        Qt6::Network
+)
+
+set_target_properties(
+    BloomModels
+    BloomConfig
+    BloomTransport
+    BloomProviders
+    BloomNetwork
+    PROPERTIES FOLDER "Bloom/Libraries"
+)

--- a/src/player/backend/WindowsMpvBackend.cpp
+++ b/src/player/backend/WindowsMpvBackend.cpp
@@ -1751,6 +1751,12 @@ QStringList WindowsMpvBackend::sanitizeStartupArgs(const QStringList &args) cons
             continue;
         }
 
+        if (name.compare(QStringLiteral("profile"), Qt::CaseInsensitive) == 0
+            && MpvArgFilter::isSafeBuiltinProfileArg(arg)) {
+            finalArgs.append(arg);
+            continue;
+        }
+
         if (MpvArgFilter::isBloomManagedOptionName(name)) {
             if (equalsIndex < 0) {
                 skipNextValue = true;

--- a/src/utils/ConfigManager.cpp
+++ b/src/utils/ConfigManager.cpp
@@ -540,6 +540,13 @@ QString preferredConfigDir()
 {
 #ifdef Q_OS_WIN
     // Keep Windows config rooted at %APPDATA%/Bloom (no nested org/app suffix).
+    // Read APPDATA directly when available so callers can explicitly isolate
+    // configuration storage (including tests) without depending on the
+    // process-wide QStandardPaths cache.
+    const QString appData = qEnvironmentVariable("APPDATA").trimmed();
+    if (!appData.isEmpty()) {
+        return QDir::cleanPath(appData) + "/Bloom";
+    }
     return QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/Bloom";
 #else
     return QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + "/Bloom";

--- a/src/viewmodels/LibraryViewModel.cpp
+++ b/src/viewmodels/LibraryViewModel.cpp
@@ -1491,7 +1491,13 @@ QString LibraryViewModel::cacheDir() const
     if (m_configManager) {
         baseDir = m_configManager->getConfigDir();
     } else {
+#ifdef Q_OS_WIN
+        // Match the normal application layout even when a lightweight consumer
+        // (such as a unit test) has no ConfigManager registered.
+        baseDir = ConfigManager::getConfigDir();
+#else
         baseDir = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/Bloom";
+#endif
     }
     const QString scope = DetailViewCache::connectionScopeCacheKey(connectionScopeId());
     return baseDir + QStringLiteral("/cache/connections/") + scope + QStringLiteral("/library");

--- a/src/viewmodels/SeriesDetailsViewModel.h
+++ b/src/viewmodels/SeriesDetailsViewModel.h
@@ -139,6 +139,7 @@ class SeriesDetailsViewModel : public BaseViewModel
 {
     Q_OBJECT
 
+    friend class SeriesDetailsCacheTest;
     friend class SimilarItemsRetryTest;
 
     // Series metadata properties

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,49 @@ set(TEST_CONFIG_SOURCES
     ${TEST_LOGGING_SOURCES}
 )
 
+# These sources remain listed on individual tests for IDE/source ownership,
+# but their compiled objects come from the reusable production libraries in
+# src/cmake/BloomLibraries.cmake. This prevents every test executable from
+# independently compiling the same provider, network, config, and model code.
+set(BLOOM_LINKED_PRODUCTION_SOURCES
+    ${TEST_LOGGING_SOURCES}
+    ${TEST_PROVIDER_BOUNDARY_SOURCES}
+    ${TEST_CONFIG_SOURCES}
+    ${CMAKE_SOURCE_DIR}/src/models/MediaModels.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/AuthenticationService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/HttpTransport.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/LibraryService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/MediaSegmentProviderService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/NextEpisodeResolver.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/PlaybackService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/SeerrService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/SessionManager.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/SessionService.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/Types.cpp
+    ${CMAKE_SOURCE_DIR}/src/profiles/BloomProfile.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/ActiveArtworkProvider.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/ServerConnection.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinAuthenticator.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinArtworkProvider.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinModelMapper.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinPlaybackProvider.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/jellyfin/JellyfinRequestFactory.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloArtworkProvider.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloModelMapper.cpp
+    ${CMAKE_SOURCE_DIR}/src/providers/silo/SiloPlaybackProvider.cpp
+    ${CMAKE_SOURCE_DIR}/src/security/CredentialStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/BloomLogging.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/ConfigManager.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/ConfigStorage.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/Logger.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/LoggingConfig.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/MpvArgFilter.cpp
+)
+list(REMOVE_DUPLICATES BLOOM_LINKED_PRODUCTION_SOURCES)
+set_source_files_properties(${BLOOM_LINKED_PRODUCTION_SOURCES}
+    PROPERTIES HEADER_FILE_ONLY TRUE
+)
+
 add_executable(BaseViewModelTest
     BaseViewModelTest.cpp
     ${CMAKE_SOURCE_DIR}/src/viewmodels/BaseViewModel.cpp
@@ -696,6 +739,38 @@ endif()
 
 add_test(NAME UpdateServiceTest COMMAND UpdateServiceTest)
 
+set(BLOOM_UNIT_TEST_TARGETS
+    BaseViewModelTest
+    SeriesDetailsCacheTest
+    LibraryCacheStoreTest
+    LibraryItemQueryTest
+    LibraryViewModelCanonicalTest
+    LoggingConfigTest
+    ConfigManagerThemeTest
+    ConnectionPersistenceTest
+    BloomProfileRepositoryTest
+    ProviderTransportTest
+    SiloAuthenticationTest
+    SiloPlaybackProviderTest
+    ProviderCatalogTest
+    SiloCatalogServiceTest
+    ArtworkRefreshTest
+    CanonicalModelsTest
+    InputBindingManagerTest
+    PlayerBackendFactoryTest
+    PlayerControllerAutoplayContextTest
+    MediaSegmentProviderServiceTest
+    NextEpisodeResolverTest
+    EpisodeSelectionScriptTest
+    TrackPreferencesManagerTest
+    SimilarItemsRetryTest
+    UpNextRecommendationsViewModelTest
+    UpdateServiceTest
+)
+foreach(test_target IN LISTS BLOOM_UNIT_TEST_TARGETS)
+    target_link_libraries(${test_target} PRIVATE Bloom::Network)
+endforeach()
+
 if(BLOOM_BUILD_VISUAL_TESTS)
 # ============================================================================
 # Visual Regression Test Fixtures
@@ -915,6 +990,7 @@ target_include_directories(VisualRegressionTest PRIVATE
 )
 
 target_link_libraries(VisualRegressionTest PRIVATE
+    Bloom::Network
     Qt6::Core
     Qt6::Test
     Qt6::Quick

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,10 +43,9 @@ set(TEST_CONFIG_SOURCES
     ${TEST_LOGGING_SOURCES}
 )
 
-# These sources remain listed on individual tests for IDE/source ownership,
-# but their compiled objects come from the reusable production libraries in
-# src/cmake/BloomLibraries.cmake. This prevents every test executable from
-# independently compiling the same provider, network, config, and model code.
+# Production sources historically listed on individual tests. They are removed
+# from each target after declaration so both compiled objects and Qt metaobjects
+# come exclusively from the reusable libraries in src/cmake/BloomLibraries.cmake.
 set(BLOOM_LINKED_PRODUCTION_SOURCES
     ${TEST_LOGGING_SOURCES}
     ${TEST_PROVIDER_BOUNDARY_SOURCES}
@@ -82,9 +81,13 @@ set(BLOOM_LINKED_PRODUCTION_SOURCES
     ${CMAKE_SOURCE_DIR}/src/utils/MpvArgFilter.cpp
 )
 list(REMOVE_DUPLICATES BLOOM_LINKED_PRODUCTION_SOURCES)
-set_source_files_properties(${BLOOM_LINKED_PRODUCTION_SOURCES}
-    PROPERTIES HEADER_FILE_ONLY TRUE
-)
+
+function(bloom_use_production_libraries test_target)
+    get_target_property(test_sources ${test_target} SOURCES)
+    list(REMOVE_ITEM test_sources ${BLOOM_LINKED_PRODUCTION_SOURCES})
+    set_property(TARGET ${test_target} PROPERTY SOURCES "${test_sources}")
+    target_link_libraries(${test_target} PRIVATE Bloom::Network)
+endfunction()
 
 add_executable(BaseViewModelTest
     BaseViewModelTest.cpp
@@ -768,7 +771,7 @@ set(BLOOM_UNIT_TEST_TARGETS
     UpdateServiceTest
 )
 foreach(test_target IN LISTS BLOOM_UNIT_TEST_TARGETS)
-    target_link_libraries(${test_target} PRIVATE Bloom::Network)
+    bloom_use_production_libraries(${test_target})
 endforeach()
 
 if(BLOOM_BUILD_VISUAL_TESTS)
@@ -1032,6 +1035,7 @@ target_compile_definitions(VisualRegressionTest PRIVATE
     TEST_FIXTURES_PATH="${TEST_FIXTURES_PATH}"
 )
 
+bloom_use_production_libraries(VisualRegressionTest)
 add_test(NAME VisualRegressionTest COMMAND VisualRegressionTest)
 
 # Copy golden directory to build directory for runtime access

--- a/tests/LibraryViewModelCanonicalTest.cpp
+++ b/tests/LibraryViewModelCanonicalTest.cpp
@@ -189,6 +189,7 @@ void LibraryViewModelCanonicalTest::init()
     m_cacheDir = std::make_unique<QTemporaryDir>();
     QVERIFY(m_cacheDir->isValid());
     qputenv("XDG_CACHE_HOME", m_cacheDir->path().toUtf8());
+    qputenv("APPDATA", m_cacheDir->path().toUtf8());
     m_libraryService = new ControlledLibraryService(this);
     ServiceLocator::registerService<LibraryService>(m_libraryService);
 }

--- a/tests/SeriesDetailsCacheTest.cpp
+++ b/tests/SeriesDetailsCacheTest.cpp
@@ -4,12 +4,7 @@
 #include <QJsonDocument>
 #include <QFile>
 #include <QDateTime>
-// Expose cache helpers for white-box tests
-#define private public
-#define protected public
 #include "../src/viewmodels/SeriesDetailsViewModel.h"
-#undef private
-#undef protected
 
 class SeriesDetailsCacheTest : public QObject
 {


### PR DESCRIPTION
## Summary

- compile shared models, configuration, transport, provider, and network code once through reusable `Bloom::*` CMake targets instead of rebuilding it in each test executable
- switch clean Nix builds to Ninja, honor `NIX_BUILD_CORES`, and narrow derivation source sets so documentation/workflow edits do not invalidate C++ builds
- make Windows CI build and run deterministic tests, cache only the checksum-verified mpv SDK archive, and keep visual tests explicitly opt-in
- make Windows config/cache isolation deterministic and preserve the safe built-in mpv profiles used by embedded playback
- document the resulting build architecture and CI policy in `docs/build.md` and `AGENTS.md`

## Measured impact

Pinned Release toolchain, clean local derivations:

| Configuration | Test build phase |
| --- | ---: |
| Previous Make/two-core baseline | 13m24s |
| Reusable targets + Make/two cores | 5m44s |
| Reusable targets + Ninja/two cores | 4m47s |
| Reusable targets + Ninja/four cores (CI setting) | 2m42s |

The Release application build phase fell from 2m55s to 1m45s. A full clean `nix flake check` now completes the app, tests, and QML lint derivations in roughly six minutes locally. The full app/test object audit also fell from 416 duplicated production object instances to 82.

On GitHub's hosted Linux runner, the combined checks/application step fell from 17m49s on the preceding PR to 10m42s on this exact head: about a 40% reduction. The exact-head Windows job completed build, 27 native tests, portable packaging, NSIS installer construction, and artifact upload in 8m15s; its test step took 14 seconds.

## Verification

- `./scripts/dev-build.sh --tests --jobs 8`
- `nix develop --command ctest --test-dir build-dev --output-on-failure` — 28/28 passed, including visual regression
- `nix flake check --print-build-logs --option max-jobs 1 --option cores 4` — Release app, 26 CI tests, metadata, release manifest, and QML lint passed
- hosted Linux CI on `cd99759` — passed in 10m54s total
- hosted Windows x86_64 CI on `cd99759` — build, 27/27 tests, portable package, NSIS installer, and upload passed in 8m15s
- `actionlint .github/workflows/ci.yml`
- `nixfmt --check nix/package.nix nix/qml-lint.nix nix/source.nix nix/tests.nix`
- diff whitespace validation, including CRLF-aware validation for `scripts/build.ps1`

Existing QML lint warnings remain visible and non-fatal; this PR does not suppress or weaken them.