### PR TITLE
refactor(player): make mpv lifecycle asynchronous

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ Windows embedded playback guardrail (regression prevention):
 
 Backend policy (high level): Windows always uses embedded libmpv (`win-libmpv`) for playback. Linux embedded libmpv remains experimental/validation-only; keep current Linux fallback behavior (Wayland defaults to `external-mpv-ipc` unless explicitly opted in for validation, and unsupported embedded runtime conditions fall back to `external-mpv-ipc`).
 
+External mpv process/IPC lifecycle is owned by `Bloom::PlayerProcess`. It is
+fully event-driven: never add UI-thread `QProcess::waitFor*` calls. Preserve the
+graceful-quit/escalation sequence, queued replacement playback, bounded IPC
+deadlines/queues, and per-user/per-instance private endpoints documented in
+`docs/playback.md`.
+
 Build & run (blessed path):
 ```
 nix build

--- a/docs/developer_notes.md
+++ b/docs/developer_notes.md
@@ -40,7 +40,9 @@ Coding style
 - Write small unit tests for C++ core logic and integration tests for critical flows if feasible.
 
 Useful utilities
-- `PlayerProcessManager` for mpv lifecycle.
+- `PlayerProcessManager` for external mpv lifecycle. Link `Bloom::PlayerProcess`
+  in tests; keep process and IPC control asynchronous and bounded as documented
+  in `docs/playback.md`.
 - `HttpTransport` for shared HTTP execution/retry/cancellation policy.
 - `IProviderRequestFactory` implementations for provider URL/header construction.
 - `ConfigManager` for settings and QML exposures.

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -131,10 +131,10 @@ processes from colliding.
 IPC connection and reconnection are asynchronous. The default connection
 window is 5 seconds with 100 ms per-attempt retry pacing and at most 50
 attempts. A disconnect queues reconnection after the socket notification has
-unwound. Pending commands are capped at 256 (oldest dropped), outgoing socket
-buffering at 256 KiB, and each incoming/outgoing JSON message at 1 MiB. Incoming
-documents must be JSON objects with a valid event shape; property values and
-client-message arguments are type-checked before signals are emitted. Logs
+unwound. Pending commands are capped at 256 (oldest dropped), while outgoing
+socket buffering and each incoming/outgoing JSON message are capped at 1 MiB.
+Incoming documents must be JSON objects with a valid event shape; property
+values and client-message arguments are type-checked before signals are emitted. Logs
 record command names and lifecycle timing but never command payloads, media
 URLs, or signed credentials.
 

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -101,7 +101,7 @@ Key components
 - LinuxMpvBackend: Linux embedded backend entry point.
 - LinuxMpvBackend now includes basic `mpv_handle` lifecycle, property/event observation, and a Qt Quick `beforeRendering`-driven `mpv_render_context` render path (Linux runtime validation still pending).
 - MpvVideoItem / VideoSurface: minimal viewport plumbing for embedded backend integration.
-- PlayerProcessManager: manages external mpv process lifetime, sockets/pipes, scripts and config dir through the reusable `Bloom::PlayerProcess` production target. Observes `time-pos`, `duration`, `pause`, `aid`, and `sid` properties.
+- PlayerProcessManager: manages external mpv process lifetime, sockets/pipes, scripts and config dir through the reusable `Bloom::PlayerProcess` production target. Observes `time-pos`, `duration`, `pause`, `aid`, `sid`, `paused-for-cache`, `volume`, `mute`, `playlist-pos`, `playlist-count`, `demuxer-cache-time`, and `audio-device-list`.
 - PlayerController: provider-neutral state machine that handles play/pause/resume, listens for backend updates, manages track selection, and sends canonical playback state through `PlaybackService`.
 - `IPlaybackProvider` / `JellyfinPlaybackProvider` / `SiloPlaybackProvider`: finalize provider PlaybackInfo into Bloom `PlaybackDescriptor` values and serialize canonical playback reports into provider endpoints and wire payloads. Silo uses its pinned legacy native envelope; Jellyfin retains its synchronous descriptor path.
 - `PlaybackService`: stable application façade for playback preparation and reporting transport; its public timing contract uses milliseconds.
@@ -127,6 +127,11 @@ Windows uses an equivalently unique named pipe. Bloom intentionally supports
 multiple application instances and therefore does not enforce an app-wide
 single-instance lock; independent endpoints prevent their external mpv
 processes from colliding.
+
+When Linux embedded rendering fails, `PlayerController` keeps that backend
+alive until its asynchronous stopped signal arrives, then replaces it with the
+external-mpv backend on the next event-loop turn. Repeated render errors during
+that shutdown do not start overlapping fallback or terminal transitions.
 
 IPC connection and reconnection are asynchronous. The default connection
 window is 5 seconds with 100 ms per-attempt retry pacing and at most 50

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -101,11 +101,48 @@ Key components
 - LinuxMpvBackend: Linux embedded backend entry point.
 - LinuxMpvBackend now includes basic `mpv_handle` lifecycle, property/event observation, and a Qt Quick `beforeRendering`-driven `mpv_render_context` render path (Linux runtime validation still pending).
 - MpvVideoItem / VideoSurface: minimal viewport plumbing for embedded backend integration.
-- PlayerProcessManager: manages external mpv process lifetime, sockets/pipes, scripts and config dir. Observes `time-pos`, `duration`, `pause`, `aid`, and `sid` properties.
+- PlayerProcessManager: manages external mpv process lifetime, sockets/pipes, scripts and config dir through the reusable `Bloom::PlayerProcess` production target. Observes `time-pos`, `duration`, `pause`, `aid`, and `sid` properties.
 - PlayerController: provider-neutral state machine that handles play/pause/resume, listens for backend updates, manages track selection, and sends canonical playback state through `PlaybackService`.
 - `IPlaybackProvider` / `JellyfinPlaybackProvider` / `SiloPlaybackProvider`: finalize provider PlaybackInfo into Bloom `PlaybackDescriptor` values and serialize canonical playback reports into provider endpoints and wire payloads. Silo uses its pinned legacy native envelope; Jellyfin retains its synchronous descriptor path.
 - `PlaybackService`: stable application façade for playback preparation and reporting transport; its public timing contract uses milliseconds.
 - TrackPreferencesManager: persists explicit audio/subtitle user choices to a separate JSON file using a versioned schema.
+
+### External mpv lifecycle and IPC
+
+`PlayerProcessManager` never waits synchronously for a child process or local
+socket. Starting replacement playback records the newest request, asks the
+active mpv to quit over IPC, waits for its process-finished event, and launches
+the replacement on the next event-loop turn. Explicit stop cancels any queued
+replacement. Shutdown progresses through bounded stages: graceful IPC `quit`
+(750 ms by default), `QProcess::terminate()` (another 750 ms), and finally
+`QProcess::kill()`. An intentional terminate/kill result is not reported as a
+new playback failure.
+
+Each manager and launch uses a collision-resistant endpoint containing a
+non-reversible user token, the Bloom PID, a random instance token, and a launch
+sequence. Unix sockets live under `QStandardPaths::RuntimeLocation` in an
+owner-only directory, with an owner-only cache/runtime or unique temporary
+directory fallback when required; overlong Unix socket paths are rejected.
+Windows uses an equivalently unique named pipe. Bloom intentionally supports
+multiple application instances and therefore does not enforce an app-wide
+single-instance lock; independent endpoints prevent their external mpv
+processes from colliding.
+
+IPC connection and reconnection are asynchronous. The default connection
+window is 5 seconds with 100 ms per-attempt retry pacing and at most 50
+attempts. A disconnect queues reconnection after the socket notification has
+unwound. Pending commands are capped at 256 (oldest dropped), outgoing socket
+buffering at 256 KiB, and each incoming/outgoing JSON message at 1 MiB. Incoming
+documents must be JSON objects with a valid event shape; property values and
+client-message arguments are type-checked before signals are emitted. Logs
+record command names and lifecycle timing but never command payloads, media
+URLs, or signed credentials.
+
+Startup and IPC connection latency are logged and exposed through
+`startupLatencyMeasured`, `ipcConnectionLatencyMeasured`, and `diagnostics()`.
+`PlayerProcessManagerTest` runs a local fake-mpv child to cover graceful and
+forced shutdown, replacement ordering, private endpoints, startup/IPC failure,
+reconnection, bounded queues, and malformed JSON without playback hardware.
 
 HDR and Dolby Vision policy
 - Bloom keeps `enableHDR` as the master switch. With `enableHDR=false`, HDR and Dolby Vision sources are direct-played where possible and locally tone-mapped to SDR by mpv/libplacebo.

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -73,6 +73,7 @@ stdenv.mkDerivation {
       CanonicalModelsTest \
       InputBindingManagerTest \
       PlayerBackendFactoryTest \
+      PlayerProcessManagerTest \
       PlayerControllerAutoplayContextTest \
       MediaSegmentProviderServiceTest \
       NextEpisodeResolverTest \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,6 @@ qt_add_executable(Bloom
     resources/sounds.qrc
     resources/images.qrc
     resources/mpv-shaders.qrc
-    player/PlayerProcessManager.cpp
     player/PlayerController.cpp
     player/MpvVideoItem.h
     player/MpvVideoItem.cpp
@@ -414,6 +413,7 @@ target_link_libraries(Bloom
     PRIVATE
     Bloom::ImageCache
     Bloom::Network
+    Bloom::PlayerProcess
     Qt6::Core
     Qt6::Gui
     Qt6::Quick

--- a/src/cmake/BloomLibraries.cmake
+++ b/src/cmake/BloomLibraries.cmake
@@ -82,6 +82,23 @@ target_link_libraries(BloomImageCache
         Qt6::Sql
 )
 
+add_library(BloomPlayerProcess STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/player/PlayerProcessManager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/player/PlayerProcessManager.h
+)
+add_library(Bloom::PlayerProcess ALIAS BloomPlayerProcess)
+target_include_directories(BloomPlayerProcess
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+)
+target_link_libraries(BloomPlayerProcess
+    PUBLIC
+        Bloom::Models
+        Qt6::Core
+        Qt6::Network
+)
+
 add_library(BloomProviders STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/providers/jellyfin/JellyfinAuthenticator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/providers/jellyfin/JellyfinModelMapper.cpp
@@ -136,6 +153,7 @@ set_target_properties(
     BloomConfig
     BloomTransport
     BloomImageCache
+    BloomPlayerProcess
     BloomProviders
     BloomNetwork
     PROPERTIES FOLDER "Bloom/Libraries"

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -702,16 +702,48 @@ bool PlayerController::tryFallbackToExternalBackend(const QString &reason)
     m_attemptedLinuxEmbeddedFallback = true;
     qCWarning(lcPlayback) << "Embedded Linux backend failed; switching to external-mpv-ipc. Reason:" << reason;
 
-    QObject::disconnect(m_playerBackend, nullptr, this, nullptr);
+    m_backendFallbackSource = m_playerBackend;
     if (m_playerBackend->isRunning()) {
         m_playerBackend->stopMpv();
     }
+    if (!m_backendFallbackSource || !m_backendFallbackSource->isRunning()) {
+        queueBackendFallbackFinalization();
+    }
 
-    #if defined(BLOOM_TESTING)
+    return true;
+}
+
+void PlayerController::queueBackendFallbackFinalization()
+{
+    if (!m_backendFallbackSource || m_backendFallbackFinalizationQueued) {
+        return;
+    }
+    m_backendFallbackFinalizationQueued = true;
+    const QPointer<IPlayerBackend> source = m_backendFallbackSource;
+    QMetaObject::invokeMethod(this, [this, source]() {
+        m_backendFallbackFinalizationQueued = false;
+        if (!source || source != m_backendFallbackSource
+            || source != m_playerBackend || source->isRunning()) {
+            return;
+        }
+        finalizeBackendFallback();
+    }, Qt::QueuedConnection);
+}
+
+void PlayerController::finalizeBackendFallback()
+{
+    IPlayerBackend *source = m_backendFallbackSource;
+    if (!source || source != m_playerBackend || source->isRunning()) {
+        return;
+    }
+    QObject::disconnect(source, nullptr, this, nullptr);
+    m_backendFallbackSource.clear();
+
+#if defined(BLOOM_TESTING)
     m_ownedBackend = std::make_unique<NullPlayerBackend>(this);
-    #else
+#else
     m_ownedBackend = std::make_unique<ExternalMpvBackend>(this);
-    #endif
+#endif
 
     m_playerBackend = m_ownedBackend.get();
     connectBackendSignals(m_playerBackend);
@@ -721,8 +753,6 @@ bool PlayerController::tryFallbackToExternalBackend(const QString &reason)
         qCInfo(lcPlayback) << "Retrying current media with external-mpv-ipc fallback backend";
         initiateMpvStart();
     }
-
-    return true;
 }
 
 void PlayerController::setupStateMachine()
@@ -1292,6 +1322,13 @@ void PlayerController::onProcessStateChanged(bool running)
                                 << "terminalActive=" << m_terminalTransitionActive
                                 << "backendStopRequested=" << m_backendStopRequested;
 
+        if (m_backendFallbackSource == m_playerBackend) {
+            qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
+                                    << "] embedded-backend stop confirmed for fallback";
+            queueBackendFallbackFinalization();
+            return;
+        }
+
         if (m_suppressBackendStopHandling) {
             qCInfo(lcPlaybackTrace) << "[attempt" << m_playbackAttemptId
                                     << "] backend-stop ignored during replacement playback";
@@ -1318,9 +1355,14 @@ void PlayerController::onProcessError(const QString &error)
                                << "] process-error"
                                << error;
 
-    if (error.startsWith(QStringLiteral("linux-libmpv-render-unavailable"))
-        && tryFallbackToExternalBackend(error)) {
-        return;
+    if (error.startsWith(QStringLiteral("linux-libmpv-render-unavailable"))) {
+        if (m_backendFallbackSource == m_playerBackend) {
+            qCInfo(lcPlayback) << "Ignoring repeated embedded-render failure while fallback shutdown completes";
+            return;
+        }
+        if (tryFallbackToExternalBackend(error)) {
+            return;
+        }
     }
 
     setWaitingForRemoteMountInitialCache(false);

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -639,6 +639,8 @@ private:
     void scheduleReplacementPlayback(const std::function<void()> &action);
     void finalizeReplacementPlaybackStop();
     bool runPendingReplacementPlaybackAction();
+    void queueBackendFallbackFinalization();
+    void finalizeBackendFallback();
     /**
      * Attempt to fall back from the internal player backend to an external backend for the current attempt.
      * @param reason Human-readable reason for attempting the fallback.
@@ -785,6 +787,8 @@ private:
 
     IPlayerBackend *m_playerBackend;
     std::unique_ptr<IPlayerBackend> m_ownedBackend;
+    QPointer<IPlayerBackend> m_backendFallbackSource;
+    bool m_backendFallbackFinalizationQueued = false;
     ConfigManager *m_config;
     TrackPreferencesManager *m_trackPrefs;
     DisplayManager *m_displayManager;

--- a/src/player/PlayerProcessManager.cpp
+++ b/src/player/PlayerProcessManager.cpp
@@ -1,392 +1,924 @@
 #include "PlayerProcessManager.h"
-#include <QCoreApplication>
-#include <QDir>
-#include <QJsonDocument>
-#include <QJsonArray>
-#include <QDebug>
-#include <QThread>
-#include <QTimer>
-#include <QtMath>
+
 #include "../utils/BloomLogging.h"
 
+#include <QCoreApplication>
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonParseError>
+#include <QJsonValue>
+#include <QStandardPaths>
+#include <QUuid>
+#include <QtMath>
+
+#include <algorithm>
+#include <utility>
+
+#ifdef Q_OS_UNIX
+#include <unistd.h>
+#endif
+
+namespace {
+
+QString stripQuotesFromArgValue(const QString &arg)
+{
+    const int equalsPosition = arg.indexOf('=');
+    if (equalsPosition == -1) {
+        return arg;
+    }
+
+    const QString key = arg.left(equalsPosition + 1);
+    QString value = arg.mid(equalsPosition + 1);
+    if ((value.startsWith('"') && value.endsWith('"'))
+        || (value.startsWith('\'') && value.endsWith('\''))) {
+        value = value.mid(1, value.length() - 2);
+    }
+    return key + value;
+}
+
+QString userIdentityToken()
+{
+#ifdef Q_OS_UNIX
+    const QByteArray identity = QByteArray::number(static_cast<qulonglong>(geteuid()));
+#else
+    QByteArray identity = qEnvironmentVariable("USERNAME").toUtf8();
+    if (identity.isEmpty()) {
+        identity = qEnvironmentVariable("USER").toUtf8();
+    }
+    if (identity.isEmpty()) {
+        identity = QStandardPaths::writableLocation(
+                       QStandardPaths::HomeLocation).toUtf8();
+    }
+#endif
+    return QString::fromLatin1(
+        QCryptographicHash::hash(identity, QCryptographicHash::Sha256).toHex().left(10));
+}
+
+#ifdef Q_OS_UNIX
+bool preparePrivateRuntimeDirectory(const QString &path)
+{
+    if (path.isEmpty() || !QDir().mkpath(path)) {
+        return false;
+    }
+    const QFileInfo info(path);
+    if (!info.isDir() || info.ownerId() != static_cast<uint>(geteuid())) {
+        return false;
+    }
+    return QFile::setPermissions(path,
+                                 QFileDevice::ReadOwner
+                                     | QFileDevice::WriteOwner
+                                     | QFileDevice::ExeOwner);
+}
+
+QString privateRuntimeDirectory(const QString &instanceToken)
+{
+    QStringList candidates;
+    const QString runtimeLocation =
+        QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+    if (!runtimeLocation.isEmpty()) {
+        candidates.append(QDir(runtimeLocation).filePath(QStringLiteral("bloom")));
+    }
+
+    const QString cacheLocation =
+        QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    if (!cacheLocation.isEmpty()) {
+        candidates.append(QDir(cacheLocation).filePath(QStringLiteral("runtime")));
+    }
+
+    const QString temporaryBase = QStandardPaths::writableLocation(
+        QStandardPaths::TempLocation);
+    if (!temporaryBase.isEmpty()) {
+        candidates.append(QDir(temporaryBase).filePath(
+            QStringLiteral("bloom-%1-%2")
+                .arg(static_cast<qulonglong>(geteuid()))
+                .arg(instanceToken)));
+    }
+
+    for (const QString &candidate : std::as_const(candidates)) {
+        const QString longestEndpoint = QDir(candidate).filePath(
+            QStringLiteral("mpv-%1-18446744073709551615.sock").arg(instanceToken));
+        if (longestEndpoint.toUtf8().size() <= 100
+            && preparePrivateRuntimeDirectory(candidate)) {
+            return candidate;
+        }
+    }
+    return {};
+}
+#endif
+
+bool isFiniteNumber(const QJsonValue &value)
+{
+    return value.isDouble() && qIsFinite(value.toDouble());
+}
+
+} // namespace
+
 PlayerProcessManager::PlayerProcessManager(QObject *parent)
+    : PlayerProcessManager(PlayerProcessOptions{}, parent)
+{
+}
+
+PlayerProcessManager::PlayerProcessManager(const PlayerProcessOptions &options,
+                                           QObject *parent)
     : QObject(parent)
+    , m_options(options)
     , m_process(new QProcess(this))
     , m_ipcSocket(new QLocalSocket(this))
 {
+    m_options.gracefulQuitTimeoutMs = std::max(1, m_options.gracefulQuitTimeoutMs);
+    m_options.terminateTimeoutMs = std::max(1, m_options.terminateTimeoutMs);
+    m_options.ipcRetryIntervalMs = std::max(1, m_options.ipcRetryIntervalMs);
+    m_options.ipcConnectionDeadlineMs = std::max(1, m_options.ipcConnectionDeadlineMs);
+    m_options.maximumIpcAttempts = std::max(1, m_options.maximumIpcAttempts);
+    m_options.maximumPendingCommands = std::max(1, m_options.maximumPendingCommands);
+    m_options.maximumIpcMessageBytes = std::max<qint64>(128,
+                                                        m_options.maximumIpcMessageBytes);
+    m_options.maximumBufferedWriteBytes = std::max<qint64>(128,
+                                                           m_options.maximumBufferedWriteBytes);
+
+    const QString uniquePart = QUuid::createUuid().toString(QUuid::WithoutBraces).left(12);
+    m_instanceToken = QStringLiteral("%1-%2-%3")
+                          .arg(userIdentityToken())
+                          .arg(QCoreApplication::applicationPid())
+                          .arg(uniquePart);
+    m_ipcPath = createIpcPath();
+
+    m_gracefulQuitTimer.setSingleShot(true);
+    m_terminateTimer.setSingleShot(true);
+    m_ipcRetryTimer.setSingleShot(true);
+    m_ipcDeadlineTimer.setSingleShot(true);
+
+    connect(&m_gracefulQuitTimer, &QTimer::timeout,
+            this, &PlayerProcessManager::escalateToTerminate);
+    connect(&m_terminateTimer, &QTimer::timeout,
+            this, &PlayerProcessManager::escalateToKill);
+    connect(&m_ipcRetryTimer, &QTimer::timeout,
+            this, &PlayerProcessManager::retryIpcConnection);
+    connect(&m_ipcDeadlineTimer, &QTimer::timeout, this, [this]() {
+        failIpcConnection(QStringLiteral("connection deadline exceeded"));
+    });
+
+    connect(m_process, &QProcess::started,
+            this, &PlayerProcessManager::onProcessStarted);
     connect(m_process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
             this, &PlayerProcessManager::onProcessFinished);
     connect(m_process, &QProcess::errorOccurred,
             this, &PlayerProcessManager::onProcessError);
+    connect(m_process, &QProcess::readyReadStandardOutput,
+            m_process, [process = m_process]() { process->readAllStandardOutput(); });
+    connect(m_process, &QProcess::readyReadStandardError,
+            m_process, [process = m_process]() { process->readAllStandardError(); });
 
-    connect(m_ipcSocket, &QLocalSocket::connected, this, &PlayerProcessManager::onSocketConnected);
-    connect(m_ipcSocket, &QLocalSocket::readyRead, this, &PlayerProcessManager::onSocketReadyRead);
-    
-    // Determine IPC path once
-    m_ipcPath = getIpcPath();
+    connect(m_ipcSocket, &QLocalSocket::connected,
+            this, &PlayerProcessManager::onSocketConnected);
+    connect(m_ipcSocket, &QLocalSocket::disconnected,
+            this, &PlayerProcessManager::onSocketDisconnected);
+    connect(m_ipcSocket, &QLocalSocket::readyRead,
+            this, &PlayerProcessManager::onSocketReadyRead);
+    connect(m_ipcSocket, &QLocalSocket::errorOccurred, this,
+            [this](QLocalSocket::LocalSocketError) {
+                if (m_stopStage == StopStage::None && isRunning()
+                    && !m_isConnected && !m_ipcRetryTimer.isActive()) {
+                    m_ipcRetryTimer.start(m_options.ipcRetryIntervalMs);
+                }
+            });
 }
 
 PlayerProcessManager::~PlayerProcessManager()
 {
-    stopMpv();
+    m_pendingLaunch.reset();
+    m_gracefulQuitTimer.stop();
+    m_terminateTimer.stop();
+    resetIpcConnection();
+    if (m_process->state() != QProcess::NotRunning) {
+        // QProcess::~QProcess waits for a live child. Detach the process object
+        // before killing so manager destruction never turns into a UI-thread
+        // wait; it deletes itself after the asynchronous finished event.
+        QProcess *process = m_process;
+        QObject::disconnect(process, nullptr, this, nullptr);
+        process->setParent(nullptr);
+        connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+                process, &QObject::deleteLater);
+        process->kill();
+        m_process = nullptr;
+    }
+    removeIpcEndpoint();
 }
 
-QString PlayerProcessManager::getIpcPath() const
+QString PlayerProcessManager::createIpcPath() const
 {
+    const QString endpoint = QStringLiteral("mpv-%1-%2")
+                                 .arg(m_instanceToken)
+                                 .arg(m_launchSequence);
 #ifdef Q_OS_WIN
-    return "\\\\.\\pipe\\bloom-mpv-socket";
+    return QStringLiteral("\\\\.\\pipe\\bloom-%1").arg(endpoint);
 #else
-    return QDir::tempPath() + "/bloom-mpv-socket";
+    const QString runtimeDirectory = privateRuntimeDirectory(m_instanceToken);
+    if (runtimeDirectory.isEmpty()) {
+        return {};
+    }
+    return QDir(runtimeDirectory).filePath(endpoint + QStringLiteral(".sock"));
 #endif
 }
 
-// Helper to strip unnecessary quotes from argument values
-// Users often copy args like --glsl-shader="path with spaces" but QProcess handles quoting automatically
-static QString stripQuotesFromArgValue(const QString &arg)
+QString PlayerProcessManager::ipcServerName() const
 {
-    int eqPos = arg.indexOf('=');
-    if (eqPos == -1) {
-        return arg;  // No '=' means no value to unquote
+#ifdef Q_OS_WIN
+    constexpr auto pipePrefix = "\\\\.\\pipe\\";
+    if (m_ipcPath.startsWith(QLatin1StringView(pipePrefix))) {
+        return m_ipcPath.mid(int(std::char_traits<char>::length(pipePrefix)));
     }
-    
-    QString key = arg.left(eqPos + 1);  // Include the '='
-    QString value = arg.mid(eqPos + 1);
-    
-    // Strip surrounding quotes from value (both " and ')
-    if ((value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith('\'') && value.endsWith('\''))) {
-        value = value.mid(1, value.length() - 2);
-    }
-    
-    return key + value;
+#endif
+    return m_ipcPath;
 }
 
-void PlayerProcessManager::startMpv(const QString &mpvBin, const QStringList &args, const QString &mediaUrl)
+void PlayerProcessManager::removeIpcEndpoint()
 {
-    if (isRunning()) {
-        stopMpv();
-        // Give it a moment to close? Or just force kill?
-        // For now, assume stopMpv() handles it or we wait.
-        // But QProcess::kill is async.
-        m_process->waitForFinished(1000);
+#ifndef Q_OS_WIN
+    if (!m_ipcPath.isEmpty()) {
+        QFile::remove(m_ipcPath);
+    }
+#endif
+}
+
+void PlayerProcessManager::startMpv(const QString &mpvBin,
+                                    const QStringList &args,
+                                    const QString &mediaUrl)
+{
+    if (mpvBin.trimmed().isEmpty() || mediaUrl.isEmpty()) {
+        emit errorOccurred(QStringLiteral("Cannot start mpv: executable or media URL is empty"));
+        return;
     }
 
-    QStringList finalArgs;
-    // Strip quotes from argument values - QProcess handles quoting automatically,
-    // so user-provided quotes like --glsl-shader="path" cause issues
+    LaunchRequest request;
+    request.executable = mpvBin;
+    request.mediaUrl = mediaUrl;
+    request.arguments.reserve(args.size());
     for (const QString &arg : args) {
-        finalArgs << stripQuotesFromArgValue(arg);
+        request.arguments.append(stripQuotesFromArgValue(arg));
     }
-    
-    // Add IPC server argument
-    // On Windows, mpv expects just the pipe name for --input-ipc-server=\\.\pipe\name
-    // On Linux, it expects the path.
-    // QLocalSocket serverName on Windows is just "name".
-    
-    QString ipcArg = m_ipcPath;
-    finalArgs << "--input-ipc-server=" + ipcArg;
-    
-    // Add media
-    finalArgs << mediaUrl;
+    m_pendingLaunch = std::move(request);
 
-    // Observe properties for playback reporting
-    // Note: --observe-property is not a valid CLI arg, we must send it via IPC once connected.
+    if (isRunning()) {
+        qCInfo(lcPlaybackIpc) << "Queueing replacement mpv playback after process exit";
+        beginStop();
+        return;
+    }
+    launchPending();
+}
+
+void PlayerProcessManager::launchPending()
+{
+    if (!m_pendingLaunch.has_value() || m_process->state() != QProcess::NotRunning
+        || m_launchActive) {
+        return;
+    }
+
+    LaunchRequest request = std::move(*m_pendingLaunch);
+    m_pendingLaunch.reset();
+    ++m_launchSequence;
+    removeIpcEndpoint();
+    m_ipcPath = createIpcPath();
+    if (m_ipcPath.isEmpty()) {
+        emit errorOccurred(QStringLiteral("Cannot start mpv: no private IPC runtime directory"));
+        return;
+    }
+
+    resetIpcConnection();
+    m_ipcFailureReported = false;
+    m_stopStage = StopStage::None;
     m_playlistPosition = -1;
     m_playlistCount = 0;
-    
-    qCInfo(lcPlaybackIpc) << "Starting mpv:" << mpvBin;
-    m_process->start(mpvBin, finalArgs);
-    
-    // Try to connect IPC after a short delay or retry loop
-    // We'll use a simple retry mechanism in connectIpc
-    QTimer::singleShot(500, this, &PlayerProcessManager::connectIpc);
-    
-    emit stateChanged(true);
+    m_pendingCommands.clear();
+
+    QStringList finalArguments = std::move(request.arguments);
+    finalArguments.append(QStringLiteral("--input-ipc-server=%1").arg(m_ipcPath));
+    finalArguments.append(request.mediaUrl);
+
+    m_launchActive = true;
+    m_startupElapsed.restart();
+    qCInfo(lcPlaybackIpc) << "Starting external mpv process:" << request.executable;
+    m_process->start(request.executable, finalArguments);
 }
 
 void PlayerProcessManager::appendUrlsToPlaylist(const QStringList &mediaUrls)
 {
     for (const QString &mediaUrl : mediaUrls) {
-        if (mediaUrl.isEmpty()) {
-            continue;
+        if (!mediaUrl.isEmpty()) {
+            sendVariantCommand(QVariantList{QStringLiteral("loadfile"),
+                                            mediaUrl,
+                                            QStringLiteral("append-play")});
         }
-        sendVariantCommand(QVariantList{"loadfile", mediaUrl, "append-play"});
     }
 }
 
 void PlayerProcessManager::stopMpv()
 {
-    if (m_process->state() != QProcess::NotRunning) {
-        // Try to quit gracefully via IPC first
-        sendCommand({"quit"});
-        
-        if (!m_process->waitForFinished(1000)) {
-            m_process->kill();
+    m_pendingLaunch.reset();
+    beginStop();
+}
+
+void PlayerProcessManager::beginStop()
+{
+    if (m_process->state() == QProcess::NotRunning) {
+        if (m_launchActive) {
+            finishProcessLifecycle(m_process->exitCode(), m_process->exitStatus());
         }
+        return;
     }
-    m_ipcSocket->abort();
-    m_isConnected = false;
+    if (m_stopStage != StopStage::None) {
+        return;
+    }
+
+    m_stopStage = StopStage::GracefulQuit;
+    m_ipcRetryTimer.stop();
+    m_ipcDeadlineTimer.stop();
     m_pendingCommands.clear();
-    m_playlistPosition = -1;
-    m_playlistCount = 0;
+    if (m_ipcSocket->state() == QLocalSocket::ConnectedState) {
+        writeCommand(QVariantList{QStringLiteral("quit")});
+    }
+    qCInfo(lcPlaybackIpc) << "Requested graceful mpv shutdown";
+    m_gracefulQuitTimer.start(m_options.gracefulQuitTimeoutMs);
+}
+
+void PlayerProcessManager::escalateToTerminate()
+{
+    if (m_process->state() == QProcess::NotRunning) {
+        return;
+    }
+    m_stopStage = StopStage::Terminating;
+    ++m_terminateEscalations;
+    qCWarning(lcPlaybackIpc) << "mpv did not quit within the grace period; terminating";
+    m_process->terminate();
+    m_terminateTimer.start(m_options.terminateTimeoutMs);
+}
+
+void PlayerProcessManager::escalateToKill()
+{
+    if (m_process->state() == QProcess::NotRunning) {
+        return;
+    }
+    m_stopStage = StopStage::Killing;
+    ++m_killEscalations;
+    qCWarning(lcPlaybackIpc) << "mpv did not terminate within the deadline; killing";
+    m_process->kill();
 }
 
 bool PlayerProcessManager::isRunning() const
 {
-    return m_process->state() != QProcess::NotRunning;
+    return m_launchActive || m_process->state() != QProcess::NotRunning;
 }
 
-void PlayerProcessManager::connectIpc()
+QString PlayerProcessManager::ipcPath() const
 {
-    if (!isRunning()) return;
+    return m_ipcPath;
+}
 
-    if (m_ipcSocket->state() == QLocalSocket::ConnectedState ||
-        m_ipcSocket->state() == QLocalSocket::ConnectingState) {
+QVariantMap PlayerProcessManager::diagnostics() const
+{
+    QString stopStage;
+    switch (m_stopStage) {
+    case StopStage::None:
+        stopStage = QStringLiteral("none");
+        break;
+    case StopStage::GracefulQuit:
+        stopStage = QStringLiteral("graceful-quit");
+        break;
+    case StopStage::Terminating:
+        stopStage = QStringLiteral("terminating");
+        break;
+    case StopStage::Killing:
+        stopStage = QStringLiteral("killing");
+        break;
+    }
+    return {
+        {QStringLiteral("ipcPath"), m_ipcPath},
+        {QStringLiteral("processState"), int(m_process->state())},
+        {QStringLiteral("stopStage"), stopStage},
+        {QStringLiteral("pendingCommands"), m_pendingCommands.size()},
+        {QStringLiteral("droppedPendingCommands"),
+         QVariant::fromValue(m_droppedPendingCommands)},
+        {QStringLiteral("invalidIpcMessages"), QVariant::fromValue(m_invalidIpcMessages)},
+        {QStringLiteral("ipcAttempts"), m_ipcAttempts},
+        {QStringLiteral("terminateEscalations"),
+         QVariant::fromValue(m_terminateEscalations)},
+        {QStringLiteral("killEscalations"), QVariant::fromValue(m_killEscalations)},
+        {QStringLiteral("lastStartupLatencyMs"), m_lastStartupLatencyMs},
+        {QStringLiteral("lastIpcLatencyMs"), m_lastIpcLatencyMs},
+    };
+}
+
+void PlayerProcessManager::onProcessStarted()
+{
+    if (!m_launchActive) {
+        return;
+    }
+    m_lastStartupLatencyMs = m_startupElapsed.elapsed();
+    qCInfo(lcPlaybackIpc) << "mpv process started in" << m_lastStartupLatencyMs << "ms";
+    emit startupLatencyMeasured(m_lastStartupLatencyMs);
+    if (!m_runningReported) {
+        m_runningReported = true;
+        emit stateChanged(true);
+    }
+    if (m_stopStage == StopStage::None) {
+        beginIpcConnectionWindow();
+    }
+}
+
+void PlayerProcessManager::onProcessFinished(int exitCode,
+                                             QProcess::ExitStatus exitStatus)
+{
+    finishProcessLifecycle(exitCode, exitStatus);
+}
+
+void PlayerProcessManager::finishProcessLifecycle(int exitCode,
+                                                  QProcess::ExitStatus exitStatus)
+{
+    if (!m_launchActive) {
         return;
     }
 
-    // On Windows, QLocalSocket connects to "bloom-mpv-socket" if path is "\\.\pipe\bloom-mpv-socket"
-    QString serverName = m_ipcPath;
-#ifdef Q_OS_WIN
-    if (serverName.startsWith("\\\\.\\pipe\\")) {
-        serverName = serverName.mid(9);
-    }
-#endif
-
-    m_ipcSocket->abort();
-    m_ipcSocket->connectToServer(serverName);
-    scheduleIpcReconnect();
-}
-
-void PlayerProcessManager::scheduleIpcReconnect()
-{
-    if (m_ipcReconnectScheduled || !isRunning()) {
-        return;
-    }
-
-    m_ipcReconnectScheduled = true;
-    QTimer::singleShot(500, this, [this]() {
-        m_ipcReconnectScheduled = false;
-
-        if (!isRunning() || m_ipcSocket->state() == QLocalSocket::ConnectedState) {
-            return;
-        }
-
-        if (m_ipcSocket->state() == QLocalSocket::ConnectingState) {
-            m_ipcSocket->abort();
-        }
-
-        connectIpc();
-    });
-}
-
-void PlayerProcessManager::sendCommand(const QStringList &command)
-{
-    QVariantList variantCmd;
-    for (const QString &arg : command) {
-        variantCmd.append(arg);
-    }
-    sendVariantCommand(variantCmd);
-}
-
-void PlayerProcessManager::sendVariantCommand(const QVariantList &command)
-{
-    if (m_ipcSocket->state() != QLocalSocket::ConnectedState) {
-        // Queue the command for later if we're starting up
-        if (isRunning()) {
-            qCDebug(lcPlaybackIpc) << "IPC: Queueing command (not connected yet):" << command;
-            m_pendingCommands.append(command);
-        } else {
-            qCDebug(lcPlaybackIpc) << "IPC: Not connected, dropping command:" << command;
-        }
-        return;
-    }
-
-    QJsonArray cmdArray;
-    for (const QVariant &arg : command) {
-        cmdArray.append(QJsonValue::fromVariant(arg));
-    }
-    
-    QJsonObject jsonObj;
-    jsonObj["command"] = cmdArray;
-    
-    QJsonDocument doc(jsonObj);
-    qCDebug(lcPlaybackIpc) << "IPC >" << doc.toJson(QJsonDocument::Compact);
-    m_ipcSocket->write(doc.toJson(QJsonDocument::Compact));
-    m_ipcSocket->write("\n");
-    m_ipcSocket->flush();
-}
-
-void PlayerProcessManager::flushPendingCommands()
-{
-    if (m_pendingCommands.isEmpty()) return;
-    
-    qCDebug(lcPlaybackIpc) << "IPC: Flushing" << m_pendingCommands.size() << "pending commands";
-    QList<QVariantList> commands = m_pendingCommands;
-    m_pendingCommands.clear();
-    
-    for (const QVariantList &cmd : commands) {
-        sendVariantCommand(cmd);
-    }
-}
-
-void PlayerProcessManager::onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus)
-{
-    if (exitStatus == QProcess::CrashExit || exitCode != 0) {
-        qCWarning(lcPlaybackIpc) << "mpv process exited abnormally: exitCode=" << exitCode 
-                   << "status=" << (exitStatus == QProcess::CrashExit ? "crashed" : "normal");
-    } else {
-        qCInfo(lcPlaybackIpc) << "mpv process exited normally";
-    }
-    m_ipcSocket->abort();
-    m_isConnected = false;
-    m_ipcReconnectScheduled = false;
+    m_launchActive = false;
+    m_gracefulQuitTimer.stop();
+    m_terminateTimer.stop();
+    resetIpcConnection();
+    removeIpcEndpoint();
     m_pendingCommands.clear();
     m_playlistPosition = -1;
     m_playlistCount = 0;
-    emit stateChanged(false);
+    m_stopStage = StopStage::None;
+
+    const bool crashed = exitStatus == QProcess::CrashExit;
+    if (crashed || exitCode != 0) {
+        qCWarning(lcPlaybackIpc) << "mpv process exited abnormally"
+                                 << "exitCode=" << exitCode
+                                 << "crashed=" << crashed;
+    } else {
+        qCInfo(lcPlaybackIpc) << "mpv process exited normally";
+    }
+
+    emit processFinished(exitCode, crashed);
+    if (m_runningReported) {
+        m_runningReported = false;
+        emit stateChanged(false);
+    }
+
+    if (m_pendingLaunch.has_value()) {
+        QMetaObject::invokeMethod(this, &PlayerProcessManager::launchPending,
+                                  Qt::QueuedConnection);
+    }
 }
 
 void PlayerProcessManager::onProcessError(QProcess::ProcessError error)
 {
-    QString errorStr;
-    switch (error) {
-    case QProcess::FailedToStart: errorStr = QStringLiteral("FailedToStart"); break;
-    case QProcess::Crashed: errorStr = QStringLiteral("Crashed"); break;
-    case QProcess::Timedout: errorStr = QStringLiteral("Timedout"); break;
-    case QProcess::WriteError: errorStr = QStringLiteral("WriteError"); break;
-    case QProcess::ReadError: errorStr = QStringLiteral("ReadError"); break;
-    default: errorStr = QStringLiteral("Unknown"); break;
+    if (error == QProcess::FailedToStart) {
+        const QString message = QStringLiteral("Failed to start mpv: %1")
+                                    .arg(m_process->errorString());
+        qCWarning(lcPlaybackIpc) << message;
+        emit errorOccurred(message);
+        finishProcessLifecycle(-1, QProcess::CrashExit);
+        return;
     }
-    qCWarning(lcPlaybackIpc) << "mpv process error:" << errorStr;
-    emit errorOccurred("mpv process error");
+
+    if (error == QProcess::Crashed && m_stopStage != StopStage::None) {
+        // terminate()/kill() report Crashed even though this is the expected
+        // result of Bloom's bounded shutdown escalation.
+        return;
+    }
+
+    QString errorName;
+    switch (error) {
+    case QProcess::Crashed:
+        errorName = QStringLiteral("crashed");
+        break;
+    case QProcess::Timedout:
+        errorName = QStringLiteral("timed out");
+        break;
+    case QProcess::WriteError:
+        errorName = QStringLiteral("write failed");
+        break;
+    case QProcess::ReadError:
+        errorName = QStringLiteral("read failed");
+        break;
+    case QProcess::UnknownError:
+        errorName = QStringLiteral("unknown error");
+        break;
+    case QProcess::FailedToStart:
+        Q_UNREACHABLE();
+    }
+    const QString message = QStringLiteral("mpv process %1: %2")
+                                .arg(errorName, m_process->errorString());
+    qCWarning(lcPlaybackIpc) << message;
+    emit errorOccurred(message);
+}
+
+void PlayerProcessManager::beginIpcConnectionWindow()
+{
+    resetIpcConnection();
+    m_ipcFailureReported = false;
+    m_ipcElapsed.restart();
+    m_ipcDeadlineTimer.start(m_options.ipcConnectionDeadlineMs);
+    attemptIpcConnection();
+}
+
+void PlayerProcessManager::attemptIpcConnection()
+{
+    if (!isRunning() || m_stopStage != StopStage::None || m_isConnected) {
+        return;
+    }
+    if (m_ipcAttempts >= m_options.maximumIpcAttempts) {
+        failIpcConnection(QStringLiteral("maximum reconnect attempts reached"));
+        return;
+    }
+
+    ++m_ipcAttempts;
+    if (m_ipcSocket->state() != QLocalSocket::UnconnectedState) {
+        m_ipcSocket->abort();
+    }
+    m_ipcSocket->connectToServer(ipcServerName(), QIODevice::ReadWrite);
+    m_ipcRetryTimer.start(m_options.ipcRetryIntervalMs);
+}
+
+void PlayerProcessManager::retryIpcConnection()
+{
+    if (m_isConnected || !isRunning() || m_stopStage != StopStage::None) {
+        return;
+    }
+    if (m_ipcSocket->state() != QLocalSocket::UnconnectedState) {
+        m_ipcSocket->abort();
+    }
+    attemptIpcConnection();
+}
+
+void PlayerProcessManager::failIpcConnection(const QString &reason)
+{
+    if (m_ipcFailureReported || !isRunning() || m_stopStage != StopStage::None) {
+        return;
+    }
+    m_ipcFailureReported = true;
+    m_ipcRetryTimer.stop();
+    m_ipcDeadlineTimer.stop();
+    const QString message = QStringLiteral("mpv IPC connection failed: %1")
+                                .arg(reason);
+    qCWarning(lcPlaybackIpc) << message << "attempts=" << m_ipcAttempts;
+    emit errorOccurred(message);
+    beginStop();
+}
+
+void PlayerProcessManager::resetIpcConnection()
+{
+    m_ipcRetryTimer.stop();
+    m_ipcDeadlineTimer.stop();
+    m_ipcSocket->abort();
+    m_isConnected = false;
+    m_ipcAttempts = 0;
+    m_ipcReadBuffer.clear();
 }
 
 void PlayerProcessManager::onSocketConnected()
 {
-    qCInfo(lcPlaybackIpc) << "mpv IPC connected";
-    m_isConnected = true;
-    m_ipcReconnectScheduled = false;
-    
-    // Start observing properties
-    // Use integers for IDs as mpv expects
-    sendVariantCommand(QVariantList{"observe_property", 1, "time-pos"});
-    sendVariantCommand(QVariantList{"observe_property", 2, "duration"});
-    sendVariantCommand(QVariantList{"observe_property", 3, "pause"});
-    sendVariantCommand(QVariantList{"observe_property", 4, "aid"});  // Audio track ID
-    sendVariantCommand(QVariantList{"observe_property", 5, "sid"});  // Subtitle track ID
-    sendVariantCommand(QVariantList{"observe_property", 6, "paused-for-cache"});  // Buffering state
-    sendVariantCommand(QVariantList{"observe_property", 7, "volume"});
-    sendVariantCommand(QVariantList{"observe_property", 8, "mute"});
-    sendVariantCommand(QVariantList{"observe_property", 9, "playlist-pos"});
-    sendVariantCommand(QVariantList{"observe_property", 10, "playlist-count"});
-    sendVariantCommand(QVariantList{"observe_property", 11, "demuxer-cache-time"});
-    sendVariantCommand(QVariantList{"observe_property", 12, "audio-device-list"});  // Audio output device hotplug
+    if (!isRunning() || m_stopStage != StopStage::None) {
+        m_ipcSocket->abort();
+        return;
+    }
 
-    // Flush any commands that were queued while connecting
+    m_isConnected = true;
+    m_ipcRetryTimer.stop();
+    m_ipcDeadlineTimer.stop();
+    m_lastIpcLatencyMs = m_ipcElapsed.elapsed();
+    qCInfo(lcPlaybackIpc) << "mpv IPC connected in" << m_lastIpcLatencyMs
+                          << "ms after" << m_ipcAttempts << "attempts";
+    emit ipcConnectionLatencyMeasured(m_lastIpcLatencyMs);
+
+    sendVariantCommand(QVariantList{QStringLiteral("observe_property"), 1,
+                                    QStringLiteral("time-pos")});
+    sendVariantCommand(QVariantList{QStringLiteral("observe_property"), 2,
+                                    QStringLiteral("duration")});
+    sendVariantCommand(QVariantList{QStringLiteral("observe_property"), 3,
+                                    QStringLiteral("pause")});
+    sendVariantCommand(QVariantList{QStringLiteral("observe_property"), 4,
+                                    QStringLiteral("aid")});
+    sendVariantCommand(QVariantList{QStringLiteral("observe_property"), 5,
+                                    QStringLiteral("sid")});
+    sendVariantCommand(QVariantList{QStringLiteral("observe_property"), 6,
+                                    QStringLiteral("paused-for-cache")});
+    sendVariantCommand(QVariantList{QStringLiteral("observe_property"), 7,
+                                    QStringLiteral("volume")});
+    sendVariantCommand(QVariantList{QStringLiteral("observe_property"), 8,
+                                    QStringLiteral("mute")});
+    sendVariantCommand(QVariantList{QStringLiteral("observe_property"), 9,
+                                    QStringLiteral("playlist-pos")});
+    sendVariantCommand(QVariantList{QStringLiteral("observe_property"), 10,
+                                    QStringLiteral("playlist-count")});
+    sendVariantCommand(QVariantList{QStringLiteral("observe_property"), 11,
+                                    QStringLiteral("demuxer-cache-time")});
+    sendVariantCommand(QVariantList{QStringLiteral("observe_property"), 12,
+                                    QStringLiteral("audio-device-list")});
     flushPendingCommands();
+}
+
+void PlayerProcessManager::onSocketDisconnected()
+{
+    const bool wasConnected = std::exchange(m_isConnected, false);
+    if (!wasConnected || !isRunning() || m_stopStage != StopStage::None) {
+        return;
+    }
+    qCWarning(lcPlaybackIpc) << "mpv IPC disconnected; reconnecting within deadline";
+    // QLocalSocket is still unwinding its disconnect notification here. Reusing
+    // it synchronously can corrupt its internal write buffer, so reconnect only
+    // after control returns to the event loop.
+    QMetaObject::invokeMethod(this, [this]() {
+        if (!m_isConnected && isRunning() && m_stopStage == StopStage::None) {
+            beginIpcConnectionWindow();
+        }
+    }, Qt::QueuedConnection);
+}
+
+void PlayerProcessManager::sendCommand(const QStringList &command)
+{
+    QVariantList variantCommand;
+    variantCommand.reserve(command.size());
+    for (const QString &argument : command) {
+        variantCommand.append(argument);
+    }
+    sendVariantCommand(variantCommand);
+}
+
+bool PlayerProcessManager::serializeCommand(const QVariantList &command,
+                                            QByteArray *payload,
+                                            QString *commandName) const
+{
+    if (command.isEmpty() || command.first().metaType().id() != QMetaType::QString
+        || command.first().toString().trimmed().isEmpty()) {
+        return false;
+    }
+
+    QJsonArray commandArray;
+    for (const QVariant &argument : command) {
+        const QJsonValue value = QJsonValue::fromVariant(argument);
+        if (value.isUndefined()) {
+            return false;
+        }
+        commandArray.append(value);
+    }
+
+    QJsonObject object;
+    object.insert(QStringLiteral("command"), commandArray);
+    QByteArray serialized = QJsonDocument(object).toJson(QJsonDocument::Compact);
+    if (serialized.size() + 1 > m_options.maximumIpcMessageBytes) {
+        return false;
+    }
+    serialized.append('\n');
+    if (payload) {
+        *payload = std::move(serialized);
+    }
+    if (commandName) {
+        *commandName = command.first().toString();
+    }
+    return true;
+}
+
+bool PlayerProcessManager::writeCommand(const QVariantList &command)
+{
+    QByteArray payload;
+    QString commandName;
+    if (!serializeCommand(command, &payload, &commandName)) {
+        qCWarning(lcPlaybackIpc) << "Rejected invalid or oversized mpv IPC command";
+        return false;
+    }
+    if (m_ipcSocket->state() != QLocalSocket::ConnectedState) {
+        return false;
+    }
+    if (m_ipcSocket->bytesToWrite() + payload.size()
+        > m_options.maximumBufferedWriteBytes) {
+        qCWarning(lcPlaybackIpc) << "Dropping mpv IPC command because the write buffer is full"
+                                 << "command=" << commandName;
+        return false;
+    }
+    if (m_ipcSocket->write(payload) != payload.size()) {
+        return false;
+    }
+    qCDebug(lcPlaybackIpc) << "IPC command sent:" << commandName;
+    return true;
+}
+
+void PlayerProcessManager::sendVariantCommand(const QVariantList &command)
+{
+    QByteArray validatedPayload;
+    QString commandName;
+    if (!serializeCommand(command, &validatedPayload, &commandName)) {
+        qCWarning(lcPlaybackIpc) << "Rejected invalid or oversized mpv IPC command";
+        return;
+    }
+
+    if (m_ipcSocket->state() == QLocalSocket::ConnectedState) {
+        if (!writeCommand(command)) {
+            qCWarning(lcPlaybackIpc) << "Unable to write mpv IPC command"
+                                     << "command=" << commandName;
+        }
+        return;
+    }
+    if (isRunning() && m_stopStage == StopStage::None) {
+        enqueueCommand(command);
+    }
+}
+
+void PlayerProcessManager::enqueueCommand(const QVariantList &command)
+{
+    if (m_pendingCommands.size() >= m_options.maximumPendingCommands) {
+        m_pendingCommands.removeFirst();
+        ++m_droppedPendingCommands;
+        qCWarning(lcPlaybackIpc) << "mpv IPC pending-command limit reached; dropped oldest command";
+    }
+    m_pendingCommands.append(command);
+}
+
+void PlayerProcessManager::flushPendingCommands()
+{
+    while (!m_pendingCommands.isEmpty()
+           && m_ipcSocket->state() == QLocalSocket::ConnectedState) {
+        const QVariantList command = m_pendingCommands.takeFirst();
+        if (!writeCommand(command)) {
+            m_pendingCommands.prepend(command);
+            break;
+        }
+    }
 }
 
 void PlayerProcessManager::onSocketReadyRead()
 {
-    // Handle events if needed
-    while (m_ipcSocket->canReadLine()) {
-        QByteArray line = m_ipcSocket->readLine();
-        qCDebug(lcPlaybackIpc) << "IPC <" << line;
-        
-        QJsonDocument doc = QJsonDocument::fromJson(line);
-        QJsonObject obj = doc.object();
-        
-        if (obj["event"].toString() == "property-change") {
-            QString name = obj["name"].toString();
-            if (name == "time-pos") {
-                if (!obj["data"].isNull()) {
-                    emit positionChanged(obj["data"].toDouble());
-                }
-            } else if (name == "duration") {
-                if (!obj["data"].isNull()) {
-                    emit durationChanged(obj["data"].toDouble());
-                }
-            } else if (name == "pause") {
-                if (!obj["data"].isNull()) {
-                    emit pauseChanged(obj["data"].toBool());
-                }
-            } else if (name == "aid") {
-                if (!obj["data"].isNull()) {
-                    int mpvTrackId = obj["data"].toInt();
-                    emit audioTrackChanged(mpvTrackId > 0 ? mpvTrackId : -1);
-                }
-            } else if (name == "sid") {
-                if (obj["data"].isBool() && !obj["data"].toBool()) {
-                    emit subtitleTrackChanged(-1);
-                } else if (obj["data"].isString() && obj["data"].toString() == QStringLiteral("no")) {
-                    emit subtitleTrackChanged(-1);
-                } else if (!obj["data"].isNull() && obj["data"].isDouble()) {
-                    int mpvTrackId = obj["data"].toInt();
-                    emit subtitleTrackChanged(mpvTrackId > 0 ? mpvTrackId : -1);
-                }
-            } else if (name == "paused-for-cache") {
-                if (!obj["data"].isNull()) {
-                    emit pausedForCacheChanged(obj["data"].toBool());
-                }
-            } else if (name == "volume") {
-                if (!obj["data"].isNull()) {
-                    emit volumeChanged(qRound(obj["data"].toDouble()));
-                }
-            } else if (name == "mute") {
-                if (!obj["data"].isNull()) {
-                    emit muteChanged(obj["data"].toBool());
-                }
-            } else if (name == "playlist-pos") {
-                if (!obj["data"].isNull()) {
-                    m_playlistPosition = obj["data"].toInt(-1);
-                    emit playlistPositionChanged(m_playlistPosition);
-                }
-            } else if (name == "playlist-count") {
-                if (!obj["data"].isNull()) {
-                    m_playlistCount = obj["data"].toInt(0);
-                }
-            } else if (name == "demuxer-cache-time") {
-                if (!obj["data"].isNull()) {
-                    emit cacheEndChanged(obj["data"].toDouble());
-                }
-            } else if (name == "audio-device-list") {
-                if (obj["data"].isArray()) {
-                    QVariantList devices;
-                    const QJsonArray deviceArray = obj["data"].toArray();
-                    for (const QJsonValue &entry : deviceArray) {
-                        if (!entry.isObject()) {
-                            continue;
-                        }
-                        const QJsonObject deviceObj = entry.toObject();
-                        QVariantMap device;
-                        device["name"] = deviceObj["name"].toString();
-                        device["description"] = deviceObj["description"].toString();
-                        devices.append(device);
-                    }
-                    emit audioDeviceListChanged(devices);
-                }
-            }
-        } else if (obj["event"].toString() == "end-file") {
-            const bool hasRemainingPlaylistItems = m_playlistCount > 0
-                && m_playlistPosition >= 0
-                && (m_playlistPosition + 1) < m_playlistCount;
-            if (!hasRemainingPlaylistItems) {
-                emit playbackEnded();
-            }
-        } else if (obj["event"].toString() == "client-message") {
-            // Handle client-message events from mpv scripts/extensions (if any user scripts are loaded)
-            // The "args" array contains the message name followed by any arguments
-            QJsonArray argsArray = obj["args"].toArray();
-            if (!argsArray.isEmpty()) {
-                QString messageName = argsArray.at(0).toString();
-                QStringList messageArgs;
-                for (int i = 1; i < argsArray.size(); ++i) {
-                    messageArgs.append(argsArray.at(i).toString());
-                }
-                qCDebug(lcPlaybackIpc) << "IPC: client-message received:" << messageName << messageArgs;
-                emit scriptMessage(messageName, messageArgs);
-            }
+    const qint64 remainingCapacity = m_options.maximumIpcMessageBytes + 1
+        - m_ipcReadBuffer.size();
+    if (remainingCapacity > 0) {
+        m_ipcReadBuffer.append(m_ipcSocket->read(remainingCapacity));
+    }
+    while (true) {
+        const qsizetype newline = m_ipcReadBuffer.indexOf('\n');
+        if (newline < 0) {
+            break;
         }
+        QByteArray line = m_ipcReadBuffer.left(newline).trimmed();
+        m_ipcReadBuffer.remove(0, newline + 1);
+        if (line.isEmpty()) {
+            continue;
+        }
+        if (line.size() > m_options.maximumIpcMessageBytes) {
+            recordInvalidIpcMessage(QStringLiteral("message exceeds size limit"));
+            continue;
+        }
+
+        QJsonParseError parseError;
+        const QJsonDocument document = QJsonDocument::fromJson(line, &parseError);
+        if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+            recordInvalidIpcMessage(QStringLiteral("malformed JSON object"));
+            continue;
+        }
+        handleIpcObject(document.object());
+    }
+
+    if (m_ipcReadBuffer.size() > m_options.maximumIpcMessageBytes) {
+        m_ipcReadBuffer.clear();
+        recordInvalidIpcMessage(QStringLiteral("unterminated message exceeds size limit"));
+        failIpcConnection(QStringLiteral("received oversized IPC message"));
+    }
+}
+
+void PlayerProcessManager::recordInvalidIpcMessage(const QString &reason)
+{
+    ++m_invalidIpcMessages;
+    qCWarning(lcPlaybackIpc) << "Ignored invalid mpv IPC message:" << reason;
+}
+
+void PlayerProcessManager::handleIpcObject(const QJsonObject &object)
+{
+    const QJsonValue eventValue = object.value(QStringLiteral("event"));
+    if (eventValue.isUndefined()) {
+        // Command replies carry request_id/error but no event and need no handling.
+        return;
+    }
+    if (!eventValue.isString() || eventValue.toString().isEmpty()) {
+        recordInvalidIpcMessage(QStringLiteral("event is not a non-empty string"));
+        return;
+    }
+
+    const QString event = eventValue.toString();
+    if (event == QStringLiteral("property-change")) {
+        const QJsonValue nameValue = object.value(QStringLiteral("name"));
+        if (!nameValue.isString() || !object.contains(QStringLiteral("data"))) {
+            recordInvalidIpcMessage(QStringLiteral("property change lacks name or data"));
+            return;
+        }
+        const QString name = nameValue.toString();
+        const QJsonValue data = object.value(QStringLiteral("data"));
+        if (name == QStringLiteral("time-pos")) {
+            if (!data.isNull() && isFiniteNumber(data)) {
+                emit positionChanged(data.toDouble());
+            }
+        } else if (name == QStringLiteral("duration")) {
+            if (!data.isNull() && isFiniteNumber(data)) {
+                emit durationChanged(data.toDouble());
+            }
+        } else if (name == QStringLiteral("pause")) {
+            if (!data.isNull() && data.isBool()) {
+                emit pauseChanged(data.toBool());
+            }
+        } else if (name == QStringLiteral("aid")) {
+            if (!data.isNull() && isFiniteNumber(data)) {
+                const int trackId = data.toInt();
+                emit audioTrackChanged(trackId > 0 ? trackId : -1);
+            }
+        } else if (name == QStringLiteral("sid")) {
+            if ((data.isBool() && !data.toBool())
+                || (data.isString() && data.toString() == QStringLiteral("no"))) {
+                emit subtitleTrackChanged(-1);
+            } else if (!data.isNull() && isFiniteNumber(data)) {
+                const int trackId = data.toInt();
+                emit subtitleTrackChanged(trackId > 0 ? trackId : -1);
+            }
+        } else if (name == QStringLiteral("paused-for-cache")) {
+            if (!data.isNull() && data.isBool()) {
+                emit pausedForCacheChanged(data.toBool());
+            }
+        } else if (name == QStringLiteral("volume")) {
+            if (!data.isNull() && isFiniteNumber(data)) {
+                emit volumeChanged(qRound(data.toDouble()));
+            }
+        } else if (name == QStringLiteral("mute")) {
+            if (!data.isNull() && data.isBool()) {
+                emit muteChanged(data.toBool());
+            }
+        } else if (name == QStringLiteral("playlist-pos")) {
+            if (!data.isNull() && isFiniteNumber(data)) {
+                m_playlistPosition = data.toInt(-1);
+                emit playlistPositionChanged(m_playlistPosition);
+            }
+        } else if (name == QStringLiteral("playlist-count")) {
+            if (!data.isNull() && isFiniteNumber(data)) {
+                m_playlistCount = data.toInt(0);
+            }
+        } else if (name == QStringLiteral("demuxer-cache-time")) {
+            if (!data.isNull() && isFiniteNumber(data)) {
+                emit cacheEndChanged(data.toDouble());
+            }
+        } else if (name == QStringLiteral("audio-device-list") && data.isArray()) {
+            QVariantList devices;
+            const QJsonArray deviceArray = data.toArray();
+            devices.reserve(deviceArray.size());
+            for (const QJsonValue &entry : deviceArray) {
+                if (!entry.isObject()) {
+                    continue;
+                }
+                const QJsonObject deviceObject = entry.toObject();
+                if (!deviceObject.value(QStringLiteral("name")).isString()
+                    || !deviceObject.value(QStringLiteral("description")).isString()) {
+                    continue;
+                }
+                devices.append(QVariantMap{
+                    {QStringLiteral("name"),
+                     deviceObject.value(QStringLiteral("name")).toString()},
+                    {QStringLiteral("description"),
+                     deviceObject.value(QStringLiteral("description")).toString()},
+                });
+            }
+            emit audioDeviceListChanged(devices);
+        }
+        return;
+    }
+
+    if (event == QStringLiteral("end-file")) {
+        const bool hasRemainingPlaylistItems = m_playlistCount > 0
+            && m_playlistPosition >= 0
+            && (m_playlistPosition + 1) < m_playlistCount;
+        if (!hasRemainingPlaylistItems) {
+            emit playbackEnded();
+        }
+        return;
+    }
+
+    if (event == QStringLiteral("client-message")) {
+        const QJsonValue argumentsValue = object.value(QStringLiteral("args"));
+        if (!argumentsValue.isArray()) {
+            recordInvalidIpcMessage(QStringLiteral("client message args is not an array"));
+            return;
+        }
+        const QJsonArray argumentArray = argumentsValue.toArray();
+        if (argumentArray.isEmpty() || !argumentArray.first().isString()) {
+            recordInvalidIpcMessage(QStringLiteral("client message has no string name"));
+            return;
+        }
+        QStringList arguments;
+        arguments.reserve(argumentArray.size() - 1);
+        for (qsizetype index = 1; index < argumentArray.size(); ++index) {
+            if (!argumentArray.at(index).isString()) {
+                recordInvalidIpcMessage(QStringLiteral("client message argument is not a string"));
+                return;
+            }
+            arguments.append(argumentArray.at(index).toString());
+        }
+        emit scriptMessage(argumentArray.first().toString(), arguments);
     }
 }

--- a/src/player/PlayerProcessManager.cpp
+++ b/src/player/PlayerProcessManager.cpp
@@ -137,8 +137,9 @@ PlayerProcessManager::PlayerProcessManager(const PlayerProcessOptions &options,
     m_options.maximumPendingCommands = std::max(1, m_options.maximumPendingCommands);
     m_options.maximumIpcMessageBytes = std::max<qint64>(128,
                                                         m_options.maximumIpcMessageBytes);
-    m_options.maximumBufferedWriteBytes = std::max<qint64>(128,
-                                                           m_options.maximumBufferedWriteBytes);
+    m_options.maximumBufferedWriteBytes = std::max(
+        m_options.maximumIpcMessageBytes,
+        m_options.maximumBufferedWriteBytes);
 
     const QString uniquePart = QUuid::createUuid().toString(QUuid::WithoutBraces).left(12);
     m_instanceToken = QStringLiteral("%1-%2-%3")
@@ -179,6 +180,11 @@ PlayerProcessManager::PlayerProcessManager(const PlayerProcessOptions &options,
             this, &PlayerProcessManager::onSocketDisconnected);
     connect(m_ipcSocket, &QLocalSocket::readyRead,
             this, &PlayerProcessManager::onSocketReadyRead);
+    connect(m_ipcSocket, &QLocalSocket::bytesWritten, this, [this](qint64) {
+        if (m_isConnected && !m_pendingCommands.isEmpty()) {
+            flushPendingCommands();
+        }
+    });
     connect(m_ipcSocket, &QLocalSocket::errorOccurred, this,
             [this](QLocalSocket::LocalSocketError) {
                 if (m_stopStage == StopStage::None && isRunning()
@@ -717,8 +723,10 @@ void PlayerProcessManager::sendVariantCommand(const QVariantList &command)
 
     if (m_ipcSocket->state() == QLocalSocket::ConnectedState) {
         if (!writeCommand(command)) {
-            qCWarning(lcPlaybackIpc) << "Unable to write mpv IPC command"
-                                     << "command=" << commandName;
+            qCWarning(lcPlaybackIpc)
+                << "Deferring mpv IPC command until write capacity is available"
+                << "command=" << commandName;
+            enqueueCommand(command);
         }
         return;
     }
@@ -751,39 +759,51 @@ void PlayerProcessManager::flushPendingCommands()
 
 void PlayerProcessManager::onSocketReadyRead()
 {
-    const qint64 remainingCapacity = m_options.maximumIpcMessageBytes + 1
-        - m_ipcReadBuffer.size();
-    if (remainingCapacity > 0) {
-        m_ipcReadBuffer.append(m_ipcSocket->read(remainingCapacity));
-    }
-    while (true) {
-        const qsizetype newline = m_ipcReadBuffer.indexOf('\n');
-        if (newline < 0) {
+    while (m_ipcSocket->bytesAvailable() > 0) {
+        const qint64 remainingCapacity = m_options.maximumIpcMessageBytes + 1
+            - m_ipcReadBuffer.size();
+        if (remainingCapacity <= 0) {
+            m_ipcReadBuffer.clear();
+            recordInvalidIpcMessage(QStringLiteral("unterminated message exceeds size limit"));
+            failIpcConnection(QStringLiteral("received oversized IPC message"));
+            return;
+        }
+        const QByteArray chunk = m_ipcSocket->read(remainingCapacity);
+        if (chunk.isEmpty()) {
             break;
         }
-        QByteArray line = m_ipcReadBuffer.left(newline).trimmed();
-        m_ipcReadBuffer.remove(0, newline + 1);
-        if (line.isEmpty()) {
-            continue;
-        }
-        if (line.size() > m_options.maximumIpcMessageBytes) {
-            recordInvalidIpcMessage(QStringLiteral("message exceeds size limit"));
-            continue;
+        m_ipcReadBuffer.append(chunk);
+
+        while (true) {
+            const qsizetype newline = m_ipcReadBuffer.indexOf('\n');
+            if (newline < 0) {
+                break;
+            }
+            QByteArray line = m_ipcReadBuffer.left(newline).trimmed();
+            m_ipcReadBuffer.remove(0, newline + 1);
+            if (line.isEmpty()) {
+                continue;
+            }
+            if (line.size() > m_options.maximumIpcMessageBytes) {
+                recordInvalidIpcMessage(QStringLiteral("message exceeds size limit"));
+                continue;
+            }
+
+            QJsonParseError parseError;
+            const QJsonDocument document = QJsonDocument::fromJson(line, &parseError);
+            if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+                recordInvalidIpcMessage(QStringLiteral("malformed JSON object"));
+                continue;
+            }
+            handleIpcObject(document.object());
         }
 
-        QJsonParseError parseError;
-        const QJsonDocument document = QJsonDocument::fromJson(line, &parseError);
-        if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
-            recordInvalidIpcMessage(QStringLiteral("malformed JSON object"));
-            continue;
+        if (m_ipcReadBuffer.size() > m_options.maximumIpcMessageBytes) {
+            m_ipcReadBuffer.clear();
+            recordInvalidIpcMessage(QStringLiteral("unterminated message exceeds size limit"));
+            failIpcConnection(QStringLiteral("received oversized IPC message"));
+            return;
         }
-        handleIpcObject(document.object());
-    }
-
-    if (m_ipcReadBuffer.size() > m_options.maximumIpcMessageBytes) {
-        m_ipcReadBuffer.clear();
-        recordInvalidIpcMessage(QStringLiteral("unterminated message exceeds size limit"));
-        failIpcConnection(QStringLiteral("received oversized IPC message"));
     }
 }
 

--- a/src/player/PlayerProcessManager.h
+++ b/src/player/PlayerProcessManager.h
@@ -1,21 +1,41 @@
 #pragma once
 
-#include <QObject>
+#include <QElapsedTimer>
 #include <QJsonObject>
 #include <QLocalSocket>
+#include <QObject>
 #include <QProcess>
 #include <QString>
 #include <QStringList>
+#include <QTimer>
 #include <QVariantList>
+#include <QVariantMap>
+
+#include <optional>
+
+struct PlayerProcessOptions {
+    int gracefulQuitTimeoutMs = 750;
+    int terminateTimeoutMs = 750;
+    int ipcRetryIntervalMs = 100;
+    int ipcConnectionDeadlineMs = 5000;
+    int maximumIpcAttempts = 50;
+    int maximumPendingCommands = 256;
+    qint64 maximumIpcMessageBytes = 1024 * 1024;
+    qint64 maximumBufferedWriteBytes = 256 * 1024;
+};
 
 class PlayerProcessManager : public QObject
 {
     Q_OBJECT
 public:
     explicit PlayerProcessManager(QObject *parent = nullptr);
-    ~PlayerProcessManager();
+    explicit PlayerProcessManager(const PlayerProcessOptions &options,
+                                  QObject *parent = nullptr);
+    ~PlayerProcessManager() override;
 
-    void startMpv(const QString &mpvBin, const QStringList &args, const QString &mediaUrl);
+    void startMpv(const QString &mpvBin,
+                  const QStringList &args,
+                  const QString &mediaUrl);
     void appendUrlsToPlaylist(const QStringList &mediaUrls);
     void stopMpv();
     bool isRunning() const;
@@ -23,9 +43,15 @@ public:
     void sendCommand(const QStringList &command);
     void sendVariantCommand(const QVariantList &command);
 
+    QString ipcPath() const;
+    QVariantMap diagnostics() const;
+
 signals:
     void stateChanged(bool running);
+    void processFinished(int exitCode, bool crashed);
     void errorOccurred(const QString &error);
+    void startupLatencyMeasured(qint64 milliseconds);
+    void ipcConnectionLatencyMeasured(qint64 milliseconds);
     void positionChanged(double seconds);
     void durationChanged(double seconds);
     void pauseChanged(bool paused);
@@ -35,35 +61,92 @@ signals:
     void volumeChanged(int volume);
     void muteChanged(bool muted);
     void playlistPositionChanged(int index);
-    
-    // Track change notifications use raw mpv track IDs (1-based per track type, -1 for none/off).
+
+    // Track change notifications use raw mpv track IDs (1-based per track type,
+    // -1 for none/off).
     void audioTrackChanged(int trackIndex);
     void subtitleTrackChanged(int trackIndex);
 
-    // Emitted when mpv's available audio output device list changes (hotplug).
+    // Each entry is a QVariantMap with name and description fields.
     void audioDeviceListChanged(const QVariantList &devices);
-    
-    // Script message from mpv scripts/extensions (via client-message event)
+
+    // Script message from mpv scripts/extensions (via client-message event).
     void scriptMessage(const QString &messageName, const QStringList &args);
 
 private slots:
+    void onProcessStarted();
     void onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
     void onProcessError(QProcess::ProcessError error);
     void onSocketConnected();
+    void onSocketDisconnected();
     void onSocketReadyRead();
 
 private:
-    QString getIpcPath() const;
-    void connectIpc();
-    void scheduleIpcReconnect();
-    void flushPendingCommands();
+    struct LaunchRequest {
+        QString executable;
+        QStringList arguments;
+        QString mediaUrl;
+    };
 
+    enum class StopStage {
+        None,
+        GracefulQuit,
+        Terminating,
+        Killing,
+    };
+
+    QString createIpcPath() const;
+    QString ipcServerName() const;
+    void removeIpcEndpoint();
+
+    void launchPending();
+    void beginStop();
+    void escalateToTerminate();
+    void escalateToKill();
+    void finishProcessLifecycle(int exitCode, QProcess::ExitStatus exitStatus);
+
+    void beginIpcConnectionWindow();
+    void attemptIpcConnection();
+    void retryIpcConnection();
+    void failIpcConnection(const QString &reason);
+    void resetIpcConnection();
+
+    bool serializeCommand(const QVariantList &command,
+                          QByteArray *payload,
+                          QString *commandName) const;
+    bool writeCommand(const QVariantList &command);
+    void enqueueCommand(const QVariantList &command);
+    void flushPendingCommands();
+    void handleIpcObject(const QJsonObject &object);
+    void recordInvalidIpcMessage(const QString &reason);
+
+    PlayerProcessOptions m_options;
     QProcess *m_process = nullptr;
     QLocalSocket *m_ipcSocket = nullptr;
+    QTimer m_gracefulQuitTimer;
+    QTimer m_terminateTimer;
+    QTimer m_ipcRetryTimer;
+    QTimer m_ipcDeadlineTimer;
+    QElapsedTimer m_startupElapsed;
+    QElapsedTimer m_ipcElapsed;
+    std::optional<LaunchRequest> m_pendingLaunch;
     QString m_ipcPath;
+    QString m_instanceToken;
+    quint64 m_launchSequence = 0;
+    StopStage m_stopStage = StopStage::None;
+    bool m_launchActive = false;
+    bool m_runningReported = false;
     bool m_isConnected = false;
-    bool m_ipcReconnectScheduled = false;
+    bool m_ipcFailureReported = false;
+    int m_ipcAttempts = 0;
     QList<QVariantList> m_pendingCommands;
+    QByteArray m_ipcReadBuffer;
+    quint64 m_droppedPendingCommands = 0;
+    quint64 m_invalidIpcMessages = 0;
+    quint64 m_terminateEscalations = 0;
+    quint64 m_killEscalations = 0;
+    qint64 m_lastStartupLatencyMs = -1;
+    qint64 m_lastIpcLatencyMs = -1;
     int m_playlistPosition = -1;
     int m_playlistCount = 0;
 };

--- a/src/player/PlayerProcessManager.h
+++ b/src/player/PlayerProcessManager.h
@@ -21,7 +21,7 @@ struct PlayerProcessOptions {
     int maximumIpcAttempts = 50;
     int maximumPendingCommands = 256;
     qint64 maximumIpcMessageBytes = 1024 * 1024;
-    qint64 maximumBufferedWriteBytes = 256 * 1024;
+    qint64 maximumBufferedWriteBytes = 1024 * 1024;
 };
 
 class PlayerProcessManager : public QObject

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ set(BLOOM_LINKED_PRODUCTION_SOURCES
     ${CMAKE_SOURCE_DIR}/src/security/CredentialStore.cpp
     ${CMAKE_SOURCE_DIR}/src/ui/ImageCacheProvider.cpp
     ${CMAKE_SOURCE_DIR}/src/ui/ImageCacheStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/player/PlayerProcessManager.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/BloomLogging.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/ConfigManager.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/ConfigStorage.cpp
@@ -91,6 +92,10 @@ function(bloom_use_production_libraries test_target)
     if(image_cache_provider_source IN_LIST test_sources
        OR image_cache_store_source IN_LIST test_sources)
         target_link_libraries(${test_target} PRIVATE Bloom::ImageCache)
+    endif()
+    set(player_process_source ${CMAKE_SOURCE_DIR}/src/player/PlayerProcessManager.cpp)
+    if(player_process_source IN_LIST test_sources)
+        target_link_libraries(${test_target} PRIVATE Bloom::PlayerProcess)
     endif()
     list(REMOVE_ITEM test_sources ${BLOOM_LINKED_PRODUCTION_SOURCES})
     set_property(TARGET ${test_target} PROPERTY SOURCES "${test_sources}")
@@ -598,6 +603,25 @@ target_link_libraries(PlayerBackendFactoryTest
 
 add_test(NAME PlayerBackendFactoryTest COMMAND PlayerBackendFactoryTest)
 
+add_executable(PlayerProcessManagerTest
+    PlayerProcessManagerTest.cpp
+)
+
+target_include_directories(PlayerProcessManagerTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+target_link_libraries(PlayerProcessManagerTest
+    PRIVATE
+        Bloom::PlayerProcess
+        Qt6::Core
+        Qt6::Network
+        Qt6::Test
+)
+
+add_test(NAME PlayerProcessManagerTest COMMAND PlayerProcessManagerTest)
+
 add_executable(PlayerControllerAutoplayContextTest
     PlayerControllerAutoplayContextTest.cpp
     ${CMAKE_SOURCE_DIR}/src/player/backend/IPlayerBackend.h
@@ -821,6 +845,7 @@ set(BLOOM_UNIT_TEST_TARGETS
     CanonicalModelsTest
     InputBindingManagerTest
     PlayerBackendFactoryTest
+    PlayerProcessManagerTest
     PlayerControllerAutoplayContextTest
     MediaSegmentProviderServiceTest
     NextEpisodeResolverTest

--- a/tests/PlayerControllerAutoplayContextTest.cpp
+++ b/tests/PlayerControllerAutoplayContextTest.cpp
@@ -30,7 +30,7 @@ public:
 
     QString backendName() const override
     {
-        return QStringLiteral("fake-backend");
+        return backendNameValue;
     }
 
     void startMpv(const QString &mpvBin, const QStringList &args, const QString &mediaUrl) override
@@ -51,6 +51,9 @@ public:
     {
         ++stopCallCount;
         if (!m_running) {
+            return;
+        }
+        if (keepRunningUntilStopCompletion) {
             return;
         }
         m_running = false;
@@ -100,6 +103,8 @@ private:
 
 public:
     bool emitStopStateChangeSynchronously = true;
+    bool keepRunningUntilStopCompletion = false;
+    QString backendNameValue = QStringLiteral("fake-backend");
     int stopCallCount = 0;
     QList<QVariantList> variantCommands;
     QList<QStringList> commands;
@@ -110,6 +115,17 @@ public:
     void setRunning(bool running)
     {
         m_running = running;
+    }
+
+    void completeStop()
+    {
+        m_running = false;
+        emit stateChanged(false);
+    }
+
+    void emitError(const QString &error)
+    {
+        emit errorOccurred(error);
     }
 
     void emitAudioTrackId(int mpvTrackId)
@@ -538,6 +554,7 @@ private slots:
     void recoverableBackendStreamErrorStartsRecovery();
     void recoverableErrorAfterBackendStopUpgradesTerminalTransition();
     void backendStopWithoutRecoverableErrorGoesIdle();
+    void embeddedFallbackWaitsForAsynchronousBackendStop();
     void playbackInfoDirectStreamUrlIsPreferred();
     void multipartIntermediateEndIsIgnoredUntilFinalSegment();
     void versionAffinityPrefersMatchingParentPath();
@@ -3271,6 +3288,47 @@ void PlayerControllerAutoplayContextTest::backendStopWithoutRecoverableErrorGoes
     QVERIFY(!controller.m_recoveryContext.valid);
     QVERIFY(!controller.m_isRecovering);
     QVERIFY(!controller.isPlaybackActive());
+}
+
+void PlayerControllerAutoplayContextTest::embeddedFallbackWaitsForAsynchronousBackendStop()
+{
+    ConfigManager config;
+    TrackPreferencesManager trackPrefs;
+    DisplayManager displayManager(&config);
+    AuthenticationService authService(nullptr);
+    PlaybackService playbackService(&authService);
+    FakeLibraryService libraryService(&authService);
+    FakePlayerBackend backend;
+    backend.backendNameValue = QStringLiteral("linux-libmpv-opengl");
+    backend.keepRunningUntilStopCompletion = true;
+    backend.setRunning(true);
+
+    PlayerController controller(&backend,
+                                &config,
+                                &trackPrefs,
+                                &displayManager,
+                                &playbackService,
+                                &libraryService,
+                                &authService);
+    controller.m_playbackState = PlayerController::Loading;
+    controller.m_pendingUrl = QStringLiteral("https://example.invalid/fallback-media");
+
+    backend.emitError(QStringLiteral("linux-libmpv-render-unavailable: test failure"));
+
+    QCOMPARE(backend.stopCallCount, 1);
+    QCOMPARE(controller.m_playerBackend, &backend);
+    QCOMPARE(controller.m_backendFallbackSource.data(), &backend);
+    backend.emitError(QStringLiteral("linux-libmpv-render-unavailable: repeated failure"));
+    QCOMPARE(backend.stopCallCount, 1);
+    QCOMPARE(controller.playbackState(), PlayerController::Loading);
+    QCoreApplication::processEvents();
+    QCOMPARE(controller.m_playerBackend, &backend);
+
+    backend.completeStop();
+    QTRY_VERIFY(controller.m_playerBackend != &backend);
+    QCOMPARE(controller.m_playerBackend->backendName(), QStringLiteral("null-backend"));
+    QVERIFY(controller.m_backendFallbackSource.isNull());
+    QCOMPARE(controller.playbackState(), PlayerController::Loading);
 }
 
 void PlayerControllerAutoplayContextTest::playbackInfoDirectStreamUrlIsPreferred()

--- a/tests/PlayerProcessManagerTest.cpp
+++ b/tests/PlayerProcessManagerTest.cpp
@@ -1,0 +1,419 @@
+#include <QtTest/QtTest>
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QPointer>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QTimer>
+
+#include "player/PlayerProcessManager.h"
+
+#ifdef Q_OS_UNIX
+#include <csignal>
+#include <unistd.h>
+#endif
+
+namespace {
+
+QString optionValue(const QStringList &arguments, const QString &prefix)
+{
+    for (const QString &argument : arguments) {
+        if (argument.startsWith(prefix)) {
+            return argument.mid(prefix.size());
+        }
+    }
+    return {};
+}
+
+QString localServerName(QString ipcPath)
+{
+#ifdef Q_OS_WIN
+    const QString prefix = QStringLiteral("\\\\.\\pipe\\");
+    if (ipcPath.startsWith(prefix)) {
+        ipcPath.remove(0, prefix.size());
+    }
+#endif
+    return ipcPath;
+}
+
+void appendLaunchRecord(const QString &path, const QString &mediaUrl)
+{
+    if (path.isEmpty()) {
+        return;
+    }
+    QFile file(path);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+        file.write(mediaUrl.toUtf8());
+        file.write("\n");
+    }
+}
+
+int runFakeMpv(const QStringList &arguments)
+{
+#ifdef Q_OS_UNIX
+    if (arguments.contains(QStringLiteral("--fake-ignore-terminate"))) {
+        std::signal(SIGTERM, SIG_IGN);
+    }
+#endif
+
+    const QString mediaUrl = arguments.isEmpty() ? QString() : arguments.last();
+    appendLaunchRecord(optionValue(arguments, QStringLiteral("--fake-log=")), mediaUrl);
+
+    if (arguments.contains(QStringLiteral("--fake-no-ipc"))) {
+        QTimer::singleShot(30000, QCoreApplication::instance(), &QCoreApplication::quit);
+        return QCoreApplication::exec();
+    }
+
+    const QString ipcPath = optionValue(arguments, QStringLiteral("--input-ipc-server="));
+    if (ipcPath.isEmpty()) {
+        return 40;
+    }
+
+    QLocalServer server;
+    if (!server.listen(localServerName(ipcPath))) {
+        return 41;
+    }
+
+    const bool ignoreQuit = arguments.contains(QStringLiteral("--fake-ignore-quit"));
+    const bool sendEvents = arguments.contains(QStringLiteral("--fake-send-events"));
+    const bool disconnectOnce = arguments.contains(QStringLiteral("--fake-disconnect-once"));
+    int connectionCount = 0;
+    QObject::connect(&server, &QLocalServer::newConnection, &server, [&]() {
+        while (server.hasPendingConnections()) {
+            QLocalSocket *socket = server.nextPendingConnection();
+            ++connectionCount;
+            QObject::connect(socket, &QLocalSocket::readyRead, socket,
+                             [socket, ignoreQuit]() {
+                QByteArray buffer = socket->property("buffer").toByteArray();
+                buffer.append(socket->readAll());
+                while (true) {
+                    const qsizetype newline = buffer.indexOf('\n');
+                    if (newline < 0) {
+                        break;
+                    }
+                    const QByteArray line = buffer.left(newline);
+                    buffer.remove(0, newline + 1);
+                    const QJsonDocument document = QJsonDocument::fromJson(line);
+                    if (!document.isObject()) {
+                        continue;
+                    }
+                    const QJsonArray command = document.object()
+                                                   .value(QStringLiteral("command"))
+                                                   .toArray();
+                    if (!ignoreQuit && !command.isEmpty()
+                        && command.first().toString() == QStringLiteral("quit")) {
+                        QCoreApplication::quit();
+                        return;
+                    }
+                }
+                socket->setProperty("buffer", buffer);
+            });
+
+            if (sendEvents) {
+                socket->write("{bad-json}\n");
+                socket->write("[]\n");
+                QJsonObject propertyEvent{
+                    {QStringLiteral("event"), QStringLiteral("property-change")},
+                    {QStringLiteral("name"), QStringLiteral("time-pos")},
+                    {QStringLiteral("data"), 12.5},
+                };
+                socket->write(QJsonDocument(propertyEvent).toJson(QJsonDocument::Compact));
+                socket->write("\n");
+                socket->flush();
+            }
+            if (disconnectOnce && connectionCount == 1) {
+                QTimer::singleShot(20, socket, &QLocalSocket::disconnectFromServer);
+            }
+        }
+    });
+
+    return QCoreApplication::exec();
+}
+
+PlayerProcessOptions fastOptions()
+{
+    PlayerProcessOptions options;
+    options.gracefulQuitTimeoutMs = 80;
+    options.terminateTimeoutMs = 80;
+    options.ipcRetryIntervalMs = 15;
+    options.ipcConnectionDeadlineMs = 500;
+    options.maximumIpcAttempts = 40;
+    options.maximumPendingCommands = 3;
+    options.maximumIpcMessageBytes = 4096;
+    options.maximumBufferedWriteBytes = 64 * 1024;
+    return options;
+}
+
+QStringList fakeArguments(const QString &logPath = {},
+                          const QStringList &extra = {})
+{
+    QStringList arguments{QStringLiteral("--fake-mpv")};
+    if (!logPath.isEmpty()) {
+        arguments.append(QStringLiteral("--fake-log=%1").arg(logPath));
+    }
+    arguments.append(extra);
+    return arguments;
+}
+
+QStringList launchRecords(const QString &path)
+{
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return {};
+    }
+    QStringList records;
+    for (const QByteArray &line : file.readAll().split('\n')) {
+        if (!line.isEmpty()) {
+            records.append(QString::fromUtf8(line));
+        }
+    }
+    return records;
+}
+
+} // namespace
+
+class PlayerProcessManagerTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void endpointsAreUniqueAndPrivate();
+    void replacementWaitsForFinishedWithoutBlocking();
+    void gracefulStopEscalatesWithoutBlocking();
+    void destructionDoesNotBlockRunningProcess();
+    void killEscalationIsBounded();
+    void ipcConnectionDeadlineIsBounded();
+    void ipcReconnectAttemptsAreBounded();
+    void pendingCommandsAreBounded();
+    void disconnectedIpcReconnectsWithinDeadline();
+    void malformedIpcIsIgnoredBeforeValidEvent();
+    void startupFailureIsClear();
+};
+
+void PlayerProcessManagerTest::endpointsAreUniqueAndPrivate()
+{
+    PlayerProcessManager first;
+    PlayerProcessManager second;
+    QVERIFY(!first.ipcPath().isEmpty());
+    QVERIFY(!second.ipcPath().isEmpty());
+    QVERIFY(first.ipcPath() != second.ipcPath());
+
+#ifdef Q_OS_UNIX
+    const QFileInfo directory(QFileInfo(first.ipcPath()).absolutePath());
+    QVERIFY(directory.isDir());
+    QCOMPARE(directory.ownerId(), static_cast<uint>(geteuid()));
+    const QFileDevice::Permissions groupOrOther =
+        QFileDevice::ReadGroup | QFileDevice::WriteGroup | QFileDevice::ExeGroup
+        | QFileDevice::ReadOther | QFileDevice::WriteOther | QFileDevice::ExeOther;
+    QVERIFY(!(directory.permissions() & groupOrOther));
+#endif
+}
+
+void PlayerProcessManagerTest::replacementWaitsForFinishedWithoutBlocking()
+{
+    QTemporaryDir directory;
+    QVERIFY(directory.isValid());
+    const QString logPath = directory.filePath(QStringLiteral("launches.log"));
+    PlayerProcessManager manager(fastOptions());
+    QSignalSpy stateSpy(&manager, &PlayerProcessManager::stateChanged);
+    QSignalSpy finishedSpy(&manager, &PlayerProcessManager::processFinished);
+    QSignalSpy ipcSpy(&manager, &PlayerProcessManager::ipcConnectionLatencyMeasured);
+
+    manager.startMpv(QCoreApplication::applicationFilePath(),
+                     fakeArguments(logPath), QStringLiteral("first-media"));
+    QTRY_VERIFY_WITH_TIMEOUT(manager.isRunning(), 1000);
+    QTRY_COMPARE_WITH_TIMEOUT(ipcSpy.count(), 1, 2000);
+
+    QElapsedTimer callTimer;
+    callTimer.start();
+    manager.startMpv(QCoreApplication::applicationFilePath(),
+                     fakeArguments(logPath), QStringLiteral("second-media"));
+    QVERIFY2(callTimer.elapsed() < 50, "replacement start blocked the caller");
+
+    QTRY_COMPARE_WITH_TIMEOUT(finishedSpy.count(), 1, 2000);
+    QTRY_COMPARE_WITH_TIMEOUT(launchRecords(logPath).size(), 2, 2000);
+    QTRY_COMPARE_WITH_TIMEOUT(ipcSpy.count(), 2, 2000);
+    QCOMPARE(launchRecords(logPath),
+             QStringList({QStringLiteral("first-media"), QStringLiteral("second-media")}));
+
+    manager.stopMpv();
+    QTRY_VERIFY_WITH_TIMEOUT(!manager.isRunning(), 2000);
+    QVERIFY(stateSpy.count() >= 4);
+}
+
+void PlayerProcessManagerTest::gracefulStopEscalatesWithoutBlocking()
+{
+    PlayerProcessManager manager(fastOptions());
+    QSignalSpy stateSpy(&manager, &PlayerProcessManager::stateChanged);
+    QSignalSpy ipcSpy(&manager, &PlayerProcessManager::ipcConnectionLatencyMeasured);
+    QSignalSpy errorSpy(&manager, &PlayerProcessManager::errorOccurred);
+    manager.startMpv(QCoreApplication::applicationFilePath(),
+                     fakeArguments({}, {QStringLiteral("--fake-ignore-quit")}),
+                     QStringLiteral("stubborn-media"));
+    QTRY_COMPARE_WITH_TIMEOUT(ipcSpy.count(), 1, 2000);
+
+    QElapsedTimer callTimer;
+    callTimer.start();
+    manager.stopMpv();
+    QVERIFY2(callTimer.elapsed() < 50, "stopMpv blocked the caller");
+    QTRY_VERIFY_WITH_TIMEOUT(!manager.isRunning(), 2000);
+    QVERIFY(manager.diagnostics().value(QStringLiteral("terminateEscalations"))
+                .toULongLong() >= 1);
+    QCOMPARE(errorSpy.count(), 0);
+    QVERIFY(stateSpy.count() >= 2);
+}
+
+void PlayerProcessManagerTest::destructionDoesNotBlockRunningProcess()
+{
+    auto *manager = new PlayerProcessManager(fastOptions());
+    QSignalSpy startedSpy(manager, &PlayerProcessManager::startupLatencyMeasured);
+    manager->startMpv(QCoreApplication::applicationFilePath(),
+                      fakeArguments({}, {QStringLiteral("--fake-no-ipc"),
+                                         QStringLiteral("--fake-ignore-terminate")}),
+                      QStringLiteral("destructor-media"));
+    QTRY_COMPARE_WITH_TIMEOUT(startedSpy.count(), 1, 1000);
+
+    QElapsedTimer callTimer;
+    callTimer.start();
+    delete manager;
+    QVERIFY2(callTimer.elapsed() < 50, "manager destruction blocked on the child process");
+    QTest::qWait(50);
+}
+
+void PlayerProcessManagerTest::killEscalationIsBounded()
+{
+#ifndef Q_OS_UNIX
+    QSKIP("QProcess::terminate cannot be ignored portably on this platform");
+#else
+    PlayerProcessManager manager(fastOptions());
+    QSignalSpy ipcSpy(&manager, &PlayerProcessManager::ipcConnectionLatencyMeasured);
+    manager.startMpv(QCoreApplication::applicationFilePath(),
+                     fakeArguments({}, {QStringLiteral("--fake-ignore-quit"),
+                                        QStringLiteral("--fake-ignore-terminate")}),
+                     QStringLiteral("unkillable-media"));
+    QTRY_COMPARE_WITH_TIMEOUT(ipcSpy.count(), 1, 2000);
+    manager.stopMpv();
+    QTRY_VERIFY_WITH_TIMEOUT(!manager.isRunning(), 2000);
+    QVERIFY(manager.diagnostics().value(QStringLiteral("killEscalations"))
+                .toULongLong() >= 1);
+#endif
+}
+
+void PlayerProcessManagerTest::ipcConnectionDeadlineIsBounded()
+{
+    PlayerProcessOptions options = fastOptions();
+    options.ipcConnectionDeadlineMs = 120;
+    PlayerProcessManager manager(options);
+    QSignalSpy errorSpy(&manager, &PlayerProcessManager::errorOccurred);
+    manager.startMpv(QCoreApplication::applicationFilePath(),
+                     fakeArguments({}, {QStringLiteral("--fake-no-ipc")}),
+                     QStringLiteral("no-ipc-media"));
+
+    QTRY_VERIFY_WITH_TIMEOUT(errorSpy.count() >= 1, 1000);
+    QVERIFY(errorSpy.first().first().toString().contains(QStringLiteral("IPC connection failed")));
+    QTRY_VERIFY_WITH_TIMEOUT(!manager.isRunning(), 2000);
+}
+
+void PlayerProcessManagerTest::ipcReconnectAttemptsAreBounded()
+{
+    PlayerProcessOptions options = fastOptions();
+    options.ipcConnectionDeadlineMs = 2000;
+    options.maximumIpcAttempts = 3;
+    PlayerProcessManager manager(options);
+    QSignalSpy errorSpy(&manager, &PlayerProcessManager::errorOccurred);
+    manager.startMpv(QCoreApplication::applicationFilePath(),
+                     fakeArguments({}, {QStringLiteral("--fake-no-ipc")}),
+                     QStringLiteral("attempt-limit-media"));
+
+    QTRY_VERIFY_WITH_TIMEOUT(errorSpy.count() >= 1, 1000);
+    QVERIFY(errorSpy.first().first().toString().contains(
+        QStringLiteral("maximum reconnect attempts")));
+    QCOMPARE(manager.diagnostics().value(QStringLiteral("ipcAttempts")).toInt(), 3);
+    QTRY_VERIFY_WITH_TIMEOUT(!manager.isRunning(), 2000);
+}
+
+void PlayerProcessManagerTest::pendingCommandsAreBounded()
+{
+    PlayerProcessManager manager(fastOptions());
+    QSignalSpy startedSpy(&manager, &PlayerProcessManager::startupLatencyMeasured);
+    manager.startMpv(QCoreApplication::applicationFilePath(),
+                     fakeArguments({}, {QStringLiteral("--fake-no-ipc")}),
+                     QStringLiteral("queued-command-media"));
+    QTRY_COMPARE_WITH_TIMEOUT(startedSpy.count(), 1, 1000);
+
+    manager.sendVariantCommand({});
+    manager.sendVariantCommand(QVariantList{42, QStringLiteral("not-a-command")});
+    for (int index = 0; index < 10; ++index) {
+        manager.sendVariantCommand(QVariantList{QStringLiteral("set_property"),
+                                                QStringLiteral("volume"), index});
+    }
+    const QVariantMap diagnostics = manager.diagnostics();
+    QCOMPARE(diagnostics.value(QStringLiteral("pendingCommands")).toInt(), 3);
+    QCOMPARE(diagnostics.value(QStringLiteral("droppedPendingCommands")).toULongLong(),
+             quint64(7));
+    manager.stopMpv();
+    QTRY_VERIFY_WITH_TIMEOUT(!manager.isRunning(), 2000);
+}
+
+void PlayerProcessManagerTest::disconnectedIpcReconnectsWithinDeadline()
+{
+    PlayerProcessManager manager(fastOptions());
+    QSignalSpy ipcSpy(&manager, &PlayerProcessManager::ipcConnectionLatencyMeasured);
+    manager.startMpv(QCoreApplication::applicationFilePath(),
+                     fakeArguments({}, {QStringLiteral("--fake-disconnect-once")}),
+                     QStringLiteral("reconnect-media"));
+
+    QTRY_COMPARE_WITH_TIMEOUT(ipcSpy.count(), 2, 2000);
+    QVERIFY(manager.isRunning());
+    manager.stopMpv();
+    QTRY_VERIFY_WITH_TIMEOUT(!manager.isRunning(), 2000);
+}
+
+void PlayerProcessManagerTest::malformedIpcIsIgnoredBeforeValidEvent()
+{
+    PlayerProcessManager manager(fastOptions());
+    QSignalSpy positionSpy(&manager, &PlayerProcessManager::positionChanged);
+    manager.startMpv(QCoreApplication::applicationFilePath(),
+                     fakeArguments({}, {QStringLiteral("--fake-send-events")}),
+                     QStringLiteral("event-media"));
+
+    QTRY_COMPARE_WITH_TIMEOUT(positionSpy.count(), 1, 2000);
+    QCOMPARE(positionSpy.first().first().toDouble(), 12.5);
+    QVERIFY(manager.diagnostics().value(QStringLiteral("invalidIpcMessages"))
+                .toULongLong() >= 2);
+    manager.stopMpv();
+    QTRY_VERIFY_WITH_TIMEOUT(!manager.isRunning(), 2000);
+}
+
+void PlayerProcessManagerTest::startupFailureIsClear()
+{
+    PlayerProcessManager manager(fastOptions());
+    QSignalSpy errorSpy(&manager, &PlayerProcessManager::errorOccurred);
+    manager.startMpv(QStringLiteral("/definitely/missing/bloom-mpv"), {},
+                     QStringLiteral("failure-media"));
+    QTRY_COMPARE_WITH_TIMEOUT(errorSpy.count(), 1, 1000);
+    QVERIFY(errorSpy.first().first().toString().startsWith(QStringLiteral("Failed to start mpv:")));
+    QVERIFY(!manager.isRunning());
+}
+
+int main(int argc, char **argv)
+{
+    QCoreApplication application(argc, argv);
+    const QStringList arguments = application.arguments();
+    if (arguments.contains(QStringLiteral("--fake-mpv"))) {
+        return runFakeMpv(arguments.mid(1));
+    }
+
+    PlayerProcessManagerTest test;
+    return QTest::qExec(&test, argc, argv);
+}
+
+#include "PlayerProcessManagerTest.moc"

--- a/tests/PlayerProcessManagerTest.cpp
+++ b/tests/PlayerProcessManagerTest.cpp
@@ -369,7 +369,9 @@ void PlayerProcessManagerTest::ipcReconnectAttemptsAreBounded()
 
 void PlayerProcessManagerTest::pendingCommandsAreBounded()
 {
-    PlayerProcessManager manager(fastOptions());
+    PlayerProcessOptions options = fastOptions();
+    options.ipcConnectionDeadlineMs = 10000;
+    PlayerProcessManager manager(options);
     QSignalSpy startedSpy(&manager, &PlayerProcessManager::startupLatencyMeasured);
     manager.startMpv(QCoreApplication::applicationFilePath(),
                      fakeArguments({}, {QStringLiteral("--fake-no-ipc")}),

--- a/tests/PlayerProcessManagerTest.cpp
+++ b/tests/PlayerProcessManagerTest.cpp
@@ -84,6 +84,9 @@ int runFakeMpv(const QStringList &arguments)
 
     const bool ignoreQuit = arguments.contains(QStringLiteral("--fake-ignore-quit"));
     const bool sendEvents = arguments.contains(QStringLiteral("--fake-send-events"));
+    const bool sendBurst = arguments.contains(QStringLiteral("--fake-send-burst"));
+    const bool acknowledgeCommands = arguments.contains(
+        QStringLiteral("--fake-ack-commands"));
     const bool disconnectOnce = arguments.contains(QStringLiteral("--fake-disconnect-once"));
     int connectionCount = 0;
     QObject::connect(&server, &QLocalServer::newConnection, &server, [&]() {
@@ -91,7 +94,7 @@ int runFakeMpv(const QStringList &arguments)
             QLocalSocket *socket = server.nextPendingConnection();
             ++connectionCount;
             QObject::connect(socket, &QLocalSocket::readyRead, socket,
-                             [socket, ignoreQuit]() {
+                             [socket, ignoreQuit, acknowledgeCommands]() {
                 QByteArray buffer = socket->property("buffer").toByteArray();
                 buffer.append(socket->readAll());
                 while (true) {
@@ -113,6 +116,16 @@ int runFakeMpv(const QStringList &arguments)
                         QCoreApplication::quit();
                         return;
                     }
+                    if (acknowledgeCommands && !command.isEmpty()
+                        && command.first().toString() == QStringLiteral("script-message")) {
+                        const QJsonObject event{
+                            {QStringLiteral("event"), QStringLiteral("client-message")},
+                            {QStringLiteral("args"),
+                             QJsonArray{QStringLiteral("command-ack")}},
+                        };
+                        socket->write(QJsonDocument(event).toJson(QJsonDocument::Compact));
+                        socket->write("\n");
+                    }
                 }
                 socket->setProperty("buffer", buffer);
             });
@@ -127,6 +140,18 @@ int runFakeMpv(const QStringList &arguments)
                 };
                 socket->write(QJsonDocument(propertyEvent).toJson(QJsonDocument::Compact));
                 socket->write("\n");
+                socket->flush();
+            }
+            if (sendBurst) {
+                for (int index = 0; index < 100; ++index) {
+                    const QJsonObject event{
+                        {QStringLiteral("event"), QStringLiteral("property-change")},
+                        {QStringLiteral("name"), QStringLiteral("time-pos")},
+                        {QStringLiteral("data"), index},
+                    };
+                    socket->write(QJsonDocument(event).toJson(QJsonDocument::Compact));
+                    socket->write("\n");
+                }
                 socket->flush();
             }
             if (disconnectOnce && connectionCount == 1) {
@@ -193,6 +218,8 @@ private slots:
     void ipcConnectionDeadlineIsBounded();
     void ipcReconnectAttemptsAreBounded();
     void pendingCommandsAreBounded();
+    void validCommandLargerThanInitialWriteLimitIsDelivered();
+    void batchedIpcMessagesAreFullyDrained();
     void disconnectedIpcReconnectsWithinDeadline();
     void malformedIpcIsIgnoredBeforeValidEvent();
     void startupFailureIsClear();
@@ -359,6 +386,46 @@ void PlayerProcessManagerTest::pendingCommandsAreBounded()
     QCOMPARE(diagnostics.value(QStringLiteral("pendingCommands")).toInt(), 3);
     QCOMPARE(diagnostics.value(QStringLiteral("droppedPendingCommands")).toULongLong(),
              quint64(7));
+    manager.stopMpv();
+    QTRY_VERIFY_WITH_TIMEOUT(!manager.isRunning(), 2000);
+}
+
+void PlayerProcessManagerTest::validCommandLargerThanInitialWriteLimitIsDelivered()
+{
+    PlayerProcessOptions options = fastOptions();
+    options.maximumIpcMessageBytes = 4096;
+    options.maximumBufferedWriteBytes = 128;
+    options.maximumPendingCommands = 16;
+    PlayerProcessManager manager(options);
+    QSignalSpy ipcSpy(&manager, &PlayerProcessManager::ipcConnectionLatencyMeasured);
+    QSignalSpy messageSpy(&manager, &PlayerProcessManager::scriptMessage);
+    manager.startMpv(QCoreApplication::applicationFilePath(),
+                     fakeArguments({}, {QStringLiteral("--fake-ack-commands")}),
+                     QStringLiteral("large-command-media"));
+    QTRY_COMPARE_WITH_TIMEOUT(ipcSpy.count(), 1, 2000);
+
+    for (int index = 0; index < 6; ++index) {
+        manager.sendVariantCommand(QVariantList{QStringLiteral("script-message"),
+                                                QString(1024, QLatin1Char('x'))});
+    }
+    QTRY_COMPARE_WITH_TIMEOUT(messageSpy.count(), 6, 2000);
+    QCOMPARE(messageSpy.first().first().toString(), QStringLiteral("command-ack"));
+    manager.stopMpv();
+    QTRY_VERIFY_WITH_TIMEOUT(!manager.isRunning(), 2000);
+}
+
+void PlayerProcessManagerTest::batchedIpcMessagesAreFullyDrained()
+{
+    PlayerProcessOptions options = fastOptions();
+    options.maximumIpcMessageBytes = 512;
+    PlayerProcessManager manager(options);
+    QSignalSpy positionSpy(&manager, &PlayerProcessManager::positionChanged);
+    manager.startMpv(QCoreApplication::applicationFilePath(),
+                     fakeArguments({}, {QStringLiteral("--fake-send-burst")}),
+                     QStringLiteral("burst-media"));
+
+    QTRY_COMPARE_WITH_TIMEOUT(positionSpy.count(), 100, 2000);
+    QCOMPARE(positionSpy.last().first().toDouble(), 99.0);
     manager.stopMpv();
     QTRY_VERIFY_WITH_TIMEOUT(!manager.isRunning(), 2000);
 }


### PR DESCRIPTION
## Summary

- replace blocking external-mpv startup and shutdown waits with an event-driven graceful quit, terminate, kill, finished, and queued-replacement lifecycle
- give every manager and launch a private collision-resistant IPC endpoint, with bounded connection retries, queues, message sizes, validation, and credential-safe diagnostics
- extract the production implementation into reusable `Bloom::PlayerProcess` and add fake-mpv lifecycle/IPC regression coverage that requires no playback hardware

## Behavior preserved

- external-mpv replacement playback and playlist append flow
- mpv property observation, playback-ended behavior, track/device events, and script messages
- Linux external-mpv fallback and Windows named-pipe support
- intentional multi-instance support with isolated IPC endpoints

## Verification

- `./scripts/dev-build.sh --tests --jobs 4`
- `ctest --test-dir build-dev --output-on-failure` (32/32, including visual regression)
- focused playback suite: `PlayerBackendFactoryTest`, `PlayerProcessManagerTest`, `PlayerControllerAutoplayContextTest`, `NextEpisodeResolverTest`, `TrackPreferencesManagerTest`
- `PlayerProcessManagerTest` repeated 10 consecutive runs, then 5 after destructor hardening
- `nix build .#checks.x86_64-linux.tests`
- `PATH=/nix/var/nix/profiles/default/bin:$PATH nix flake check`
- `PATH=/nix/var/nix/profiles/default/bin:$PATH nix build`
- clean Release build plus focused `PlayerProcessManagerTest` and `PlayerBackendFactoryTest`

## Notes

The fake-mpv integration test caught a reconnect-time `QLocalSocket` write-buffer crash; reconnection is now deliberately queued until the disconnect notification unwinds. Real mpv playback hardware, Windows named-pipe behavior, and Linux compositor/display paths remain CI/manual validation responsibilities.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make mpv process and IPC lifecycle fully asynchronous in `PlayerProcessManager`
> - Replaces blocking `QProcess::waitFor*` calls with event-driven state machines for start, stop, and IPC connection; the destructor no longer blocks the UI thread.
> - Adds staged shutdown: graceful quit → terminate → kill, each with configurable timeouts; replacement playback is queued rather than immediate.
> - IPC connections use bounded retry/deadline logic; pending command queues and message sizes are capped; strict JSON validation is enforced on all incoming messages.
> - Exposes unique per-instance private IPC endpoints (collision-resistant token per user/PID/random), expanded property observation, diagnostics signals, and a `PlayerProcessOptions` config struct.
> - `PlayerController` fallback from the embedded Linux backend now waits for the failing backend to fully stop before switching to `ExternalMpvBackend`, with repeated error events during shutdown ignored.
> - Risk: the fallback transition is now asynchronous — code that assumed an immediate backend switch after an embedded render failure will need to handle the deferred `stopped` signal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e1610e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Playback Improvements**
  * Improved external playback process startup, shutdown, reconnection, and replacement playback handling.
  * Added safer, private communication endpoints for each playback instance.
  * Added bounded communication and validation to better handle malformed or oversized playback messages.
  * Improved diagnostics for startup, connection, shutdown, and playback communication activity.

* **Reliability**
  * Playback lifecycle operations now remain responsive without blocking the interface.
  * Added stronger handling for process failures, disconnects, and unresponsive playback processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->