### PR TITLE
refactor(player): extract pure playback policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,11 @@ and restoration asynchronous and generation-safe; external display commands
 must retain deadlines and bounded output, and `PlayerController` must preserve
 HDR-before-refresh startup plus HDR-before-refresh restoration ordering.
 
+Pure playback decisions are owned by the Qt-Core-only `Bloom::PlayerPolicy`
+target. Keep language, track, HDR, version, completion, and autoplay policy free
+of I/O and `QObject`; `PlayerController` remains the stable QML-facing facade
+and state coordinator documented in `docs/playback.md`.
+
 Build & run (blessed path):
 ```
 nix build

--- a/docs/developer_notes.md
+++ b/docs/developer_notes.md
@@ -46,6 +46,9 @@ Useful utilities
 - `DisplayManager` for HDR and refresh-rate lifecycle. Link `Bloom::Display` in
   tests; never wait for an external display command on the GUI thread, and keep
   playback preparation/restoration generation-safe.
+- `PlaybackPolicy` for pure language, track, HDR, version, completion, and
+  next-episode decisions. Link `Bloom::PlayerPolicy` in focused tests and keep
+  the target Qt-Core-only with all inputs supplied explicitly.
 - `HttpTransport` for shared HTTP execution/retry/cancellation policy.
 - `IProviderRequestFactory` implementations for provider URL/header construction.
 - `ConfigManager` for settings and QML exposures.

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -27,6 +27,23 @@ Backend architecture
   - Non-Windows: `BLOOM_PLAYER_BACKEND` env override -> config `player_backend` -> platform default.
 - Unknown backend names safely resolve to `external-mpv-ipc`.
 
+Playback policy boundary
+- `PlayerController` remains the stable QML-facing playback facade and owns
+  state-machine coordination, service calls, backend commands, and reporting.
+- Deterministic decisions that do not require controller state mutation live in
+  `Bloom::PlaybackPolicy` and are built through the reusable
+  `Bloom::PlayerPolicy` target. This includes common language normalization,
+  stream scoring and initial track selection, HDR/Dolby Vision classification
+  and output policy, alternate-version affinity, multipart primary-source
+  filtering, completion thresholds, and next-episode prefetch validation.
+- Keep this policy layer Qt-Core-only and free of `QObject`, timers, networking,
+  configuration reads, backend calls, and other I/O. Callers pass settings and
+  playback snapshots explicitly, which makes policy behavior directly testable
+  without a media server, mpv, display hardware, or a QML engine.
+- This extraction is behavior-preserving: track precedence, Dolby Vision
+  fallback, version affinity, completion thresholds, autoplay/Up Next, and
+  multipart behavior retain the contracts documented below.
+
 Windows embedded backend details
 - Added `WindowsMpvBackend` scaffold under `src/player/backend/`.
 - Selector token: `win-libmpv`.

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation {
       InputBindingManagerTest \
       PlayerBackendFactoryTest \
       PlayerProcessManagerTest \
+      PlaybackPolicyTest \
       DisplayManagerTest \
       PlayerControllerAutoplayContextTest \
       MediaSegmentProviderServiceTest \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -412,6 +412,7 @@ target_link_libraries(Bloom
     Bloom::ImageCache
     Bloom::Display
     Bloom::Network
+    Bloom::PlayerPolicy
     Bloom::PlayerProcess
     Qt6::Core
     Qt6::Gui

--- a/src/cmake/BloomLibraries.cmake
+++ b/src/cmake/BloomLibraries.cmake
@@ -2,6 +2,7 @@
 # Keep dependency direction acyclic:
 #   Models -> Config / Transport / ImageCache / PlayerProcess -> Providers -> Network
 #                     Config -> Display
+#                     Qt Core -> PlayerPolicy
 
 add_library(BloomModels STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/models/MediaModels.cpp
@@ -118,6 +119,21 @@ target_link_libraries(BloomPlayerProcess
         Qt6::Network
 )
 
+add_library(BloomPlayerPolicy STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/player/PlaybackPolicy.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/player/PlaybackPolicy.h
+)
+add_library(Bloom::PlayerPolicy ALIAS BloomPlayerPolicy)
+target_include_directories(BloomPlayerPolicy
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+)
+target_link_libraries(BloomPlayerPolicy
+    PUBLIC
+        Qt6::Core
+)
+
 add_library(BloomProviders STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/providers/jellyfin/JellyfinAuthenticator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/providers/jellyfin/JellyfinModelMapper.cpp
@@ -174,6 +190,7 @@ set_target_properties(
     BloomTransport
     BloomImageCache
     BloomPlayerProcess
+    BloomPlayerPolicy
     BloomProviders
     BloomNetwork
     PROPERTIES FOLDER "Bloom/Libraries"

--- a/src/player/PlaybackPolicy.cpp
+++ b/src/player/PlaybackPolicy.cpp
@@ -1,0 +1,594 @@
+#include "PlaybackPolicy.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QHash>
+#include <QStringList>
+#include <QtGlobal>
+
+#include <limits>
+#include <utility>
+
+namespace Bloom::PlaybackPolicy {
+namespace {
+
+QVariantList mediaStreamsForType(const QVariantMap &mediaSource,
+                                 const QString &streamType)
+{
+    QVariantList result;
+    for (const QVariant &streamVariant :
+         mediaSource.value(QStringLiteral("mediaStreams")).toList()) {
+        const QVariantMap stream = streamVariant.toMap();
+        if (stream.value(QStringLiteral("type")).toString() == streamType) {
+            result.append(stream);
+        }
+    }
+    return result;
+}
+
+bool hasStreamIndex(const QVariantList &streams, int streamIndex)
+{
+    for (const QVariant &streamVariant : streams) {
+        if (streamVariant.toMap().value(QStringLiteral("index"), -1).toInt()
+            == streamIndex) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template<typename Predicate>
+int firstMatchingStreamIndex(const QVariantList &streams, Predicate predicate)
+{
+    for (const QVariant &streamVariant : streams) {
+        const QVariantMap stream = streamVariant.toMap();
+        if (predicate(stream)) {
+            return stream.value(QStringLiteral("index"), -1).toInt();
+        }
+    }
+    return -1;
+}
+
+QString normalizedMetadataText(const QVariantMap &stream)
+{
+    return QStringList{
+        stream.value(QStringLiteral("codec")).toString(),
+        stream.value(QStringLiteral("title")).toString(),
+        stream.value(QStringLiteral("displayTitle")).toString(),
+        stream.value(QStringLiteral("videoRange")).toString(),
+        stream.value(QStringLiteral("videoRangeType")).toString(),
+        stream.value(QStringLiteral("videoDoViTitle")).toString(),
+        stream.value(QStringLiteral("codecTag")).toString(),
+        stream.value(QStringLiteral("codecTagString")).toString(),
+        stream.value(QStringLiteral("codecId")).toString(),
+        stream.value(QStringLiteral("profile")).toString()
+    }.join(QLatin1Char(' ')).trimmed().toLower();
+}
+
+QString normalizedMediaSourceMetadataText(const QVariantMap &mediaSource)
+{
+    return QStringList{
+        mediaSource.value(QStringLiteral("name")).toString(),
+        mediaSource.value(QStringLiteral("path")).toString(),
+        mediaSource.value(QStringLiteral("container")).toString()
+    }.join(QLatin1Char(' ')).trimmed().toLower();
+}
+
+bool metadataContainsDolbyVisionProfile(const QString &metadata, int profile)
+{
+    const QString profileText = QString::number(profile);
+    return metadata.contains(QStringLiteral("dvhe.0") + profileText)
+        || metadata.contains(QStringLiteral("dvh1.0") + profileText)
+        || metadata.contains(QStringLiteral("profile ") + profileText)
+        || metadata.contains(QStringLiteral("profile-") + profileText)
+        || metadata.contains(QStringLiteral("profile.") + profileText)
+        || metadata.contains(QStringLiteral(" p") + profileText);
+}
+
+bool rangeTokenIndicatesHdr(const QString &token)
+{
+    const QString normalized = token.trimmed().toUpper();
+    return !normalized.isEmpty()
+        && normalized != QStringLiteral("UNKNOWN")
+        && normalized != QStringLiteral("SDR")
+        && normalized != QStringLiteral("0")
+        && normalized != QStringLiteral("1");
+}
+
+HdrContentKind classifyVideoStream(const QVariantMap &stream,
+                                   const QString &mediaSourceMetadata)
+{
+    const QString metadata = QStringList{
+        normalizedMetadataText(stream), mediaSourceMetadata
+    }.join(QLatin1Char(' ')).trimmed().toLower();
+    const int dvProfile =
+        stream.value(QStringLiteral("dolbyVisionProfile")).toInt();
+    const int compatibilityId = stream.value(
+        QStringLiteral("dolbyVisionBlSignalCompatibilityId")).toInt();
+    const QString range = stream.value(
+        QStringLiteral("videoRange")).toString().trimmed().toUpper();
+    const QString rangeType = stream.value(
+        QStringLiteral("videoRangeType")).toString().trimmed().toUpper();
+    const bool hasHdr10OrHlgBaseLayer = metadata.contains(QStringLiteral("hdr10"))
+        || metadata.contains(QStringLiteral("hlg"))
+        || compatibilityId == 1 || compatibilityId == 4 || compatibilityId == 6;
+    const bool isDolbyVision = dvProfile > 0
+        || metadata.contains(QStringLiteral("dovi"))
+        || metadata.contains(QStringLiteral("dolby vision"))
+        || metadata.contains(QStringLiteral("dvhe"))
+        || metadata.contains(QStringLiteral("dvh1"));
+
+    if (isDolbyVision) {
+        if (dvProfile == 7 || dvProfile == 8
+            || metadataContainsDolbyVisionProfile(metadata, 7)
+            || metadataContainsDolbyVisionProfile(metadata, 8)
+            || hasHdr10OrHlgBaseLayer) {
+            return HdrContentKind::DolbyVisionCompatible;
+        }
+        return HdrContentKind::DolbyVisionUnsupported;
+    }
+    if (rangeTokenIndicatesHdr(range)
+        || rangeTokenIndicatesHdr(rangeType)
+        || hasHdr10OrHlgBaseLayer) {
+        return HdrContentKind::Hdr;
+    }
+    return HdrContentKind::Sdr;
+}
+
+QString normalizedStringKey(const QString &value)
+{
+    return value.trimmed().toLower();
+}
+
+QString mediaSourceVideoDescriptor(const QVariantMap &mediaSource)
+{
+    QString codec;
+    QString profile;
+    QString videoRange;
+    int width = 0;
+    int height = 0;
+    const QVariantList streams = mediaStreamsForType(
+        mediaSource, QStringLiteral("Video"));
+    if (!streams.isEmpty()) {
+        const QVariantMap videoStream = streams.first().toMap();
+        codec = normalizedStringKey(
+            videoStream.value(QStringLiteral("codec")).toString());
+        profile = normalizedStringKey(
+            videoStream.value(QStringLiteral("profile")).toString());
+        videoRange = normalizedStringKey(
+            videoStream.value(QStringLiteral("videoRange")).toString());
+        width = videoStream.value(QStringLiteral("width")).toInt();
+        height = videoStream.value(QStringLiteral("height")).toInt();
+    }
+    return QStringLiteral("%1|%2|%3|%4x%5|%6|%7")
+        .arg(codec,
+             profile,
+             videoRange,
+             QString::number(width),
+             QString::number(height),
+             normalizedStringKey(
+                 mediaSource.value(QStringLiteral("container")).toString()),
+             QString::number(
+                 mediaSource.value(QStringLiteral("bitRate")).toInt()));
+}
+
+} // namespace
+
+QString normalizeLanguageCode(const QString &language)
+{
+    const QString normalized = language.trimmed().toLower();
+    static const QHash<QString, QString> aliases = {
+        {QStringLiteral("en"), QStringLiteral("eng")}, {QStringLiteral("eng"), QStringLiteral("eng")},
+        {QStringLiteral("ja"), QStringLiteral("jpn")}, {QStringLiteral("jpn"), QStringLiteral("jpn")},
+        {QStringLiteral("es"), QStringLiteral("spa")}, {QStringLiteral("spa"), QStringLiteral("spa")},
+        {QStringLiteral("fr"), QStringLiteral("fre")}, {QStringLiteral("fre"), QStringLiteral("fre")},
+        {QStringLiteral("fra"), QStringLiteral("fre")},
+        {QStringLiteral("de"), QStringLiteral("ger")}, {QStringLiteral("ger"), QStringLiteral("ger")},
+        {QStringLiteral("deu"), QStringLiteral("ger")},
+        {QStringLiteral("it"), QStringLiteral("ita")}, {QStringLiteral("ita"), QStringLiteral("ita")},
+        {QStringLiteral("pt"), QStringLiteral("por")}, {QStringLiteral("por"), QStringLiteral("por")},
+        {QStringLiteral("ru"), QStringLiteral("rus")}, {QStringLiteral("rus"), QStringLiteral("rus")},
+        {QStringLiteral("zh"), QStringLiteral("chi")}, {QStringLiteral("chi"), QStringLiteral("chi")},
+        {QStringLiteral("zho"), QStringLiteral("chi")},
+        {QStringLiteral("ko"), QStringLiteral("kor")}, {QStringLiteral("kor"), QStringLiteral("kor")},
+        {QStringLiteral("ar"), QStringLiteral("ara")}, {QStringLiteral("ara"), QStringLiteral("ara")},
+        {QStringLiteral("hi"), QStringLiteral("hin")}, {QStringLiteral("hin"), QStringLiteral("hin")},
+        {QStringLiteral("nl"), QStringLiteral("dut")}, {QStringLiteral("dut"), QStringLiteral("dut")},
+        {QStringLiteral("nld"), QStringLiteral("dut")},
+        {QStringLiteral("sv"), QStringLiteral("swe")}, {QStringLiteral("swe"), QStringLiteral("swe")},
+        {QStringLiteral("no"), QStringLiteral("nor")}, {QStringLiteral("nor"), QStringLiteral("nor")},
+        {QStringLiteral("da"), QStringLiteral("dan")}, {QStringLiteral("dan"), QStringLiteral("dan")},
+        {QStringLiteral("fi"), QStringLiteral("fin")}, {QStringLiteral("fin"), QStringLiteral("fin")},
+        {QStringLiteral("pl"), QStringLiteral("pol")}, {QStringLiteral("pol"), QStringLiteral("pol")},
+        {QStringLiteral("tr"), QStringLiteral("tur")}, {QStringLiteral("tur"), QStringLiteral("tur")},
+        {QStringLiteral("cs"), QStringLiteral("cze")}, {QStringLiteral("cze"), QStringLiteral("cze")},
+        {QStringLiteral("ces"), QStringLiteral("cze")},
+        {QStringLiteral("el"), QStringLiteral("gre")}, {QStringLiteral("gre"), QStringLiteral("gre")},
+        {QStringLiteral("ell"), QStringLiteral("gre")},
+        {QStringLiteral("he"), QStringLiteral("heb")}, {QStringLiteral("heb"), QStringLiteral("heb")},
+        {QStringLiteral("id"), QStringLiteral("ind")}, {QStringLiteral("ind"), QStringLiteral("ind")},
+        {QStringLiteral("tha"), QStringLiteral("tha")}, {QStringLiteral("th"), QStringLiteral("tha")},
+        {QStringLiteral("vi"), QStringLiteral("vie")}, {QStringLiteral("vie"), QStringLiteral("vie")}
+    };
+    return aliases.value(normalized, normalized);
+}
+
+int bestLanguageStreamIndex(const QVariantList &streams,
+                            const QString &language,
+                            bool subtitle)
+{
+    const QString preference = normalizeLanguageCode(language);
+    if (preference.isEmpty()) {
+        return -1;
+    }
+    int bestIndex = -1;
+    int bestScore = -1;
+    int ordinal = 0;
+    for (const QVariant &streamVariant : streams) {
+        const QVariantMap stream = streamVariant.toMap();
+        if (normalizeLanguageCode(
+                stream.value(QStringLiteral("language")).toString())
+            != preference) {
+            ++ordinal;
+            continue;
+        }
+        int score = 10000 - ordinal;
+        if (stream.value(QStringLiteral("isDefault"), false).toBool()) {
+            score += 100000;
+        } else if (subtitle) {
+            const bool forced =
+                stream.value(QStringLiteral("isForced"), false).toBool();
+            const bool hearingImpaired = stream.value(
+                QStringLiteral("isHearingImpaired"), false).toBool();
+            score += !forced && !hearingImpaired ? 50000
+                : forced ? 30000 : 10000;
+        }
+        if (score > bestScore) {
+            bestScore = score;
+            bestIndex = stream.value(QStringLiteral("index"), -1).toInt();
+        }
+        ++ordinal;
+    }
+    return bestIndex;
+}
+
+ResolvedTrackSelection resolveTrackSelection(
+    const QVariantMap &mediaSource,
+    const ScopedTrackPreferences &preferences,
+    const QString &defaultAudioSelection,
+    const QString &defaultSubtitleSelection,
+    int preferredAudioIndex,
+    int preferredSubtitleIndex)
+{
+    const QVariantList audioStreams = mediaStreamsForType(
+        mediaSource, QStringLiteral("Audio"));
+    const QVariantList subtitleStreams = mediaStreamsForType(
+        mediaSource, QStringLiteral("Subtitle"));
+    const auto providerAudio = [&]() -> std::pair<int, QString> {
+        const int index = mediaSource.value(
+            QStringLiteral("defaultAudioStreamIndex"), -1).toInt();
+        return index >= 0 && hasStreamIndex(audioStreams, index)
+            ? std::pair{index, QStringLiteral("jellyfin-default")}
+            : std::pair{-1, QString{}};
+    };
+    const auto fileAudio = [&]() -> std::pair<int, QString> {
+        const int index = firstMatchingStreamIndex(audioStreams,
+            [](const QVariantMap &stream) {
+                return stream.value(QStringLiteral("isDefault"), false).toBool();
+            });
+        return index >= 0 ? std::pair{index, QStringLiteral("file-default")}
+                          : std::pair{-1, QString{}};
+    };
+    const auto builtInAudio = [&]() -> std::pair<int, QString> {
+        const auto provider = providerAudio();
+        if (provider.first >= 0) return provider;
+        const auto file = fileAudio();
+        if (file.first >= 0) return file;
+        const int index = firstMatchingStreamIndex(audioStreams,
+                                                   [](const QVariantMap &) { return true; });
+        return {index, index >= 0 ? QStringLiteral("fallback")
+                                  : QStringLiteral("none")};
+    };
+    const auto providerSubtitle = [&]() -> std::pair<int, QString> {
+        const int index = mediaSource.value(
+            QStringLiteral("defaultSubtitleStreamIndex"), -1).toInt();
+        return index >= 0 && hasStreamIndex(subtitleStreams, index)
+            ? std::pair{index, QStringLiteral("jellyfin-default")}
+            : std::pair{-1, QString{}};
+    };
+    const auto fileSubtitle = [&]() -> std::pair<int, QString> {
+        const int index = firstMatchingStreamIndex(subtitleStreams,
+            [](const QVariantMap &stream) {
+                return stream.value(QStringLiteral("isDefault"), false).toBool();
+            });
+        return index >= 0 ? std::pair{index, QStringLiteral("file-default")}
+                          : std::pair{-1, QString{}};
+    };
+    const auto builtInSubtitle = [&]() -> std::pair<int, QString> {
+        const auto provider = providerSubtitle();
+        if (provider.first >= 0) return provider;
+        const auto file = fileSubtitle();
+        if (file.first >= 0) return file;
+        const int forced = firstMatchingStreamIndex(subtitleStreams,
+            [](const QVariantMap &stream) {
+                return stream.value(QStringLiteral("isForced"), false).toBool();
+            });
+        return forced >= 0
+            ? std::pair{forced, QStringLiteral("forced-default")}
+            : std::pair{-1, QStringLiteral("fallback-off")};
+    };
+    const auto globalAudio = [&]() -> std::pair<int, QString> {
+        if (defaultAudioSelection == QStringLiteral("file-default")) {
+            const auto file = fileAudio();
+            return file.first >= 0 ? file : builtInAudio();
+        }
+        if (defaultAudioSelection != QStringLiteral("jellyfin-default")) {
+            const int index = bestLanguageStreamIndex(
+                audioStreams, defaultAudioSelection, false);
+            if (index >= 0) return {index, QStringLiteral("global-language")};
+        }
+        return builtInAudio();
+    };
+    const auto globalSubtitle = [&]() -> std::pair<int, QString> {
+        if (defaultSubtitleSelection == QStringLiteral("off")) {
+            return {-1, QStringLiteral("global-off")};
+        }
+        if (defaultSubtitleSelection == QStringLiteral("forced")) {
+            const int forced = firstMatchingStreamIndex(subtitleStreams,
+                [](const QVariantMap &stream) {
+                    return stream.value(QStringLiteral("isForced"), false).toBool();
+                });
+            return forced >= 0
+                ? std::pair{forced, QStringLiteral("global-forced")}
+                : std::pair{-1, QStringLiteral("global-forced-off")};
+        }
+        if (defaultSubtitleSelection == QStringLiteral("file-default")) {
+            const auto file = fileSubtitle();
+            return file.first >= 0 ? file : builtInSubtitle();
+        }
+        if (defaultSubtitleSelection != QStringLiteral("jellyfin-default")) {
+            const int index = bestLanguageStreamIndex(
+                subtitleStreams, defaultSubtitleSelection, true);
+            if (index >= 0) return {index, QStringLiteral("global-language")};
+        }
+        return builtInSubtitle();
+    };
+
+    std::pair<int, QString> audio;
+    if (preferredAudioIndex >= 0
+        && hasStreamIndex(audioStreams, preferredAudioIndex)) {
+        audio = {preferredAudioIndex, QStringLiteral("override")};
+    } else if (preferences.audio.mode == TrackPreferenceMode::ExplicitStream
+               && hasStreamIndex(audioStreams,
+                                 preferences.audio.streamIndex)) {
+        audio = {preferences.audio.streamIndex, QStringLiteral("explicit")};
+    } else {
+        audio = globalAudio();
+    }
+
+    std::pair<int, QString> subtitle;
+    if (preferredSubtitleIndex == -1) {
+        subtitle = {-1, QStringLiteral("override-off")};
+    } else if (preferredSubtitleIndex >= 0
+               && hasStreamIndex(subtitleStreams, preferredSubtitleIndex)) {
+        subtitle = {preferredSubtitleIndex, QStringLiteral("override")};
+    } else if (preferences.subtitle.mode == TrackPreferenceMode::Off) {
+        subtitle = {-1, QStringLiteral("explicit-off")};
+    } else if (preferences.subtitle.mode == TrackPreferenceMode::ExplicitStream
+               && hasStreamIndex(subtitleStreams,
+                                 preferences.subtitle.streamIndex)) {
+        subtitle = {preferences.subtitle.streamIndex, QStringLiteral("explicit")};
+    } else {
+        subtitle = globalSubtitle();
+    }
+    return {audio.first, subtitle.first, audio.second, subtitle.second};
+}
+
+HdrContentKind classifyMediaSourceHdr(const QVariantMap &mediaSource)
+{
+    HdrContentKind result = HdrContentKind::Sdr;
+    const QString sourceMetadata = normalizedMediaSourceMetadataText(mediaSource);
+    for (const QVariant &streamVariant : mediaStreamsForType(
+             mediaSource, QStringLiteral("Video"))) {
+        const HdrContentKind kind = classifyVideoStream(
+            streamVariant.toMap(), sourceMetadata);
+        if (kind == HdrContentKind::DolbyVisionUnsupported) return kind;
+        if (kind == HdrContentKind::DolbyVisionCompatible) result = kind;
+        else if (kind == HdrContentKind::Hdr
+                 && result == HdrContentKind::Sdr) result = kind;
+    }
+    return result;
+}
+
+bool isHdr(HdrContentKind kind)
+{
+    return kind != HdrContentKind::Sdr;
+}
+
+bool shouldToneMapToSdr(HdrContentKind kind,
+                        const QString &dolbyVisionFallbackMode)
+{
+    return kind == HdrContentKind::DolbyVisionUnsupported
+        && dolbyVisionFallbackMode != QStringLiteral("experimental-direct-play");
+}
+
+QString hdrContentKindName(HdrContentKind kind)
+{
+    switch (kind) {
+    case HdrContentKind::Sdr: return QStringLiteral("sdr");
+    case HdrContentKind::Hdr: return QStringLiteral("hdr");
+    case HdrContentKind::DolbyVisionCompatible:
+        return QStringLiteral("dolby-vision-compatible");
+    case HdrContentKind::DolbyVisionUnsupported:
+        return QStringLiteral("dolby-vision-unsupported");
+    }
+    return QStringLiteral("unknown");
+}
+
+HdrPlaybackPolicy evaluateHdrPlayback(bool contentIsHdr,
+                                      bool contentShouldToneMapToSdr,
+                                      bool hdrEnabled,
+                                      const QString &hdrOutputMode)
+{
+    HdrPlaybackPolicy policy;
+    if (!contentIsHdr) return policy;
+    policy.toneMapToSdr = contentShouldToneMapToSdr
+        || !hdrEnabled
+        || hdrOutputMode == QStringLiteral("tone-map-to-sdr");
+    policy.outputHdr = hdrEnabled
+        && !policy.toneMapToSdr
+        && (hdrOutputMode == QStringLiteral("match-content")
+            || hdrOutputMode == QStringLiteral("force-hdr-experimental"));
+    policy.shouldToggleDisplayHdr = policy.outputHdr;
+    return policy;
+}
+
+QString mediaSourceParentPath(const QVariantMap &mediaSource)
+{
+    QFileInfo info(mediaSource.value(QStringLiteral("path")).toString());
+    return normalizedStringKey(
+        info.dir().absolutePath().replace(QLatin1Char('\\'), QLatin1Char('/')));
+}
+
+QString mediaSourceSignature(const QVariantMap &mediaSource)
+{
+    return mediaSourceVideoDescriptor(mediaSource);
+}
+
+QString buildVersionSubtitle(const QVariantMap &mediaSource)
+{
+    QStringList parts;
+    const QVariantList videos = mediaStreamsForType(mediaSource,
+                                                    QStringLiteral("Video"));
+    if (!videos.isEmpty()) {
+        const QVariantMap video = videos.first().toMap();
+        const int width = video.value(QStringLiteral("width")).toInt();
+        const int height = video.value(QStringLiteral("height")).toInt();
+        if (width > 0 && height > 0) {
+            parts.append(QStringLiteral("%1x%2").arg(width).arg(height));
+        }
+        const QString range = video.value(
+            QStringLiteral("videoRange")).toString().trimmed();
+        if (!range.isEmpty()
+            && range.compare(QStringLiteral("SDR"), Qt::CaseInsensitive) != 0) {
+            parts.append(range.toUpper());
+        }
+        const QString codec = video.value(
+            QStringLiteral("codec")).toString().trimmed();
+        if (!codec.isEmpty()) parts.append(codec.toUpper());
+        const QString profile = video.value(
+            QStringLiteral("profile")).toString().trimmed();
+        if (!profile.isEmpty()) parts.append(profile);
+    }
+    const QString container = mediaSource.value(
+        QStringLiteral("container")).toString().trimmed();
+    if (!container.isEmpty()) parts.append(container.toUpper());
+    const int bitrate = mediaSource.value(QStringLiteral("bitRate")).toInt();
+    if (bitrate > 0) {
+        parts.append(QStringLiteral("%1 Mbps").arg(
+            QString::number(double(bitrate) / 1000000.0, 'f', 1)));
+    }
+    return parts.join(QStringLiteral(" • "));
+}
+
+QVariantMap selectMediaSource(const QVariantList &mediaSources,
+                              const QString &forcedMediaSourceId,
+                              bool useAffinityFallback,
+                              const VersionAffinity &affinity)
+{
+    if (!forcedMediaSourceId.isEmpty()) {
+        for (const QVariant &value : mediaSources) {
+            const QVariantMap source = value.toMap();
+            if (source.value(QStringLiteral("id")).toString()
+                == forcedMediaSourceId) return source;
+        }
+    }
+    if (useAffinityFallback) {
+        const QString parentPath = normalizedStringKey(affinity.parentPath);
+        if (!parentPath.isEmpty()) {
+            for (const QVariant &value : mediaSources) {
+                const QVariantMap source = value.toMap();
+                if (mediaSourceParentPath(source) == parentPath) return source;
+            }
+        }
+        const QString name = normalizedStringKey(affinity.name);
+        if (!name.isEmpty()) {
+            for (const QVariant &value : mediaSources) {
+                const QVariantMap source = value.toMap();
+                if (normalizedStringKey(
+                        source.value(QStringLiteral("name")).toString()) == name) {
+                    return source;
+                }
+            }
+        }
+        if (!affinity.signature.isEmpty()) {
+            for (const QVariant &value : mediaSources) {
+                const QVariantMap source = value.toMap();
+                if (mediaSourceSignature(source) == affinity.signature) return source;
+            }
+        }
+    }
+    return mediaSources.isEmpty() ? QVariantMap{} : mediaSources.first().toMap();
+}
+
+QVariantList primaryPresentationSources(const QVariantList &mediaSources)
+{
+    int firstPart = std::numeric_limits<int>::max();
+    for (const QVariant &value : mediaSources) {
+        const int part = value.toMap().value(
+            QStringLiteral("presentationPartIndex")).toInt();
+        if (part > 0) firstPart = qMin(firstPart, part);
+    }
+    if (firstPart == std::numeric_limits<int>::max()) return mediaSources;
+    QVariantList result;
+    for (const QVariant &value : mediaSources) {
+        if (value.toMap().value(QStringLiteral("presentationPartIndex")).toInt()
+            == firstPart) result.append(value);
+    }
+    return result;
+}
+
+bool meetsCompletionThreshold(const CompletionInput &input)
+{
+    return !input.alreadyEvaluated
+        && !input.itemId.isEmpty()
+        && !input.seriesId.isEmpty()
+        && input.durationSeconds > 0.0
+        && (input.positionSeconds / input.durationSeconds) * 100.0
+            >= input.thresholdPercent;
+}
+
+bool shouldPrefetchNextEpisode(const PrefetchInput &input)
+{
+    return !input.alreadyRequested
+        && input.playbackActive
+        && !input.seriesId.isEmpty()
+        && !input.itemId.isEmpty()
+        && input.durationSeconds > 0.0
+        && (input.positionSeconds / input.durationSeconds) * 100.0
+            >= input.triggerPercent;
+}
+
+bool isUsablePrefetchedEpisode(const PrefetchedEpisodeInput &input)
+{
+    const QString episodeId = input.episode.value(
+        QStringLiteral("itemId")).toString();
+    return input.ready
+        && !input.episode.isEmpty()
+        && !episodeId.isEmpty()
+        && !input.prefetchedSeriesId.isEmpty()
+        && input.prefetchedSeriesId == input.pendingSeriesId
+        && !input.prefetchedForItemId.isEmpty()
+        && input.prefetchedForItemId == input.pendingItemId
+        && episodeId != input.pendingItemId;
+}
+
+QString nextEpisodeRequestContext(const QString &mode,
+                                  const QString &seriesId,
+                                  const QString &itemId)
+{
+    if (mode.isEmpty() || seriesId.isEmpty() || itemId.isEmpty()) return {};
+    return QStringLiteral("player:%1:%2:%3").arg(mode, seriesId, itemId);
+}
+
+} // namespace Bloom::PlaybackPolicy

--- a/src/player/PlaybackPolicy.h
+++ b/src/player/PlaybackPolicy.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <QString>
+#include <QVariantList>
+#include <QVariantMap>
+
+#include "utils/TrackPreferencesManager.h"
+
+namespace Bloom::PlaybackPolicy {
+
+enum class HdrContentKind {
+    Sdr,
+    Hdr,
+    DolbyVisionCompatible,
+    DolbyVisionUnsupported
+};
+
+struct HdrPlaybackPolicy
+{
+    bool toneMapToSdr = false;
+    bool outputHdr = false;
+    bool shouldToggleDisplayHdr = false;
+};
+
+struct ResolvedTrackSelection
+{
+    int audioIndex = -1;
+    int subtitleIndex = -1;
+    QString audioSource;
+    QString subtitleSource;
+};
+
+struct VersionAffinity
+{
+    QString parentPath;
+    QString name;
+    QString signature;
+};
+
+struct CompletionInput
+{
+    bool alreadyEvaluated = false;
+    QString itemId;
+    QString seriesId;
+    double positionSeconds = 0.0;
+    double durationSeconds = 0.0;
+    int thresholdPercent = 0;
+};
+
+struct PrefetchInput
+{
+    bool alreadyRequested = false;
+    bool playbackActive = false;
+    QString seriesId;
+    QString itemId;
+    double positionSeconds = 0.0;
+    double durationSeconds = 0.0;
+    double triggerPercent = 0.0;
+};
+
+struct PrefetchedEpisodeInput
+{
+    bool ready = false;
+    QVariantMap episode;
+    QString prefetchedSeriesId;
+    QString prefetchedForItemId;
+    QString pendingSeriesId;
+    QString pendingItemId;
+};
+
+[[nodiscard]] QString normalizeLanguageCode(const QString &language);
+[[nodiscard]] int bestLanguageStreamIndex(const QVariantList &streams,
+                                          const QString &language,
+                                          bool subtitle);
+[[nodiscard]] ResolvedTrackSelection resolveTrackSelection(
+    const QVariantMap &mediaSource,
+    const ScopedTrackPreferences &preferences,
+    const QString &defaultAudioSelection,
+    const QString &defaultSubtitleSelection,
+    int preferredAudioIndex = -2,
+    int preferredSubtitleIndex = -2);
+
+[[nodiscard]] HdrContentKind classifyMediaSourceHdr(const QVariantMap &mediaSource);
+[[nodiscard]] bool isHdr(HdrContentKind kind);
+[[nodiscard]] bool shouldToneMapToSdr(HdrContentKind kind,
+                                      const QString &dolbyVisionFallbackMode);
+[[nodiscard]] QString hdrContentKindName(HdrContentKind kind);
+[[nodiscard]] HdrPlaybackPolicy evaluateHdrPlayback(bool contentIsHdr,
+                                                    bool contentShouldToneMapToSdr,
+                                                    bool hdrEnabled,
+                                                    const QString &hdrOutputMode);
+
+[[nodiscard]] QString mediaSourceParentPath(const QVariantMap &mediaSource);
+[[nodiscard]] QString mediaSourceSignature(const QVariantMap &mediaSource);
+[[nodiscard]] QString buildVersionSubtitle(const QVariantMap &mediaSource);
+[[nodiscard]] QVariantMap selectMediaSource(const QVariantList &mediaSources,
+                                            const QString &forcedMediaSourceId,
+                                            bool useAffinityFallback,
+                                            const VersionAffinity &affinity);
+[[nodiscard]] QVariantList primaryPresentationSources(const QVariantList &mediaSources);
+
+[[nodiscard]] bool meetsCompletionThreshold(const CompletionInput &input);
+[[nodiscard]] bool shouldPrefetchNextEpisode(const PrefetchInput &input);
+[[nodiscard]] bool isUsablePrefetchedEpisode(const PrefetchedEpisodeInput &input);
+[[nodiscard]] QString nextEpisodeRequestContext(const QString &mode,
+                                                const QString &seriesId,
+                                                const QString &itemId);
+
+} // namespace Bloom::PlaybackPolicy

--- a/src/player/PlayerController.cpp
+++ b/src/player/PlayerController.cpp
@@ -1,4 +1,5 @@
 #include "PlayerController.h"
+#include "PlaybackPolicy.h"
 #include "TrickplayProcessor.h"
 #if !defined(BLOOM_TESTING)
 #include "backend/ExternalMpvBackend.h"
@@ -8,7 +9,6 @@
 #include "../network/AuthenticationService.h"
 #include "../network/Types.h"
 #include <QFile>
-#include <QFileInfo>
 #include <QBuffer>
 #include <QNetworkReply>
 #include <QJsonDocument>
@@ -29,11 +29,12 @@
 #include <QThread>
 #include <atomic>
 #include <algorithm>
-#include <limits>
 #include "../utils/BloomLogging.h"
 #include "../utils/MpvArgFilter.h"
 
 namespace {
+namespace PlayerPolicy = Bloom::PlaybackPolicy;
+
 std::atomic<quint64> gPlaybackAttemptCounter{0};
 bool isLinuxEmbeddedLibmpvBackend(const IPlayerBackend *backend)
 {
@@ -64,16 +65,6 @@ static QString formatMpvDisplayFps(double fps)
         value.chop(1);
     }
     return value;
-}
-
-QString buildNextEpisodeRequestContext(const QString &mode,
-                                       const QString &seriesId,
-                                       const QString &itemId)
-{
-    if (mode.isEmpty() || seriesId.isEmpty() || itemId.isEmpty()) {
-        return {};
-    }
-    return QStringLiteral("player:%1:%2:%3").arg(mode, seriesId, itemId);
 }
 
 class NullPlayerBackend final : public IPlayerBackend
@@ -122,245 +113,6 @@ QVariantList mediaStreamsForType(const QVariantMap &mediaSource, const QString &
     return result;
 }
 
-enum class HdrContentKind {
-    Sdr,
-    Hdr,
-    DolbyVisionCompatible,
-    DolbyVisionUnsupported
-};
-
-QString normalizedMetadataText(const QVariantMap &stream)
-{
-    return QStringList{
-        stream.value(QStringLiteral("codec")).toString(),
-        stream.value(QStringLiteral("title")).toString(),
-        stream.value(QStringLiteral("displayTitle")).toString(),
-        stream.value(QStringLiteral("videoRange")).toString(),
-        stream.value(QStringLiteral("videoRangeType")).toString(),
-        stream.value(QStringLiteral("videoDoViTitle")).toString(),
-        stream.value(QStringLiteral("codecTag")).toString(),
-        stream.value(QStringLiteral("codecTagString")).toString(),
-        stream.value(QStringLiteral("codecId")).toString(),
-        stream.value(QStringLiteral("profile")).toString()
-    }.join(QLatin1Char(' ')).trimmed().toLower();
-}
-
-QString normalizedMediaSourceMetadataText(const QVariantMap &mediaSource)
-{
-    return QStringList{
-        mediaSource.value(QStringLiteral("name")).toString(),
-        mediaSource.value(QStringLiteral("path")).toString(),
-        mediaSource.value(QStringLiteral("container")).toString()
-    }.join(QLatin1Char(' ')).trimmed().toLower();
-}
-
-bool metadataContainsDolbyVisionProfile(const QString &metadata, int profile)
-{
-    const QString profileText = QString::number(profile);
-    return metadata.contains(QStringLiteral("dvhe.0") + profileText)
-        || metadata.contains(QStringLiteral("dvh1.0") + profileText)
-        || metadata.contains(QStringLiteral("profile ") + profileText)
-        || metadata.contains(QStringLiteral("profile-") + profileText)
-        || metadata.contains(QStringLiteral("profile.") + profileText)
-        || metadata.contains(QStringLiteral(" p") + profileText);
-}
-
-bool rangeTokenIndicatesHdr(const QString &token)
-{
-    const QString normalized = token.trimmed().toUpper();
-    return !normalized.isEmpty()
-        && normalized != QStringLiteral("UNKNOWN")
-        && normalized != QStringLiteral("SDR")
-        && normalized != QStringLiteral("0")
-        && normalized != QStringLiteral("1");
-}
-
-HdrContentKind classifyVideoStream(const QVariantMap &stream, const QString &mediaSourceMetadata = QString())
-{
-    const QString metadata = QStringList{normalizedMetadataText(stream), mediaSourceMetadata}
-        .join(QLatin1Char(' '))
-        .trimmed()
-        .toLower();
-    const int dvProfile = stream.value(QStringLiteral("dolbyVisionProfile")).toInt();
-    const int dvBlSignalCompatibilityId =
-        stream.value(QStringLiteral("dolbyVisionBlSignalCompatibilityId")).toInt();
-    const QString range = stream.value(QStringLiteral("videoRange")).toString().trimmed().toUpper();
-    const QString rangeType = stream.value(QStringLiteral("videoRangeType")).toString().trimmed().toUpper();
-    const bool hasHdr10OrHlgBaseLayer = metadata.contains(QStringLiteral("hdr10"))
-        || metadata.contains(QStringLiteral("hlg"))
-        || dvBlSignalCompatibilityId == 1
-        || dvBlSignalCompatibilityId == 4
-        || dvBlSignalCompatibilityId == 6;
-    const bool isDolbyVision = dvProfile > 0
-        || metadata.contains(QStringLiteral("dovi"))
-        || metadata.contains(QStringLiteral("dolby vision"))
-        || metadata.contains(QStringLiteral("dvhe"))
-        || metadata.contains(QStringLiteral("dvh1"));
-
-    if (isDolbyVision) {
-        if (dvProfile == 7 || dvProfile == 8
-            || metadataContainsDolbyVisionProfile(metadata, 7)
-            || metadataContainsDolbyVisionProfile(metadata, 8)
-            || hasHdr10OrHlgBaseLayer) {
-            return HdrContentKind::DolbyVisionCompatible;
-        }
-        return HdrContentKind::DolbyVisionUnsupported;
-    }
-
-    if (rangeTokenIndicatesHdr(range)
-        || rangeTokenIndicatesHdr(rangeType)
-        || hasHdr10OrHlgBaseLayer) {
-        return HdrContentKind::Hdr;
-    }
-
-    return HdrContentKind::Sdr;
-}
-
-HdrContentKind classifyMediaSourceHdr(const QVariantMap &mediaSource)
-{
-    HdrContentKind result = HdrContentKind::Sdr;
-    const QString mediaSourceMetadata = normalizedMediaSourceMetadataText(mediaSource);
-    for (const QVariant &streamVariant : mediaStreamsForType(mediaSource, QStringLiteral("Video"))) {
-        const HdrContentKind streamKind = classifyVideoStream(streamVariant.toMap(), mediaSourceMetadata);
-        if (streamKind == HdrContentKind::DolbyVisionUnsupported) {
-            return streamKind;
-        }
-        if (streamKind == HdrContentKind::DolbyVisionCompatible) {
-            result = streamKind;
-        } else if (streamKind == HdrContentKind::Hdr && result == HdrContentKind::Sdr) {
-            result = streamKind;
-        }
-    }
-    return result;
-}
-
-bool kindIsHdr(HdrContentKind kind)
-{
-    return kind != HdrContentKind::Sdr;
-}
-
-bool kindShouldToneMapToSdr(HdrContentKind kind, const QString &dolbyVisionFallbackMode)
-{
-    return kind == HdrContentKind::DolbyVisionUnsupported
-        && dolbyVisionFallbackMode != QStringLiteral("experimental-direct-play");
-}
-
-const char *hdrContentKindName(HdrContentKind kind)
-{
-    switch (kind) {
-    case HdrContentKind::Sdr:
-        return "sdr";
-    case HdrContentKind::Hdr:
-        return "hdr";
-    case HdrContentKind::DolbyVisionCompatible:
-        return "dolby-vision-compatible";
-    case HdrContentKind::DolbyVisionUnsupported:
-        return "dolby-vision-unsupported";
-    }
-    return "unknown";
-}
-
-bool hasStreamIndex(const QVariantList &streams, int streamIndex)
-{
-    for (const QVariant &streamVariant : streams) {
-        if (streamVariant.toMap().value(QStringLiteral("index"), -1).toInt() == streamIndex) {
-            return true;
-        }
-    }
-    return false;
-}
-
-int firstMatchingStreamIndex(const QVariantList &streams, const std::function<bool(const QVariantMap &)> &predicate)
-{
-    for (const QVariant &streamVariant : streams) {
-        const QVariantMap stream = streamVariant.toMap();
-        if (predicate(stream)) {
-            return stream.value(QStringLiteral("index"), -1).toInt();
-        }
-    }
-    return -1;
-}
-
-QString normalizedLanguageCode(const QString &language)
-{
-    const QString normalized = language.trimmed().toLower();
-    static const QHash<QString, QString> aliases = {
-        {QStringLiteral("en"), QStringLiteral("eng")}, {QStringLiteral("eng"), QStringLiteral("eng")},
-        {QStringLiteral("ja"), QStringLiteral("jpn")}, {QStringLiteral("jpn"), QStringLiteral("jpn")},
-        {QStringLiteral("es"), QStringLiteral("spa")}, {QStringLiteral("spa"), QStringLiteral("spa")},
-        {QStringLiteral("fr"), QStringLiteral("fre")}, {QStringLiteral("fre"), QStringLiteral("fre")},
-        {QStringLiteral("fra"), QStringLiteral("fre")},
-        {QStringLiteral("de"), QStringLiteral("ger")}, {QStringLiteral("ger"), QStringLiteral("ger")},
-        {QStringLiteral("deu"), QStringLiteral("ger")},
-        {QStringLiteral("it"), QStringLiteral("ita")}, {QStringLiteral("ita"), QStringLiteral("ita")},
-        {QStringLiteral("pt"), QStringLiteral("por")}, {QStringLiteral("por"), QStringLiteral("por")},
-        {QStringLiteral("ru"), QStringLiteral("rus")}, {QStringLiteral("rus"), QStringLiteral("rus")},
-        {QStringLiteral("zh"), QStringLiteral("chi")}, {QStringLiteral("chi"), QStringLiteral("chi")},
-        {QStringLiteral("zho"), QStringLiteral("chi")},
-        {QStringLiteral("ko"), QStringLiteral("kor")}, {QStringLiteral("kor"), QStringLiteral("kor")},
-        {QStringLiteral("ar"), QStringLiteral("ara")}, {QStringLiteral("ara"), QStringLiteral("ara")},
-        {QStringLiteral("hi"), QStringLiteral("hin")}, {QStringLiteral("hin"), QStringLiteral("hin")},
-        {QStringLiteral("nl"), QStringLiteral("dut")}, {QStringLiteral("dut"), QStringLiteral("dut")},
-        {QStringLiteral("nld"), QStringLiteral("dut")},
-        {QStringLiteral("sv"), QStringLiteral("swe")}, {QStringLiteral("swe"), QStringLiteral("swe")},
-        {QStringLiteral("no"), QStringLiteral("nor")}, {QStringLiteral("nor"), QStringLiteral("nor")},
-        {QStringLiteral("da"), QStringLiteral("dan")}, {QStringLiteral("dan"), QStringLiteral("dan")},
-        {QStringLiteral("fi"), QStringLiteral("fin")}, {QStringLiteral("fin"), QStringLiteral("fin")},
-        {QStringLiteral("pl"), QStringLiteral("pol")}, {QStringLiteral("pol"), QStringLiteral("pol")},
-        {QStringLiteral("tr"), QStringLiteral("tur")}, {QStringLiteral("tur"), QStringLiteral("tur")},
-        {QStringLiteral("cs"), QStringLiteral("cze")}, {QStringLiteral("cze"), QStringLiteral("cze")},
-        {QStringLiteral("ces"), QStringLiteral("cze")},
-        {QStringLiteral("el"), QStringLiteral("gre")}, {QStringLiteral("gre"), QStringLiteral("gre")},
-        {QStringLiteral("ell"), QStringLiteral("gre")},
-        {QStringLiteral("he"), QStringLiteral("heb")}, {QStringLiteral("heb"), QStringLiteral("heb")},
-        {QStringLiteral("id"), QStringLiteral("ind")}, {QStringLiteral("ind"), QStringLiteral("ind")},
-        {QStringLiteral("tha"), QStringLiteral("tha")}, {QStringLiteral("th"), QStringLiteral("tha")},
-        {QStringLiteral("vi"), QStringLiteral("vie")}, {QStringLiteral("vie"), QStringLiteral("vie")}
-    };
-    return aliases.value(normalized, normalized);
-}
-
-int bestLanguageStreamIndex(const QVariantList &streams, const QString &language, bool subtitle)
-{
-    const QString normalizedPreference = normalizedLanguageCode(language);
-    if (normalizedPreference.isEmpty()) {
-        return -1;
-    }
-
-    int bestIndex = -1;
-    int bestScore = -1;
-    int ordinal = 0;
-    for (const QVariant &streamVariant : streams) {
-        const QVariantMap stream = streamVariant.toMap();
-        if (normalizedLanguageCode(stream.value(QStringLiteral("language")).toString()) != normalizedPreference) {
-            ++ordinal;
-            continue;
-        }
-
-        int score = 10000 - ordinal;
-        if (stream.value(QStringLiteral("isDefault"), false).toBool()) {
-            score += 100000;
-        } else if (subtitle) {
-            const bool forced = stream.value(QStringLiteral("isForced"), false).toBool();
-            const bool hearingImpaired = stream.value(QStringLiteral("isHearingImpaired"), false).toBool();
-            if (!forced && !hearingImpaired) {
-                score += 50000;
-            } else if (forced) {
-                score += 30000;
-            } else if (hearingImpaired) {
-                score += 10000;
-            }
-        }
-
-        if (score > bestScore) {
-            bestScore = score;
-            bestIndex = stream.value(QStringLiteral("index"), -1).toInt();
-        }
-        ++ordinal;
-    }
-    return bestIndex;
-}
-
 QString trackTitleForStream(const QVariantMap &stream)
 {
     const QString displayTitle = stream.value(QStringLiteral("displayTitle")).toString().trimmed();
@@ -395,66 +147,6 @@ QString trackTitleForStream(const QVariantMap &stream)
     return parts.join(QStringLiteral(" • "));
 }
 
-QString normalizedStringKey(const QString &value)
-{
-    return value.trimmed().toLower();
-}
-
-QString fileParentPathKey(const QString &value)
-{
-    QFileInfo info(value);
-    const QString parentPath = info.dir().absolutePath().replace(QLatin1Char('\\'), QLatin1Char('/'));
-    return normalizedStringKey(parentPath);
-}
-
-QString mediaSourceVideoDescriptor(const QVariantMap &mediaSource)
-{
-    QString codec;
-    QString profile;
-    QString videoRange;
-    int width = 0;
-    int height = 0;
-
-    const QVariantList streams = mediaStreamsForType(mediaSource, QStringLiteral("Video"));
-    if (!streams.isEmpty()) {
-        const QVariantMap videoStream = streams.first().toMap();
-        codec = normalizedStringKey(videoStream.value(QStringLiteral("codec")).toString());
-        profile = normalizedStringKey(videoStream.value(QStringLiteral("profile")).toString());
-        videoRange = normalizedStringKey(videoStream.value(QStringLiteral("videoRange")).toString());
-        width = videoStream.value(QStringLiteral("width")).toInt();
-        height = videoStream.value(QStringLiteral("height")).toInt();
-    }
-
-    return QStringLiteral("%1|%2|%3|%4x%5|%6|%7")
-        .arg(codec,
-             profile,
-             videoRange,
-             QString::number(width),
-             QString::number(height),
-             normalizedStringKey(mediaSource.value(QStringLiteral("container")).toString()),
-             QString::number(mediaSource.value(QStringLiteral("bitRate")).toInt()));
-}
-QVariantList primaryPresentationSources(const QVariantList &mediaSources)
-{
-    int firstPart = std::numeric_limits<int>::max();
-    for (const QVariant &value : mediaSources) {
-        const int part = value.toMap().value(QStringLiteral("presentationPartIndex")).toInt();
-        if (part > 0) {
-            firstPart = qMin(firstPart, part);
-        }
-    }
-    if (firstPart == std::numeric_limits<int>::max()) {
-        return mediaSources;
-    }
-
-    QVariantList result;
-    for (const QVariant &value : mediaSources) {
-        if (value.toMap().value(QStringLiteral("presentationPartIndex")).toInt() == firstPart) {
-            result.append(value);
-        }
-    }
-    return result;
-}
 }
 
 PlayerController::PlayerController(IPlayerBackend *playerBackend, ConfigManager *config, TrackPreferencesManager *trackPrefs, DisplayManager *displayManager, PlaybackService *playbackService, LibraryService *libraryService, AuthenticationService *authService, QObject *parent)
@@ -2570,7 +2262,8 @@ void PlayerController::maybeFinalizePendingPlaybackRequest(const QString &reques
 
     const PlaybackInfoResponse primaryPlaybackInfo = it->playbackInfos.value(it->itemId);
     const QVariantList primarySources =
-        primaryPresentationSources(primaryPlaybackInfo.getMediaSourcesVariant());
+        PlayerPolicy::primaryPresentationSources(
+            primaryPlaybackInfo.getMediaSourcesVariant());
     if (primarySources.size() > 1
         && it->allowVersionPrompt
         && it->chosenMediaSourceId.isEmpty()) {
@@ -2597,7 +2290,8 @@ void PlayerController::launchResolvedPlaybackRequest(const QString &requestId)
     const PlaybackInfoResponse primaryPlaybackInfo =
         request.playbackInfos.value(request.itemId);
     const QVariantList primaryMediaSources =
-        primaryPresentationSources(primaryPlaybackInfo.getMediaSourcesVariant());
+        PlayerPolicy::primaryPresentationSources(
+            primaryPlaybackInfo.getMediaSourcesVariant());
 
     if (primaryMediaSources.isEmpty()) {
         failPendingPlaybackRequest(requestId, tr("No playable media sources found."));
@@ -2871,8 +2565,9 @@ void PlayerController::onPlaybackDescriptorLoadedForRequest(
                               : mediaSourceIsHdr(m_pendingAutoplayDescriptorSource),
                           m_pendingAutoplayDescriptorSource.isEmpty()
                               ? m_pendingAutoplayToneMapToSdr
-                              : kindShouldToneMapToSdr(
-                                  classifyMediaSourceHdr(m_pendingAutoplayDescriptorSource),
+                              : PlayerPolicy::shouldToneMapToSdr(
+                                  PlayerPolicy::classifyMediaSourceHdr(
+                                      m_pendingAutoplayDescriptorSource),
                                   m_config->getDolbyVisionFallbackMode()));
         m_pendingAutoplayDescriptorContext.clear();
         return;
@@ -2947,7 +2642,8 @@ QVariantMap PlayerController::buildPlaybackVersionDialogModel(const QString &req
     QVariantList options;
     const PlaybackInfoResponse playbackInfo = it->playbackInfos.value(it->itemId);
     const QVariantList mediaSources =
-        primaryPresentationSources(playbackInfo.getMediaSourcesVariant());
+        PlayerPolicy::primaryPresentationSources(
+            playbackInfo.getMediaSourcesVariant());
     for (const QVariant &mediaSourceVariant : mediaSources) {
         const QVariantMap mediaSource = mediaSourceVariant.toMap();
         options.append(QVariantMap{
@@ -2968,47 +2664,15 @@ QVariantMap PlayerController::selectMediaSourceForRequest(const QVariantList &me
                                                           const QString &forcedMediaSourceId,
                                                           bool useAffinityFallback) const
 {
-    if (!forcedMediaSourceId.isEmpty()) {
-        for (const QVariant &mediaSourceVariant : mediaSources) {
-            const QVariantMap mediaSource = mediaSourceVariant.toMap();
-            if (mediaSource.value(QStringLiteral("id")).toString() == forcedMediaSourceId) {
-                return mediaSource;
-            }
-        }
-    }
-
-    if (useAffinityFallback) {
-        const QString preferredParentPath = normalizedStringKey(m_lastVersionParentPath);
-        if (!preferredParentPath.isEmpty()) {
-            for (const QVariant &mediaSourceVariant : mediaSources) {
-                const QVariantMap mediaSource = mediaSourceVariant.toMap();
-                if (mediaSourceParentPath(mediaSource) == preferredParentPath) {
-                    return mediaSource;
-                }
-            }
-        }
-
-        const QString preferredName = normalizedStringKey(m_lastVersionName);
-        if (!preferredName.isEmpty()) {
-            for (const QVariant &mediaSourceVariant : mediaSources) {
-                const QVariantMap mediaSource = mediaSourceVariant.toMap();
-                if (normalizedStringKey(mediaSource.value(QStringLiteral("name")).toString()) == preferredName) {
-                    return mediaSource;
-                }
-            }
-        }
-
-        if (!m_lastVersionSignature.isEmpty()) {
-            for (const QVariant &mediaSourceVariant : mediaSources) {
-                const QVariantMap mediaSource = mediaSourceVariant.toMap();
-                if (mediaSourceSignature(mediaSource) == m_lastVersionSignature) {
-                    return mediaSource;
-                }
-            }
-        }
-    }
-
-    return mediaSources.isEmpty() ? QVariantMap{} : mediaSources.first().toMap();
+    return PlayerPolicy::selectMediaSource(
+        mediaSources,
+        forcedMediaSourceId,
+        useAffinityFallback,
+        PlayerPolicy::VersionAffinity{
+            m_lastVersionParentPath,
+            m_lastVersionName,
+            m_lastVersionSignature
+        });
 }
 
 QVariantMap PlayerController::resolveSegmentPlaybackContext(const QString &scopeId, bool isMovie,
@@ -3032,7 +2696,8 @@ QVariantMap PlayerController::resolveSegmentPlaybackContext(const QString &scope
                                                                            isMovie,
                                                                            preferredAudioIndex,
                                                                            preferredSubtitleIndex);
-    const HdrContentKind hdrKind = classifyMediaSourceHdr(resolvedSource);
+    const PlayerPolicy::HdrContentKind hdrKind =
+        PlayerPolicy::classifyMediaSourceHdr(resolvedSource);
     return QVariantMap{
         {QStringLiteral("mediaSource"), resolvedSource},
         {QStringLiteral("mediaSourceId"), resolvedSource.value(QStringLiteral("id")).toString()},
@@ -3042,9 +2707,10 @@ QVariantMap PlayerController::resolveSegmentPlaybackContext(const QString &scope
         {QStringLiteral("availableAudioTracks"), buildAvailableTrackOptions(resolvedSource, QStringLiteral("Audio"))},
         {QStringLiteral("availableSubtitleTracks"), buildAvailableTrackOptions(resolvedSource, QStringLiteral("Subtitle"))},
         {QStringLiteral("framerate"), videoFramerateForMediaSource(resolvedSource)},
-        {QStringLiteral("isHDR"), kindIsHdr(hdrKind)},
-        {QStringLiteral("hdrKind"), QString::fromLatin1(hdrContentKindName(hdrKind))},
-        {QStringLiteral("toneMapToSdr"), kindShouldToneMapToSdr(hdrKind, m_config->getDolbyVisionFallbackMode())}
+        {QStringLiteral("isHDR"), PlayerPolicy::isHdr(hdrKind)},
+        {QStringLiteral("hdrKind"), PlayerPolicy::hdrContentKindName(hdrKind)},
+        {QStringLiteral("toneMapToSdr"), PlayerPolicy::shouldToneMapToSdr(
+             hdrKind, m_config->getDolbyVisionFallbackMode())}
     };
 }
 
@@ -3320,53 +2986,17 @@ void PlayerController::updateVersionAffinityFromMediaSource(const QVariantMap &m
 
 QString PlayerController::mediaSourceParentPath(const QVariantMap &mediaSource) const
 {
-    return fileParentPathKey(mediaSource.value(QStringLiteral("path")).toString());
+    return PlayerPolicy::mediaSourceParentPath(mediaSource);
 }
 
 QString PlayerController::mediaSourceSignature(const QVariantMap &mediaSource) const
 {
-    return mediaSourceVideoDescriptor(mediaSource);
+    return PlayerPolicy::mediaSourceSignature(mediaSource);
 }
 
 QString PlayerController::buildVersionSubtitle(const QVariantMap &mediaSource) const
 {
-    QStringList parts;
-    const QVariantList videoStreams = mediaStreamsForType(mediaSource, QStringLiteral("Video"));
-    if (!videoStreams.isEmpty()) {
-        const QVariantMap videoStream = videoStreams.first().toMap();
-        const int width = videoStream.value(QStringLiteral("width")).toInt();
-        const int height = videoStream.value(QStringLiteral("height")).toInt();
-        if (width > 0 && height > 0) {
-            parts.append(QStringLiteral("%1x%2").arg(width).arg(height));
-        }
-
-        const QString videoRange = videoStream.value(QStringLiteral("videoRange")).toString().trimmed();
-        if (!videoRange.isEmpty() && videoRange.compare(QStringLiteral("SDR"), Qt::CaseInsensitive) != 0) {
-            parts.append(videoRange.toUpper());
-        }
-
-        const QString codec = videoStream.value(QStringLiteral("codec")).toString().trimmed();
-        if (!codec.isEmpty()) {
-            parts.append(codec.toUpper());
-        }
-
-        const QString profile = videoStream.value(QStringLiteral("profile")).toString().trimmed();
-        if (!profile.isEmpty()) {
-            parts.append(profile);
-        }
-    }
-
-    const QString container = mediaSource.value(QStringLiteral("container")).toString().trimmed();
-    if (!container.isEmpty()) {
-        parts.append(container.toUpper());
-    }
-
-    const int bitrate = mediaSource.value(QStringLiteral("bitRate")).toInt();
-    if (bitrate > 0) {
-        parts.append(QStringLiteral("%1 Mbps").arg(QString::number(static_cast<double>(bitrate) / 1000000.0, 'f', 1)));
-    }
-
-    return parts.join(QStringLiteral(" • "));
+    return PlayerPolicy::buildVersionSubtitle(mediaSource);
 }
 
 /**
@@ -4843,167 +4473,15 @@ PlayerController::ResolvedTrackSelection PlayerController::resolveTrackSelection
                                                                                  int preferredAudioIndex,
                                                                                  int preferredSubtitleIndex) const
 {
-    ResolvedTrackSelection resolved;
-    const QVariantList audioStreams = mediaStreamsForType(mediaSource, QStringLiteral("Audio"));
-    const QVariantList subtitleStreams = mediaStreamsForType(mediaSource, QStringLiteral("Subtitle"));
-
-    const auto resolveProviderAudioDefault = [&]() -> std::pair<int, QString> {
-        const int providerDefault = mediaSource.value(QStringLiteral("defaultAudioStreamIndex"), -1).toInt();
-        if (providerDefault >= 0 && hasStreamIndex(audioStreams, providerDefault)) {
-            return {providerDefault, QStringLiteral("jellyfin-default")};
-        }
-        return {-1, {}};
-    };
-
-    const auto resolveFileAudioDefault = [&]() -> std::pair<int, QString> {
-        const int fileDefault = firstMatchingStreamIndex(audioStreams, [](const QVariantMap &stream) {
-            return stream.value(QStringLiteral("isDefault"), false).toBool();
-        });
-        if (fileDefault >= 0) {
-            return {fileDefault, QStringLiteral("file-default")};
-        }
-        return {-1, {}};
-    };
-
-    const auto resolveBuiltInAudioFallback = [&]() -> std::pair<int, QString> {
-        const auto [providerDefault, providerSource] = resolveProviderAudioDefault();
-        if (providerDefault >= 0) {
-            return {providerDefault, providerSource};
-        }
-
-        const auto [fileDefault, fileSource] = resolveFileAudioDefault();
-        if (fileDefault >= 0) {
-            return {fileDefault, fileSource};
-        }
-
-        const int fallback = firstMatchingStreamIndex(audioStreams, [](const QVariantMap &) {
-            return true;
-        });
-        return {fallback, fallback >= 0 ? QStringLiteral("fallback") : QStringLiteral("none")};
-    };
-
-    const auto resolveProviderSubtitleDefault = [&]() -> std::pair<int, QString> {
-        const int providerDefault = mediaSource.value(QStringLiteral("defaultSubtitleStreamIndex"), -1).toInt();
-        if (providerDefault >= 0 && hasStreamIndex(subtitleStreams, providerDefault)) {
-            return {providerDefault, QStringLiteral("jellyfin-default")};
-        }
-        return {-1, {}};
-    };
-
-    const auto resolveFileSubtitleDefault = [&]() -> std::pair<int, QString> {
-        const int fileDefault = firstMatchingStreamIndex(subtitleStreams, [](const QVariantMap &stream) {
-            return stream.value(QStringLiteral("isDefault"), false).toBool();
-        });
-        if (fileDefault >= 0) {
-            return {fileDefault, QStringLiteral("file-default")};
-        }
-        return {-1, {}};
-    };
-
-    const auto resolveBuiltInSubtitleFallback = [&]() -> std::pair<int, QString> {
-        const auto [providerDefault, providerSource] = resolveProviderSubtitleDefault();
-        if (providerDefault >= 0) {
-            return {providerDefault, providerSource};
-        }
-
-        const auto [fileDefault, fileSource] = resolveFileSubtitleDefault();
-        if (fileDefault >= 0) {
-            return {fileDefault, fileSource};
-        }
-
-        const int forcedDefault = firstMatchingStreamIndex(subtitleStreams, [](const QVariantMap &stream) {
-            return stream.value(QStringLiteral("isForced"), false).toBool();
-        });
-        if (forcedDefault >= 0) {
-            return {forcedDefault, QStringLiteral("forced-default")};
-        }
-
-        return {-1, QStringLiteral("fallback-off")};
-    };
-
-    const auto resolveGlobalAudioDefault = [&]() -> std::pair<int, QString> {
-        const QString selection = m_config ? m_config->getDefaultAudioTrackSelection() : QStringLiteral("jellyfin-default");
-        if (selection == QStringLiteral("file-default")) {
-            const auto [fileDefault, fileSource] = resolveFileAudioDefault();
-            if (fileDefault >= 0) {
-                return {fileDefault, fileSource};
-            }
-            return resolveBuiltInAudioFallback();
-        }
-        if (selection != QStringLiteral("jellyfin-default")) {
-            const int languageDefault = bestLanguageStreamIndex(audioStreams, selection, false);
-            if (languageDefault >= 0) {
-                return {languageDefault, QStringLiteral("global-language")};
-            }
-        }
-        return resolveBuiltInAudioFallback();
-    };
-
-    const auto resolveGlobalSubtitleDefault = [&]() -> std::pair<int, QString> {
-        const QString selection = m_config ? m_config->getDefaultSubtitleTrackSelection() : QStringLiteral("jellyfin-default");
-        if (selection == QStringLiteral("off")) {
-            return {-1, QStringLiteral("global-off")};
-        }
-        if (selection == QStringLiteral("forced")) {
-            const int forcedDefault = firstMatchingStreamIndex(subtitleStreams, [](const QVariantMap &stream) {
-                return stream.value(QStringLiteral("isForced"), false).toBool();
-            });
-            if (forcedDefault >= 0) {
-                return {forcedDefault, QStringLiteral("global-forced")};
-            }
-            return {-1, QStringLiteral("global-forced-off")};
-        }
-        if (selection == QStringLiteral("file-default")) {
-            const auto [fileDefault, fileSource] = resolveFileSubtitleDefault();
-            if (fileDefault >= 0) {
-                return {fileDefault, fileSource};
-            }
-            return resolveBuiltInSubtitleFallback();
-        }
-        if (selection != QStringLiteral("jellyfin-default")) {
-            const int languageDefault = bestLanguageStreamIndex(subtitleStreams, selection, true);
-            if (languageDefault >= 0) {
-                return {languageDefault, QStringLiteral("global-language")};
-            }
-        }
-        return resolveBuiltInSubtitleFallback();
-    };
-
-    const auto resolveAudio = [&]() -> std::pair<int, QString> {
-        if (preferredAudioIndex >= 0 && hasStreamIndex(audioStreams, preferredAudioIndex)) {
-            return {preferredAudioIndex, QStringLiteral("override")};
-        }
-        if (preferences.audio.mode == TrackPreferenceMode::ExplicitStream
-            && hasStreamIndex(audioStreams, preferences.audio.streamIndex)) {
-            return {preferences.audio.streamIndex, QStringLiteral("explicit")};
-        }
-        return resolveGlobalAudioDefault();
-    };
-
-    const auto resolveSubtitle = [&]() -> std::pair<int, QString> {
-        if (preferredSubtitleIndex == -1) {
-            return {-1, QStringLiteral("override-off")};
-        }
-        if (preferredSubtitleIndex >= 0 && hasStreamIndex(subtitleStreams, preferredSubtitleIndex)) {
-            return {preferredSubtitleIndex, QStringLiteral("override")};
-        }
-        if (preferences.subtitle.mode == TrackPreferenceMode::Off) {
-            return {-1, QStringLiteral("explicit-off")};
-        }
-        if (preferences.subtitle.mode == TrackPreferenceMode::ExplicitStream
-            && hasStreamIndex(subtitleStreams, preferences.subtitle.streamIndex)) {
-            return {preferences.subtitle.streamIndex, QStringLiteral("explicit")};
-        }
-        return resolveGlobalSubtitleDefault();
-    };
-
-    const auto [audioIndex, audioSource] = resolveAudio();
-    const auto [subtitleIndex, subtitleSource] = resolveSubtitle();
-    resolved.audioIndex = audioIndex;
-    resolved.subtitleIndex = subtitleIndex;
-    resolved.audioSource = audioSource;
-    resolved.subtitleSource = subtitleSource;
-    return resolved;
+    return PlayerPolicy::resolveTrackSelection(
+        mediaSource,
+        preferences,
+        m_config ? m_config->getDefaultAudioTrackSelection()
+                 : QStringLiteral("jellyfin-default"),
+        m_config ? m_config->getDefaultSubtitleTrackSelection()
+                 : QStringLiteral("jellyfin-default"),
+        preferredAudioIndex,
+        preferredSubtitleIndex);
 }
 
 void PlayerController::syncBackendAudioTrack(int mpvTrackId)
@@ -5278,7 +4756,8 @@ double PlayerController::videoFramerateForMediaSource(const QVariantMap &mediaSo
 
 bool PlayerController::mediaSourceIsHdr(const QVariantMap &mediaSource) const
 {
-    return kindIsHdr(classifyMediaSourceHdr(mediaSource));
+    return PlayerPolicy::isHdr(
+        PlayerPolicy::classifyMediaSourceHdr(mediaSource));
 }
 
 // === PRIVATE HELPERS ===
@@ -5504,12 +4983,14 @@ void PlayerController::checkCompletionThreshold()
 
 bool PlayerController::wouldMeetCompletionThreshold() const
 {
-    return !m_hasEvaluatedCompletionForAttempt
-           && !m_currentItemId.isEmpty()
-           && m_duration > 0
-           && !m_currentSeriesId.isEmpty()
-           && ((m_currentPosition / m_duration) * 100.0)
-                  >= m_config->getPlaybackCompletionThreshold();
+    return PlayerPolicy::meetsCompletionThreshold({
+        m_hasEvaluatedCompletionForAttempt,
+        m_currentItemId,
+        m_currentSeriesId,
+        m_currentPosition,
+        m_duration,
+        m_config->getPlaybackCompletionThreshold()
+    });
 }
 
 /**
@@ -5554,19 +5035,19 @@ bool PlayerController::checkCompletionThresholdAndAutoplay()
  */
 void PlayerController::maybeTriggerNextEpisodePrefetch()
 {
-    if (m_nextEpisodePrefetchRequestedForAttempt
-        || m_currentSeriesId.isEmpty()
-        || m_currentItemId.isEmpty()
-        || m_duration <= 0.0
-        || (m_playbackState != Playing && m_playbackState != Paused)) {
+    if (!PlayerPolicy::shouldPrefetchNextEpisode({
+            m_nextEpisodePrefetchRequestedForAttempt,
+            m_playbackState == Playing || m_playbackState == Paused,
+            m_currentSeriesId,
+            m_currentItemId,
+            m_currentPosition,
+            m_duration,
+            kNextEpisodePrefetchTriggerPercent
+        })) {
         return;
     }
 
     const double progressPercent = (m_currentPosition / m_duration) * 100.0;
-    if (progressPercent < kNextEpisodePrefetchTriggerPercent) {
-        return;
-    }
-
     m_nextEpisodePrefetchRequestedForAttempt = true;
     qCDebug(lcPlayback) << "Triggering next-episode prefetch"
                         << "itemId=" << m_currentItemId
@@ -5579,16 +5060,16 @@ void PlayerController::maybeTriggerNextEpisodePrefetch()
 
 QString PlayerController::expectedPrefetchRequestContext() const
 {
-    return buildNextEpisodeRequestContext(QStringLiteral("prefetch"),
-                                          m_currentSeriesId,
-                                          m_currentItemId);
+    return PlayerPolicy::nextEpisodeRequestContext(
+        QStringLiteral("prefetch"), m_currentSeriesId, m_currentItemId);
 }
 
 QString PlayerController::expectedAutoplayResolutionRequestContext() const
 {
-    return buildNextEpisodeRequestContext(QStringLiteral("resolve"),
-                                          m_pendingAutoplaySeriesId,
-                                          m_pendingAutoplayItemId);
+    return PlayerPolicy::nextEpisodeRequestContext(
+        QStringLiteral("resolve"),
+        m_pendingAutoplaySeriesId,
+        m_pendingAutoplayItemId);
 }
 
 bool PlayerController::matchesPlaybackRequestContext(const QString &requestContext,
@@ -5621,26 +5102,14 @@ bool PlayerController::matchesPlaybackRequestContext(const QString &requestConte
  */
 bool PlayerController::hasUsablePrefetchedNextEpisode() const
 {
-    const QString prefetchedEpisodeId = m_prefetchedNextEpisodeData.value(QStringLiteral("itemId")).toString();
-    if (!m_nextEpisodePrefetchReady
-        || m_prefetchedNextEpisodeData.isEmpty()
-        || prefetchedEpisodeId.isEmpty()) {
-        return false;
-    }
-    if (m_prefetchedNextEpisodeSeriesId.isEmpty()
-        || m_prefetchedNextEpisodeSeriesId != m_pendingAutoplaySeriesId) {
-        return false;
-    }
-    if (m_prefetchedForItemId.isEmpty()
-        || m_prefetchedForItemId != m_pendingAutoplayItemId) {
-        return false;
-    }
-    // Jellyfin may still return the currently playing episode until mark-played settles.
-    // Never consume a prefetched candidate that points to the just-finished item.
-    if (prefetchedEpisodeId == m_pendingAutoplayItemId) {
-        return false;
-    }
-    return true;
+    return PlayerPolicy::isUsablePrefetchedEpisode({
+        m_nextEpisodePrefetchReady,
+        m_prefetchedNextEpisodeData,
+        m_prefetchedNextEpisodeSeriesId,
+        m_prefetchedForItemId,
+        m_pendingAutoplaySeriesId,
+        m_pendingAutoplayItemId
+    });
 }
 
 /**
@@ -5957,21 +5426,11 @@ void PlayerController::startPlayback(const QString &url)
 
 PlayerController::HdrPlaybackPolicy PlayerController::computeEffectiveHdrPlaybackPolicy() const
 {
-    HdrPlaybackPolicy policy;
-    if (!m_contentIsHDR) {
-        return policy;
-    }
-
-    const QString hdrOutputMode = m_config->getHDROutputMode();
-    policy.toneMapToSdr = m_contentShouldToneMapToSdr
-        || !m_config->getEnableHDR()
-        || hdrOutputMode == QStringLiteral("tone-map-to-sdr");
-    policy.outputHdr = m_config->getEnableHDR()
-        && !policy.toneMapToSdr
-        && (hdrOutputMode == QStringLiteral("match-content")
-            || hdrOutputMode == QStringLiteral("force-hdr-experimental"));
-    policy.shouldToggleDisplayHdr = policy.outputHdr;
-    return policy;
+    return PlayerPolicy::evaluateHdrPlayback(
+        m_contentIsHDR,
+        m_contentShouldToneMapToSdr,
+        m_config->getEnableHDR(),
+        m_config->getHDROutputMode());
 }
 
 void PlayerController::applyFramerateMatchingAndStart()

--- a/src/player/PlayerController.h
+++ b/src/player/PlayerController.h
@@ -16,6 +16,7 @@
 #include <functional>
 #include <memory>
 #include "backend/IPlayerBackend.h"
+#include "PlaybackPolicy.h"
 #include "TrickplayProcessor.h"
 #include "../network/Types.h"
 #include "../models/MediaModels.h"
@@ -471,12 +472,7 @@ private:
     };
 
     struct PendingPlaybackRequest;
-    struct HdrPlaybackPolicy
-    {
-        bool toneMapToSdr = false;
-        bool outputHdr = false;
-        bool shouldToggleDisplayHdr = false;
-    };
+    using HdrPlaybackPolicy = Bloom::PlaybackPolicy::HdrPlaybackPolicy;
     // State machine
     void setupStateMachine();
     bool processEvent(Event event);
@@ -646,13 +642,8 @@ private:
      * @returns `true` if a fallback was initiated, `false` otherwise.
      */
     bool tryFallbackToExternalBackend(const QString &reason);
-    struct ResolvedTrackSelection
-    {
-        int audioIndex = -1;
-        int subtitleIndex = -1;
-        QString audioSource;
-        QString subtitleSource;
-    };
+    using ResolvedTrackSelection =
+        Bloom::PlaybackPolicy::ResolvedTrackSelection;
 
     void updateTrackMappings(const QVariantMap &mediaSource);
     /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ set(BLOOM_LINKED_PRODUCTION_SOURCES
     ${CMAKE_SOURCE_DIR}/src/security/CredentialStore.cpp
     ${CMAKE_SOURCE_DIR}/src/ui/ImageCacheProvider.cpp
     ${CMAKE_SOURCE_DIR}/src/ui/ImageCacheStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/player/PlaybackPolicy.cpp
     ${CMAKE_SOURCE_DIR}/src/player/PlayerProcessManager.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/BloomLogging.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/DisplayManager.cpp
@@ -97,6 +98,12 @@ function(bloom_use_production_libraries test_target)
     set(player_process_source ${CMAKE_SOURCE_DIR}/src/player/PlayerProcessManager.cpp)
     if(player_process_source IN_LIST test_sources)
         target_link_libraries(${test_target} PRIVATE Bloom::PlayerProcess)
+    endif()
+    set(player_controller_source ${CMAKE_SOURCE_DIR}/src/player/PlayerController.cpp)
+    set(player_policy_source ${CMAKE_SOURCE_DIR}/src/player/PlaybackPolicy.cpp)
+    if(player_controller_source IN_LIST test_sources
+       OR player_policy_source IN_LIST test_sources)
+        target_link_libraries(${test_target} PRIVATE Bloom::PlayerPolicy)
     endif()
     set(display_manager_source ${CMAKE_SOURCE_DIR}/src/utils/DisplayManager.cpp)
     if(display_manager_source IN_LIST test_sources)
@@ -626,6 +633,24 @@ target_link_libraries(PlayerProcessManagerTest
 )
 
 add_test(NAME PlayerProcessManagerTest COMMAND PlayerProcessManagerTest)
+
+add_executable(PlaybackPolicyTest
+    PlaybackPolicyTest.cpp
+)
+
+target_include_directories(PlaybackPolicyTest PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+target_link_libraries(PlaybackPolicyTest
+    PRIVATE
+        Bloom::PlayerPolicy
+        Qt6::Core
+        Qt6::Test
+)
+
+add_test(NAME PlaybackPolicyTest COMMAND PlaybackPolicyTest)
 
 add_executable(DisplayManagerTest
     DisplayManagerTest.cpp

--- a/tests/PlaybackPolicyTest.cpp
+++ b/tests/PlaybackPolicyTest.cpp
@@ -1,0 +1,419 @@
+#include <QtTest/QtTest>
+
+#include "player/PlaybackPolicy.h"
+
+namespace PlayerPolicy = Bloom::PlaybackPolicy;
+
+namespace {
+
+QVariantMap stream(const QString &type,
+                   int index,
+                   const QString &language = {},
+                   bool isDefault = false,
+                   bool isForced = false,
+                   bool isHearingImpaired = false)
+{
+    return {
+        {QStringLiteral("type"), type},
+        {QStringLiteral("index"), index},
+        {QStringLiteral("language"), language},
+        {QStringLiteral("isDefault"), isDefault},
+        {QStringLiteral("isForced"), isForced},
+        {QStringLiteral("isHearingImpaired"), isHearingImpaired}
+    };
+}
+
+QVariantMap mediaSource(const QString &id,
+                        const QString &name,
+                        const QString &path,
+                        const QVariantList &streams = {})
+{
+    return {
+        {QStringLiteral("id"), id},
+        {QStringLiteral("name"), name},
+        {QStringLiteral("path"), path},
+        {QStringLiteral("mediaStreams"), streams}
+    };
+}
+
+QVariantMap videoStream(const QString &range,
+                        int dolbyVisionProfile = 0,
+                        int compatibilityId = 0,
+                        const QString &title = {})
+{
+    QVariantMap result = stream(QStringLiteral("Video"), 0);
+    result.insert(QStringLiteral("videoRange"), range);
+    result.insert(QStringLiteral("dolbyVisionProfile"), dolbyVisionProfile);
+    result.insert(QStringLiteral("dolbyVisionBlSignalCompatibilityId"),
+                  compatibilityId);
+    result.insert(QStringLiteral("title"), title);
+    return result;
+}
+
+} // namespace
+
+class PlaybackPolicyTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void normalizesLanguageAliases_data();
+    void normalizesLanguageAliases();
+    void scoresLanguageStreamsDeterministically();
+    void resolvesTrackSelectionPrecedence();
+    void classifiesHdrAndDolbyVision();
+    void evaluatesHdrOutputPolicy();
+    void selectsVersionsByForcedIdAndAffinity();
+    void filtersMultipartSourcesAndBuildsSubtitles();
+    void evaluatesCompletionAndPrefetchThresholds();
+    void validatesPrefetchedEpisodesAndContexts();
+};
+
+void PlaybackPolicyTest::normalizesLanguageAliases_data()
+{
+    QTest::addColumn<QString>("input");
+    QTest::addColumn<QString>("expected");
+
+    QTest::newRow("English ISO-639-1") << QStringLiteral(" EN ")
+                                        << QStringLiteral("eng");
+    QTest::newRow("French terminology") << QStringLiteral("fra")
+                                         << QStringLiteral("fre");
+    QTest::newRow("German bibliographic") << QStringLiteral("ger")
+                                           << QStringLiteral("ger");
+    QTest::newRow("unknown normalized") << QStringLiteral(" X-Custom ")
+                                         << QStringLiteral("x-custom");
+    QTest::newRow("empty") << QString{} << QString{};
+}
+
+void PlaybackPolicyTest::normalizesLanguageAliases()
+{
+    QFETCH(QString, input);
+    QFETCH(QString, expected);
+    QCOMPARE(PlayerPolicy::normalizeLanguageCode(input), expected);
+}
+
+void PlaybackPolicyTest::scoresLanguageStreamsDeterministically()
+{
+    const QVariantList audioStreams{
+        stream(QStringLiteral("Audio"), 1, QStringLiteral("eng")),
+        stream(QStringLiteral("Audio"), 2, QStringLiteral("en"), true),
+        stream(QStringLiteral("Audio"), 3, QStringLiteral("jpn"))
+    };
+    QCOMPARE(PlayerPolicy::bestLanguageStreamIndex(
+                 audioStreams, QStringLiteral("en"), false),
+             2);
+
+    const QVariantList subtitleStreams{
+        stream(QStringLiteral("Subtitle"), 10, QStringLiteral("eng"),
+               false, true),
+        stream(QStringLiteral("Subtitle"), 11, QStringLiteral("en"),
+               false, false, true),
+        stream(QStringLiteral("Subtitle"), 12, QStringLiteral("eng")),
+        stream(QStringLiteral("Subtitle"), 13, QStringLiteral("jpn"))
+    };
+    QCOMPARE(PlayerPolicy::bestLanguageStreamIndex(
+                 subtitleStreams, QStringLiteral("eng"), true),
+             12);
+    QCOMPARE(PlayerPolicy::bestLanguageStreamIndex(
+                 subtitleStreams, QStringLiteral("spa"), true),
+             -1);
+}
+
+void PlaybackPolicyTest::resolvesTrackSelectionPrecedence()
+{
+    QVariantMap source = mediaSource(
+        QStringLiteral("source"),
+        QStringLiteral("Version"),
+        QStringLiteral("/media/show/episode.mkv"),
+        {
+            stream(QStringLiteral("Audio"), 1, QStringLiteral("eng"), true),
+            stream(QStringLiteral("Audio"), 2, QStringLiteral("jpn")),
+            stream(QStringLiteral("Subtitle"), 5, QStringLiteral("eng"),
+                   false, true),
+            stream(QStringLiteral("Subtitle"), 6, QStringLiteral("jpn"), true),
+            stream(QStringLiteral("Subtitle"), 7, QStringLiteral("eng"))
+        });
+    source.insert(QStringLiteral("defaultAudioStreamIndex"), 1);
+    source.insert(QStringLiteral("defaultSubtitleStreamIndex"), 5);
+
+    ScopedTrackPreferences preferences;
+    preferences.audio.mode = TrackPreferenceMode::ExplicitStream;
+    preferences.audio.streamIndex = 2;
+    preferences.subtitle.mode = TrackPreferenceMode::ExplicitStream;
+    preferences.subtitle.streamIndex = 6;
+
+    auto resolved = PlayerPolicy::resolveTrackSelection(
+        source,
+        preferences,
+        QStringLiteral("eng"),
+        QStringLiteral("eng"),
+        1,
+        -1);
+    QCOMPARE(resolved.audioIndex, 1);
+    QCOMPARE(resolved.audioSource, QStringLiteral("override"));
+    QCOMPARE(resolved.subtitleIndex, -1);
+    QCOMPARE(resolved.subtitleSource, QStringLiteral("override-off"));
+
+    resolved = PlayerPolicy::resolveTrackSelection(
+        source,
+        preferences,
+        QStringLiteral("eng"),
+        QStringLiteral("eng"));
+    QCOMPARE(resolved.audioIndex, 2);
+    QCOMPARE(resolved.audioSource, QStringLiteral("explicit"));
+    QCOMPARE(resolved.subtitleIndex, 6);
+    QCOMPARE(resolved.subtitleSource, QStringLiteral("explicit"));
+
+    preferences = {};
+    preferences.subtitle.mode = TrackPreferenceMode::Off;
+    resolved = PlayerPolicy::resolveTrackSelection(
+        source,
+        preferences,
+        QStringLiteral("jpn"),
+        QStringLiteral("jellyfin-default"));
+    QCOMPARE(resolved.audioIndex, 2);
+    QCOMPARE(resolved.audioSource, QStringLiteral("global-language"));
+    QCOMPARE(resolved.subtitleIndex, -1);
+    QCOMPARE(resolved.subtitleSource, QStringLiteral("explicit-off"));
+
+    preferences = {};
+    resolved = PlayerPolicy::resolveTrackSelection(
+        source,
+        preferences,
+        QStringLiteral("jellyfin-default"),
+        QStringLiteral("forced"));
+    QCOMPARE(resolved.audioIndex, 1);
+    QCOMPARE(resolved.audioSource, QStringLiteral("jellyfin-default"));
+    QCOMPARE(resolved.subtitleIndex, 5);
+    QCOMPARE(resolved.subtitleSource, QStringLiteral("global-forced"));
+
+    source.remove(QStringLiteral("defaultSubtitleStreamIndex"));
+    source[QStringLiteral("mediaStreams")] = QVariantList{
+        stream(QStringLiteral("Audio"), 8),
+        stream(QStringLiteral("Subtitle"), 9, QStringLiteral("eng"))
+    };
+    resolved = PlayerPolicy::resolveTrackSelection(
+        source,
+        {},
+        QStringLiteral("jellyfin-default"),
+        QStringLiteral("forced"));
+    QCOMPARE(resolved.audioIndex, 8);
+    QCOMPARE(resolved.audioSource, QStringLiteral("fallback"));
+    QCOMPARE(resolved.subtitleIndex, -1);
+    QCOMPARE(resolved.subtitleSource, QStringLiteral("global-forced-off"));
+}
+
+void PlaybackPolicyTest::classifiesHdrAndDolbyVision()
+{
+    using enum PlayerPolicy::HdrContentKind;
+
+    QCOMPARE(PlayerPolicy::classifyMediaSourceHdr(
+                 mediaSource(QStringLiteral("sdr"), {}, {},
+                             {videoStream(QStringLiteral("SDR"))})),
+             Sdr);
+    QCOMPARE(PlayerPolicy::classifyMediaSourceHdr(
+                 mediaSource(QStringLiteral("hdr"), {}, {},
+                             {videoStream(QStringLiteral("HDR10"))})),
+             Hdr);
+    QCOMPARE(PlayerPolicy::classifyMediaSourceHdr(
+                 mediaSource(QStringLiteral("dv5"), {}, {},
+                             {videoStream({}, 5)})),
+             DolbyVisionUnsupported);
+    QCOMPARE(PlayerPolicy::classifyMediaSourceHdr(
+                 mediaSource(QStringLiteral("dv7"), {}, {},
+                             {videoStream({}, 7)})),
+             DolbyVisionCompatible);
+    QCOMPARE(PlayerPolicy::classifyMediaSourceHdr(
+                 mediaSource(QStringLiteral("dv-compatible"), {}, {},
+                             {videoStream({}, 5, 1)})),
+             DolbyVisionCompatible);
+    QCOMPARE(PlayerPolicy::classifyMediaSourceHdr(
+                 mediaSource(QStringLiteral("metadata"),
+                             QStringLiteral("Dolby Vision HDR10"),
+                             QStringLiteral("/media/episode.mkv"),
+                             {videoStream({})})),
+             DolbyVisionCompatible);
+
+    QVERIFY(PlayerPolicy::isHdr(DolbyVisionUnsupported));
+    QVERIFY(!PlayerPolicy::isHdr(Sdr));
+    QVERIFY(PlayerPolicy::shouldToneMapToSdr(
+        DolbyVisionUnsupported, QStringLiteral("tone-map")));
+    QVERIFY(!PlayerPolicy::shouldToneMapToSdr(
+        DolbyVisionUnsupported,
+        QStringLiteral("experimental-direct-play")));
+    QCOMPARE(PlayerPolicy::hdrContentKindName(DolbyVisionCompatible),
+             QStringLiteral("dolby-vision-compatible"));
+}
+
+void PlaybackPolicyTest::evaluatesHdrOutputPolicy()
+{
+    auto policy = PlayerPolicy::evaluateHdrPlayback(
+        false, false, true, QStringLiteral("match-content"));
+    QVERIFY(!policy.toneMapToSdr);
+    QVERIFY(!policy.outputHdr);
+    QVERIFY(!policy.shouldToggleDisplayHdr);
+
+    policy = PlayerPolicy::evaluateHdrPlayback(
+        true, false, true, QStringLiteral("match-content"));
+    QVERIFY(!policy.toneMapToSdr);
+    QVERIFY(policy.outputHdr);
+    QVERIFY(policy.shouldToggleDisplayHdr);
+
+    policy = PlayerPolicy::evaluateHdrPlayback(
+        true, false, false, QStringLiteral("match-content"));
+    QVERIFY(policy.toneMapToSdr);
+    QVERIFY(!policy.outputHdr);
+
+    policy = PlayerPolicy::evaluateHdrPlayback(
+        true, true, true, QStringLiteral("force-hdr-experimental"));
+    QVERIFY(policy.toneMapToSdr);
+    QVERIFY(!policy.outputHdr);
+}
+
+void PlaybackPolicyTest::selectsVersionsByForcedIdAndAffinity()
+{
+    QVariantMap first = mediaSource(QStringLiteral("first"),
+                                    QStringLiteral("1080p"),
+                                    QStringLiteral("/media/show/1080/ep.mkv"),
+                                    {videoStream(QStringLiteral("SDR"))});
+    QVariantMap sameParent = mediaSource(QStringLiteral("parent"),
+                                         QStringLiteral("Other"),
+                                         QStringLiteral("/media/show/4k/next.mkv"),
+                                         {videoStream(QStringLiteral("HDR10"))});
+    QVariantMap sameName = mediaSource(QStringLiteral("name"),
+                                       QStringLiteral("1080P"),
+                                       QStringLiteral("/elsewhere/next.mkv"),
+                                       {videoStream(QStringLiteral("SDR"))});
+    QVariantMap sameSignature = mediaSource(QStringLiteral("signature"),
+                                            QStringLiteral("Different"),
+                                            QStringLiteral("/third/next.mkv"),
+                                            {videoStream(QStringLiteral("SDR"))});
+    QVariantList signatureStreams = sameSignature.value(
+        QStringLiteral("mediaStreams")).toList();
+    QVariantMap signatureVideo = signatureStreams.first().toMap();
+    signatureVideo.insert(QStringLiteral("codec"), QStringLiteral("av1"));
+    signatureStreams[0] = signatureVideo;
+    sameSignature[QStringLiteral("mediaStreams")] = signatureStreams;
+    const QVariantList sources{first, sameParent, sameName, sameSignature};
+
+    PlayerPolicy::VersionAffinity affinity{
+        PlayerPolicy::mediaSourceParentPath(sameParent),
+        QStringLiteral("1080p"),
+        PlayerPolicy::mediaSourceSignature(first)
+    };
+    QCOMPARE(PlayerPolicy::selectMediaSource(
+                 sources, QStringLiteral("signature"), true, affinity)
+                 .value(QStringLiteral("id")).toString(),
+             QStringLiteral("signature"));
+    QCOMPARE(PlayerPolicy::selectMediaSource(
+                 sources, {}, true, affinity)
+                 .value(QStringLiteral("id")).toString(),
+             QStringLiteral("parent"));
+
+    affinity.parentPath.clear();
+    affinity.name = QStringLiteral("Other");
+    QCOMPARE(PlayerPolicy::selectMediaSource(sources, {}, true, affinity)
+                 .value(QStringLiteral("id")).toString(),
+             QStringLiteral("parent"));
+
+    affinity.name.clear();
+    affinity.signature = PlayerPolicy::mediaSourceSignature(sameSignature);
+    QCOMPARE(PlayerPolicy::selectMediaSource(sources, {}, true, affinity)
+                 .value(QStringLiteral("id")).toString(),
+             QStringLiteral("signature"));
+
+    QCOMPARE(PlayerPolicy::selectMediaSource(sources, {}, false, affinity)
+                 .value(QStringLiteral("id")).toString(),
+             QStringLiteral("first"));
+    QVERIFY(PlayerPolicy::selectMediaSource({}, {}, true, affinity).isEmpty());
+}
+
+void PlaybackPolicyTest::filtersMultipartSourcesAndBuildsSubtitles()
+{
+    QVariantMap partTwo = mediaSource(QStringLiteral("part-two"), {}, {});
+    partTwo.insert(QStringLiteral("presentationPartIndex"), 2);
+    QVariantMap partOneA = mediaSource(QStringLiteral("part-one-a"), {}, {});
+    partOneA.insert(QStringLiteral("presentationPartIndex"), 1);
+    QVariantMap partOneB = mediaSource(QStringLiteral("part-one-b"), {}, {});
+    partOneB.insert(QStringLiteral("presentationPartIndex"), 1);
+
+    const QVariantList primary = PlayerPolicy::primaryPresentationSources(
+        {partTwo, partOneA, partOneB});
+    QCOMPARE(primary.size(), 2);
+    QCOMPARE(primary.at(0).toMap().value(QStringLiteral("id")).toString(),
+             QStringLiteral("part-one-a"));
+
+    QVariantMap source = mediaSource(
+        QStringLiteral("source"), {}, {},
+        {QVariantMap{
+            {QStringLiteral("type"), QStringLiteral("Video")},
+            {QStringLiteral("width"), 3840},
+            {QStringLiteral("height"), 2160},
+            {QStringLiteral("videoRange"), QStringLiteral("HDR10")},
+            {QStringLiteral("codec"), QStringLiteral("hevc")},
+            {QStringLiteral("profile"), QStringLiteral("Main 10")}
+        }});
+    source.insert(QStringLiteral("container"), QStringLiteral("mkv"));
+    source.insert(QStringLiteral("bitRate"), 25000000);
+    QCOMPARE(PlayerPolicy::buildVersionSubtitle(source),
+             QStringLiteral("3840x2160 • HDR10 • HEVC • Main 10 • MKV • 25.0 Mbps"));
+}
+
+void PlaybackPolicyTest::evaluatesCompletionAndPrefetchThresholds()
+{
+    PlayerPolicy::CompletionInput completion{
+        false, QStringLiteral("episode"), QStringLiteral("series"),
+        90.0, 100.0, 90
+    };
+    QVERIFY(PlayerPolicy::meetsCompletionThreshold(completion));
+    completion.positionSeconds = 89.999;
+    QVERIFY(!PlayerPolicy::meetsCompletionThreshold(completion));
+    completion.positionSeconds = 100.0;
+    completion.alreadyEvaluated = true;
+    QVERIFY(!PlayerPolicy::meetsCompletionThreshold(completion));
+    completion.alreadyEvaluated = false;
+    completion.seriesId.clear();
+    QVERIFY(!PlayerPolicy::meetsCompletionThreshold(completion));
+
+    PlayerPolicy::PrefetchInput prefetch{
+        false, true, QStringLiteral("series"), QStringLiteral("episode"),
+        75.0, 100.0, 75.0
+    };
+    QVERIFY(PlayerPolicy::shouldPrefetchNextEpisode(prefetch));
+    prefetch.playbackActive = false;
+    QVERIFY(!PlayerPolicy::shouldPrefetchNextEpisode(prefetch));
+    prefetch.playbackActive = true;
+    prefetch.alreadyRequested = true;
+    QVERIFY(!PlayerPolicy::shouldPrefetchNextEpisode(prefetch));
+}
+
+void PlaybackPolicyTest::validatesPrefetchedEpisodesAndContexts()
+{
+    PlayerPolicy::PrefetchedEpisodeInput input{
+        true,
+        QVariantMap{{QStringLiteral("itemId"), QStringLiteral("next")}},
+        QStringLiteral("series"),
+        QStringLiteral("current"),
+        QStringLiteral("series"),
+        QStringLiteral("current")
+    };
+    QVERIFY(PlayerPolicy::isUsablePrefetchedEpisode(input));
+    input.episode[QStringLiteral("itemId")] = QStringLiteral("current");
+    QVERIFY(!PlayerPolicy::isUsablePrefetchedEpisode(input));
+    input.episode[QStringLiteral("itemId")] = QStringLiteral("next");
+    input.prefetchedSeriesId = QStringLiteral("stale-series");
+    QVERIFY(!PlayerPolicy::isUsablePrefetchedEpisode(input));
+
+    QCOMPARE(PlayerPolicy::nextEpisodeRequestContext(
+                 QStringLiteral("prefetch"),
+                 QStringLiteral("series"),
+                 QStringLiteral("episode")),
+             QStringLiteral("player:prefetch:series:episode"));
+    QVERIFY(PlayerPolicy::nextEpisodeRequestContext(
+                {}, QStringLiteral("series"), QStringLiteral("episode"))
+                .isEmpty());
+}
+
+QTEST_APPLESS_MAIN(PlaybackPolicyTest)
+
+#include "PlaybackPolicyTest.moc"


### PR DESCRIPTION
## Summary
- extract language normalization, stream scoring/selection, HDR/Dolby Vision policy, version affinity, completion, and next-episode decisions from `PlayerController`
- keep `PlayerController` as the stable QML-facing state coordinator and preserve existing playback behavior
- add the Qt-Core-only reusable `Bloom::PlayerPolicy` target with focused regression coverage
- document the new playback policy boundary and CMake ownership

## Verification
- `./scripts/dev-build.sh --tests --jobs 4`
- `nix develop --command ctest --test-dir build-dev --output-on-failure` (34/34, including visual regression)
- `nix flake check --print-build-logs` (Release, QML lint, isolated 32-test derivation)
- `nix build --print-build-logs`

## Platform notes
- Pure-policy tests require no media server, mpv, display, GPU, or playback hardware.
- Windows embedded libmpv and physical HDR/display behavior are unchanged and remain covered by exact-head CI plus the existing manual hardware validation requirements.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract pure playback policy logic from `PlayerController` into `Bloom::PlayerPolicy`
> - Moves all stateless playback decisions (language normalization, track selection, HDR/Dolby Vision classification, media source selection, completion thresholds, next-episode prefetch logic) out of `PlayerController` and into a new `Bloom::PlaybackPolicy` namespace in [PlaybackPolicy.cpp](https://github.com/crowquillx/Bloom/pull/129/files#diff-b9cb51cc4d600c772c9f95f1b202830401eaceab349b89ceafad4163ed528b8a) and [PlaybackPolicy.h](https://github.com/crowquillx/Bloom/pull/129/files#diff-351f200fad7d5d087d0b71b6663b7c88c185de2ce8b1957c4dd502e400086df8).
> - Builds the new code as a separate static library target `BloomPlayerPolicy` (linked as `Bloom::PlayerPolicy`), constrained to Qt6::Core only — no I/O, no QObject.
> - `PlayerController` is reduced to a QML-facing facade that delegates all policy decisions to `PlayerPolicy::*` free functions via a namespace alias.
> - Adds a `PlaybackPolicyTest` Qt test executable in [tests/PlaybackPolicyTest.cpp](https://github.com/crowquillx/Bloom/pull/129/files#diff-0a64233a331d7323564132fc4f90a7cfb7786f17e994fcf0602654b480a00701) covering language normalization, track selection precedence, HDR classification, media source affinity, completion/prefetch thresholds, and episode validation.
> - Behavioral Change: logic is preserved by contract, but the extracted functions are now independently testable and the separation means future changes to policy are isolated from QML/controller state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 278e142.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->