### PR TITLE
ci: add production analysis and smoke checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,18 @@
 ---
-Checks:          'bugprone-*,performance-*,readability-*,qt-*'
-WarningsAsErrors: 'qt-*'
-CheckOptions:
-  - key:             readability-identifier-naming.ClassCase
-    value:           CamelCase
+Checks: >-
+  -*,
+  clang-analyzer-core.*,
+  clang-analyzer-cplusplus.*,
+  clang-analyzer-unix.*,
+  bugprone-dangling-handle,
+  bugprone-sizeof-expression,
+  bugprone-suspicious-enum-usage,
+  bugprone-unchecked-optional-access,
+  bugprone-unique-ptr-array-mismatch,
+  bugprone-use-after-move,
+  performance-move-const-arg,
+  performance-unnecessary-copy-initialization
+WarningsAsErrors: '*'
+HeaderFilterRegex: '^.*/src/'
+SystemHeaders: false
 ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,12 @@ jobs:
             done
           }
           retry nix build \
+            .#checks.x86_64-linux.automation-lint \
             .#checks.x86_64-linux.qml-lint \
             .#checks.x86_64-linux.tests \
             .#checks.x86_64-linux.metadata \
             .#checks.x86_64-linux.release-manifest \
+            .#checks.x86_64-linux.release-smoke \
             --print-build-logs --option max-jobs 1 --option cores 4
           retry nix build .#bloom --print-build-logs --option max-jobs 1 --option cores 4
 

--- a/.github/workflows/deep-analysis.yml
+++ b/.github/workflows/deep-analysis.yml
@@ -1,0 +1,87 @@
+name: Deep analysis
+
+on:
+  schedule:
+    - cron: '41 7 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: bloom-deep-analysis-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  clang-tidy:
+    name: Targeted clang-tidy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+      - name: Analyze ownership and security boundaries
+        env:
+          BLOOM_BUILD_JOBS: '4'
+        run: nix develop .#analysis --command ./scripts/run-clang-tidy.sh
+
+  sanitizers:
+    name: ${{ matrix.label }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mode: address
+            label: ASan and UBSan
+          - mode: thread
+            label: Targeted TSAN
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+      - name: Build and run instrumented tests
+        env:
+          BLOOM_BUILD_JOBS: '4'
+        run: nix develop .#analysis --command ./scripts/run-sanitizers.sh '${{ matrix.mode }}'
+
+  coverage:
+    name: Coverage report
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+      - name: Build tests and collect coverage
+        env:
+          BLOOM_BUILD_JOBS: '4'
+        run: nix develop .#analysis --command ./scripts/run-coverage.sh
+      - name: Add coverage to run summary
+        run: |
+          {
+            echo '## Bloom coverage'
+            echo '```text'
+            cat build-analysis/coverage-report/coverage.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: bloom-coverage-${{ github.sha }}
+          path: build-analysis/coverage-report
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -24,10 +24,12 @@ jobs:
           BLOOM_BUILD_JOBS: '2'
         run: |
           nix build \
+            .#checks.x86_64-linux.automation-lint \
             .#checks.x86_64-linux.qml-lint \
             .#checks.x86_64-linux.tests \
             .#checks.x86_64-linux.metadata \
             .#checks.x86_64-linux.release-manifest \
+            .#checks.x86_64-linux.release-smoke \
             .#bloom \
             --print-build-logs --option max-jobs 1 --option cores 2
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # ===========================
 build/
 build-dev/
+build-analysis/
 build_verify/
 build-docker/
 build-windows/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,8 +124,11 @@ License: See `LICENSE`.
 
 Testing policy:
 - The Nix `.#checks.x86_64-linux.tests` derivation runs automatically in CI,
-  alongside the other flake checks; `nix flake check` remains the blessed local
-  command for the full check suite.
+  alongside structural QML lint and the offscreen Release startup smoke;
+  `nix flake check` remains the blessed local command for the full check suite.
+- Targeted clang-tidy, ASan/UBSan, concurrency-focused TSAN, and coverage run
+  in the scheduled/on-demand deep-analysis workflow. Keep those checks scoped
+  to meaningful ownership boundaries and do not make normal PR CI unbounded.
 - Live provider/server, display, GPU, and playback contracts requiring hosts or
   runtime hardware remain manual validation; unavailable environments are not
   automated passes.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
+include(cmake/BloomAnalysis.cmake)
+
 if(WIN32)
     add_compile_definitions(NOMINMAX)
 endif()

--- a/cmake/BloomAnalysis.cmake
+++ b/cmake/BloomAnalysis.cmake
@@ -1,0 +1,36 @@
+# Opt-in compiler instrumentation used by local and scheduled deep checks.
+# Normal developer, pull-request, packaging, and release builds remain unchanged.
+set(BLOOM_SANITIZER "none" CACHE STRING "Compiler sanitizer: none, address, or thread")
+set_property(CACHE BLOOM_SANITIZER PROPERTY STRINGS none address thread)
+option(BLOOM_ENABLE_COVERAGE "Instrument Bloom tests for gcov-compatible coverage" OFF)
+
+set(_bloom_valid_sanitizers none address thread)
+if(NOT BLOOM_SANITIZER IN_LIST _bloom_valid_sanitizers)
+    message(FATAL_ERROR
+        "Invalid BLOOM_SANITIZER '${BLOOM_SANITIZER}'. Expected one of: ${_bloom_valid_sanitizers}")
+endif()
+
+if((NOT BLOOM_SANITIZER STREQUAL "none" OR BLOOM_ENABLE_COVERAGE)
+   AND NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    message(FATAL_ERROR "Bloom analysis instrumentation requires GCC or Clang")
+endif()
+
+if(BLOOM_ENABLE_COVERAGE AND NOT BLOOM_SANITIZER STREQUAL "none")
+    message(FATAL_ERROR "Coverage and sanitizer instrumentation use separate build trees")
+endif()
+
+if(BLOOM_SANITIZER STREQUAL "address")
+    # Several focused tests intentionally link narrow PlayerController stubs;
+    # vptr instrumentation requires the omitted facade RTTI. All other UBSan
+    # checks remain enabled alongside ASan.
+    add_compile_options(
+        -fsanitize=address,undefined -fno-sanitize=vptr -fno-omit-frame-pointer)
+    add_link_options(
+        -fsanitize=address,undefined -fno-sanitize=vptr -fno-omit-frame-pointer)
+elseif(BLOOM_SANITIZER STREQUAL "thread")
+    add_compile_options(-fsanitize=thread -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=thread -fno-omit-frame-pointer)
+elseif(BLOOM_ENABLE_COVERAGE)
+    add_compile_options(--coverage -fprofile-abs-path -fno-omit-frame-pointer)
+    add_link_options(--coverage)
+endif()

--- a/docs/build.md
+++ b/docs/build.md
@@ -111,8 +111,8 @@ full report for 90 days, providing a lightweight history without adding a
 third-party reporting credential. Coverage is a trend signal rather than a
 line-percentage merge gate; behavior-specific regression tests remain the
 primary requirement. The initial deterministic-suite baseline measured on
-August 11, 2026 is 54.5% lines (16,216/29,781), 57.1% functions
-(1,410/2,471), and 44.9% branches (19,426/43,247).
+August 11, 2026 is 54.9% lines (16,352/29,781), 57.5% functions
+(1,422/2,471), and 45.4% branches (19,633/43,247).
 
 For custom CMake-based instrumentation, `BLOOM_SANITIZER` accepts `none`,
 `address`, or `thread`, and `BLOOM_ENABLE_COVERAGE=ON` enables gcov-compatible

--- a/docs/build.md
+++ b/docs/build.md
@@ -61,12 +61,64 @@ nix flake check --print-build-logs \
 ```
 
 This builds Bloom and runs the deterministic unit/contract tests, QML lint,
-desktop/AppStream validation, and release-manifest validation. The CI `nix`
+desktop/AppStream validation, release-manifest validation, and an offscreen
+Release startup/version smoke test. ShellCheck and actionlint also validate the
+deep-analysis scripts and workflow definitions. The CI `nix`
 job builds the same `.#checks.x86_64-linux.tests` derivation alongside the
 other checks, so pull requests and dependency updates exercise automated
 tests. Live provider/server, display, GPU, and playback contracts that require
 hosts or runtime hardware remain manual validation; unavailable environments
 are recorded as unavailable rather than treated as automated passes.
+
+QML lint treats structural diagnostics such as duplicate bindings, cycles,
+invalid directives, assignments in conditions, and unreachable code as
+errors. Context-property and generated-type diagnostics remain visible but are
+not promoted globally because several runtime-injected QML objects cannot yet
+be modeled accurately by `qmllint`.
+
+## Deep analysis
+
+The normal pull-request workflow stays focused on the reproducible Release
+build, deterministic tests, QML lint, and Windows packaging. More expensive
+compiler instrumentation runs every Sunday and on demand through the `Deep
+analysis` workflow:
+
+```bash
+./scripts/run-clang-tidy.sh
+./scripts/run-sanitizers.sh address
+./scripts/run-sanitizers.sh thread
+./scripts/run-coverage.sh
+```
+
+Each script enters the pinned `.#analysis` Nix shell automatically, leaving the
+normal development shell unchanged, and uses a separate ignored directory
+below `build-analysis/`. The clang-tidy gate covers
+the image-cache, process/IPC, display, playback-policy, and updater ownership
+boundaries with high-confidence analyzer, lifetime, optional, move, and copy
+checks. The address job combines ASan with UBSan; vptr instrumentation alone is
+disabled because focused updater tests intentionally link a narrow
+`PlayerController` stub instead of the full facade. TSAN is limited to the
+process-manager and display-manager concurrency tests. The image-cache worker
+remains covered by direct concurrent-access tests and ASan/UBSan; TSAN against
+the system's uninstrumented Qt library reports the queued
+`QMetaObject::invokeMethod` allocation handoff as a framework race, so Bloom
+does not hide that report with a broad Qt-event suppression.
+
+Coverage runs the deterministic Linux suite and writes Cobertura XML, HTML,
+JSON summary, and text output to `build-analysis/coverage-report/`. Scheduled
+runs publish the text totals in the GitHub Actions run summary and retain the
+full report for 90 days, providing a lightweight history without adding a
+third-party reporting credential. Coverage is a trend signal rather than a
+line-percentage merge gate; behavior-specific regression tests remain the
+primary requirement. The initial deterministic-suite baseline measured on
+August 11, 2026 is 54.5% lines (16,216/29,781), 57.1% functions
+(1,410/2,471), and 44.9% branches (19,426/43,247).
+
+For custom CMake-based instrumentation, `BLOOM_SANITIZER` accepts `none`,
+`address`, or `thread`, and `BLOOM_ENABLE_COVERAGE=ON` enables gcov-compatible
+coverage. Sanitizer and coverage instrumentation must use separate build
+trees. These options require GCC or Clang and are intentionally off for MSVC,
+packaging, and release builds.
 
 Production models, configuration, transport, provider, and network code is
 compiled through reusable `Bloom::*` CMake libraries. Tests link those targets

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,44 @@
           inherit bloom;
           tests = pkgs.callPackage ./nix/tests.nix { };
           qml-lint = pkgs.callPackage ./nix/qml-lint.nix { };
+          release-smoke =
+            pkgs.runCommand "bloom-release-smoke"
+              {
+                nativeBuildInputs = [ pkgs.gnugrep ];
+              }
+              ''
+                export HOME="$TMPDIR/home"
+                export XDG_CACHE_HOME="$TMPDIR/cache"
+                mkdir -p "$HOME" "$XDG_CACHE_HOME"
+                export FONTCONFIG_FILE=${pkgs.fontconfig.out}/etc/fonts/fonts.conf
+                export LC_ALL=C.UTF-8
+                export QT_QPA_PLATFORM=offscreen
+                output="$(${bloom}/bin/bloom --version 2>&1)"
+                printf '%s\n' "$output"
+                test "$output" = "Bloom ${bloom.version}"
+                help_output="$(${bloom}/bin/bloom --help 2>&1)"
+                printf '%s\n' "$help_output" | grep -F -- "--verbose, -v"
+                touch "$out"
+              '';
+          automation-lint =
+            pkgs.runCommand "bloom-automation-lint"
+              {
+                nativeBuildInputs = with pkgs; [
+                  actionlint
+                  shellcheck
+                ];
+              }
+              ''
+                shellcheck \
+                  ${./scripts/run-clang-tidy.sh} \
+                  ${./scripts/run-coverage.sh} \
+                  ${./scripts/run-sanitizers.sh}
+                actionlint \
+                  ${./.github/workflows/ci.yml} \
+                  ${./.github/workflows/deep-analysis.yml} \
+                  ${./.github/workflows/update-dependencies.yml}
+                touch "$out"
+              '';
           metadata =
             pkgs.runCommand "bloom-metadata-check"
               {
@@ -126,26 +164,24 @@
         let
           pkgs = import nixpkgs { inherit system; };
           bloom = self.packages.${system}.bloom;
-        in
-        {
-          default = pkgs.mkShell {
-            name = "bloom";
+          commonPackages = with pkgs; [
+            appstream
+            cachix
+            ccache
+            desktop-file-utils
+            flatpak
+            flatpak-builder
+            gdb
+            git
+            jq
+            nixfmt
+            podman
+            python3
+            skopeo
+          ];
+          commonShellArgs = {
             inputsFrom = [ bloom ];
-            packages = with pkgs; [
-              appstream
-              cachix
-              ccache
-              desktop-file-utils
-              flatpak
-              flatpak-builder
-              gdb
-              git
-              jq
-              nixfmt
-              podman
-              python3
-              skopeo
-            ];
+            packages = commonPackages;
             shellHook = ''
               export QT_PLUGIN_PATH="${
                 pkgs.lib.makeSearchPath "lib/qt-6/plugins" [
@@ -177,6 +213,22 @@
               echo "  package:  nix run .#package-linux -- --output dist"
             '';
           };
+        in
+        {
+          default = pkgs.mkShell (commonShellArgs // { name = "bloom"; });
+          analysis = pkgs.mkShell (
+            commonShellArgs
+            // {
+              name = "bloom-analysis";
+              packages = commonPackages ++ [
+                pkgs.clang-tools
+                pkgs.gcovr
+              ];
+              shellHook = commonShellArgs.shellHook + ''
+                export BLOOM_ANALYSIS_SHELL=1
+              '';
+            }
+          );
         }
       );
 

--- a/nix/qml-lint.nix
+++ b/nix/qml-lint.nix
@@ -45,7 +45,17 @@ stdenv.mkDerivation {
     cmake --build . --parallel "$NIX_BUILD_CORES" --target \
       Bloom_copy_qml Bloom_copy_res Bloom_qmltyperegistration
     mapfile -t qml_files < <(find src/BloomUI/ui -type f -name '*.qml' | sort)
-    qmllint -I src -I ${qt6.qtdeclarative}/lib/qt-6/qml "''${qml_files[@]}"
+    # Keep context-dependent warnings visible while making high-confidence
+    # structural defects fail the build.
+    qmllint \
+      --alias-cycle error \
+      --assignment-in-condition error \
+      --duplicate-import error \
+      --duplicate-property-binding error \
+      --inheritance-cycle error \
+      --invalid-lint-directive error \
+      --unreachable-code error \
+      -I src -I ${qt6.qtdeclarative}/lib/qt-6/qml "''${qml_files[@]}"
     runHook postBuild
   '';
   installPhase = ''

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -9,6 +9,7 @@ lib.fileset.toSource {
     [
       ../CMakeLists.txt
       ../VERSION
+      ../cmake
       ../config
       ../src
       ../third_party/monocypher

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${BLOOM_ANALYSIS_BUILD_DIR:-$ROOT/build-analysis/clang-tidy}"
+JOBS="${BLOOM_BUILD_JOBS:-$(nproc)}"
+
+if [[ -z "${BLOOM_ANALYSIS_SHELL:-}" ]]; then
+    exec nix develop "$ROOT#analysis" --command "$ROOT/scripts/run-clang-tidy.sh"
+fi
+
+for required_command in cmake clang-tidy xargs; do
+    command -v "$required_command" >/dev/null || {
+        echo "Required analysis command not found: $required_command" >&2
+        exit 1
+    }
+done
+
+cmake -S "$ROOT" -B "$BUILD_DIR" -G Ninja \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -DBUILD_TESTING=OFF \
+    -DBLOOM_BUNDLE_LIBMPV=OFF
+
+# Keep the normal PR signal high by statically analyzing the ownership and
+# security boundaries changed by the production refactor. Scheduled runs use
+# this same deterministic list.
+sources=(
+    "$ROOT/src/player/PlaybackPolicy.cpp"
+    "$ROOT/src/player/PlayerProcessManager.cpp"
+    "$ROOT/src/ui/ImageCacheStore.cpp"
+    "$ROOT/src/updates/UpdateManifestVerifier.cpp"
+    "$ROOT/src/updates/UpdateNetworkPolicy.cpp"
+    "$ROOT/src/updates/WindowsNsisUpdateApplier.cpp"
+    "$ROOT/src/utils/DisplayManager.cpp"
+)
+
+printf '%s\0' "${sources[@]}" \
+    | xargs -0 -n 1 -P "$JOBS" clang-tidy -p "$BUILD_DIR" --quiet

--- a/scripts/run-coverage.sh
+++ b/scripts/run-coverage.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${BLOOM_ANALYSIS_BUILD_DIR:-$ROOT/build-analysis/coverage}"
+REPORT_DIR="${BLOOM_COVERAGE_REPORT_DIR:-$ROOT/build-analysis/coverage-report}"
+JOBS="${BLOOM_BUILD_JOBS:-$(nproc)}"
+
+if [[ -z "${BLOOM_ANALYSIS_SHELL:-}" ]]; then
+    exec nix develop "$ROOT#analysis" --command "$ROOT/scripts/run-coverage.sh"
+fi
+
+for required_command in cmake gcovr jq; do
+    command -v "$required_command" >/dev/null || {
+        echo "Required coverage command not found: $required_command" >&2
+        exit 1
+    }
+done
+
+cmake -S "$ROOT" -B "$BUILD_DIR" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DBUILD_TESTING=ON \
+    -DBLOOM_BUILD_VISUAL_TESTS=OFF \
+    -DBLOOM_BUNDLE_LIBMPV=OFF \
+    -DBLOOM_ENABLE_COVERAGE=ON
+cmake --build "$BUILD_DIR" --parallel "$JOBS"
+
+export QT_QPA_PLATFORM=offscreen
+ctest --test-dir "$BUILD_DIR" --output-on-failure --timeout 120 \
+    --exclude-regex '^(VisualRegressionTest|SeriesDetailsCacheTest)$'
+
+cmake -E make_directory "$REPORT_DIR"
+gcovr --root "$ROOT" \
+    --filter "$ROOT/src" \
+    --exclude "$ROOT/src/test" \
+    --exclude-unreachable-branches \
+    --exclude-throw-branches \
+    --xml "$REPORT_DIR/coverage.xml" \
+    --xml-pretty \
+    --html-details "$REPORT_DIR/coverage.html" \
+    --json-summary "$REPORT_DIR/coverage-summary.json" \
+    --json-summary-pretty \
+    "$BUILD_DIR"
+jq -r '
+    "Lines:     \(.line_covered)/\(.line_total) (\(.line_percent)%)",
+    "Functions: \(.function_covered)/\(.function_total) (\(.function_percent)%)",
+    "Branches:  \(.branch_covered)/\(.branch_total) (\(.branch_percent)%)"
+' "$REPORT_DIR/coverage-summary.json" > "$REPORT_DIR/coverage.txt"
+cat "$REPORT_DIR/coverage.txt"

--- a/scripts/run-coverage.sh
+++ b/scripts/run-coverage.sh
@@ -25,9 +25,16 @@ cmake -S "$ROOT" -B "$BUILD_DIR" -G Ninja \
     -DBLOOM_ENABLE_COVERAGE=ON
 cmake --build "$BUILD_DIR" --parallel "$JOBS"
 
+configured_root="$(sed -n 's/^CMAKE_HOME_DIRECTORY:INTERNAL=//p' "$BUILD_DIR/CMakeCache.txt")"
+if [[ "$configured_root" != "$ROOT" ]]; then
+    echo "Refusing to clear coverage counters outside Bloom's configured build tree: $BUILD_DIR" >&2
+    exit 1
+fi
+find "$BUILD_DIR" -type f -name '*.gcda' -delete
+
 export QT_QPA_PLATFORM=offscreen
 ctest --test-dir "$BUILD_DIR" --output-on-failure --timeout 120 \
-    --exclude-regex '^(VisualRegressionTest|SeriesDetailsCacheTest)$'
+    --exclude-regex '^VisualRegressionTest$'
 
 cmake -E make_directory "$REPORT_DIR"
 gcovr --root "$ROOT" \

--- a/scripts/run-sanitizers.sh
+++ b/scripts/run-sanitizers.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODE="${1:-address}"
+JOBS="${BLOOM_BUILD_JOBS:-$(nproc)}"
+
+case "$MODE" in
+    address)
+        BUILD_DIR="${BLOOM_ANALYSIS_BUILD_DIR:-$ROOT/build-analysis/address}"
+        TEST_REGEX='^(ImageCacheStoreTest|PlayerProcessManagerTest|PlaybackPolicyTest|DisplayManagerTest|ProviderTransportTest|UpdateServiceTest)$'
+        ;;
+    thread)
+        BUILD_DIR="${BLOOM_ANALYSIS_BUILD_DIR:-$ROOT/build-analysis/thread}"
+        TEST_REGEX='^(PlayerProcessManagerTest|DisplayManagerTest)$'
+        ;;
+    *)
+        echo "Usage: $0 address|thread" >&2
+        exit 2
+        ;;
+esac
+
+if [[ -z "${BLOOM_ANALYSIS_SHELL:-}" ]]; then
+    exec nix develop "$ROOT#analysis" --command "$ROOT/scripts/run-sanitizers.sh" "$MODE"
+fi
+
+cmake -S "$ROOT" -B "$BUILD_DIR" -G Ninja \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DBUILD_TESTING=ON \
+    -DBLOOM_BUILD_VISUAL_TESTS=OFF \
+    -DBLOOM_BUNDLE_LIBMPV=OFF \
+    -DBLOOM_SANITIZER="$MODE"
+
+if [[ "$MODE" == "address" ]]; then
+    targets=(
+        ImageCacheStoreTest
+        PlayerProcessManagerTest
+        PlaybackPolicyTest
+        DisplayManagerTest
+        ProviderTransportTest
+        UpdateServiceTest
+    )
+    export ASAN_OPTIONS="detect_leaks=1:halt_on_error=1:strict_string_checks=1"
+    export UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1"
+else
+    targets=(PlayerProcessManagerTest DisplayManagerTest)
+    # QtTest intentionally leaves its process-wide watchdog thread to process
+    # teardown. Ignore thread-leak reports from that framework watchdog while
+    # retaining all data-race failures; lifecycle completion has direct tests.
+    export TSAN_OPTIONS="halt_on_error=1:history_size=7:report_thread_leaks=0"
+fi
+
+cmake --build "$BUILD_DIR" --parallel "$JOBS" --target "${targets[@]}"
+export QT_QPA_PLATFORM=offscreen
+ctest --test-dir "$BUILD_DIR" --output-on-failure --timeout 120 \
+    --tests-regex "$TEST_REGEX"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -139,7 +139,12 @@ int main(int argc, char *argv[])
     QCommandLineParser parser;
     parser.setApplicationDescription("Bloom - Media Client for Jellyfin and Silo Servers (experimental native Silo support)");
     parser.addHelpOption();
-    parser.addVersionOption();
+    // Keep -v available for the documented verbose mode. Qt's convenience
+    // version option also claims -v, so Bloom owns a long-only version option.
+    QCommandLineOption versionOption(
+        QStringList() << "version",
+        "Displays version information."
+    );
     
     QCommandLineOption testModeOption(
         QStringList() << "test-mode",
@@ -162,11 +167,17 @@ int main(int argc, char *argv[])
         "Enable full debug logging (overrides settings.logging.level for this session)."
     );
     
+    parser.addOption(versionOption);
     parser.addOption(testModeOption);
     parser.addOption(fixtureOption);
     parser.addOption(resolutionOption);
     parser.addOption(verboseOption);
     parser.process(app);
+
+    if (parser.isSet(versionOption)) {
+        std::printf("Bloom %s\n", BLOOM_VERSION);
+        return 0;
+    }
     
     // Initialize test mode if requested
     if (parser.isSet(testModeOption)) {

--- a/src/providers/jellyfin/JellyfinCatalogProvider.h
+++ b/src/providers/jellyfin/JellyfinCatalogProvider.h
@@ -4,6 +4,7 @@
 
 #include <QJsonDocument>
 #include <QJsonParseError>
+#include <QTimeZone>
 #include <QUrl>
 #include <QUrlQuery>
 #include <QtGlobal>
@@ -386,17 +387,17 @@ private:
         if (query.minPremiereDate.isValid()) {
             urlQuery.addQueryItem(
                 QStringLiteral("MinPremiereDate"),
-                query.minPremiereDate.startOfDay(Qt::UTC).toString(Qt::ISODate));
+                query.minPremiereDate.startOfDay(QTimeZone::UTC).toString(Qt::ISODate));
         }
         if (query.maxPremiereDate.isValid()) {
             urlQuery.addQueryItem(
                 QStringLiteral("MaxPremiereDate"),
-                query.maxPremiereDate.endOfDay(Qt::UTC).toString(Qt::ISODate));
+                query.maxPremiereDate.endOfDay(QTimeZone::UTC).toString(Qt::ISODate));
         }
         if (query.minDateLastSaved.isValid()) {
             urlQuery.addQueryItem(
                 QStringLiteral("MinDateLastSaved"),
-                query.minDateLastSaved.startOfDay(Qt::UTC).toString(Qt::ISODate));
+                query.minDateLastSaved.startOfDay(QTimeZone::UTC).toString(Qt::ISODate));
         }
         if (query.watched != ProviderCatalogTriState::Any) {
             urlQuery.addQueryItem(

--- a/src/ui/HeroBanner.qml
+++ b/src/ui/HeroBanner.qml
@@ -372,8 +372,8 @@ FocusScope {
         id: combinedLayoutComponent
         Item {
             anchors.fill: parent
-            property alias playButton: heroActions.playButtonRef
-            property alias detailsButton: heroActions.detailsButtonRef
+            property alias playButton: combinedHeroActions.playButtonRef
+            property alias detailsButton: combinedHeroActions.detailsButtonRef
 
             HeroBannerLayoutHost {
                 id: combinedHost
@@ -386,7 +386,7 @@ FocusScope {
                 HeroMetadataRow { layoutBlockAlignment: combinedHost.contentLayoutAlignment }
                 HeroSynopsisText { layoutBlockAlignment: combinedHost.contentLayoutAlignment }
                 HeroActionsRow {
-                    id: heroActions
+                    id: combinedHeroActions
                     layoutBlockAlignment: combinedHost.contentLayoutAlignment
                 }
             }
@@ -397,8 +397,8 @@ FocusScope {
         id: splitLayoutComponent
         Item {
             anchors.fill: parent
-            property alias playButton: heroActions.playButtonRef
-            property alias detailsButton: heroActions.detailsButtonRef
+            property alias playButton: splitHeroActions.playButtonRef
+            property alias detailsButton: splitHeroActions.detailsButtonRef
 
             HeroBannerLayoutHost {
                 id: logoHost
@@ -418,7 +418,7 @@ FocusScope {
                 HeroMetadataRow { layoutBlockAlignment: infoHost.contentLayoutAlignment }
                 HeroSynopsisText { layoutBlockAlignment: infoHost.contentLayoutAlignment }
                 HeroActionsRow {
-                    id: heroActions
+                    id: splitHeroActions
                     layoutBlockAlignment: infoHost.contentLayoutAlignment
                 }
             }

--- a/src/ui/ImageCacheStore.cpp
+++ b/src/ui/ImageCacheStore.cpp
@@ -784,7 +784,7 @@ private:
 };
 
 ImageCacheStore::ImageCacheStore(QString cacheDirectory, qint64 maximumSizeBytes)
-    : m_cacheDirectory(QDir::cleanPath(std::move(cacheDirectory)))
+    : m_cacheDirectory(QDir::cleanPath(cacheDirectory))
     , m_worker(new ImageCacheStoreWorker(m_cacheDirectory, maximumSizeBytes))
 {
     m_thread.setObjectName(QStringLiteral("BloomImageCacheStore"));

--- a/tests/ImageCacheStoreTest.cpp
+++ b/tests/ImageCacheStoreTest.cpp
@@ -392,5 +392,5 @@ void ImageCacheStoreTest::persistedIdentityIsCredentialFree()
     QVERIFY(!bytes.contains("token"));
 }
 
-QTEST_MAIN(ImageCacheStoreTest)
+QTEST_GUILESS_MAIN(ImageCacheStoreTest)
 #include "ImageCacheStoreTest.moc"

--- a/tests/ProviderCatalogTest.cpp
+++ b/tests/ProviderCatalogTest.cpp
@@ -1,5 +1,6 @@
 #include <QtTest/QtTest>
 
+#include <QDate>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -87,6 +88,9 @@ void ProviderCatalogTest::jellyfinItemsRequestRetainsNativeContract()
     query.sortOrder = QStringLiteral("descending");
     query.watched = ProviderCatalogTriState::No;
     query.recursive = true;
+    query.minPremiereDate = QDate(2020, 2, 3);
+    query.maxPremiereDate = QDate(2024, 11, 12);
+    query.minDateLastSaved = QDate(2026, 8, 7);
     query.useCacheValidation = true;
     query.etag = QByteArrayLiteral("\"catalog-v2\"");
     query.lastModified = QByteArrayLiteral("Fri, 07 Aug 2026 10:00:00 GMT");
@@ -124,6 +128,12 @@ void ProviderCatalogTest::jellyfinItemsRequestRetainsNativeContract()
              QStringLiteral("false"));
     QCOMPARE(parameters.queryItemValue(QStringLiteral("Recursive")),
              QStringLiteral("true"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("MinPremiereDate")),
+             QStringLiteral("2020-02-03T00:00:00Z"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("MaxPremiereDate")),
+             QStringLiteral("2024-11-12T23:59:59Z"));
+    QCOMPARE(parameters.queryItemValue(QStringLiteral("MinDateLastSaved")),
+             QStringLiteral("2026-08-07T00:00:00Z"));
     QVERIFY(parameters.queryItemValue(QStringLiteral("Fields"))
                 .contains(QStringLiteral("MediaSources")));
     QCOMPARE(parameters.queryItemValue(QStringLiteral("EnableImageTypes")),


### PR DESCRIPTION
## Summary

- add a scheduled/on-demand deep-analysis workflow for targeted clang-tidy, ASan/UBSan, concurrency-focused TSAN, and retained coverage reports
- add opt-in CMake sanitizer/coverage instrumentation and keep the normal development/PR path lean through a separate Nix analysis shell
- strengthen QML structural lint, add ShellCheck/actionlint, and add an offscreen Release startup/version smoke to normal CI
- fix defects exposed by the new checks: duplicate HeroBanner component IDs, the `-v` version/verbose collision, a misleading non-move in the image store, and deprecated UTC date construction
- document analysis scope, TSAN's uninstrumented-Qt limitation, commands, and the initial coverage baseline

## Verification

- `./scripts/dev-build.sh --tests`
- full local CTest including `VisualRegressionTest`: 36/36 passed (18.71s)
- targeted clang-tidy: passed
- ASan/UBSan: 6/6 focused suites passed
- targeted TSAN: 2/2 focused suites passed
- coverage suite: 34/34 passed; 54.5% lines, 57.1% functions, 44.9% branches
- QML lint plus Release smoke: passed
- ShellCheck and actionlint: passed
- Release CLI smoke emits exactly `Bloom 0.8.0`; help retains `--verbose, -v`

## Platform scope

The automated smoke validates Linux offscreen Release startup/version reporting only. Live Jellyfin/Silo servers, playback hardware, GPU/HDR/display switching, and Windows runtime playback remain unavailable locally and retain their documented manual validation gates. TSAN is intentionally limited to process/display tests because the system's uninstrumented Qt reports its queued `invokeMethod` allocation handoff in the image-cache worker; no broad suppression was added.

## Documentation

Please confirm the updated testing policy in `AGENTS.md` and detailed analysis/coverage guidance in `docs/build.md` accurately describe the intended CI split.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add production analysis and smoke check workflows to CI
> - Adds a scheduled [deep-analysis.yml](.github/workflows/deep-analysis.yml) workflow running clang-tidy, ASan+UBSan, TSAN, and coverage collection via new scripts in [scripts/](https://github.com/crowquillx/Bloom/pull/132/files#diff-a3e5b0c952772d5628c96fd5690e62cea1f56648b523ecca58ab5d2d82da382a).
> - Adds `release-smoke` and `automation-lint` Nix checks to both the main [ci.yml](.github/workflows/ci.yml) and [update-dependencies.yml](.github/workflows/update-dependencies.yml) workflows; smoke check runs `bloom --version` and `--help` offscreen.
> - Adds a new [cmake/BloomAnalysis.cmake](https://github.com/crowquillx/Bloom/pull/132/files#diff-403a6f5e1fda8e8f0905b7438a5c8d1c8a335e397fc4c3a74ed74c2da776b8b6) module supporting `BLOOM_SANITIZER` (address|thread) and `BLOOM_ENABLE_COVERAGE` build options.
> - Tightens [.clang-tidy](https://github.com/crowquillx/Bloom/pull/132/files#diff-0534891fbc8b89b4c521057e7e8dff70d3cbeb822cc9991a3abad77848c289f8) to an explicit allowlist with `WarningsAsErrors='*'` and restricts analysis to `src/`.
> - Fixes `--version` CLI flag in [src/main.cpp](https://github.com/crowquillx/Bloom/pull/132/files#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2) to print `Bloom <version>` and exit without conflicting with `-v` (verbose).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27a3ebc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--version` command-line option that displays the application version.
  * Added optional tooling for sanitizer checks, coverage reports, and static analysis.

* **Bug Fixes**
  * Improved date filtering consistency by using UTC.
  * Resolved ambiguous action references in hero layouts.

* **Quality Improvements**
  * Strengthened QML linting and automated validation.
  * Added release startup checks and expanded continuous analysis workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->